### PR TITLE
Address static analyzer warnings and UNSAFE_BUFFER_USAGE in ParkingLot

### DIFF
--- a/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,5 +1,4 @@
 wtf/ParallelHelperPool.cpp
-wtf/ParkingLot.cpp
 wtf/RecursiveLockAdapter.h
 wtf/RedBlackTree.h
 wtf/WorkerPool.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,5 +1,4 @@
 wtf/AutomaticThread.cpp
-wtf/ParkingLot.cpp
 wtf/PrintStream.h
 wtf/RunLoop.h
 wtf/SuspendableWorkQueue.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,7 +1,6 @@
 wtf/AutomaticThread.cpp
 wtf/MemoryPressureHandler.cpp
 wtf/MetaAllocator.h
-wtf/ParkingLot.cpp
 wtf/RecursiveLockAdapter.h
 wtf/RedBlackTree.h
 wtf/Ref.h

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -28,6 +28,7 @@
 
 #include <mutex>
 #include <wtf/DataLog.h>
+#include <wtf/FixedVector.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/ThreadSpecific.h>
@@ -35,8 +36,6 @@
 #include <wtf/Vector.h>
 #include <wtf/WeakRandom.h>
 #include <wtf/WordLock.h>
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace WTF {
 
@@ -67,7 +66,7 @@ public:
 
     const void* address { nullptr };
     
-    ThreadData* nextInQueue { nullptr };
+    RefPtr<ThreadData> nextInQueue;
     
     intptr_t token { 0 };
 };
@@ -138,8 +137,8 @@ public:
         // queueTail to previous, which in this case is queueHead - thus making the queue look like a
         // proper one-element queue with queueHead == queueTail.
         bool shouldContinue = true;
-        ThreadData** currentPtr = &queueHead;
-        ThreadData* previous = nullptr;
+        RefPtr<ThreadData>* currentPtr = &queueHead;
+        RefPtr<ThreadData> previous;
 
         MonotonicTime time = MonotonicTime::now();
         bool timeToBeFair = false;
@@ -149,16 +148,16 @@ public:
         bool didDequeue = false;
         
         while (shouldContinue) {
-            ThreadData* current = *currentPtr;
+            RefPtr current = *currentPtr;
             if (verbose)
-                dataLogForCurrentThread(": got thread ", RawPointer(current), "\n");
+                dataLogForCurrentThread(": got thread ", RawPointer(current.get()), "\n");
             if (!current)
                 break;
-            DequeueResult result = functor(current, timeToBeFair);
+            DequeueResult result = functor(current.get(), timeToBeFair);
             switch (result) {
             case DequeueResult::Ignore:
                 if (verbose)
-                    dataLogForCurrentThread(": currentPtr = ", RawPointer(currentPtr), ", *currentPtr = ", RawPointer(*currentPtr), "\n");
+                    dataLogForCurrentThread(": currentPtr = ", RawPointer(currentPtr), ", *currentPtr = ", RawPointer((*currentPtr).get()), "\n");
                 previous = current;
                 currentPtr = &(*currentPtr)->nextInQueue;
                 break;
@@ -167,7 +166,7 @@ public:
                 FALLTHROUGH;
             case DequeueResult::RemoveAndContinue:
                 if (verbose)
-                    dataLogForCurrentThread(": dequeueing ", RawPointer(current), " from ", RawPointer(this), "\n");
+                    dataLogForCurrentThread(": dequeueing ", RawPointer(current.get()), " from ", RawPointer(this), "\n");
                 if (current == queueTail)
                     queueTail = previous;
                 didDequeue = true;
@@ -194,8 +193,8 @@ public:
         return result;
     }
 
-    ThreadData* queueHead { nullptr };
-    ThreadData* queueTail { nullptr };
+    RefPtr<ThreadData> queueHead;
+    RefPtr<ThreadData> queueTail;
 
     // This lock protects the entire bucket. Thou shall not make changes to Bucket without holding
     // this lock.
@@ -217,16 +216,12 @@ Vector<Hashtable*>* hashtables;
 WordLock hashtablesLock;
 
 struct Hashtable {
-    unsigned size;
-    Atomic<Bucket*> data[1];
+    WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
-    static Hashtable* create(unsigned size)
+    Hashtable(unsigned size)
+        : data(size)
     {
         ASSERT(size >= 1);
-        
-        Hashtable* result = static_cast<Hashtable*>(
-            fastZeroedMalloc(sizeof(Hashtable) + sizeof(Atomic<Bucket*>) * (size - 1)));
-        result->size = size;
 
         {
             // This is not fast and it's not data-access parallel, but that's fine, because
@@ -235,22 +230,20 @@ struct Hashtable {
             Locker locker(hashtablesLock);
             if (!hashtables)
                 hashtables = new Vector<Hashtable*>();
-            hashtables->append(result);
+            hashtables->append(this);
         }
-        
-        return result;
     }
 
-    static void destroy(Hashtable* hashtable)
+    ~Hashtable()
     {
         {
             // This is not fast, but that's OK. See comment in create().
             Locker locker(hashtablesLock);
-            hashtables->removeFirst(hashtable);
+            hashtables->removeFirst(this);
         }
-        
-        fastFree(hashtable);
     }
+
+    FixedVector<Atomic<Bucket*>> data;
 };
 
 Atomic<Hashtable*> hashtable;
@@ -276,14 +269,12 @@ Hashtable* ensureHashtable()
             return currentHashtable;
 
         if (!currentHashtable) {
-            currentHashtable = Hashtable::create(maxLoadFactor);
-            if (hashtable.compareExchangeWeak(nullptr, currentHashtable)) {
+            auto currentHashtable = makeUnique<Hashtable>(maxLoadFactor);
+            if (hashtable.compareExchangeWeak(nullptr, currentHashtable.get())) {
                 if (verbose)
-                    dataLogForCurrentThread(": created initial hashtable ", RawPointer(currentHashtable), "\n");
-                return currentHashtable;
+                    dataLogForCurrentThread(": created initial hashtable ", RawPointer(currentHashtable.get()), "\n");
+                return currentHashtable.release(); // Leak the hash table.
             }
-
-            Hashtable::destroy(currentHashtable);
         }
     }
 }
@@ -301,7 +292,7 @@ Vector<Bucket*> lockHashtable()
         // Now find all of the buckets. This makes sure that the hashtable is full of buckets so that
         // we can lock all of the buckets, not just the ones that are materialized.
         Vector<Bucket*> buckets;
-        for (unsigned i = currentHashtable->size; i--;) {
+        for (unsigned i = currentHashtable->data.size(); i--;) {
             Atomic<Bucket*>& bucketPointer = currentHashtable->data[i];
 
             for (;;) {
@@ -352,9 +343,9 @@ void ensureHashtableSize(unsigned numThreads)
 
     // First do a fast check to see if rehashing is needed.
     Hashtable* oldHashtable = hashtable.load();
-    if (oldHashtable && static_cast<double>(oldHashtable->size) / static_cast<double>(numThreads) >= maxLoadFactor) {
+    if (oldHashtable && static_cast<double>(oldHashtable->data.size()) / static_cast<double>(numThreads) >= maxLoadFactor) {
         if (verbose)
-            dataLogForCurrentThread(": no need to rehash because ", oldHashtable->size, " / ", numThreads, " >= ", maxLoadFactor, "\n");
+            dataLogForCurrentThread(": no need to rehash because ", oldHashtable->data.size(), " / ", numThreads, " >= ", maxLoadFactor, "\n");
         return;
     }
 
@@ -365,9 +356,9 @@ void ensureHashtableSize(unsigned numThreads)
     // lockHashtable() creates an initial hashtable for us.
     oldHashtable = hashtable.load();
     RELEASE_ASSERT(oldHashtable);
-    if (static_cast<double>(oldHashtable->size) / static_cast<double>(numThreads) >= maxLoadFactor) {
+    if (static_cast<double>(oldHashtable->data.size()) / static_cast<double>(numThreads) >= maxLoadFactor) {
         if (verbose)
-            dataLogForCurrentThread(": after locking, no need to rehash because ", oldHashtable->size, " / ", numThreads, " >= ", maxLoadFactor, "\n");
+            dataLogForCurrentThread(": after locking, no need to rehash because ", oldHashtable->data.size(), " / ", numThreads, " >= ", maxLoadFactor, "\n");
         unlockHashtable(bucketsToUnlock);
         return;
     }
@@ -376,23 +367,23 @@ void ensureHashtableSize(unsigned numThreads)
 
     // OK, now we resize. First we gather all thread datas from the old hashtable. These thread datas
     // are placed into the vector in queue order.
-    Vector<ThreadData*> threadDatas;
+    Vector<RefPtr<ThreadData>> threadDatas;
     for (Bucket* bucket : reusableBuckets) {
-        while (ThreadData* threadData = bucket->dequeue())
-            threadDatas.append(threadData);
+        while (RefPtr threadData = bucket->dequeue())
+            threadDatas.append(WTFMove(threadData));
     }
 
     unsigned newSize = numThreads * growthFactor * maxLoadFactor;
-    RELEASE_ASSERT(newSize > oldHashtable->size);
+    RELEASE_ASSERT(newSize > oldHashtable->data.size());
     
-    Hashtable* newHashtable = Hashtable::create(newSize);
+    auto newHashtable = makeUnique<Hashtable>(newSize);
     if (verbose)
-        dataLogForCurrentThread(": created new hashtable: ", RawPointer(newHashtable), "\n");
-    for (ThreadData* threadData : threadDatas) {
+        dataLogForCurrentThread(": created new hashtable: ", RawPointer(newHashtable.get()), "\n");
+    for (auto& threadData : threadDatas) {
         if (verbose)
-            dataLogForCurrentThread(": rehashing thread data ", RawPointer(threadData), " with address = ", RawPointer(threadData->address), "\n");
+            dataLogForCurrentThread(": rehashing thread data ", RawPointer(threadData.get()), " with address = ", RawPointer(threadData->address), "\n");
         unsigned hash = hashAddress(threadData->address);
-        unsigned index = hash % newHashtable->size;
+        unsigned index = hash % newHashtable->data.size();
         if (verbose)
             dataLogForCurrentThread(": index = ", index, "\n");
         Bucket* bucket = newHashtable->data[index].load();
@@ -404,14 +395,14 @@ void ensureHashtableSize(unsigned numThreads)
             newHashtable->data[index].store(bucket);
         }
         
-        bucket->enqueue(threadData);
+        bucket->enqueue(threadData.get());
     }
     
     // At this point there may be some buckets left unreused. This could easily happen if the
     // number of enqueued threads right now is low but the high watermark of the number of threads
     // enqueued was high. We place these buckets into the hashtable basically at random, just to
     // make sure we don't leak them.
-    for (unsigned i = 0; i < newHashtable->size && !reusableBuckets.isEmpty(); ++i) {
+    for (unsigned i = 0; i < newHashtable->data.size() && !reusableBuckets.isEmpty(); ++i) {
         Atomic<Bucket*>& bucketPtr = newHashtable->data[i];
         if (bucketPtr.load())
             continue;
@@ -425,7 +416,7 @@ void ensureHashtableSize(unsigned numThreads)
     // OK, right now the old hashtable is locked up and the new hashtable is ready to rock and
     // roll. After we install the new hashtable, we can release all bucket locks.
     
-    bool result = hashtable.compareExchangeStrong(oldHashtable, newHashtable) == oldHashtable;
+    bool result = hashtable.compareExchangeStrong(oldHashtable, newHashtable.release()) == oldHashtable; // Leak the hash table.
     RELEASE_ASSERT(result);
 
     unlockHashtable(bucketsToUnlock);
@@ -473,13 +464,13 @@ ThreadData* myThreadData()
 }
 
 template<typename Functor>
-bool enqueue(const void* address, const Functor& functor)
+bool enqueue(const void* address, NOESCAPE const Functor& functor)
 {
     unsigned hash = hashAddress(address);
 
     for (;;) {
         Hashtable* myHashtable = ensureHashtable();
-        unsigned index = hash % myHashtable->size;
+        unsigned index = hash % myHashtable->data.size();
         Atomic<Bucket*>& bucketPointer = myHashtable->data[index];
         Bucket* bucket;
         for (;;) {
@@ -503,12 +494,12 @@ bool enqueue(const void* address, const Functor& functor)
             continue;
         }
 
-        ThreadData* threadData = functor();
+        RefPtr<ThreadData> threadData = functor();
         bool result;
         if (threadData) {
             if (verbose)
-                dataLogForCurrentThread(": proceeding to enqueue ", RawPointer(threadData), "\n");
-            bucket->enqueue(threadData);
+                dataLogForCurrentThread(": proceeding to enqueue ", RawPointer(threadData.get()), "\n");
+            bucket->enqueue(threadData.get());
             result = true;
         } else
             result = false;
@@ -531,7 +522,7 @@ bool dequeue(
 
     for (;;) {
         Hashtable* myHashtable = ensureHashtable();
-        unsigned index = hash % myHashtable->size;
+        unsigned index = hash % myHashtable->data.size();
         Atomic<Bucket*>& bucketPointer = myHashtable->data[index];
         Bucket* bucket = bucketPointer.load();
         if (!bucket) {
@@ -578,7 +569,7 @@ NEVER_INLINE ParkingLot::ParkResult ParkingLot::parkConditionallyImpl(
     if (verbose)
         dataLogForCurrentThread(": parking.\n");
     
-    ThreadData* me = myThreadData();
+    RefPtr me = myThreadData();
     me->token = 0;
 
     // Guard against someone calling parkConditionally() recursively from beforeSleep().
@@ -591,7 +582,7 @@ NEVER_INLINE ParkingLot::ParkResult ParkingLot::parkConditionallyImpl(
                 return nullptr;
 
             me->address = address;
-            return me;
+            return me.get();
         });
 
     if (!enqueueResult)
@@ -779,7 +770,7 @@ NEVER_INLINE unsigned ParkingLot::unparkCount(const void* address, unsigned coun
         },
         [] (bool) { });
 
-    for (RefPtr<ThreadData>& threadData : threadDatas) {
+    for (auto& threadData : threadDatas) {
         if (verbose)
             dataLogForCurrentThread(": unparking ", RawPointer(threadData.get()), " with address ", RawPointer(threadData->address), "\n");
         ASSERT(threadData->address);
@@ -806,11 +797,11 @@ NEVER_INLINE void ParkingLot::forEachImpl(const ScopedLambda<void(Thread&, const
     Vector<Bucket*> bucketsToUnlock = lockHashtable();
 
     Hashtable* currentHashtable = hashtable.load();
-    for (unsigned i = currentHashtable->size; i--;) {
+    for (unsigned i = currentHashtable->data.size(); i--;) {
         Bucket* bucket = currentHashtable->data[i].load();
         if (!bucket)
             continue;
-        for (ThreadData* currentThreadData = bucket->queueHead; currentThreadData; currentThreadData = currentThreadData->nextInQueue)
+        for (RefPtr currentThreadData = bucket->queueHead; currentThreadData; currentThreadData = currentThreadData->nextInQueue)
             callback(currentThreadData->thread.get(), currentThreadData->address);
     }
     
@@ -818,5 +809,3 @@ NEVER_INLINE void ParkingLot::forEachImpl(const ScopedLambda<void(Thread&, const
 }
 
 } // namespace WTF
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### b436f5fd9c2e60d9ee82a047eb67a73e74129da2
<pre>
Address static analyzer warnings and UNSAFE_BUFFER_USAGE in ParkingLot
<a href="https://bugs.webkit.org/show_bug.cgi?id=287446">https://bugs.webkit.org/show_bug.cgi?id=287446</a>
&lt;<a href="https://rdar.apple.com/problem/144574023">rdar://problem/144574023</a>&gt;

Reviewed by Chris Dumez.

Use FixedVector in Hashtable to avoid unsafe pointer arithmetic.

Use RefPtr instead of raw pointer for ThreadData to avoid ambiguous lifetime.
In theory all these RefPtrs are not needed, since ThreadData is per-thread
and a thread will not exit while holding a lock, but it&apos;s nice not to have to
theorize, and also pthread_exit() is a function and per-thread destruction order
is not guaranteed.

* Source/WTF/wtf/ParkingLot.cpp:
(WTF::ParkingLot::parkConditionallyImpl):
(WTF::ParkingLot::forEachImpl):

Canonical link: <a href="https://commits.webkit.org/290217@main">https://commits.webkit.org/290217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47ad9c9b06fc90891a1d8daaeeb87d1b602555a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89333 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26489 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92335 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49183 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39201 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82132 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96148 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88109 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/16513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77697 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/16769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76996 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9663 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14000 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/16527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110602 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26523 "Found 3 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->