### PR TITLE
REGRESSION(288932@main): [Unified PDF] Anchor links not working within document

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -499,6 +499,7 @@ private:
     void revealFragmentIfNeeded();
 
     // Only use this if some other function has ensured that the correct page is visible.
+    // `false` can mean a failure or an inconclusive scroll request, though no caller cares about this distinction yet.
     bool scrollToPointInContentsSpace(WebCore::FloatPoint);
 
     OptionSet<WebCore::TiledBackingScrollability> computeScrollability() const;
@@ -701,8 +702,10 @@ T UnifiedPDFPlugin::convertDown(CoordinateSpace sourceSpace, CoordinateSpace des
         if (destinationSpace == CoordinateSpace::ScrolledContents)
             return mappedValue;
 
-        mappedValue.scale(1 / m_scaleFactor);
-        mappedValue.move(-centeringOffset());
+        if (!shouldSizeToFitContent()) {
+            mappedValue.scale(1 / m_scaleFactor);
+            mappedValue.move(-centeringOffset());
+        }
         FALLTHROUGH;
 
     case CoordinateSpace::Contents:
@@ -765,7 +768,8 @@ T UnifiedPDFPlugin::convertUp(CoordinateSpace sourceSpace, CoordinateSpace desti
         if (destinationSpace == CoordinateSpace::ScrolledContents)
             return mappedValue;
 
-        mappedValue.moveBy(-WebCore::FloatPoint { m_scrollOffset });
+        if (!shouldSizeToFitContent())
+            mappedValue.moveBy(-WebCore::FloatPoint { m_scrollOffset });
         FALLTHROUGH;
 
     case CoordinateSpace::Plugin:

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2209,6 +2209,17 @@ bool UnifiedPDFPlugin::revealPage(PDFDocumentLayout::PageIndex pageIndex)
 
 bool UnifiedPDFPlugin::scrollToPointInContentsSpace(FloatPoint pointInContentsSpace)
 {
+    if (shouldSizeToFitContent()) {
+        RefPtr webPage = m_frame->page();
+        if (!webPage)
+            return false;
+
+        auto pluginPoint = convertUp(CoordinateSpace::ScrolledContents, CoordinateSpace::Plugin, pointInContentsSpace);
+        auto rootViewPoint = convertFromPluginToRootView(pluginPoint);
+        webPage->scrollToRect({ rootViewPoint, FloatSize { } }, { });
+        return true;
+    }
+
     auto oldScrollType = currentScrollType();
     setCurrentScrollType(ScrollType::Programmatic);
     bool success = scrollToPositionWithoutAnimation(roundedIntPoint(pointInContentsSpace));


### PR DESCRIPTION
#### 91624f355e6b624501619ab40d4ce5973d2aa32b
<pre>
REGRESSION(288932@main): [Unified PDF] Anchor links not working within document
<a href="https://bugs.webkit.org/show_bug.cgi?id=287443">https://bugs.webkit.org/show_bug.cgi?id=287443</a>
<a href="https://rdar.apple.com/143387526">rdar://143387526</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

After 288392@main, the scrollable area for the plugin expectedly cannot
be scrolled, i.e. has (0, 0) minimum and maximum positions. Instead,
when the plugin is inflated to fit the size of the PDF content, we
should just drive all our scrolling needs through the main frame. This
patch addresses the bug in the title by:

1. Only accounting for the `ScrolledContents` coordinate space when
   the plugin is _not_ sized the fit the PDF contents.
2. Driving scroll through the main frame rather than through the
   scrollable area representing the plugin when it is sized to fit the
   PDF contents.

API test: UnifiedPDF.RespectsPageFragment

This API test does not perform anchor link following, but revealing a
page fragment goes through the same codepath, and is sufficient to
exercise the bug.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
(WebKit::UnifiedPDFPlugin::convertDown const):
(WebKit::UnifiedPDFPlugin::convertUp const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::revealPage):
(WebKit::UnifiedPDFPlugin::scrollToPointInContentsSpace):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/290220@main">https://commits.webkit.org/290220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f35d93c49dc945a444a1cf41ade0b924bfb72fc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94273 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40051 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68795 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26465 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81038 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6806 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35422 "Found 2 new test failures: imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39158 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96105 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16470 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77670 "Failure limit exceed. At least found 2 new test failures: css3/filters/svg-filter-on-1px-element.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76970 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18994 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21386 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19986 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21795 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16225 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->