### PR TITLE
Unreviewed, reverting 290166@main (02869d6b93d6)

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -67,7 +67,8 @@ class VideoTrackPrivate;
 enum class MediaSourceReadyState { Closed, Open, Ended };
 
 class MediaSource
-    : public RefCountedAndCanMakeWeakPtr<MediaSource>
+    : public RefCounted<MediaSource>
+    , public CanMakeWeakPtr<MediaSource>
     , public ActiveDOMObject
     , public EventTarget
     , public URLRegistrable
@@ -78,8 +79,8 @@ class MediaSource
 {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED(MediaSource);
 public:
-    void ref() const final { RefCountedAndCanMakeWeakPtr::ref(); }
-    void deref() const final { RefCountedAndCanMakeWeakPtr::deref(); }
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
 
     USING_CAN_MAKE_WEAKPTR(CanMakeWeakPtr<MediaSource>);
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -420,9 +420,6 @@ ExceptionOr<void> SourceBuffer::remove(const MediaTime& start, const MediaTime& 
 
 void SourceBuffer::rangeRemoval(const MediaTime& start, const MediaTime& end)
 {
-    if (isRemoved())
-        return;
-
     // 3.5.7 Range Removal
     // https://rawgit.com/w3c/media-source/7bbe4aa33c61ec025bc7acbd80354110f6a000f9/media-source.html#sourcebuffer-range-removal
     // 1. Let start equal the starting presentation timestamp for the removal range.
@@ -578,7 +575,7 @@ void SourceBuffer::seekToTime(const MediaTime& time)
 
 bool SourceBuffer::virtualHasPendingActivity() const
 {
-    return !!m_source;
+    return m_source;
 }
 
 bool SourceBuffer::isRemoved() const
@@ -707,8 +704,7 @@ void SourceBuffer::sourceBufferPrivateDidReceiveRenderingError(int64_t error)
 
     ERROR_LOG(LOGIDENTIFIER, error);
 
-    if (!isRemoved())
-        m_source->streamEndedWithError(MediaSource::EndOfStreamError::Decode);
+    m_source->streamEndedWithError(MediaSource::EndOfStreamError::Decode);
 }
 
 uint64_t SourceBuffer::maximumBufferSize() const
@@ -784,9 +780,6 @@ void SourceBuffer::setActive(bool active)
 Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment(SourceBufferPrivateClient::InitializationSegment&& segment)
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-
-    if (isRemoved())
-        return MediaPromise::createAndReject(PlatformMediaError::NotReady);
 
     // 3.5.8 Initialization Segment Received (ctd)
     // https://rawgit.com/w3c/media-source/c3ad59c7a370d04430969ba73d18dc9bcde57a33/index.html#sourcebuffer-init-segment-received [Editor's Draft 09 January 2015]
@@ -1281,8 +1274,7 @@ void SourceBuffer::textTrackLanguageChanged(TextTrack& track)
 
 Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDurationChanged(const MediaTime& duration)
 {
-    if (!isRemoved())
-        m_source->setDurationInternal(duration);
+    m_source->setDurationInternal(duration);
     if (m_textTracks)
         m_textTracks->setDuration(duration);
     return MediaPromise::createAndResolve();
@@ -1295,8 +1287,7 @@ void SourceBuffer::sourceBufferPrivateHighestPresentationTimestampChanged(const 
 
 void SourceBuffer::sourceBufferPrivateDidDropSample()
 {
-    if (!isRemoved())
-        m_source->incrementDroppedFrameCount();
+    m_source->incrementDroppedFrameCount();
 }
 
 void SourceBuffer::reportExtraMemoryAllocated(uint64_t extraMemory)
@@ -1428,8 +1419,9 @@ void SourceBuffer::updateBuffered()
 
             queueTaskToDispatchEvent(*this, TaskSource::MediaElement, BufferedChangeEvent::create(WTFMove(addedTimeRanges), WTFMove(removedTimeRanges)));
         }
-        if (!isRemoved())
-            m_source->monitorSourceBuffers();
+        if (isRemoved())
+            return;
+        m_source->monitorSourceBuffers();
     });
 
     // 3.1 Attributes, buffered
@@ -1485,10 +1477,8 @@ void SourceBuffer::setBufferedDirty(bool flag)
 {
     if (m_bufferedDirty == flag)
         return;
-
     m_bufferedDirty = flag;
-
-    if (!isRemoved() && flag)
+    if (flag && m_source)
         m_source->sourceBufferBufferedChanged();
 }
 
@@ -1513,9 +1503,7 @@ void SourceBuffer::memoryPressure()
 {
     if (!isManaged())
         return;
-
-    if (!isRemoved())
-        m_private->memoryPressure(m_source->currentTime());
+    m_private->memoryPressure(m_source->currentTime());
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -1558,9 +1546,6 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidAttach(SourceBufferPrivate
     ALWAYS_LOG(LOGIDENTIFIER);
 
     ASSERT(m_receivedFirstInitializationSegment);
-
-    if (isRemoved())
-        return MediaPromise::createAndReject(PlatformMediaError::NotReady);
 
     // 3.2 Add the appropriate track descriptions from this initialization segment to each of the track buffers.
     ASSERT(segment.audioTracks.size() == audioTracks().length());

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -228,7 +228,7 @@ private:
     Ref<SourceBufferPrivate> m_private;
     Ref<SourceBufferClientImpl> m_client;
 
-    WeakPtr<MediaSource> m_source;
+    MediaSource* m_source;
     AppendMode m_mode { AppendMode::Segments };
 
     WTF::Observer<WebCoreOpaqueRoot()> m_opaqueRootProvider;

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -1,6 +1,7 @@
 Modules/WebGPU/GPUPresentationContextDescriptor.h
 Modules/encryptedmedia/MediaKeyStatusMap.h
 Modules/fetch/FetchBodyOwner.h
+Modules/mediasource/SourceBuffer.h
 Modules/mediastream/RTCPeerConnection.h
 Modules/mediastream/libwebrtc/LibWebRTCObservers.h
 Modules/notifications/NotificationResourcesLoader.h


### PR DESCRIPTION
#### 2bb71756c76c52a44646f3a2832f4c56faaaee73
<pre>
Unreviewed, reverting 290166@main (02869d6b93d6)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287447">https://bugs.webkit.org/show_bug.cgi?id=287447</a>
<a href="https://rdar.apple.com/144574772">rdar://144574772</a>

REGRESSION(290166@main): [macOS] ASSERTION FAILED: WTF::RawPtrTraits&lt;WTF::DefaultWeakPtrImpl&gt;&gt;::operator*() const

Reverted change:

    Address safer safer C++ warnings for SourceBuffer.h
    <a href="https://bugs.webkit.org/show_bug.cgi?id=287381">https://bugs.webkit.org/show_bug.cgi?id=287381</a>
    <a href="https://rdar.apple.com/144498751">rdar://144498751</a>
    290166@main (02869d6b93d6)

Canonical link: <a href="https://commits.webkit.org/290191@main">https://commits.webkit.org/290191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3c0f047897d0d3db975af0d65b70e7b364d7271

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44061 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/39993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/16952 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/94214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/39993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92234 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/80983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39100 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16412 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16668 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/21337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/19943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9530 "Failed to checkout and rebase branch from PR 40382") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13987 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16426 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/17948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->