### PR TITLE
Adding `text-autospace: normal` causes some pages to crash

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<style>
+body {
+  text-autospace: normal;
+}
+div {
+  color : transparent;
+}
+.dump {
+  color: black;
+}
+</style>
+</head>
+<body>
+<div class="dump">This test passes if it doesn't crash.</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<style>
+body {
+  text-autospace: normal;
+}
+div {
+  color : transparent;
+}
+.dump {
+  color: black;
+}
+</style>
+</head>
+<body>
+<div class="dump">This test passes if it doesn't crash.</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8"/>
+<link rel="match" href="text-autospace-ruby-crash-ref.html">
+<style>
+body {
+  text-autospace: normal;
+}
+div {
+  color : transparent;
+}
+.dump {
+  color: black;
+}
+</style>
+</head>
+<body>
+<div class="dump">This test passes if it doesn't crash.</div>
+<div dir="rtl">&#x5e2;<ruby><rb>&#x304e;</rb></ruby>&#x5e2; aaaaaaaaaaaaaaaaaaaa</div>
+<div dir="rtl">&#x5e2;&#x5e2;<ruby><rb>&#x304e;</rb></ruby>&#x5e2; aaaaaaaaaaaaaaaaaaaa</div>
+<div dir="rtl">&#x5e2;<ruby><rb>&#x304e;</rb></ruby>&#x5e2;&#x5e2; aaaaaaaaaaaaaaaaaaaa</div>
+<div dir="rtl">&#x5e2;&#x5e2;<ruby><rb>&#x304e;</rb></ruby>&#x5e2;&#x5e2; aaaaaaaaaaaaaaaaaaaa</div>
+<div><ruby><rb>&#x304e;</rb></ruby>a<ruby><rb>&#x304e;</rb></ruby> aaaaaaaaaaaaaaaaaaaa</div>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -787,8 +787,12 @@ InlineContentCache::InlineItems::ContentAttributes InlineItemsBuilder::computeCo
             auto needsMeasuring = inlineTextItem->length() && !inlineTextItem->isZeroWidthSpaceSeparator() && canCacheMeasuredWidthOnInlineTextItem(inlineTextItem->inlineTextBox(), inlineTextItem->isWhitespace());
             if (needsMeasuring) {
                 auto start = inlineTextItem->start();
-                if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(inlineItemIndex - 1); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
-                    extraInlineTextSpacing = inlineBoxBoundaryTextSpacing->value;
+                if (inlineItemIndex) {
+                    // Box boudary text spacing is potentially registered for inline box start items which appear logically before an inline text item
+                    auto potentialInlineBoxStartIndex = inlineItemIndex - 1;
+                    if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(potentialInlineBoxStartIndex); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
+                        extraInlineTextSpacing = inlineBoxBoundaryTextSpacing->value;
+                }
                 inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + inlineTextItem->length(), { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState) + extraInlineTextSpacing);
                 handleTextSpacing(spacingState, trimmableTextSpacings, *inlineTextItem, inlineItemIndex);
             }


### PR DESCRIPTION
#### 5e33b70649807c4c933a35e6bc7d16bd3a600c4a
<pre>
Adding `text-autospace: normal` causes some pages to crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=287423">https://bugs.webkit.org/show_bug.cgi?id=287423</a>
<a href="https://rdar.apple.com/144554727">rdar://144554727</a>

Reviewed by Alan Baradlay.

We track box boundary text spacing with inlineBoxBoundaryTextSpacings by storing
the indexes to inline box start items which represent such a boundary.

When calculating width of inline text items at computeContentAttributesAndInlineTextItemWidths,
we check if the item before it was registered in inlineBoxBoundaryTextSpacings. If so, we
add text spacing to its width for layout (On drawing it will be placed between the box boundaries).

The crash here was that we forgot to skip the check for index 0.

Besides fixing it, We are also giving a name for such index for improving readability.

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-autospace/crashtests/text-autospace-ruby-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeContentAttributesAndInlineTextItemWidths):

Canonical link: <a href="https://commits.webkit.org/290211@main">https://commits.webkit.org/290211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9847d79e4533ba95fc5dbc9c78e96594706705b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68787 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26456 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81027 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35411 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39150 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77155 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96097 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16462 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76962 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21376 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9585 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21787 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->