### PR TITLE
Add unit test for site isolation fullscreen element resizing

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,0 +1,11 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {300, 150}
+
+FIXME: Size after entering should be 600x800 like it is with site isolation off.
+The size currently comes from screenRectOfContents.
+Also, there should be exitFullScreenForElement and beganExitFullScreen callbacks like there are with site isolation off.
+
+Size after entering fullscreen: 150x300
+Size after exiting fullscreen: 150x300
+

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -1,0 +1,18 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText()
+        testRunner.dumpFullScreenCallbacks();
+    }
+    addEventListener("message", (event) => {
+        document.getElementById("mylog").innerHTML += event.data + "<br>";
+        if (event.data.startsWith('Size after exiting') && window.testRunner) { testRunner.notifyDone() }
+    });
+</script>
+<iframe allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen.html" frameborder=0></iframe>
+<div id=mylog>
+FIXME: Size after entering should be 600x800 like it is with site isolation off.<br>
+The size currently comes from screenRectOfContents.<br>
+Also, there should be exitFullScreenForElement and beganExitFullScreen callbacks like there are with site isolation off.<br><br>
+</div>

--- a/LayoutTests/http/tests/site-isolation/resources/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/resources/fullscreen.html
@@ -1,0 +1,20 @@
+<script>
+    async function enterFullScreen() {
+        await document.documentElement.requestFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+        window.parent.postMessage("Size after entering fullscreen: " + document.body.clientHeight + "x" + document.body.clientWidth, "*");
+    }
+    async function exitFullScreen() {
+        await document.exitFullscreen();
+        if (window.testRunner) { await testRunner.updatePresentation() }
+        window.parent.postMessage("Size after exiting fullscreen: " + document.body.clientHeight + "x" + document.body.clientWidth, "*");
+    }
+    if (window.internals) {
+        internals.withUserGesture(async () => {
+            await enterFullScreen();
+            await exitFullScreen();
+        });
+    }
+</script>
+<button onclick="enterFullScreen()">Enter</button>
+<button onclick="exitFullScreen()">Exit</button>

--- a/LayoutTests/platform/ios/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,0 +1,11 @@
+supportsFullScreen() == true
+enterFullScreenForElement()
+beganEnterFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
+
+FIXME: Size after entering should be 600x800 like it is with site isolation off.
+The size currently comes from screenRectOfContents.
+Also, there should be exitFullScreenForElement and beganExitFullScreen callbacks like there are with site isolation off.
+
+Size after entering fullscreen: 150x300
+Size after exiting fullscreen: 150x300
+


### PR DESCRIPTION
#### 5c2c13a2b92dc1b6a4fdab582f4072b776111b82
<pre>
Add unit test for site isolation fullscreen element resizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=287452">https://bugs.webkit.org/show_bug.cgi?id=287452</a>
<a href="https://rdar.apple.com/144579963">rdar://144579963</a>

Reviewed by Jer Noble.

* LayoutTests/http/tests/site-isolation/fullscreen-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/fullscreen.html: Added.
* LayoutTests/http/tests/site-isolation/resources/fullscreen.html: Added.

Canonical link: <a href="https://commits.webkit.org/290277@main">https://commits.webkit.org/290277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/732107bbeba6d5d8cf0682343b6a4b5b47dae05b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89453 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68910 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26570 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49272 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6925 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35567 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39324 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77781 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77093 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20105 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9785 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14036 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16388 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->