### PR TITLE
[WebGPUSwift] replace all other Metal specific functions in Command Encoder

### DIFF
--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		94200C512CADBD7200484401 /* CommandEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94200C502CADBD6B00484401 /* CommandEncoder.swift */; };
 		94200C522CADBE5200484401 /* CommandsMixin.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C582FF827E04131009B40F0 /* CommandsMixin.h */; };
 		9478714A2C98CECB003DB695 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 947871492C98CEC6003DB695 /* Buffer.swift */; };
+		94989BA12D5AA41500E9458A /* Logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 94989BA02D5AA40E00E9458A /* Logging.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		94989BA42D5ACCFF00E9458A /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94989BA22D5AC2C800E9458A /* Logging.cpp */; };
 		94CC0FE62CA203B300CB3264 /* WebGPUSwiftInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 94CC0FE52CA203AB00CB3264 /* WebGPUSwiftInternal.h */; };
 		94E02AFC2CF03B580052068F /* Buffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACAA5273A426D0095F8D5 /* Buffer.h */; };
 		97099AC12AA60D58003B41F8 /* ASTElaboratedTypeExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 97099ABE2AA60D58003B41F8 /* ASTElaboratedTypeExpression.h */; };
@@ -465,6 +467,8 @@
 		941C1EE42CA328EE004D4220 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		94200C502CADBD6B00484401 /* CommandEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandEncoder.swift; sourceTree = "<group>"; };
 		947871492C98CEC6003DB695 /* Buffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buffer.swift; sourceTree = "<group>"; };
+		94989BA02D5AA40E00E9458A /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
+		94989BA22D5AC2C800E9458A /* Logging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
 		94CC0FE52CA203AB00CB3264 /* WebGPUSwiftInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebGPUSwiftInternal.h; sourceTree = "<group>"; };
 		97099ABE2AA60D58003B41F8 /* ASTElaboratedTypeExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTElaboratedTypeExpression.h; sourceTree = "<group>"; };
 		97099ABF2AA60D58003B41F8 /* ASTReferenceTypeExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTReferenceTypeExpression.h; sourceTree = "<group>"; };
@@ -900,6 +904,8 @@
 		DD8EE22E2CE6B490004DD6F8 /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				94989BA22D5AC2C800E9458A /* Logging.cpp */,
+				94989BA02D5AA40E00E9458A /* Logging.h */,
 				DD8EE22F2CE6B4B3004DD6F8 /* module.modulemap */,
 				94CC0FE52CA203AB00CB3264 /* WebGPUSwiftInternal.h */,
 			);
@@ -920,6 +926,7 @@
 				941C64B72CAB4A0700A63214 /* Device.h in Headers */,
 				0D30F93929F1FAC50055D9F1 /* ExternalTexture.h in Headers */,
 				941C1EE72CA46829004D4220 /* Instance.h in Headers */,
+				94989BA12D5AA41500E9458A /* Logging.h in Headers */,
 				0D509DCD29CAB6EC00546D84 /* MetalSPI.h in Headers */,
 				973F784729C8A78200166C66 /* Pipeline.h in Headers */,
 				941C2CF32CBDB0E700B5DB48 /* QuerySet.h in Headers */,
@@ -1228,6 +1235,7 @@
 				0D30F93729F1F94A0055D9F1 /* ExternalTexture.mm in Sources */,
 				1C0F41EE280940650005886D /* HardwareCapabilities.mm in Sources */,
 				1C5ACA94273A41C20095F8D5 /* Instance.mm in Sources */,
+				94989BA42D5ACCFF00E9458A /* Logging.cpp in Sources */,
 				973F784829C8A78200166C66 /* Pipeline.mm in Sources */,
 				1C5ACAE5273A55DD0095F8D5 /* PipelineLayout.mm in Sources */,
 				1C9F7CDF29762F51006B5BE9 /* PresentationContext.mm in Sources */,

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -52,7 +52,7 @@ public func Buffer_getMappedRange_thunk(_ buffer: WebGPU.Buffer, offset: Int, si
 
 internal func computeRangeSize(size: Int, offset: Int) -> Int
 {
-    let result = checkedDifferenceSizeT(size, offset)
+    let result = WebGPU_Internal.checkedDifferenceSizeT(size, offset)
     if result.hasOverflowed() {
         return 0
     }

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -28,6 +28,7 @@
 #import <wtf/FastMalloc.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCountedAndCanMakeWeakPtr.h>
+#import <wtf/RetainReleaseSwift.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/WeakPtr.h>
 #import <wtf/threads/BinarySemaphore.h>
@@ -91,6 +92,16 @@ private:
     // FIXME: we should not need this semaphore - https://bugs.webkit.org/show_bug.cgi?id=272353
     BinarySemaphore m_commandBufferComplete;
     RefPtr<CommandEncoder> m_commandEncoder;
-};
+} SWIFT_SHARED_REFERENCE(refCommandBuffer, derefCommandBuffer);
 
 } // namespace WebGPU
+
+inline void refCommandBuffer(WebGPU::CommandBuffer* obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefCommandBuffer(WebGPU::CommandBuffer* obj)
+{
+    WTF::deref(obj);
+}

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -233,7 +233,11 @@ private:
         std::optional<Error> error;
         const WGPUErrorFilter filter;
     };
-
+#if ENABLE(WEBGPU_SWIFT)
+private PUBLIC_IN_WEBGPU_SWIFT:
+    id<MTLFunction> m_nopVertexFunction;
+#endif
+private:
     id<MTLDevice> m_device { nil };
     const Ref<Queue> m_defaultQueue;
 

--- a/Source/WebGPU/WebGPU/Internal/Logging.cpp
+++ b/Source/WebGPU/WebGPU/Internal/Logging.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "Logging.h"
 
-namespace WebGPU {
+namespace WebGPU_Internal {
 
-class Buffer;
-class Device;
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
-// https://gpuweb.github.io/gpuweb/#gpucommandsmixin
-class CommandsMixin {
-protected PUBLIC_IN_WEBGPU_SWIFT:
-    enum class EncoderState : uint8_t {
-        Open,
-        Locked,
-        Ended
-    };
-    bool prepareTheEncoderState() const;
-protected:
-    NSString* encoderStateName() const;
-    static bool computedSizeOverflows(const Buffer&, uint64_t offset, uint64_t& size);
+#define DEFINE_WEBGPU_LOG_CHANNEL(name) DEFINE_LOG_CHANNEL(name, LOG_CHANNEL_WEBKIT_SUBSYSTEM)
+WEBGPU_LOG_CHANNELS(DEFINE_WEBGPU_LOG_CHANNEL)
 
-    EncoderState m_state { EncoderState::Open };
-};
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
-} // namespace WebGPU
+}

--- a/Source/WebGPU/WebGPU/Internal/Logging.h
+++ b/Source/WebGPU/WebGPU/Internal/Logging.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2025 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,25 +25,28 @@
 
 #pragma once
 
-namespace WebGPU {
+#include "ExportMacros.h"
+#include <wtf/Assertions.h>
+#include <wtf/Forward.h>
 
-class Buffer;
-class Device;
+namespace WebGPU_Internal {
 
-// https://gpuweb.github.io/gpuweb/#gpucommandsmixin
-class CommandsMixin {
-protected PUBLIC_IN_WEBGPU_SWIFT:
-    enum class EncoderState : uint8_t {
-        Open,
-        Locked,
-        Ended
-    };
-    bool prepareTheEncoderState() const;
-protected:
-    NSString* encoderStateName() const;
-    static bool computedSizeOverflows(const Buffer&, uint64_t offset, uint64_t& size);
+#if !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
-    EncoderState m_state { EncoderState::Open };
-};
+#ifndef LOG_CHANNEL_PREFIX
+#define LOG_CHANNEL_PREFIX Log
+#endif
 
-} // namespace WebGPU
+#define WEBGPU_LOG_CHANNELS(M) \
+    M(WebGPUSwift)
+
+#undef DECLARE_LOG_CHANNEL
+#define DECLARE_LOG_CHANNEL(name) \
+    WEBGPU_EXPORT extern WTFLogChannel JOIN_LOG_CHANNEL_WITH_PREFIX(LOG_CHANNEL_PREFIX, name);
+
+WEBGPU_LOG_CHANNELS(DECLARE_LOG_CHANNEL)
+
+#endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
+
+} // namespace WebGPU_Internal
+

--- a/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
+++ b/Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h
@@ -27,11 +27,13 @@
 
 #include "APIConversions.h"
 #include "Buffer.h"
+#include "CommandBuffer.h"
 #include "CommandEncoder.h"
 #include "CommandsMixin.h"
 #include "ComputePassEncoder.h"
 #include "Device.h"
 #include "IsValidToUseWith.h"
+#include "Logging.h"
 #include "QuerySet.h"
 #include "Queue.h"
 #include "RenderPassEncoder.h"
@@ -51,20 +53,29 @@ using WTFRangeSizeT = WTF::Range<size_t>;
 
 __attribute__((used)) static const auto stdDynamicExtent = std::dynamic_extent;
 
-// FIXME: importing WTF::Range does not work
-namespace WTF {
-template<typename PassedType>
-class Range;
-}
-using RefComputePassEncoder = Ref<WebGPU::ComputePassEncoder>;
-inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
-inline uint32_t roundUpToMultipleOfNonPowerOfTwoUInt32UInt32(uint32_t a, uint32_t b) { return WTF::roundUpToMultipleOfNonPowerOfTwo<uint32_t, Checked<uint32_t>>(a, b); }
-
 // FIXME: rdar://140819194
 constexpr unsigned long int WGPU_COPY_STRIDE_UNDEFINED_ = WGPU_COPY_STRIDE_UNDEFINED;
 
 // FIXME: rdar://140819448
 constexpr auto MTLBlitOptionNone_ = MTLBlitOptionNone;
+
+// FIXME: importing WTF::Range does not work
+namespace WTF {
+template<typename PassedType>
+class Range;
+}
+
+namespace WebGPU_Internal {
+
+inline void logString(const char * input)
+{
+    if (input)
+        RELEASE_LOG(WebGPUSwift, "%s", input);
+}
+
+using RefComputePassEncoder = Ref<WebGPU::ComputePassEncoder>;
+inline unsigned long roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong(Checked<uint32_t> x, unsigned long y) { return WTF::roundUpToMultipleOfNonPowerOfTwo<unsigned long int, Checked<uint32_t>>(x, y); }
+inline uint32_t roundUpToMultipleOfNonPowerOfTwoUInt32UInt32(uint32_t a, uint32_t b) { return WTF::roundUpToMultipleOfNonPowerOfTwo<uint32_t, Checked<uint32_t>>(a, b); }
 
 inline Checked<size_t> checkedDifferenceSizeT(size_t left, size_t right)
 {
@@ -72,7 +83,9 @@ inline Checked<size_t> checkedDifferenceSizeT(size_t left, size_t right)
 }
 
 using RefRenderPassEncoder = Ref<WebGPU::RenderPassEncoder>;
+using RefCommandBuffer = Ref<WebGPU::CommandBuffer>;
 using SliceSet = HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
+
 inline bool isValidToUseWithTextureViewCommandEncoder(const WebGPU::TextureView& texture, const WebGPU::CommandEncoder& commandEncoder)
 {
     return WebGPU::isValidToUseWith(texture, commandEncoder);
@@ -102,6 +115,18 @@ inline double clampDouble(const double& v, const double& lo, const double& hi)
 inline bool areBuffersEqual(const WebGPU::Buffer& a, const WebGPU::Buffer& b)
 {
     return &a == &b;
+}
+
+inline NSString * convertWTFStringToNSString(const String& input)
+{
+    return nsStringNilIfEmpty(input);
+}
+
+inline ThreadSafeWeakPtr<WebGPU::CommandBuffer> commandBufferThreadSafeWeakPtr(const WebGPU::CommandBuffer* input)
+{
+    return ThreadSafeWeakPtr(input);
+}
+
 }
 
 #ifndef __swift__

--- a/Source/WebGPU/WebGPU/SwiftCXXThunk.h
+++ b/Source/WebGPU/WebGPU/SwiftCXXThunk.h
@@ -36,37 +36,53 @@
  available through reverse interop.
  */
 
+#define REMOVE_PARENTHESIS(X) REMOVE_PARENTHESIS_IMPL X
+#define REMOVE_PARENTHESIS_IMPL(...) __VA_ARGS__
+
+#define CONCAT(A, B) A##B
+
 #define _DEFINE_SWIFTCXX_THUNK0(Class, Member, ReturnType) \
 ReturnType Class::Member() { \
-    return Class ## _ ## Member ## _thunk(this); \
+    return CONCAT(Class, _##Member##_thunk)(this); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK1(Class, Member, ReturnType, TypeOfArg1) \
-ReturnType Class::Member(TypeOfArg1 arg1) { \
-    return Class ## _ ## Member ## _thunk(this, arg1); \
+ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK2(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2) \
-ReturnType Class::Member(TypeOfArg1 arg1, TypeOfArg2 arg2) { \
-    return Class ## _ ## Member ## _thunk(this, arg1, arg2); \
+ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK3(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3) \
-ReturnType Class::Member(TypeOfArg1 arg1, TypeOfArg2 arg2, TypeOfArg3 arg3) { \
-    return Class ## _ ## Member ## _thunk(this, arg1, arg2, arg3); \
+ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK4(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4) \
-ReturnType Class::Member(TypeOfArg1 arg1, TypeOfArg2 arg2, TypeOfArg3 arg3, TypeOfArg4 arg4) { \
-    return Class ## _ ## Member ## _thunk(this, arg1, arg2, arg3, arg4); \
+ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4); \
 }
 
 #define _DEFINE_SWIFTCXX_THUNK5(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4, TypeOfArg5) \
-ReturnType Class::Member(TypeOfArg1 arg1, TypeOfArg2 arg2, TypeOfArg3 arg3, TypeOfArg4 arg4, TypeOfArg5 arg5) { \
-    return Class ## _ ## Member ## _thunk(this, arg1, arg2, arg3, arg4, arg5); \
+ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4, REMOVE_PARENTHESIS((TypeOfArg5)) arg5) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5); \
 }
 
-#define _GET_NTH_ARG(_1, _2, _3, _4, _5, NAME, ...) NAME
+#define _DEFINE_SWIFTCXX_THUNK6(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4, TypeOfArg5, TypeOfArg6) \
+ReturnType Class::Member(REMOVE_PARENTHESIS((TypeOfArg1)) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4, REMOVE_PARENTHESIS((TypeOfArg5)) arg5, REMOVE_PARENTHESIS((TypeOfArg6)) arg6) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5, arg6); \
+}
+
+#define _DEFINE_SWIFTCXX_THUNK7(Class, Member, ReturnType, TypeOfArg1, TypeOfArg2, TypeOfArg3, TypeOfArg4, TypeOfArg5, TypeOfArg6, TypeOfArg7) \
+ReturnType Class::Member(REMOVE_PARENTHESIS(TypeOfArg1) arg1, REMOVE_PARENTHESIS((TypeOfArg2)) arg2, REMOVE_PARENTHESIS((TypeOfArg3)) arg3, REMOVE_PARENTHESIS((TypeOfArg4)) arg4, REMOVE_PARENTHESIS((TypeOfArg5)) arg5, REMOVE_PARENTHESIS((TypeOfArg6)) arg6, REMOVE_PARENTHESIS((TypeOfArg7)) arg7) { \
+    return CONCAT(Class, _##Member##_thunk)(this, arg1, arg2, arg3, arg4, arg5, arg6, arg7); \
+}
+
+
+#define _GET_NTH_ARG(_1, _2, _3, _4, _5, _6, _7, NAME, ...) NAME
 
 #define DEFINE_SWIFTCXX_THUNK(Class, Member, ReturnType, ...) \
-    _GET_NTH_ARG(__VA_ARGS__, _DEFINE_SWIFTCXX_THUNK5, _DEFINE_SWIFTCXX_THUNK4, _DEFINE_SWIFTCXX_THUNK3, _DEFINE_SWIFTCXX_THUNK2, _DEFINE_SWIFTCXX_THUNK1, _DEFINE_SWIFTCXX_THUNK0)(Class, Member, ReturnType, ##__VA_ARGS__)
+    _GET_NTH_ARG(__VA_ARGS__, _DEFINE_SWIFTCXX_THUNK7, _DEFINE_SWIFTCXX_THUNK6, _DEFINE_SWIFTCXX_THUNK5, _DEFINE_SWIFTCXX_THUNK4, _DEFINE_SWIFTCXX_THUNK3, _DEFINE_SWIFTCXX_THUNK2, _DEFINE_SWIFTCXX_THUNK1, _DEFINE_SWIFTCXX_THUNK0)(Class, Member, ReturnType, ##__VA_ARGS__)


### PR DESCRIPTION
#### 83b8e1d37fa1c1c39f87f84d5abb423e1930fc3f
<pre>
[WebGPUSwift] replace all other Metal specific functions in Command Encoder
<a href="https://rdar.apple.com/144317197">rdar://144317197</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287165">https://bugs.webkit.org/show_bug.cgi?id=287165</a>

Reviewed by Mike Wyrzykowski.

1-to-1 replacement of the below:

1. CommandEncoder::createSimplePso
2. CommandEncoder::runClearEncoder
3. CommandEncoder::clearTextureIfNeeded
4. CommandEncoder::finish

* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:
* Source/WebGPU/WebGPU/Buffer.swift:
* Source/WebGPU/WebGPU/CommandBuffer.h:
(refCommandBuffer):
(derefCommandBuffer):
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::create):
(WebGPU::CommandEncoder::setEncoderState):
(WebGPU::CommandEncoder::getEncoderState):
(WebGPU::CommandEncoder::encoderStateNameWrapper):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::waitForCommandBufferCompletion):
(WebGPU::CommandEncoder::encoderIsCurrent const):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(CommandEncoder_runClearEncoder_thunk(_:attachmentsToClear:depthStencilAttachmentToClear:depthAttachmentToClear:stencilAttachmentToClear:depthClearValue:stencilClearValue:existingEncoder:)):
(CommandEncoder_clearTextureIfNeeded_thunk(_:destination:slice:)):
(CommandEncoder_finish_thunk(_:descriptor:)):
(WebGPU.validateFinishError):
(WebGPU.finish(_:)):
(WebGPU.clearTextureIfNeeded(_:slice:)):
(WebGPU.clearTextureIfNeeded(_:slice:device:blitCommandEncoder:)):
(WebGPU.clearTextureIfNeeded(_:_:_:_:_:)):
(WebGPU.sourceBytesPerRow):
(WebGPU.didOverflow):
(WebGPU.checkedBytesPerImage):
(WebGPU.sourceSize):
(WebGPU.sourceBytesPerImage):
(WebGPU.options):
(WebGPU.runClearEncoder(_:depthStencilAttachmentToClear:depthAttachmentToClear:stencilAttachmentToClear:depthClearValue:stencilClearValue:existingEncoder:)):
(WebGPU.errorValidatingCopyBufferToBuffer(_:sourceOffset:destination:destinationOffset:size:)):
(WebGPU.errorValidatingCopyTextureToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingCopyTextureToBuffer(_:destination:copySize:)):
(WebGPU.errorValidatingCopyBufferToTexture(_:destination:copySize:)):
(WebGPU.loadAction(_:)):
(WebGPU.beginRenderPass(_:)):
(WebGPU.copyTextureToBuffer(_:destination:copySize:)):
(WebGPU.copyBufferToTexture(_:destination:copySize:)):
(WebGPU.copyTextureToTexture(_:destination:copySize:)):
* Source/WebGPU/WebGPU/CommandsMixin.h:
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::create):
(WebGPU::Device::Device):
* Source/WebGPU/WebGPU/Internal/Logging.cpp: Copied from Source/WebGPU/WebGPU/CommandsMixin.h.
* Source/WebGPU/WebGPU/Internal/Logging.h: Copied from Source/WebGPU/WebGPU/CommandsMixin.h.
* Source/WebGPU/WebGPU/Internal/WebGPUSwiftInternal.h:
(WebGPU_Internal::logString):
(WebGPU_Internal::convertWTFStringToNSString):
(WebGPU_Internal::commandBufferThreadSafeWeakPtr):
(roundUpToMultipleOfNonPowerOfTwoCheckedUInt32UnsignedLong): Deleted.
(roundUpToMultipleOfNonPowerOfTwoUInt32UInt32): Deleted.
(checkedDifferenceSizeT): Deleted.
(isValidToUseWithTextureViewCommandEncoder): Deleted.
(isValidToUseWithQuerySetCommandEncoder): Deleted.
(isValidToUseWithBufferCommandEncoder): Deleted.
(isValidToUseWithTextureCommandEncoder): Deleted.
(clampDouble): Deleted.
(areBuffersEqual): Deleted.
* Source/WebGPU/WebGPU/SwiftCXXThunk.h:

Canonical link: <a href="https://commits.webkit.org/290231@main">https://commits.webkit.org/290231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d02c6605974a4679812e7194a07306c970cb68e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44185 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94332 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9258 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17120 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68834 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26503 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7105 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81091 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49195 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96161 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16526 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77707 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77008 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21432 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9677 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14010 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16540 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16281 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->