### PR TITLE
Donate media playback information to Screen Time

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -133,6 +133,8 @@ public:
 #if ENABLE(SCREEN_TIME)
     void installScreenTimeWebpageController() final;
     void didChangeScreenTimeWebpageControllerURL() final;
+    void setURLIsPictureInPictureForScreenTime(bool) final;
+    void setURLIsPlayingVideoForScreenTime(bool) final;
     void updateScreenTimeWebpageControllerURL(WKWebView *);
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -349,6 +349,25 @@ void PageClientImplCocoa::updateScreenTimeWebpageControllerURL(WKWebView *webVie
 
     [screenTimeWebpageController setURL:[webView _mainFrameURL]];
 }
+
+void PageClientImplCocoa::setURLIsPictureInPictureForScreenTime(bool value)
+{
+    RetainPtr screenTimeWebpageController = [webView() _screenTimeWebpageController];
+    if (!screenTimeWebpageController)
+        return;
+
+    [screenTimeWebpageController setURLIsPictureInPicture:value];
+}
+
+void PageClientImplCocoa::setURLIsPlayingVideoForScreenTime(bool value)
+{
+    RetainPtr screenTimeWebpageController = [webView() _screenTimeWebpageController];
+    if (!screenTimeWebpageController)
+        return;
+
+    [screenTimeWebpageController setURLIsPlayingVideo:value];
+}
+
 #endif
 
 #if ENABLE(GAMEPAD)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -774,7 +774,7 @@ void VideoPresentationManagerProxy::hasVideoInPictureInPictureDidChange(bool val
     RefPtr page = m_page.get();
     if (!page)
         return;
-    page->uiClient().hasVideoInPictureInPictureDidChange(page.get(), value);
+    page->hasVideoInPictureInPictureDidChange(value);
     m_pipChangeObservers.forEach([value] (auto& observer) { observer(value); });
 }
 

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -811,6 +811,8 @@ public:
 #if ENABLE(SCREEN_TIME)
     virtual void installScreenTimeWebpageController() { }
     virtual void didChangeScreenTimeWebpageControllerURL() { };
+    virtual void setURLIsPictureInPictureForScreenTime(bool) { };
+    virtual void setURLIsPlayingVideoForScreenTime(bool) { };
 #endif
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9157,6 +9157,15 @@ WebColorPickerClient& WebPageProxy::colorPickerClient()
     return internals();
 }
 
+void WebPageProxy::hasVideoInPictureInPictureDidChange(bool value)
+{
+    uiClient().hasVideoInPictureInPictureDidChange(this, value);
+#if ENABLE(SCREEN_TIME)
+    m_pageClient->setURLIsPictureInPictureForScreenTime(value);
+#endif
+}
+
+
 void WebPageProxy::Internals::didChooseColor(const WebCore::Color& color)
 {
     Ref protectedPage = page.get();
@@ -13442,6 +13451,11 @@ void WebPageProxy::updatePlayingMediaDidChange(MediaProducerMediaStateFlags newS
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     updateMediaCapability();
+#endif
+
+#if ENABLE(SCREEN_TIME)
+    if (oldState.contains(MediaProducerMediaState::IsPlayingVideo) != newState.contains(MediaProducerMediaState::IsPlayingVideo))
+        m_pageClient->setURLIsPlayingVideoForScreenTime(newState.contains(MediaProducerMediaState::IsPlayingVideo));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2515,6 +2515,8 @@ public:
 
     void requestTextExtraction(std::optional<WebCore::FloatRect>&& collectionRectInRootView, CompletionHandler<void(WebCore::TextExtraction::Item&&)>&&);
 
+    void hasVideoInPictureInPictureDidChange(bool);
+
 #if ENABLE(WRITING_TOOLS)
     void setWritingToolsActive(bool);
 


### PR DESCRIPTION
#### a6aba3e394b3b74f9558859bf64de9d02c2923b6
<pre>
Donate media playback information to Screen Time
<a href="https://bugs.webkit.org/show_bug.cgi?id=287168">https://bugs.webkit.org/show_bug.cgi?id=287168</a>
<a href="https://rdar.apple.com/140439198">rdar://140439198</a>

Reviewed by Aditya Keerthi.

Add support for URLIsPictureInPicture and URLIsPlayingVideo on STWebpageController.
Add API tests for URLIsPlayingVideo and URLIsPictureInPicture.
Currently, there is only a mac test for URLIsPictureInPicture. This is because
TestWebKitAPI is not a UI application so can&apos;t actually go into PiP.

* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::setURLIsPictureInPictureForScreenTime):
(WebKit::PageClientImplCocoa::setURLIsPlayingVideoForScreenTime):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::hasVideoInPictureInPictureDidChange):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::setURLIsPictureInPictureForScreenTime):
(WebKit::PageClient::setURLIsPlayingVideoForScreenTime):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::hasVideoInPictureInPictureDidChange):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, URLIsPlayingVideo)):
(-[STPictureInPictureUIDelegate _webView:hasVideoInPictureInPictureDidChange:]):
(-[STPictureInPictureUIDelegate userContentController:didReceiveScriptMessage:]):
(TEST(ScreenTime, URLIsPictureInPictureMacos)):

Canonical link: <a href="https://commits.webkit.org/290235@main">https://commits.webkit.org/290235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17e9d6b87e1750dee783de4989178add2ac9d660

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89324 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40085 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91375 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92326 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7088 "Found 1 new test failure: fast/forms/ios/file-upload-panel.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6834 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35459 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html editing/undo/redo-reapply-edit-command-crash.html fast/repaint/switch-overflow-vertical-rl.html fast/workers/dedicated-worker-lifecycle.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub.html imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html imported/w3c/web-platform-tests/css/css-contain/contain-paint-containing-block-fixed-001.html imported/w3c/web-platform-tests/css/css-grid/grid-model/grid-inline-float-001.html imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/alignment/masonry-align-content-003.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39192 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96139 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16504 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77689 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76988 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9654 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14014 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21829 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->