### PR TITLE
[scroll-animations] Handle ViewTimeline subjects that are position:sticky

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
@@ -10,7 +10,7 @@ PASS animation-timeline: view(50px), view(inline 50px) without timeline range na
 PASS animation-timeline: view(inline) changes to view(inline 50px), withouttimeline range name
 PASS animation-timeline: view()
 PASS animation-timeline: view(50px)
-FAIL animation-timeline: view(auto 50px) assert_equals: At exit 0% expected "1" but got "0.666667"
+PASS animation-timeline: view(auto 50px)
 PASS animation-timeline: view(inline)
 PASS animation-timeline: view(x)
 PASS animation-timeline: view(y)

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline top-sticky during entry. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.433333"
+PASS View timeline top-sticky during entry.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline bottom-sticky during entry and top-sticky during exit. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.516667"
+PASS View timeline bottom-sticky during entry and top-sticky during exit.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline top-sticky and bottom-sticky during entry. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.383333"
+PASS View timeline top-sticky and bottom-sticky during entry.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline target > viewport, bottom-sticky during entry and top-sticky during exit. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.509091"
+FAIL View timeline target > viewport, bottom-sticky during entry and top-sticky during exit. assert_equals: Effect at the midpoint of the active range: entry 0% to entry 100% expected "0.5" but got "0.473333"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-7-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline target > viewport, bottom-sticky and top-sticky during contain. assert_equals: Effect at the midpoint of the active range: entry 0% to entry 100% expected "0.5" but got "0.466667"
+FAIL View timeline target > viewport, bottom-sticky and top-sticky during contain. assert_equals: Effect at the midpoint of the active range: contain 0% to contain 100% expected "0.5" but got "0.3"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block-expected.txt
@@ -1,4 +1,4 @@
 Subject
 
-FAIL View timeline with sticky target, block axis. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.518182"
+PASS View timeline with sticky target, block axis.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with sticky target, block axis. assert_equals: Effect at the midpoint of the active range: cover 0% to cover 100% expected "0.5" but got "0.518182"
+PASS View timeline with sticky target, block axis.
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -80,6 +80,11 @@ public:
 
     void removeTimelineFromDocument(Element*);
 
+    struct ResolvedScrollDirection {
+        bool isVertical;
+        bool isReversed;
+    };
+
 protected:
     explicit ScrollTimeline(const AtomString&, ScrollAxis);
 
@@ -93,10 +98,6 @@ protected:
 
     static ScrollableArea* scrollableAreaForSourceRenderer(const RenderElement*, Document&);
 
-    struct ResolvedScrollDirection {
-        bool isVertical;
-        bool isReversed;
-    };
     std::optional<ResolvedScrollDirection> resolvedScrollDirection() const;
 
 private:

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -40,8 +40,33 @@ class BuilderState;
 }
 
 class Element;
+class StickyPositionViewportConstraints;
 
 struct TimelineRange;
+
+struct StickinessAdjustmentData {
+    bool operator==(const StickinessAdjustmentData& other) const = default;
+
+    enum class StickinessLocation {
+        BeforeEntry,
+        DuringEntry,
+        WhileContained,
+        DuringExit,
+        AfterExit
+    };
+
+    float entryDistanceAdjustment() const;
+    float exitDistanceAdjustment() const;
+    float rangeStartAdjustment() const;
+    float rangeEndAdjustment() const;
+
+    static StickinessAdjustmentData computeStickinessAdjustmentData(const StickyPositionViewportConstraints&, ScrollTimeline::ResolvedScrollDirection, float scrollContainerSize, float subjectSize, float subjectOffset);
+
+    float stickyTopOrLeftAdjustment { 0 };
+    StickinessLocation topOrLeftAdjustmentLocation { StickinessLocation::WhileContained };
+    float stickyBottomOrRightAdjustment { 0 };
+    StickinessLocation bottomOrRightAdjustmentLocation { StickinessLocation::WhileContained };
+};
 
 class ViewTimeline final : public ScrollTimeline {
 public:
@@ -63,6 +88,7 @@ public:
     AnimationTimelinesController* controller() const override;
 
     const RenderBox* sourceScrollerRenderer() const;
+    const RenderElement* stickyContainer() const;
     Element* source() const override;
     TimelineRange defaultRange() const final;
 
@@ -87,6 +113,7 @@ private:
         float subjectSize { 0 };
         float insetStart { 0 };
         float insetEnd { 0 };
+        StickinessAdjustmentData stickinessData { };
     };
 
     void cacheCurrentTime();
@@ -103,6 +130,9 @@ private:
     ViewTimelineInsets m_insets;
     CurrentTimeData m_cachedCurrentTimeData { };
 };
+
+WTF::TextStream& operator<<(WTF::TextStream&, const StickinessAdjustmentData&);
+WTF::TextStream& operator<<(WTF::TextStream&, const StickinessAdjustmentData::StickinessLocation&);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### 544a1a4c9970857dab48c9e052cab8b6ae091da1
<pre>
[scroll-animations] Handle ViewTimeline subjects that are position:sticky
<a href="https://bugs.webkit.org/show_bug.cgi?id=287451">https://bugs.webkit.org/show_bug.cgi?id=287451</a>
<a href="https://rdar.apple.com/144584129">rdar://144584129</a>

Reviewed by Simon Fraser.

To handle ViewTimeline subjects that are position:sticky, first ignore sticky offsets when getting the
subject offset from its scroll container. To compute the distance that a sticky element remains stationary,
it is necessary to get the difference of the sticky container&apos;s edge from its containing block&apos;s edge.
It is also necessary to compute the subjects location when the stickiness occurs, to ensure we can
properly adjust the range start and end, as well as for a specific animation-range. This will need a follow
up fix for targets larger than the scrollable container, which affects view-timeline-sticky-offscreen-6/7.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-none-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-3-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/sticky/view-timeline-sticky-offscreen-6-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-block.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-sticky-inline-expected.txt:
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::StickinessAdjustmentData::computeStickinessAdjustmentData):
(WebCore::StickinessAdjustmentData::rangeStartAdjustment const):
(WebCore::StickinessAdjustmentData::rangeEndAdjustment const):
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::stickyContainer const):
(WebCore::ViewTimeline::computeTimelineData const):
(WebCore::ViewTimeline::intervalForTimelineRangeName const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/290377@main">https://commits.webkit.org/290377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e04d202f34a78f1a84b9b52c70b5e72015ee39d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69136 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26767 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7153 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35845 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39671 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96585 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12449 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77279 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77333 "Found 3 new API test failures: /TestWTF:WTF_EnumTraits.EnumNameSignedValues, /TestWTF:WTF_EnumTraits.EnumNameValid, /TestWTF:WTF_EnumTraits.EnumMinMax (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10129 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14107 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16960 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16701 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->