### PR TITLE
[ResourceMonitor] Track network usage of SharedWorker.

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/blob-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/blob-resource.html
@@ -13,7 +13,6 @@ var result;
 
 onload = async () => {
     if (!await setup()) {
-        finishJSTest();
         return;
     }
 

--- a/LayoutTests/http/tests/iframe-monitor/cached-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/cached-resource.html
@@ -13,7 +13,6 @@ var result;
 
 onload = async () => {
     if (!await setup()) {
-        finishJSTest();
         return;
     }
 

--- a/LayoutTests/http/tests/iframe-monitor/dark-mode.html
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode.html
@@ -48,9 +48,9 @@ onload = async () => {
 
         debug("In footer, scheme is dark only.")
         await test('frame3', white, white);
-    }
 
-    finishJSTest();
+        finishJSTest();
+    }
 }
 
 async function test(frameName, lightModeExpected, darkModeExpected) {

--- a/LayoutTests/http/tests/iframe-monitor/data-url-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/data-url-resource.html
@@ -13,7 +13,6 @@ var result;
 
 onload = async () => {
     if (!await setup()) {
-        finishJSTest();
         return;
     }
 

--- a/LayoutTests/http/tests/iframe-monitor/eligibility.html
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility.html
@@ -12,7 +12,6 @@ window.jsTestIsAsync = true;
 
 onload = async () => {
     if (!await setup()) {
-        finishJSTest();
         return;
     }
 

--- a/LayoutTests/http/tests/iframe-monitor/iframe-unload.html
+++ b/LayoutTests/http/tests/iframe-monitor/iframe-unload.html
@@ -12,7 +12,6 @@ window.jsTestIsAsync = true;
 
 onload = async () => {
     if (!await setup()) {
-        finishJSTest();
         return;
     }
 

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/shared-worker.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/shared-worker.html
@@ -1,0 +1,29 @@
+<h1>Shared Worker Example</h1>
+
+<p>When get message, it ask shared worker to load requested size.</p>
+
+<script>
+    // Initialize the shared worker
+    const worker = new SharedWorker("./shared-worker.js");
+
+    worker.port.start();
+    console.log("Launched shared worker");
+
+    // Handle messages from the worker
+    worker.port.onmessage = async (e) => {
+        if (e.data instanceof Blob) {
+            window.parent.postMessage(true, '*');
+        }
+    };
+
+    window.addEventListener('message', (e) => {
+        console.log("Get message from parent window");
+        if (typeof e.data === 'number') {
+            console.log("Send fetch request to worker");
+            worker.port.postMessage(e.data);
+        }
+    });
+
+    console.log("iframe is ready");
+    window.parent.postMessage(true, '*');
+</script>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/shared-worker.js
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/shared-worker.js
@@ -1,0 +1,19 @@
+let clients = [];
+
+onconnect = (e) => {
+    const port = e.ports[0];
+    clients.push(port);
+
+    port.onmessage = async (e) => {
+        if (typeof e.data === 'number') {
+            const response = await fetch(`../generate-byte.py?size=${e.data}`);
+            const blob = await response.blob();
+
+            clients.forEach((client) => client.postMessage(blob));
+        }
+    };
+
+    port.onclose = () => {
+        clients = clients.filter(client => client !== port);
+    };
+};

--- a/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
+++ b/LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js
@@ -15,8 +15,24 @@ async function setup() {
         return true;
     } else {
         console.error('ResourceMonitor is not available or cannot modify rules.');
+        finishJSTest();
         return false;
     }
+}
+
+function afterSetup(action) {
+    return async () => {
+        const result = await setup();
+        console.log(`setup() finished: ${result}`);
+        if (result) {
+            try {
+                await action();
+            } catch (e) {
+                console.error(`error on action: ${e}`);
+                finishJSTest();
+            }
+        }
+    };
 }
 
 function rule(filter, action = 'block') {

--- a/LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt
@@ -1,0 +1,20 @@
+CONSOLE MESSAGE: setup() finished: true
+CONSOLE MESSAGE: Launched shared worker
+CONSOLE MESSAGE: iframe is ready
+CONSOLE MESSAGE: Launched shared worker
+CONSOLE MESSAGE: iframe is ready
+CONSOLE MESSAGE: Get message from parent window
+CONSOLE MESSAGE: Send fetch request to worker
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+Test iframes using same shared worker are unloaded.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.querySelector('iframe[name=frame1]').srcdoc is not ""
+PASS document.querySelector('iframe[name=frame2]').srcdoc is not ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/shared-worker.html
+++ b/LayoutTests/http/tests/iframe-monitor/shared-worker.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+
+description("Test iframes using same shared worker are unloaded.");
+window.jsTestIsAsync = true;
+
+onload = afterSetup(async () => {
+    // Make sure iframe load is done after rule is set correctly.
+    const stage = document.querySelector('#stage');
+    const base = 'http://localhost:8080/iframe-monitor/resources';
+
+    let ready = 0;
+    window.addEventListener('message', (e) => {
+        ready++;
+    });
+
+    stage.innerHTML = `
+        <iframe name="frame1" src="${base}/--eligible--/shared-worker.html"></iframe>
+        <iframe name="frame2" src="${base}/--eligible--/shared-worker.html"></iframe>
+    `;
+
+    while (ready < 2)
+        await pause(10);
+
+    // Send message to one of iframe to start fetching via shared worker.
+    const frame1 = document.querySelector('iframe[name=frame1]');
+    frame1.contentWindow.postMessage(20 * 1024, '*');
+
+    await waitUntilUnload('frame1');
+    await waitUntilUnload('frame2');
+
+    shouldNotBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+    shouldNotBe(`document.querySelector('iframe[name=frame2]').srcdoc`, '""');
+
+    finishJSTest();
+});
+
+</script>
+
+<div id="stage"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/throttler.html
+++ b/LayoutTests/http/tests/iframe-monitor/throttler.html
@@ -12,7 +12,6 @@ window.jsTestIsAsync = true;
 
 onload = async () => {
     if (!await setup()) {
-        finishJSTest();
         return;
     }
 

--- a/Source/WebCore/loader/ResourceLoaderOptions.h
+++ b/Source/WebCore/loader/ResourceLoaderOptions.h
@@ -38,7 +38,9 @@
 #include "HTTPHeaderNames.h"
 #include "RequestPriority.h"
 #include "ServiceWorkerTypes.h"
+#include "SharedWorkerIdentifier.h"
 #include "StoredCredentialsPolicy.h"
+#include <variant>
 #include <wtf/HashSet.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -255,6 +257,7 @@ struct ResourceLoaderOptions : public FetchOptions {
 
     Markable<FetchIdentifier> navigationPreloadIdentifier;
     String nonce;
+    std::optional<WebCore::SharedWorkerIdentifier> workerIdentifier;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -45,6 +45,8 @@
 #include "SecurityOrigin.h"
 #include "ServiceWorker.h"
 #include "ServiceWorkerGlobalScope.h"
+#include "SharedWorkerGlobalScope.h"
+#include "SharedWorkerThread.h"
 #include "ThreadableLoader.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
@@ -157,6 +159,9 @@ WorkerThreadableLoader::MainThreadBridge::MainThreadBridge(ThreadableLoaderClien
 
     if (RefPtr serviceWorkerGlobalScope = dynamicDowncast<ServiceWorkerGlobalScope>(globalScope))
         InspectorInstrumentation::willSendRequest(*serviceWorkerGlobalScope, m_workerRequestIdentifier, request);
+
+    if (RefPtr sharedWorkerGlobalScope = dynamicDowncast<SharedWorkerGlobalScope>(globalScope))
+        optionsCopy->options.workerIdentifier = sharedWorkerGlobalScope->thread().identifier();
 
     if (!m_loaderProxy)
         return;

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class MessagePort;
 class ResourceError;
+class ResourceMonitor;
 class TrustedScriptURL;
 
 struct WorkerOptions;
@@ -60,6 +61,8 @@ public:
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final;
 
+    void reportNetworkUsage(size_t bytesTransferredOverNetworkDelta);
+
 private:
     SharedWorker(Document&, const SharedWorkerKey&, Ref<MessagePort>&&);
 
@@ -78,6 +81,10 @@ private:
     URLKeepingBlobAlive m_blobURLExtension;
     bool m_isActive { true };
     bool m_isSuspendedForBackForwardCache { false };
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    RefPtr<ResourceMonitor> m_resourceMonitor;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp
@@ -94,6 +94,15 @@ void SharedWorkerObjectConnection::postErrorToWorkerObject(SharedWorkerObjectIde
     ActiveDOMObject::queueTaskToDispatchEvent(*workerObject, TaskSource::DOMManipulation, WTFMove(event));
 }
 
+void SharedWorkerObjectConnection::reportNetworkUsageToWorkerObject(SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta)
+{
+    ASSERT(isMainThread());
+    auto* workerObject = SharedWorker::fromIdentifier(sharedWorkerObjectIdentifier);
+    CONNECTION_RELEASE_LOG("sendNetworkUsageToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING ", worker=%p, bytesTransferredOverNetworkDelta=%zu", sharedWorkerObjectIdentifier.toString().utf8().data(), workerObject, bytesTransferredOverNetworkDelta);
+    if (workerObject)
+        workerObject->reportNetworkUsage(bytesTransferredOverNetworkDelta);
+}
+
 #undef CONNECTION_RELEASE_LOG
 #undef CONNECTION_RELEASE_LOG_ERROR
 

--- a/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
+++ b/Source/WebCore/workers/shared/SharedWorkerObjectConnection.h
@@ -56,6 +56,7 @@ protected:
     WEBCORE_EXPORT void fetchScriptInClient(URL&&, WebCore::SharedWorkerObjectIdentifier, WorkerOptions&&, CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
     WEBCORE_EXPORT void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const ResourceError&);
     WEBCORE_EXPORT void postErrorToWorkerObject(SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
+    WEBCORE_EXPORT void reportNetworkUsageToWorkerObject(SharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta);
 
     WEBCORE_EXPORT SharedWorkerObjectConnection();
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -65,6 +65,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
     , std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier
     , OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep
     , std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier
+    , std::optional<WebCore::SharedWorkerIdentifier> workerIdentifier
 #if ENABLE(CONTENT_EXTENSIONS)
     , URL&& mainDocumentURL
     , std::optional<UserContentControllerIdentifier> userContentControllerIdentifier
@@ -105,6 +106,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
         , serviceWorkerRegistrationIdentifier(serviceWorkerRegistrationIdentifier)
         , httpHeadersToKeep(httpHeadersToKeep)
         , navigationPreloadIdentifier(navigationPreloadIdentifier)
+        , workerIdentifier(workerIdentifier)
 #if ENABLE(CONTENT_EXTENSIONS)
         , mainDocumentURL(WTFMove(mainDocumentURL))
         , userContentControllerIdentifier(userContentControllerIdentifier)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -37,6 +37,7 @@
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/ResourceLoaderIdentifier.h>
 #include <WebCore/SecurityContext.h>
+#include <WebCore/SharedWorkerIdentifier.h>
 #include <wtf/Seconds.h>
 
 namespace IPC {
@@ -84,6 +85,7 @@ public:
         , std::optional<WebCore::ServiceWorkerRegistrationIdentifier>
         , OptionSet<WebCore::HTTPHeadersToKeepFromCleaning>
         , std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier
+        , std::optional<WebCore::SharedWorkerIdentifier>
 #if ENABLE(CONTENT_EXTENSIONS)
         , URL&& mainDocumentURL
         , std::optional<UserContentControllerIdentifier>
@@ -134,6 +136,7 @@ public:
     std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
     OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
     std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier;
+    std::optional<WebCore::SharedWorkerIdentifier> workerIdentifier;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     URL mainDocumentURL;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -101,6 +101,7 @@ class WebKit::NetworkResourceLoadParameters : WebKit::NetworkLoadParameters {
     std::optional<WebCore::ServiceWorkerRegistrationIdentifier> serviceWorkerRegistrationIdentifier;
     OptionSet<WebCore::HTTPHeadersToKeepFromCleaning> httpHeadersToKeep;
     std::optional<WebCore::FetchIdentifier> navigationPreloadIdentifier;
+    std::optional<WebCore::SharedWorkerIdentifier> workerIdentifier;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     URL mainDocumentURL;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -284,6 +284,8 @@ private:
 
     bool shouldSendResourceLoadMessages() const;
 
+    void sendDidReceiveDataMessage(const WebCore::FragmentedSharedBuffer&, size_t encodedDataLength);
+    void reportNetworkUsageToAllSharedWorkers(WebCore::SharedWorkerIdentifier, size_t bytesTransferredOverNetworkDelta);
     uint64_t bytesTransferredOverNetworkDelta() const;
 
     NetworkResourceLoadParameters m_parameters;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -316,4 +316,17 @@ void WebSharedWorkerServer::terminateContextConnectionWhenPossible(const WebCore
     contextConnection->terminateWhenPossible();
 }
 
+void WebSharedWorkerServer::reportNetworkUsageToAllSharedWorkerClients(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, size_t bytesTransferredOverNetworkDelta)
+{
+    auto* sharedWorker = WebSharedWorker::fromIdentifier(sharedWorkerIdentifier);
+    RELEASE_LOG_ERROR(SharedWorker, "WebSharedWorkerServer::sendNetworkUsageToAllSharedWorkerClients: sharedWorkerIdentifier=%" PRIu64 ", sharedWorker=%p", sharedWorkerIdentifier.toUInt64(), sharedWorker);
+    if (!sharedWorker)
+        return;
+
+    sharedWorker->forEachSharedWorkerObject([&](auto sharedWorkerObjectIdentifier, auto&) {
+        if (auto* serverConnection = m_connections.get(sharedWorkerObjectIdentifier.processIdentifier()))
+            serverConnection->reportNetworkUsageToWorkerObject(sharedWorkerObjectIdentifier, bytesTransferredOverNetworkDelta);
+    });
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -82,6 +82,8 @@ public:
     void addConnection(Ref<WebSharedWorkerServerConnection>&&);
     void removeConnection(WebCore::ProcessIdentifier);
 
+    void reportNetworkUsageToAllSharedWorkerClients(WebCore::SharedWorkerIdentifier, size_t bytesTransferredOverNetworkDelta);
+
 private:
     void createContextConnection(const WebCore::Site&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier);
     bool needsContextConnectionForRegistrableDomain(const WebCore::RegistrableDomain&) const;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -146,6 +146,12 @@ void WebSharedWorkerServerConnection::postErrorToWorkerObject(WebCore::SharedWor
     send(Messages::WebSharedWorkerObjectConnection::PostErrorToWorkerObject { sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent });
 }
 
+void WebSharedWorkerServerConnection::reportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta)
+{
+    CONNECTION_RELEASE_LOG("reportNetworkUsageToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING ", bytesTransferredOverNetworkDelta=%zu", sharedWorkerObjectIdentifier.toString().utf8().data(), bytesTransferredOverNetworkDelta);
+    send(Messages::WebSharedWorkerObjectConnection::ReportNetworkUsageToWorkerObject { sharedWorkerObjectIdentifier, bytesTransferredOverNetworkDelta });
+}
+
 #undef CONNECTION_RELEASE_LOG
 #undef CONNECTION_RELEASE_LOG_ERROR
 #undef MESSAGE_CHECK

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -75,6 +75,7 @@ public:
     void fetchScriptInClient(const WebSharedWorker&, WebCore::SharedWorkerObjectIdentifier, CompletionHandler<void(WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&)>&&);
     void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const WebCore::ResourceError&);
     void postErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
+    void reportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta);
 
 private:
     WebSharedWorkerServerConnection(NetworkProcess&, WebSharedWorkerServer&, IPC::Connection&, WebCore::ProcessIdentifier);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -433,6 +433,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
 
     loadParameters.serviceWorkersMode = resourceLoader.options().loadedFromOpaqueSource == LoadedFromOpaqueSource::No ? resourceLoader.options().serviceWorkersMode : ServiceWorkersMode::None;
     loadParameters.serviceWorkerRegistrationIdentifier = resourceLoader.options().serviceWorkerRegistrationIdentifier;
+    loadParameters.workerIdentifier = resourceLoader.options().workerIdentifier;
     loadParameters.httpHeadersToKeep = resourceLoader.options().httpHeadersToKeep;
     if (resourceLoader.options().navigationPreloadIdentifier)
         loadParameters.navigationPreloadIdentifier = resourceLoader.options().navigationPreloadIdentifier;

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
@@ -28,4 +28,5 @@ messages -> WebSharedWorkerObjectConnection {
     FetchScriptInClient(URL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
     NotifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::ResourceError error)
     PostErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL, bool isErrorEvent)
+    ReportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta)
 }


### PR DESCRIPTION
#### deae73529c4c33d969518fd587cfac3f308d74c9
<pre>
[ResourceMonitor] Track network usage of SharedWorker.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287464">https://bugs.webkit.org/show_bug.cgi?id=287464</a>
<a href="https://rdar.apple.com/142654034">rdar://142654034</a>

Reviewed by Ben Nham.

We don&apos;t track network usage of SharedWorker created by iframe and also there&apos;s no direct connection
between SharedWorker and iframe right now. To monitor network usage, add new IPC message to report
network usage of SharedWorker to all connected iframe document.

To make this happen:
1. Add new parameter, `workerIdentifier` in NetworkResourceLoadParameters.
2. Report network usage of the SharedWorker from NetworkResourceLoader to connected SharedWorker objects.
3. Tell ResourceMonitor to treate those usage as part of the resource usage of iframe.

New layout test is added to test this usage.

* LayoutTests/http/tests/iframe-monitor/blob-resource.html: Refactoring
* LayoutTests/http/tests/iframe-monitor/cached-resource.html: Refactoring
* LayoutTests/http/tests/iframe-monitor/dark-mode.html: Refactoring
* LayoutTests/http/tests/iframe-monitor/data-url-resource.html: Refactoring
* LayoutTests/http/tests/iframe-monitor/eligibility.html: Refactoring
* LayoutTests/http/tests/iframe-monitor/iframe-unload.html: Refactoring
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/shared-worker.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/shared-worker.js: Added.
* LayoutTests/http/tests/iframe-monitor/resources/monitor-setup.js: Refactoring
* LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/shared-worker.html: Added.
* LayoutTests/http/tests/iframe-monitor/throttler.html: Refactoring
* Source/WebCore/loader/ResourceLoaderOptions.h:
* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::m_contextIdentifier):
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::m_resourceMonitor):
(WebCore::SharedWorker::reportNetworkUsage):
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.cpp:
(WebCore::SharedWorkerObjectConnection::reportNetworkUsageToWorkerObject):
* Source/WebCore/workers/shared/SharedWorkerObjectConnection.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::bufferingTimerFired):
(WebKit::NetworkResourceLoader::sendBuffer):
(WebKit::NetworkResourceLoader::dataReceivedThroughContentFilter):
(WebKit::NetworkResourceLoader::sendDidReceiveDataMessage):
(WebKit::NetworkResourceLoader::reportNetworkUsageToAllSharedWorkers):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::reportNetworkUsageToAllSharedWorkerClients):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::reportNetworkUsageToWorkerObject):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/290232@main">https://commits.webkit.org/290232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66edd0beb254ac946f9d635da5c3adb0ea9ae21a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40099 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68835 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26499 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49196 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35470 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39206 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96153 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16518 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77706 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77007 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21428 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20029 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21843 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->