### PR TITLE
Address some of the Safer CPP warnings in WKRemoteObjectCoder.mm

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm
@@ -40,6 +40,7 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/Scope.h>
 #import <wtf/SetForScope.h>
+#import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/NSStringExtras.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
@@ -91,10 +92,10 @@ bool methodSignaturesAreCompatible(NSString *wire, NSString *local)
 @end
 
 @implementation WKRemoteObjectEncoder {
-    RefPtr<API::Dictionary> _rootDictionary;
-    API::Array* _objectStream;
+    const RefPtr<API::Dictionary> _rootDictionary;
+    RefPtr<API::Array> _objectStream;
 
-    API::Dictionary* _currentDictionary;
+    RefPtr<API::Dictionary> _currentDictionary;
     HashSet<NSObject *> _objectsBeingEncoded; // Used to detect cycles.
 }
 
@@ -103,8 +104,8 @@ bool methodSignaturesAreCompatible(NSString *wire, NSString *local)
     if (!(self = [super init]))
         return nil;
 
-    _rootDictionary = API::Dictionary::create();
-    _currentDictionary = _rootDictionary.get();
+    lazyInitialize(_rootDictionary, API::Dictionary::create());
+    _currentDictionary = _rootDictionary;
 
     return self;
 }
@@ -138,12 +139,13 @@ static void encodeToObjectStream(WKRemoteObjectEncoder *encoder, id value)
 {
     ensureObjectStream(encoder);
 
-    size_t position = encoder->_objectStream->size();
-    encoder->_objectStream->elements().append(nullptr);
+    Ref objectStream = *encoder->_objectStream;
+    size_t position = objectStream->size();
+    objectStream->elements().append(nullptr);
 
     auto encodedObject = createEncodedObject(encoder, value);
-    ASSERT(!encoder->_objectStream->elements()[position]);
-    encoder->_objectStream->elements()[position] = WTFMove(encodedObject);
+    ASSERT(!objectStream->elements()[position]);
+    objectStream->elements()[position] = WTFMove(encodedObject);
 }
 
 static void encodeInvocationArguments(WKRemoteObjectEncoder *encoder, NSInvocation *invocation, NSUInteger firstArgument)
@@ -329,7 +331,7 @@ static void encodeInvocation(WKRemoteObjectEncoder *encoder, NSInvocation *invoc
 
 static void encodeString(WKRemoteObjectEncoder *encoder, NSString *string)
 {
-    encoder->_currentDictionary->set(stringKey, API::String::create(string));
+    Ref { *encoder->_currentDictionary }->set(stringKey, API::String::create(string));
 }
 
 static RetainPtr<id> decodeObjCObject(WKRemoteObjectDecoder *decoder, Class objectClass)
@@ -471,7 +473,7 @@ static void encodeObject(WKRemoteObjectEncoder *encoder, id object)
         encoder->_objectsBeingEncoded.remove(object);
     });
 
-    encoder->_currentDictionary->set(classNameKey, API::String::create(String::fromLatin1(class_getName(objectClass))));
+    Ref { *encoder->_currentDictionary }->set(classNameKey, API::String::create(String::fromLatin1(class_getName(objectClass))));
 
     if ([object isKindOfClass:[NSInvocation class]]) {
         // We have to special case NSInvocation since we don't want to encode the target.
@@ -596,32 +598,32 @@ static NSString *escapeKey(NSString *key)
 
 - (void)encodeObject:(id)object forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), createEncodedObject(self, object));
+    Ref { *_currentDictionary }->set(escapeKey(key), createEncodedObject(self, object));
 }
 
 - (void)encodeBytes:(const uint8_t *)bytes length:(NSUInteger)length forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::Data::create(unsafeMakeSpan(bytes, length)));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::Data::create(unsafeMakeSpan(bytes, length)));
 }
 
 - (void)encodeBool:(BOOL)value forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::Boolean::create(value));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::Boolean::create(value));
 }
 
 - (void)encodeInt:(int)value forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::UInt64::create(value));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::UInt64::create(value));
 }
 
 - (void)encodeInt32:(int32_t)value forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::UInt64::create(value));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::UInt64::create(value));
 }
 
 - (void)encodeInt64:(int64_t)value forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::UInt64::create(value));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::UInt64::create(value));
 }
 
 - (void)encodeInteger:(NSInteger)intv forKey:(NSString *)key
@@ -631,12 +633,12 @@ static NSString *escapeKey(NSString *key)
 
 - (void)encodeFloat:(float)value forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::Double::create(value));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::Double::create(value));
 }
 
 - (void)encodeDouble:(double)value forKey:(NSString *)key
 {
-    _currentDictionary->set(escapeKey(key), API::Double::create(value));
+    Ref { *_currentDictionary }->set(escapeKey(key), API::Double::create(value));
 }
 
 - (BOOL)requiresSecureCoding
@@ -649,12 +651,12 @@ static NSString *escapeKey(NSString *key)
 @implementation WKRemoteObjectDecoder {
     RetainPtr<_WKRemoteObjectInterface> _interface;
 
-    const API::Dictionary* _rootDictionary;
-    const API::Dictionary* _currentDictionary;
+    const RefPtr<const API::Dictionary> _rootDictionary;
+    RefPtr<const API::Dictionary> _currentDictionary;
 
     SEL _replyToSelector;
 
-    const API::Array* _objectStream;
+    const RefPtr<const API::Array> _objectStream;
     size_t _objectStreamPosition;
 
     const HashSet<CFTypeRef>* _allowedClasses;
@@ -667,12 +669,13 @@ static NSString *escapeKey(NSString *key)
 
     _interface = interface;
 
-    _rootDictionary = rootObjectDictionary;
+    lazyInitialize(_rootDictionary, Ref { *rootObjectDictionary });
     _currentDictionary = _rootDictionary;
 
     _replyToSelector = replyToSelector;
 
-    _objectStream = _rootDictionary->get<API::Array>(objectStreamKey);
+    if (RefPtr objectStream = _rootDictionary->get<API::Array>(objectStreamKey))
+        lazyInitialize(_objectStream, objectStream.releaseNonNull());
 
     return self;
 }
@@ -757,7 +760,7 @@ static NSString *escapeKey(NSString *key)
 
 - (BOOL)containsValueForKey:(NSString *)key
 {
-    return _currentDictionary->map().contains(escapeKey(key));
+    return Ref { *_currentDictionary }->map().contains(escapeKey(key));
 }
 
 - (id)decodeObjectForKey:(NSString *)key
@@ -1039,7 +1042,7 @@ static NSInvocation *decodeInvocation(WKRemoteObjectDecoder *decoder)
 
 static RetainPtr<NSString> decodeString(WKRemoteObjectDecoder *decoder)
 {
-    RefPtr string = decoder->_currentDictionary->get<API::String>(stringKey);
+    RefPtr string = Ref { *decoder->_currentDictionary }->get<API::String>(stringKey);
     if (!string)
         [NSException raise:NSInvalidUnarchiveOperationException format:@"String missing"];
 
@@ -1048,7 +1051,7 @@ static RetainPtr<NSString> decodeString(WKRemoteObjectDecoder *decoder)
 
 static id decodeObject(WKRemoteObjectDecoder *decoder)
 {
-    RefPtr classNameString = decoder->_currentDictionary->get<API::String>(classNameKey);
+    RefPtr classNameString = Ref { *decoder->_currentDictionary }->get<API::String>(classNameKey);
     if (!classNameString)
         [NSException raise:NSInvalidUnarchiveOperationException format:@"Class name missing"];
 
@@ -1092,7 +1095,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (BOOL)decodeBoolForKey:(NSString *)key
 {
-    RefPtr value = _currentDictionary->get<API::Boolean>(escapeKey(key));
+    RefPtr value = Ref { *_currentDictionary }->get<API::Boolean>(escapeKey(key));
     if (!value)
         return false;
     return value->value();
@@ -1100,7 +1103,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (int)decodeIntForKey:(NSString *)key
 {
-    RefPtr value = _currentDictionary->get<API::UInt64>(escapeKey(key));
+    RefPtr value = Ref { *_currentDictionary }->get<API::UInt64>(escapeKey(key));
     if (!value)
         return 0;
     return static_cast<int>(value->value());
@@ -1108,7 +1111,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (int32_t)decodeInt32ForKey:(NSString *)key
 {
-    RefPtr value = _currentDictionary->get<API::UInt64>(escapeKey(key));
+    RefPtr value = Ref { *_currentDictionary }->get<API::UInt64>(escapeKey(key));
     if (!value)
         return 0;
     return static_cast<int32_t>(value->value());
@@ -1116,7 +1119,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (int64_t)decodeInt64ForKey:(NSString *)key
 {
-    RefPtr value = _currentDictionary->get<API::UInt64>(escapeKey(key));
+    RefPtr value = Ref { *_currentDictionary }->get<API::UInt64>(escapeKey(key));
     if (!value)
         return 0;
     return value->value();
@@ -1129,7 +1132,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (float)decodeFloatForKey:(NSString *)key
 {
-    RefPtr value = _currentDictionary->get<API::Double>(escapeKey(key));
+    RefPtr value = Ref { *_currentDictionary }->get<API::Double>(escapeKey(key));
     if (!value)
         return 0;
     return value->value();
@@ -1137,7 +1140,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (double)decodeDoubleForKey:(NSString *)key
 {
-    RefPtr value = _currentDictionary->get<API::Double>(escapeKey(key));
+    RefPtr value = Ref { *_currentDictionary }->get<API::Double>(escapeKey(key));
     if (!value)
         return 0;
     return value->value();
@@ -1145,7 +1148,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
 
 - (const uint8_t *)decodeBytesForKey:(NSString *)key returnedLength:(NSUInteger *)length
 {
-    RefPtr data = _currentDictionary->get<API::Data>(escapeKey(key));
+    RefPtr data = Ref { *_currentDictionary }->get<API::Data>(escapeKey(key));
     if (!data || !data->size()) {
         *length = 0;
         return nullptr;
@@ -1166,7 +1169,7 @@ static id decodeObject(WKRemoteObjectDecoder *decoder, const API::Dictionary* di
     for (Class allowedClass in classes)
         allowedClasses.add((__bridge CFTypeRef)allowedClass);
 
-    RefPtr dictionary = _currentDictionary->get<API::Dictionary>(escapeKey(key));
+    RefPtr dictionary = Ref { *_currentDictionary }->get<API::Dictionary>(escapeKey(key));
     return decodeObject(self, dictionary.get(), allowedClasses);
 }
 


### PR DESCRIPTION
#### be4db26277ae5625c5ac485d25a5cadf3e67ce7e
<pre>
Address some of the Safer CPP warnings in WKRemoteObjectCoder.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=287465">https://bugs.webkit.org/show_bug.cgi?id=287465</a>

Reviewed by Darin Adler.

* Source/WebKit/Shared/API/Cocoa/WKRemoteObjectCoder.mm:
(-[WKRemoteObjectEncoder init]):
(encodeToObjectStream):
(encodeString):
(encodeObject):
(-[WKRemoteObjectEncoder encodeObject:forKey:]):
(-[WKRemoteObjectEncoder encodeBytes:length:forKey:]):
(-[WKRemoteObjectEncoder encodeBool:forKey:]):
(-[WKRemoteObjectEncoder encodeInt:forKey:]):
(-[WKRemoteObjectEncoder encodeInt32:forKey:]):
(-[WKRemoteObjectEncoder encodeInt64:forKey:]):
(-[WKRemoteObjectEncoder encodeFloat:forKey:]):
(-[WKRemoteObjectEncoder encodeDouble:forKey:]):
(-[WKRemoteObjectDecoder initWithInterface:rootObjectDictionary:replyToSelector:]):
(-[WKRemoteObjectDecoder containsValueForKey:]):
(decodeString):
(decodeObject):
(-[WKRemoteObjectDecoder decodeBoolForKey:]):
(-[WKRemoteObjectDecoder decodeIntForKey:]):
(-[WKRemoteObjectDecoder decodeInt32ForKey:]):
(-[WKRemoteObjectDecoder decodeInt64ForKey:]):
(-[WKRemoteObjectDecoder decodeFloatForKey:]):
(-[WKRemoteObjectDecoder decodeDoubleForKey:]):
(-[WKRemoteObjectDecoder decodeBytesForKey:returnedLength:]):
(-[WKRemoteObjectDecoder decodeObjectOfClasses:forKey:]):

Canonical link: <a href="https://commits.webkit.org/290294@main">https://commits.webkit.org/290294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fa7507bbc1e17e2c085ac772278c89162fb99a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40212 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26571 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6923 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39327 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77281 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96271 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16633 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77782 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77094 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19048 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21950 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16387 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18169 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->