### PR TITLE
[WebGPUSwift] make Swift.String the default String

### DIFF
--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -559,14 +559,10 @@ inline bool startsWithLettersIgnoringASCIICase(const String& string, ASCIILitera
 
 inline namespace StringLiterals {
 
-#ifndef __swift__
-// Swift will import this as global and then all literals will be WTF.String
-// instead of Swift.String
 inline String operator""_str(const char* characters, size_t)
 {
     return ASCIILiteral::fromLiteralUnsafe(characters);
 }
-#endif
 
 inline String operator""_str(const UChar* characters, size_t length)
 {

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -25,7 +25,8 @@
 
 import Metal
 import WebGPU_Internal
-
+public typealias WTFString = String
+public typealias String = Swift.String
 // FIXME: rdar://140819194
 private let WGPU_COPY_STRIDE_UNDEFINED = WGPU_COPY_STRIDE_UNDEFINED_
 
@@ -93,13 +94,13 @@ public func CommandEncoder_finish_thunk(commandEncoder: WebGPU.CommandEncoder, d
 }
 
 extension WebGPU.CommandEncoder {
-    private func validateFinishError() -> Swift.String? {
+    private func validateFinishError() -> String? {
         if !isValid() {
             return "GPUCommandEncoder.finish: encoder is not valid"
         }
 
         if getEncoderState() != WebGPU.CommandsMixin.EncoderState.Open {
-            return "GPUCommandEncoder.finish: encoder state is \(Swift.String(describing: encoderStateNameWrapper())), expected 'Open'"
+            return "GPUCommandEncoder.finish: encoder state is \(String(describing: encoderStateNameWrapper())), expected 'Open'"
         }
 
         if m_debugGroupStackSize != 0 {
@@ -114,7 +115,7 @@ extension WebGPU.CommandEncoder {
         if descriptor.nextInChain != nil ||  !isValid() || (m_existingCommandEncoder != nil && m_existingCommandEncoder !== m_blitCommandEncoder) {
             setEncoderState(WebGPU.CommandsMixin.EncoderState.Ended)
             discardCommandBuffer();
-            protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as Swift.String : Swift.String("Invalid CommandEncoder"))
+            protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as String : String("Invalid CommandEncoder"))
             return WebGPU.CommandBuffer.createInvalid(m_device.ptr())
         }
 
@@ -128,7 +129,7 @@ extension WebGPU.CommandEncoder {
         setEncoderState(WebGPU.CommandsMixin.EncoderState.Ended)
         if validationFailedError != nil {
             discardCommandBuffer()
-            protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as Swift.String : validationFailedError);
+            protectedDevice().ptr().generateAValidationError(m_lastErrorString != nil ? m_lastErrorString! as String : validationFailedError);
             return WebGPU.CommandBuffer.createInvalid(m_device.ptr())
         }
 
@@ -158,7 +159,7 @@ extension WebGPU.CommandEncoder {
         m_cachedCommandBuffer = WebGPU_Internal.commandBufferThreadSafeWeakPtr(result.ptr())
         result.ptr().setBufferMapCount(m_bufferMapCount)
         if m_makeSubmitInvalid {
-            result.ptr().makeInvalid(m_lastErrorString as Swift.String)
+            result.ptr().makeInvalid(m_lastErrorString as String)
         }
 
         return result
@@ -321,7 +322,7 @@ extension WebGPU.CommandEncoder {
                 pso = try deviceMetal.makeRenderPipelineState(descriptor: mtlRenderPipelineDescriptor)
                 depthStencil = depthStencilDescriptor != nil ? deviceMetal.makeDepthStencilState(descriptor: depthStencilDescriptor!) : nil
             } catch let e {
-                precondition(false, "\(Swift.String(describing: e))")
+                precondition(false, "\(String(describing: e))")
             }
 
             return (pso, depthStencil)
@@ -392,8 +393,8 @@ extension WebGPU.CommandEncoder {
     {
         return writeIndex == WGPU_QUERY_SET_INDEX_UNDEFINED ? 0 : writeIndex
     }
-    private func errorValidatingCopyBufferToBuffer(source: WebGPU.Buffer, sourceOffset: UInt64, destination: WebGPU.Buffer, destinationOffset: UInt64, size: UInt64) -> Swift.String? {
-        func errorString(_ format: Swift.String) -> Swift.String {
+    private func errorValidatingCopyBufferToBuffer(source: WebGPU.Buffer, sourceOffset: UInt64, destination: WebGPU.Buffer, destinationOffset: UInt64, size: UInt64) -> String? {
+        func errorString(_ format: String) -> String {
             return "GPUCommandEncoder.copyBufferToBuffer: \(format)"
         }
         if !source.isDestroyed() && !WebGPU_Internal.isValidToUseWithBufferCommandEncoder(source, self) {
@@ -458,7 +459,7 @@ extension WebGPU.CommandEncoder {
         // https://gpuweb.github.io/gpuweb/#copy-compatible
         return format1 == format2 ? true : WebGPU.Texture.removeSRGBSuffix(format1) == WebGPU.Texture.removeSRGBSuffix(format2)
     }
-    private func errorValidatingCopyTextureToTexture(source: WGPUImageCopyTexture, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) -> Swift.String? {
+    private func errorValidatingCopyTextureToTexture(source: WGPUImageCopyTexture, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) -> String? {
         func refersToAllAspects(format: WGPUTextureFormat, aspect: WGPUTextureAspect) -> Bool {
             switch (aspect) {
             case WGPUTextureAspect_All:
@@ -475,7 +476,7 @@ extension WebGPU.CommandEncoder {
                 return false
             }
         }
-        func errorString(_ error: Swift.String) -> Swift.String {
+        func errorString(_ error: String) -> String {
              "GPUCommandEncoder.copyTextureToTexture: \(error)"
         }
         let sourceTexture = WebGPU.fromAPI(source.texture)
@@ -565,8 +566,8 @@ extension WebGPU.CommandEncoder {
 
         return nil
     }
-    private func errorValidatingCopyTextureToBuffer(source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D) -> Swift.String? {
-        func errorString(_ error: Swift.String) -> Swift.String {
+    private func errorValidatingCopyTextureToBuffer(source: WGPUImageCopyTexture, destination: WGPUImageCopyBuffer, copySize: WGPUExtent3D) -> String? {
+        func errorString(_ error: String) -> String {
             return "GPUCommandEncoder.copyTextureToBuffer: \(error)"
         }
         let sourceTexture = WebGPU.fromAPI(source.texture)
@@ -631,7 +632,7 @@ extension WebGPU.CommandEncoder {
         }
         return nil
     }
-    private func errorValidatingImageCopyBuffer(imageCopyBuffer: WGPUImageCopyBuffer) -> Swift.String? {
+    private func errorValidatingImageCopyBuffer(imageCopyBuffer: WGPUImageCopyBuffer) -> String? {
         // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpuimagecopybuffer
         let buffer = WebGPU.fromAPI(imageCopyBuffer.buffer)
         if !WebGPU_Internal.isValidToUseWithBufferCommandEncoder(buffer, self) {
@@ -651,8 +652,8 @@ extension WebGPU.CommandEncoder {
         return nil
     }
 
-    private func errorValidatingCopyBufferToTexture(source: WGPUImageCopyBuffer, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) -> Swift.String? {
-        func errorString(_ error: Swift.String) -> Swift.String {
+    private func errorValidatingCopyBufferToTexture(source: WGPUImageCopyBuffer, destination: WGPUImageCopyTexture, copySize: WGPUExtent3D) -> String? {
+        func errorString(_ error: String) -> String {
             return "GPUCommandEncoder.copyBufferToTexture: \(error)"
         }
         let destinationTexture = WebGPU.fromAPI(destination.texture)
@@ -720,7 +721,7 @@ extension WebGPU.CommandEncoder {
     }
 
 
-    private func errorValidatingRenderPassDescriptor(descriptor: WGPURenderPassDescriptor) -> Swift.String? {
+    private func errorValidatingRenderPassDescriptor(descriptor: WGPURenderPassDescriptor) -> String? {
         if let wgpuOcclusionQuery = descriptor.occlusionQuerySet {
             let occlusionQuery = WebGPU.fromAPI(wgpuOcclusionQuery)
             if !WebGPU_Internal.isValidToUseWithQuerySetCommandEncoder(occlusionQuery, self) {
@@ -736,7 +737,7 @@ extension WebGPU.CommandEncoder {
         return nil
     }
 
-    private func errorValidatingTimestampWrites(timestampWrites: WGPUComputePassTimestampWrites) -> Swift.String? {
+    private func errorValidatingTimestampWrites(timestampWrites: WGPUComputePassTimestampWrites) -> String? {
 
             if (!self.protectedDevice().ptr().hasFeature(WGPUFeatureName_TimestampQuery)) {
                 return "device does not have timestamp query feature"
@@ -761,7 +762,7 @@ extension WebGPU.CommandEncoder {
             return nil
     }
 
-    private func errorValidatingComputePassDescriptor(descriptor: WGPUComputePassDescriptor) -> Swift.String? {
+    private func errorValidatingComputePassDescriptor(descriptor: WGPUComputePassDescriptor) -> String? {
         if descriptor.timestampWrites != nil {
             return errorValidatingTimestampWrites(timestampWrites: descriptor.timestampWrites.pointee)
         }
@@ -2052,7 +2053,7 @@ extension WebGPU.CommandEncoder {
 
         let error = self.errorValidatingComputePassDescriptor(descriptor: descriptor)
         guard error == nil else {
-            return WebGPU.ComputePassEncoder.createInvalid(self, m_device.ptr(), Swift.String(error!))
+            return WebGPU.ComputePassEncoder.createInvalid(self, m_device.ptr(), String(error!))
         }
 
         guard m_commandBuffer.status.rawValue < MTLCommandBufferStatus.enqueued.rawValue else {
@@ -2085,9 +2086,9 @@ extension WebGPU.CommandEncoder {
         }
 
         self.setExistingEncoder(computeCommandEncoder)
-        // FIXME: Figure out a way so that WTFString does not override Swift.String in the global
+        // FIXME: Figure out a way so that WTFString does not override String in the global
         //        namespace. At the moment it is and that's why we need this.
-        computeCommandEncoder.label = Swift.String(cString: descriptor.label)
+        computeCommandEncoder.label = String(cString: descriptor.label)
 
         return WebGPU.ComputePassEncoder.create(computeCommandEncoder, descriptor, self, m_device.ptr())
 


### PR DESCRIPTION
#### d8e90aae1092180f5e2ac7b7eb2cfc86071dc5b2
<pre>
[WebGPUSwift] make Swift.String the default String
<a href="https://rdar.apple.com/144586613">rdar://144586613</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287462">https://bugs.webkit.org/show_bug.cgi?id=287462</a>

Reviewed by Tadeu Zagallo.

In Forward.h, we have a declaration `using WTF::String` which overrides
Swift.String type. Without this change whenever you say String, it means WTF.String
which is just an unecessary brain exercise :)
The typealias declaration added should be available to all swift files
in WebGPU project and String should mean Swift.String
from now on.
WTF.String is now WTFString.
Also, now, we don&apos;t need the ifdef in WTFString.h that hides the overloaded operator&quot;&quot;().

* Source/WTF/wtf/text/WTFString.h:
* Source/WebGPU/WebGPU/CommandEncoder.h:
(WebGPU::CommandEncoder::createCommandBuffer):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.validateFinishError):
(WebGPU.finish(_:)):
(WebGPU.runClearEncoder(_:depthStencilAttachmentToClear:depthAttachmentToClear:stencilAttachmentToClear:depthClearValue:stencilClearValue:existingEncoder:)):
(WebGPU.errorValidatingCopyBufferToBuffer(_:sourceOffset:destination:destinationOffset:size:)):
(WebGPU.errorValidatingCopyTextureToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingCopyTextureToBuffer(_:destination:copySize:)):
(WebGPU.errorValidatingImageCopyBuffer(_:)):
(WebGPU.errorValidatingCopyBufferToTexture(_:destination:copySize:)):
(WebGPU.errorValidatingRenderPassDescriptor(_:)):
(WebGPU.errorValidatingTimestampWrites(_:)):
(WebGPU.errorValidatingComputePassDescriptor(_:)):
(WebGPU.beginComputePass(_:)):

Canonical link: <a href="https://commits.webkit.org/290344@main">https://commits.webkit.org/290344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e735a2672566b70134e70cb4043885678625ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44287 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94393 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40169 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49252 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6897 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35562 "Found 2 new test failures: editing/undo/redo-reapply-edit-command-crash.html imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fill-columns-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39274 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82205 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96221 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88182 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77760 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77068 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9737 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14082 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21911 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110675 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16341 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26537 "Found 191 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate, microbenchmarks/memcpy-wasm-large.js.eager-jettison-no-cjit, microbenchmarks/memcpy-wasm-large.js.mini-mode, microbenchmarks/memcpy-wasm-large.js.no-cjit-collect-continuously, microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->