### PR TITLE
Add a debug runtime user default for testing a more restrictive rendering mode in the model process

### DIFF
--- a/Source/WebKit/ModelProcess/ModelProcess.cpp
+++ b/Source/WebKit/ModelProcess/ModelProcess.cpp
@@ -193,6 +193,8 @@ void ModelProcess::initializeModelProcess(ModelProcessCreationParameters&& param
 {
     CompletionHandlerCallingScope callCompletionHandler(WTFMove(completionHandler));
 
+    WKREEngine::enableRestrictiveRenderingMode(parameters.restrictiveRenderingMode);
+
     applyProcessCreationParameters(parameters.auxiliaryProcessParameters);
     RELEASE_LOG(Process, "%p - ModelProcess::initializeModelProcess:", this);
     WTF::Thread::setCurrentThreadIsUserInitiated();

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.h
@@ -36,6 +36,7 @@ struct ModelProcessCreationParameters {
     AuxiliaryProcessCreationParameters auxiliaryProcessParameters;
     ProcessID parentPID;
     String applicationVisibleName;
+    bool restrictiveRenderingMode { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
+++ b/Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in
@@ -28,6 +28,7 @@ headers: "ModelProcessCreationParameters.h" "AuxiliaryProcessCreationParameters.
     WebKit::AuxiliaryProcessCreationParameters auxiliaryProcessParameters;
     ProcessID parentPID;
     String applicationVisibleName;
+    bool restrictiveRenderingMode;
 };
 
 #endif

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -90,6 +90,10 @@ ModelProcessProxy::ModelProcessProxy()
     parameters.auxiliaryProcessParameters = auxiliaryProcessParameters();
     parameters.parentPID = getCurrentProcessID();
 
+#if PLATFORM(COCOA)
+    updateModelProcessCreationParameters(parameters);
+#endif
+
     // Initialize the model process.
     sendWithAsyncReply(Messages::ModelProcess::InitializeModelProcess(WTFMove(parameters)), [initializationActivityAndGrant = initializationActivityAndGrant()] () { }, 0);
 

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.h
@@ -119,6 +119,10 @@ private:
     void requestSharedSimulationConnection(WebCore::ProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&&);
 #endif
 
+#if PLATFORM(COCOA)
+    void updateModelProcessCreationParameters(ModelProcessCreationParameters&);
+#endif
+
     ModelProcessCreationParameters processCreationParameters();
 
     RefPtr<ProcessThrottler::Activity> m_activityFromWebProcesses;

--- a/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(VISION) && ENABLE(GPU_PROCESS) && ENABLE(MODEL_PROCESS)
 
 #include "GPUProcessProxy.h"
+#include "ModelProcessCreationParameters.h"
 #include "RunningBoardServicesSPI.h"
 #include "SharedFileHandle.h"
 #include "SharedPreferencesForWebProcess.h"
@@ -37,6 +38,11 @@
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, connection())
 
 namespace WebKit {
+
+void ModelProcessProxy::updateModelProcessCreationParameters(ModelProcessCreationParameters& parameters)
+{
+    parameters.restrictiveRenderingMode = [[NSUserDefaults standardUserDefaults] boolForKey:@"ModelProcessDebugEnableRestrictiveRenderingMode"];
+}
 
 void ModelProcessProxy::requestSharedSimulationConnection(WebCore::ProcessIdentifier webProcessIdentifier, CompletionHandler<void(std::optional<IPC::SharedFileHandle>)>&& completionHandler)
 {


### PR DESCRIPTION
#### 0cb87fca1d7416451e09d29938338a587a3622c4
<pre>
Add a debug runtime user default for testing a more restrictive rendering mode in the model process
<a href="https://bugs.webkit.org/show_bug.cgi?id=287470">https://bugs.webkit.org/show_bug.cgi?id=287470</a>
<a href="https://rdar.apple.com/144568001">rdar://144568001</a>

Reviewed by Mike Wyrzykowski.

Add a debug runtime flag to test a more restrictive rendering
mode in the model process. The value of the flag is passed down
to the model process via the ModelProcessCreationParameters.

* Source/WebKit/ModelProcess/ModelProcess.cpp:
(WebKit::ModelProcess::initializeModelProcess):
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.h:
* Source/WebKit/ModelProcess/ModelProcessCreationParameters.serialization.in:
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::ModelProcessProxy):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.h:
* Source/WebKit/UIProcess/Model/cocoa/ModelProcessProxyCocoa.mm:
(WebKit::ModelProcessProxy::updateModelProcessCreationParameters):

Canonical link: <a href="https://commits.webkit.org/290223@main">https://commits.webkit.org/290223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf3bcfc13242235dd796f514dbe1226e87b3e023

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40042 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68811 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26458 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49147 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6799 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39149 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77156 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96096 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16461 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76961 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/18996 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/19979 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9583 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16475 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21786 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16216 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19667 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/17997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->