### PR TITLE
Experiment: will text-autospace: normal crash?

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -787,8 +787,12 @@ InlineContentCache::InlineItems::ContentAttributes InlineItemsBuilder::computeCo
             auto needsMeasuring = inlineTextItem->length() && !inlineTextItem->isZeroWidthSpaceSeparator() && canCacheMeasuredWidthOnInlineTextItem(inlineTextItem->inlineTextBox(), inlineTextItem->isWhitespace());
             if (needsMeasuring) {
                 auto start = inlineTextItem->start();
-                if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(inlineItemIndex - 1); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
-                    extraInlineTextSpacing = inlineBoxBoundaryTextSpacing->value;
+                if (inlineItemIndex) {
+                    // Box boudary text spacing is potentially registered for inline box start items which appear logically before an inline text item
+                    auto potentialInlineBoxStartIndex = inlineItemIndex - 1;
+                    if (auto inlineBoxBoundaryTextSpacing = inlineBoxBoundaryTextSpacings.find(potentialInlineBoxStartIndex); inlineBoxBoundaryTextSpacing != inlineBoxBoundaryTextSpacings.end())
+                        extraInlineTextSpacing = inlineBoxBoundaryTextSpacing->value;
+                }
                 inlineTextItem->setWidth(TextUtil::width(*inlineTextItem, inlineTextItem->style().fontCascade(), start, start + inlineTextItem->length(), { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState) + extraInlineTextSpacing);
                 handleTextSpacing(spacingState, trimmableTextSpacings, *inlineTextItem, inlineItemIndex);
             }

--- a/Source/WebCore/platform/graphics/FontCascadeDescription.h
+++ b/Source/WebCore/platform/graphics/FontCascadeDescription.h
@@ -147,7 +147,7 @@ public:
     static FontPalette initialFontPalette() { return { FontPalette::Type::Normal, nullAtom() }; }
     static FontSizeAdjust initialFontSizeAdjust() { return { FontSizeAdjust::Metric::ExHeight }; }
     static TextSpacingTrim initialTextSpacingTrim() { return { }; }
-    static TextAutospace initialTextAutospace() { return { }; }
+    static TextAutospace initialTextAutospace() { return { TextAutospace::Type::Normal }; }
     static FontFeatureSettings initialFeatureSettings() { return { }; }
     static FontVariationSettings initialVariationSettings() { return { }; }
 

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -40,6 +40,7 @@ FontDescription::FontDescription()
     : m_variantAlternates(FontCascadeDescription::initialVariantAlternates())
     , m_fontPalette({ FontPalette::Type::Normal, nullAtom() })
     , m_fontSelectionRequest { FontCascadeDescription::initialWeight(), FontCascadeDescription::initialWidth(), FontCascadeDescription::initialItalic() }
+    , m_textAutospace(FontCascadeDescription::initialTextAutospace())
     , m_orientation(enumToUnderlyingType(FontOrientation::Horizontal))
     , m_nonCJKGlyphOrientation(enumToUnderlyingType(NonCJKGlyphOrientation::Mixed))
     , m_widthVariant(enumToUnderlyingType(FontWidthVariant::RegularWidth))


### PR DESCRIPTION
#### 6510a25e5fcce92ab66f0c86a2d341bafc4cbdb4
<pre>
Experiment: will text-autospace: normal crash?
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeContentAttributesAndInlineTextItemWidths):
* Source/WebCore/platform/graphics/FontCascadeDescription.h:
(WebCore::FontCascadeDescription::initialTextAutospace):
* Source/WebCore/platform/graphics/FontDescription.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6510a25e5fcce92ab66f0c86a2d341bafc4cbdb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89327 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40088 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17096 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68826 "Found 23 new test failures: css3/font-feature-font-face-local.html fast/dynamic/text-combine.html fast/ruby/ruby-expansion-cjk-2.html fast/text/decorations-with-text-combine.html fast/text/emphasis-combined-text.html fast/text/font-fallback.html fast/text/international/synthesized-italic-vertical-latin.html fast/text/international/text-combine-image-test.html fast/text/international/wrap-CJK-001.html fast/text/justify-ideograph-leading-expansion.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26491 "Found unexpected failure with change (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92329 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7094 "97 new passes 26 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81081 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49186 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6840 "Too many flaky failures: imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window.html, imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html, imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html, imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html, imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html, imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-combine-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-upright-001.html, imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html, imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html, imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index.html, imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/back-204-205-download.html, imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html, imported/w3c/web-platform-tests/scroll-to-text-fragment/redirects.html, imported/w3c/web-platform-tests/svg/import/text-align-07-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-align-08-b-manual.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35466 "Too many flaky failures: compositing/animation/repaint-after-clearing-shared-backing.html, css3/font-feature-font-face-local.html, editing/spelling/spellcheck-async-mutation.html, editing/undo/redo-reapply-edit-command-crash.html, fast/css/text-overflow-ellipsis-text-align-center.html, fast/css/text-overflow-ellipsis-text-align-justify.html, fast/css/text-overflow-ellipsis-text-align-left.html, fast/css/text-overflow-ellipsis-text-align-right.html, fast/repaint/content-change-in-out-of-flow-container.html, fast/repaint/rtl-content-selection-hairline-gap.html, fast/repaint/simple-line-layout-shrinking-content.html, fast/repaint/text-content-shrinks-repaint.html, fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk-4.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/text/decorations-with-text-combine.html, fast/text/emphasis-combined-text.html, fast/text/font-fallback.html, fast/text/international/synthesized-italic-vertical-latin.html, fast/text/international/text-combine-image-test.html, fast/text/international/wrap-CJK-001.html, fast/text/justify-ideograph-leading-expansion.html, fast/text/ruby-justify-tatechuyoko.html, fast/text/text-combine-placement.html, http/tests/canvas/color-fonts/ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-sbix.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-color-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix.html, http/tests/canvas/color-fonts/text-sbix.html, http/tests/security/file-system-access-via-dataTransfer.html, imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-end.html, imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block-start.html, imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-block.html, imported/w3c/web-platform-tests/css/css-box/margin-trim/grid-inline.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-explicit-block.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-left-side.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-overflow-right-side.html, imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-span-row.html, imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html, imported/w3c/web-platform-tests/css/css-scroll-snap/scroll-target-margin-003.html, imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-003.html, imported/w3c/web-platform-tests/css/css-syntax/unclosed-url-at-eof.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-combine-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-upright-001.html, imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html, imported/w3c/web-platform-tests/import-maps/multiple-import-maps/resolution-consistency-in-module-tree.html, imported/w3c/web-platform-tests/preload/link-header-preload-delay-onload.html, imported/w3c/web-platform-tests/svg/import/text-align-07-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-align-08-b-manual.svg, imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html, platform/mac/svg/fonts/svg-font-general.html, svg/W3C-SVG-1.1/text-align-08-b.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39195 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77196 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36451 "Too many flaky failures: css3/font-feature-font-face-local.html, fast/canvas/canvas-drawImage-svg-image.html, fast/css/text-overflow-ellipsis-text-align-center.html, fast/css/text-overflow-ellipsis-text-align-justify.html, fast/css/text-overflow-ellipsis-text-align-left.html, fast/css/vertical-text-overflow-ellipsis-text-align-center.html, fast/css/vertical-text-overflow-ellipsis-text-align-justify.html, fast/css/viewport-units-zoom.html, fast/repaint/content-change-in-out-of-flow-container.html, fast/repaint/rtl-content-selection-hairline-gap.html, fast/repaint/simple-line-layout-shrinking-content.html, fast/repaint/text-content-shrinks-repaint.html, fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk-4.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/table/multiple-captions-crash5.html, fast/text/decorations-with-text-combine.html, fast/text/emphasis-combined-text.html, fast/text/font-fallback.html, fast/text/international/synthesized-italic-vertical-latin.html, fast/text/international/text-combine-image-test.html, fast/text/international/wrap-CJK-001.html, fast/text/justify-ideograph-leading-expansion.html, fast/text/ruby-justify-tatechuyoko.html, fast/text/text-combine-placement.html, fast/webgpu/nocrash/fuzz-284126.html, fonts/ligature.html, http/tests/canvas/color-fonts/ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-sbix.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-color-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix.html, http/tests/canvas/color-fonts/text-sbix.html, imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-combine-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-upright-001.html, imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html, imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html, imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html, imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-in-shadow-root.html, imported/w3c/web-platform-tests/css/selectors/invalidation/nth-last-child-in-shadow-root.html, imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-containing-iframe.html, imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_go_to_uri.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/navigate-top-to-aboutblank.https.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index.html, imported/w3c/web-platform-tests/svg/animations/use-animate-display-none-symbol-2.html, imported/w3c/web-platform-tests/svg/import/text-align-07-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-align-08-b-manual.svg, media/video-timeupdate-reverse-play.html, platform/mac/svg/fonts/svg-font-general.html, svg/W3C-SVG-1.1/text-align-08-b.svg (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96142 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16507 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12132 "Too many flaky failures: css3/font-feature-font-face-local.html, editing/selection/move-by-character-brute-force.html, fast/css/pseudo-in-range-on-readonly-input-basics.html, fast/css/pseudo-in-range-out-of-range-on-disabled-input-trivial.html, fast/css/text-overflow-ellipsis-text-align-right.html, fast/css/vertical-text-overflow-ellipsis-text-align-center.html, fast/innerHTML/identical-mutations.html, fast/repaint/content-change-in-out-of-flow-container.html, fast/repaint/rtl-content-selection-hairline-gap.html, fast/repaint/simple-line-layout-shrinking-content.html, fast/repaint/text-content-shrinks-repaint.html, fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/table/overflowScroll.html, fast/table/paint-collapsed-borders-rtl-section.html, fast/table/paint-section-borders-without-cells-vertical-lr.html, fast/table/paint-section-borders-without-cells-vertical-rl-rtl.html, fast/text/decorations-with-text-combine.html, fast/text/emoji-num-glyphs.html, fast/text/emphasis-combined-text.html, fast/text/font-fallback.html, fast/text/international/synthesized-italic-vertical-latin.html, fast/text/international/text-combine-image-test.html, fast/text/international/wrap-CJK-001.html, fast/text/justify-ideograph-leading-expansion.html, fast/text/ruby-justify-tatechuyoko.html, fast/text/text-combine-placement.html, fast/webgpu/regression/repro_275276_drawIndexedOOB_BundleEncoder.html, http/tests/canvas/color-fonts/ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-sbix.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-color-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix.html, http/tests/canvas/color-fonts/text-sbix.html, http/tests/security/referrer-policy-header-multipart.html, http/wpt/background-fetch/background-fetch-abort.window.html, http/wpt/mediarecorder/MediaRecorder-multiple-start-stop.html, http/wpt/opener/parent-access-child-via-windowproxy.html, imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-combine-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-upright-001.html, imported/w3c/web-platform-tests/css/css-view-transitions/capture-with-offscreen-child.html, imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html, imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html, imported/w3c/web-platform-tests/css/css-view-transitions/update-callback-called-once.html, imported/w3c/web-platform-tests/css/selectors/invalidation/fullscreen-pseudo-class-in-has.html, imported/w3c/web-platform-tests/css/selectors/invalidation/modal-pseudo-class-in-has.html, imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html, imported/w3c/web-platform-tests/html/cross-origin-opener-policy/tentative/noopener/coop-noopener-allow-popups.https.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index.html, imported/w3c/web-platform-tests/screen-orientation/hidden_document.html, imported/w3c/web-platform-tests/screen-orientation/unlock.html, imported/w3c/web-platform-tests/svg/import/text-align-07-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-align-08-b-manual.svg, imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https.html, js/promises-tests/promises-tests-2-3-3.html, loader/navigation-policy/should-open-external-urls/subframe-navigated-programatically-by-main-frame.html, media/video-webm-seek-singlekeyframe.html, pdf/annotations/radio-buttons-select-second.html, pdf/images/jpeg2000-embed-pdf.html, pdf/pdf-in-embed-with-root-page-zoom.html, pdf/pdf-in-embed.html, pdf/pdf-in-styled-embed.html, platform/mac/svg/fonts/svg-font-general.html, scrollingcoordinator/mac/latching/simple-page-rubberbands.html, storage/indexeddb/objectstore-cursor-private.html, svg/W3C-SVG-1.1/text-align-08-b.svg (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77699 "Found 27 new test failures: css3/font-feature-font-face-local.html editing/selection/move-by-character-brute-force.html fast/dynamic/text-combine.html fast/repaint/content-change-in-out-of-flow-container.html fast/repaint/simple-line-layout-shrinking-content.html fast/repaint/text-content-shrinks-repaint.html fast/ruby/ruby-expansion-cjk-2.html fast/text/decorations-with-text-combine.html fast/text/emphasis-combined-text.html fast/text/font-fallback.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16763 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21419 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20025 "Too many flaky failures: accessibility/mac/native-text-control-set-selected-textmarker-range.html, css3/color-filters/color-filter-color-property-list-item.html, css3/font-feature-font-face-local.html, fast/canvas/canvas-drawImage-svg-image.html, fast/css/text-overflow-ellipsis-text-align-center.html, fast/css/vertical-text-overflow-ellipsis-text-align-center.html, fast/css/vertical-text-overflow-ellipsis-text-align-left.html, fast/css/vertical-text-overflow-ellipsis-text-align-right.html, fast/repaint/content-change-in-out-of-flow-container.html, fast/repaint/rtl-content-selection-hairline-gap.html, fast/repaint/simple-line-layout-shrinking-content.html, fast/repaint/text-content-shrinks-repaint.html, fast/ruby/ruby-expansion-cjk-2.html, fast/ruby/ruby-expansion-cjk-3.html, fast/ruby/ruby-expansion-cjk-4.html, fast/ruby/ruby-expansion-cjk.html, fast/ruby/ruby-justification.html, fast/text/decorations-with-text-combine.html, fast/text/emphasis-combined-text.html, fast/text/font-fallback.html, fast/text/international/synthesized-italic-vertical-latin.html, fast/text/international/text-combine-image-test.html, fast/text/international/wrap-CJK-001.html, fast/text/justify-ideograph-leading-expansion.html, fast/text/ruby-justify-tatechuyoko.html, fast/text/text-combine-placement.html, http/tests/canvas/color-fonts/ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/fill-color-shadow-sbix.html, http/tests/canvas/color-fonts/fill-gradient-sbix.html, http/tests/canvas/color-fonts/stroke-color-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-ctm-sbix.html, http/tests/canvas/color-fonts/stroke-color-shadow-sbix.html, http/tests/canvas/color-fonts/stroke-gradient-sbix.html, http/tests/canvas/color-fonts/text-sbix.html, http/tests/webarchive/cross-origin-stylesheet-crash.html, http/tests/webarchive/test-css-url-encoding-shift-jis.html, http/tests/webarchive/test-css-url-encoding-utf-8.html, http/tests/webarchive/test-css-url-encoding.html, http/tests/webarchive/test-preload-resources.html, imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window.html, imported/w3c/web-platform-tests/css/css-ruby/block-ruby-003.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-loose.html, imported/w3c/web-platform-tests/css/css-text/i18n/unknown-lang/css-text-line-break-cj-normal.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-combine-001.html, imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-vertical-upright-001.html, imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html, imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html, imported/w3c/web-platform-tests/fetch/http-cache/invalidate.any.html, imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html, imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/117.html, imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-destination-dynamic-index.html, imported/w3c/web-platform-tests/permissions/permissions-garbage-collect.https.html, imported/w3c/web-platform-tests/requestidlecallback/callback-idle-periods.html, imported/w3c/web-platform-tests/scroll-animations/view-timelines/duration.html, imported/w3c/web-platform-tests/svg/animations/use-animate-display-none-symbol-2.html, imported/w3c/web-platform-tests/svg/import/text-align-07-t-manual.svg, imported/w3c/web-platform-tests/svg/import/text-align-08-b-manual.svg, imported/w3c/web-platform-tests/svg/painting/parsing/stroke-linecap-valid.svg, platform/mac/svg/fonts/svg-font-general.html, svg/W3C-SVG-1.1/text-align-08-b.svg, webgl/2.0.0/conformance/textures/misc/copy-tex-sub-image-2d-partial-texture.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9657 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21832 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16262 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->