### PR TITLE
[UnifiedPDF] [iOS] Plugin should not handle scale factor updates

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -190,10 +190,6 @@ enum class TapHandlingResult : uint8_t;
 
 - (BOOL)_tryToHandleKeyEventInCustomContentView:(UIPressesEvent *)event;
 
-#if ENABLE(PDF_PLUGIN)
-- (void)_pluginDidInstallPDFDocument:(double)initialScale;
-#endif
-
 @property (nonatomic, readonly) WKPasswordView *_passwordView;
 @property (nonatomic, readonly) WKWebViewContentProviderRegistry *_contentProviderRegistry;
 @property (nonatomic, readonly) WKSelectionGranularity _selectionGranularity;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2107,11 +2107,6 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (scrollView.pinchGestureRecognizer.state == UIGestureRecognizerStateBegan) {
         _page->willStartUserTriggeredZooming();
 
-#if ENABLE(PDF_PLUGIN)
-        if (_page->mainFramePluginHandlesPageScaleGesture())
-            return;
-#endif
-
         [_contentView scrollViewWillStartPanOrPinchGesture];
     }
     [_contentView willStartZoomOrScroll];
@@ -2327,14 +2322,6 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (![self usesStandardContentView] && [_customContentView respondsToSelector:@selector(web_scrollViewDidZoom:)])
         [_customContentView web_scrollViewDidZoom:scrollView];
 
-#if ENABLE(PDF_PLUGIN)
-    if (_page->mainFramePluginHandlesPageScaleGesture()) {
-        auto gestureOrigin = WebCore::IntPoint([scrollView.pinchGestureRecognizer locationInView:self]);
-        _page->setPluginScaleFactor(contentZoomScale(self), gestureOrigin);
-        return;
-    }
-#endif
-
     [self _updateScrollViewBackground];
     [self _scheduleVisibleContentRectUpdateAfterScrollInView:scrollView];
 }
@@ -2346,13 +2333,6 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     ASSERT(scrollView == _scrollView);
 
-#if ENABLE(PDF_PLUGIN)
-    if (_page->mainFramePluginHandlesPageScaleGesture()) {
-        _page->didEndUserTriggeredZooming();
-        return;
-    }
-#endif
-
     // FIXME: remove when rdar://problem/36065495 is fixed.
     // When rotating with two fingers down, UIScrollView can set a bogus content view position.
     // "Center" is top left because we set the anchorPoint to 0,0.
@@ -2360,6 +2340,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     [self _scheduleVisibleContentRectUpdateAfterScrollInView:scrollView];
     [_contentView didZoomToScale:scale];
+
+    _page->didEndUserTriggeredZooming();
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView
@@ -3906,13 +3888,6 @@ static bool isLockdownModeWarningNeeded()
 {
     _overriddenZoomScaleParameters = std::nullopt;
 }
-
-#if ENABLE(PDF_PLUGIN)
-- (void)_pluginDidInstallPDFDocument:(double)initialScale
-{
-    [_scrollView setZoomScale:initialScale];
-}
-#endif
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKWebViewIOSInternalAdditionsAfter.mm>)
 #import <WebKitAdditions/WKWebViewIOSInternalAdditionsAfter.mm>

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -305,10 +305,6 @@ public:
     virtual void removeAllPDFHUDs() = 0;
 #endif
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(IOS_FAMILY)
-    virtual void pluginDidInstallPDFDocument(double initialScale) { };
-#endif
-
     virtual bool handleRunOpenPanel(WebPageProxy*, WebFrameProxy*, const FrameInfoData&, API::OpenPanelParameters*, WebOpenPanelResultListenerProxy*) { return false; }
     virtual bool showShareSheet(const WebCore::ShareDataWithParsedURL&, WTF::CompletionHandler<void (bool)>&&) { return false; }
     virtual void showContactPicker(const WebCore::ContactsRequestData&, WTF::CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&& completionHandler) { completionHandler(std::nullopt); }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1388,9 +1388,6 @@ public:
     double viewScaleFactor() const { return m_viewScaleFactor; }
     void scaleView(double scale);
     void setShouldScaleViewToFitDocument(bool);
-#if ENABLE(PDF_PLUGIN)
-    void setPluginScaleFactor(double scaleFactor, WebCore::IntPoint origin);
-#endif
     
     float deviceScaleFactor() const;
 #if USE(GRAPHICS_LAYER_WC) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
@@ -1764,13 +1761,9 @@ public:
     void saveDataToFileInDownloadsFolder(String&& suggestedFilename, String&& mimeType, URL&& originatingURL, API::Data&);
     void savePDFToFileInDownloadsFolder(String&& suggestedFilename, URL&& originatingURL, std::span<const uint8_t>);
 
-#if ENABLE(PDF_PLUGIN)
-#if PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
     void savePDFToTemporaryFolderAndOpenWithNativeApplication(const String& suggestedFilename, FrameInfoData&&, std::span<const uint8_t>, const String& pdfUUID);
     void showPDFContextMenu(const PDFContextMenu&, PDFPluginIdentifier, CompletionHandler<void(std::optional<int32_t>&&)>&&);
-#else
-    void pluginDidInstallPDFDocument(double initialScale);
-#endif
 #endif
 
     WebCore::IntRect visibleScrollerThumbRect() const;
@@ -3500,8 +3493,8 @@ RefPtr<SpeechRecognitionPermissionManager> protectedSpeechRecognitionPermissionM
 
     double m_pluginZoomFactor { 1 };
 
-    double m_pluginMinZoomFactor { 1 };
-    double m_pluginMaxZoomFactor { 1 };
+    std::optional<double> m_pluginMinZoomFactor;
+    std::optional<double> m_pluginMaxZoomFactor;
 
     double m_pluginScaleFactor { 1 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -559,10 +559,6 @@ messages -> WebPageProxy {
     ShowPDFContextMenu(struct WebKit::PDFContextMenu contextMenu, WebKit::PDFPluginIdentifier identifier) -> (std::optional<int32_t> selectedItem)
 #endif
 
-#if PLATFORM(IOS_FAMILY)
-    PluginDidInstallPDFDocument(double initialScale);
-#endif
-
 #endif
 
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -364,10 +364,6 @@ private:
     const String& spatialTrackingLabel() const final;
 #endif
 
-#if ENABLE(PDF_PLUGIN)
-    void pluginDidInstallPDFDocument(double initialScale) final;
-#endif
-
     void scheduleVisibleContentRectUpdate() final;
 
     RetainPtr<WKContentView> contentView() const { return m_contentView.get(); }

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1265,13 +1265,6 @@ void PageClientImpl::scheduleVisibleContentRectUpdate()
     [webView() _scheduleVisibleContentRectUpdate];
 }
 
-#if ENABLE(PDF_PLUGIN)
-void PageClientImpl::pluginDidInstallPDFDocument(double initialScale)
-{
-    [webView() _pluginDidInstallPDFDocument:initialScale];
-}
-#endif
-
 bool PageClientImpl::isPotentialTapInProgress() const
 {
     return [m_contentView isPotentialTapInProgress];

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1759,13 +1759,6 @@ void WebPageProxy::setPromisedDataForImage(IPC::Connection&, const String&, Shar
 
 #endif
 
-#if ENABLE(PDF_PLUGIN)
-void WebPageProxy::pluginDidInstallPDFDocument(double initialScale)
-{
-    protectedPageClient()->pluginDidInstallPDFDocument(initialScale);
-}
-#endif
-
 #if PLATFORM(IOS_FAMILY)
 
 void WebPageProxy::isPotentialTapInProgress(CompletionHandler<void(bool)>&& completion)

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -333,8 +333,6 @@ public:
 
     bool populateEditorStateIfNeeded(EditorState&) const;
 
-    virtual bool shouldRespectPageScaleAdjustments() const { return true; }
-
     virtual bool shouldSizeToFitContent() const { return false; }
 
 protected:

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -237,7 +237,11 @@ bool PDFPluginBase::isFullFramePlugin() const
 
 bool PDFPluginBase::handlesPageScaleFactor() const
 {
+#if PLATFORM(IOS_FAMILY)
+    return false;
+#else
     return m_frame && m_frame->isMainFrame() && isFullFramePlugin();
+#endif
 }
 
 bool PDFPluginBase::isLocked() const

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -380,7 +380,6 @@ void PDFScrollingPresentationController::tiledBackingUsageChanged(const Graphics
 
 void PDFScrollingPresentationController::paintContents(const GraphicsLayer* layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)
 {
-
     if (layer == m_contentsLayer.get()) {
         RefPtr asyncRenderer = asyncRendererIfExists();
         m_plugin->paintPDFContent(layer, context, clipRect, { }, asyncRenderer.get());

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -215,8 +215,6 @@ public:
     double minScaleFactor() const final;
     double maxScaleFactor() const final;
 
-    bool shouldRespectPageScaleAdjustments() const final;
-
     bool shouldSizeToFitContent() const final;
 
 private:

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -360,6 +360,8 @@ double PluginView::pageScaleFactor() const
 
 void PluginView::pluginScaleFactorDidChange()
 {
+    if (!protectedPlugin()->handlesPageScaleFactor())
+        return;
     auto scaleFactor = pageScaleFactor();
     RefPtr webPage = m_webPage.get();
     webPage->send(Messages::WebPageProxy::PluginScaleFactorDidChange(scaleFactor));
@@ -426,7 +428,7 @@ void PluginView::initializePlugin()
         if (RefPtr frameView = frame->view())
             frameView->setNeedsLayoutAfterViewConfigurationChange();
         if (frame->isMainFrame() && plugin->isFullFramePlugin())
-            WebFrame::fromCoreFrame(*frame)->protectedPage()->send(Messages::WebPageProxy::MainFramePluginHandlesPageScaleGestureDidChange(true, plugin->minScaleFactor(), plugin->maxScaleFactor()));
+            WebFrame::fromCoreFrame(*frame)->protectedPage()->send(Messages::WebPageProxy::MainFramePluginHandlesPageScaleGestureDidChange(plugin->handlesPageScaleFactor(), plugin->minScaleFactor(), plugin->maxScaleFactor()));
     }
 }
 
@@ -1128,11 +1130,6 @@ void PluginView::openWithPreview(CompletionHandler<void(const String&, FrameInfo
 
 #if PLATFORM(IOS_FAMILY)
 
-void PluginView::pluginDidInstallPDFDocument(double initialScale)
-{
-    protectedWebPage()->pluginDidInstallPDFDocument(initialScale);
-}
-
 void PluginView::setSelectionRange(FloatPoint pointInRootView, TextGranularity granularity)
 {
     protectedPlugin()->setSelectionRange(pointInRootView, granularity);
@@ -1185,14 +1182,6 @@ bool PluginView::populateEditorStateIfNeeded(EditorState& state) const
     return protectedPlugin()->populateEditorStateIfNeeded(state);
 }
 
-bool PluginView::shouldRespectPageScaleAdjustments() const
-{
-    if (!m_isInitialized)
-        return false;
-
-    return protectedPlugin()->shouldRespectPageScaleAdjustments();
-}
-
 void PluginView::updateDocumentForPluginSizingBehavior()
 {
     if (!protectedPlugin()->shouldSizeToFitContent())
@@ -1200,6 +1189,14 @@ void PluginView::updateDocumentForPluginSizingBehavior()
     // The styles in PluginDocumentParser are constructed to respond to this class.
     if (RefPtr documentElement = protectedPluginElement()->protectedDocument()->protectedDocumentElement())
         documentElement->setAttributeWithoutSynchronization(HTMLNames::classAttr, "plugin-fits-content"_s);
+}
+
+bool PluginView::pluginHandlesPageScaleFactor() const
+{
+    if (!m_isInitialized)
+        return false;
+
+    return protectedPlugin()->handlesPageScaleFactor();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -99,7 +99,6 @@ public:
     double pageScaleFactor() const;
     void pluginScaleFactorDidChange();
 #if PLATFORM(IOS_FAMILY)
-    void pluginDidInstallPDFDocument(double initialScaleFactor);
     std::pair<URL, WebCore::FloatRect> linkURLAndBoundsAtPoint(WebCore::FloatPoint pointInRootView) const;
     std::optional<WebCore::FloatRect> highlightRectForTapAtPoint(WebCore::FloatPoint pointInRootView) const;
     void handleSyntheticClick(WebCore::PlatformMouseEvent&&);
@@ -160,7 +159,7 @@ public:
 
     void focusPluginElement();
 
-    bool shouldRespectPageScaleAdjustments() const;
+    bool pluginHandlesPageScaleFactor() const;
 
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -790,15 +790,6 @@ public:
     double totalScaleFactor() const;
     double viewScaleFactor() const;
 
-#if ENABLE(PDF_PLUGIN)
-    void setPluginScaleFactor(double scaleFactor, WebCore::IntPoint origin);
-
-#if PLATFORM(IOS_FAMILY)
-    void pluginDidInstallPDFDocument(double initialScale);
-#endif
-
-#endif
-
     void didScalePage(double scale, const WebCore::IntPoint& origin);
     void didScalePageInViewCoordinates(double scale, const WebCore::IntPoint& origin);
     void didScalePageRelativeToScrollPosition(double scale, const WebCore::IntPoint& origin);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -301,9 +301,6 @@ messages -> WebPage WantsAsyncDispatchMessage {
     DidScalePageInViewCoordinates(double scale, WebCore::IntPoint origin)
     DidScalePageRelativeToScrollPosition(double scale, WebCore::IntPoint origin)
     DidScaleView(double scale)
-#if ENABLE(PDF_PLUGIN)
-    SetPluginScaleFactor(double scale, WebCore::IntPoint origin);
-#endif
 
     SetUseFixedLayout(bool fixed)
     SetFixedLayoutSize(WebCore::IntSize size)


### PR DESCRIPTION
#### 31189e349c98f949823e56eb195be961c19b5650
<pre>
[UnifiedPDF] [iOS] Plugin should not handle scale factor updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=287475">https://bugs.webkit.org/show_bug.cgi?id=287475</a>
<a href="https://rdar.apple.com/144415916">rdar://144415916</a>

Reviewed by Sammy Gill.

On iOS, we are currently applying scale factor updates on both the main
frame and on the plugin. This causes the subscrollable region under the
plugin to assume a separate scale factor (and independent scroll bar!),
which manifests in issues such as unstable pinch zoom origins, broken
keyboard scrolling, and unexpected rubberbanding.

This patch continues the direction set by 288932@main. We persist the
&quot;plugin fits content&quot; behavior on scale factor updates (either through
pinch zoom gestures or through programmatic zooming) by opting _out_ of
handling said scale factor updates. Note that we do so only for iOS
family. This makes main frame PDF plugin behavior (on iOS) align with
subframe PDF plugin behavior (on all platforms).

This patch needs to be followed up with more polish. Currently, we do
not respect the scale limits for the plugin (min: 1, max: 6) and instead
fall back to those for general web content (max: 5). This is tracked in
webkit.org/b/287508. Moreover, we need to actually apply page scale
updates to the core Page object under updateVisibleContentRects. We omit
that change from this patch because currently that causes us to easily
exhaust the GPU process. This is being tracked in webkit.org/b/287511.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView scrollViewWillBeginZooming:withView:]):
(-[WKWebView scrollViewDidZoom:]):
(-[WKWebView scrollViewDidEndZooming:withView:atScale:]):
(-[WKWebView _pluginDidInstallPDFDocument:]): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::pluginDidInstallPDFDocument): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::minPageZoomFactor const):
(WebKit::WebPageProxy::maxPageZoomFactor const):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::mainFramePluginHandlesPageScaleGestureDidChange):
(WebKit::WebPageProxy::setPluginScaleFactor): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::pluginDidInstallPDFDocument): Deleted.
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::pluginDidInstallPDFDocument): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::shouldRespectPageScaleAdjustments const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::handlesPageScaleFactor const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::paintContents):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::didEndMagnificationGesture):
(WebKit::UnifiedPDFPlugin::shouldRespectPageScaleAdjustments const): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::pluginScaleFactorDidChange):
(WebKit::PluginView::initializePlugin):
(WebKit::PluginView::pluginHandlesPageScaleFactor const):
(WebKit::PluginView::pluginDidInstallPDFDocument): Deleted.
(WebKit::PluginView::shouldRespectPageScaleAdjustments const): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::textZoomFactor const):
(WebKit::WebPage::didSetTextZoomFactor):
(WebKit::WebPage::pageZoomFactor const):
(WebKit::WebPage::didSetPageZoomFactor):
(WebKit::WebPage::didScalePage):
(WebKit::WebPage::totalScaleFactor const):
(WebKit::WebPage::scaleView):
(WebKit::WebPage::handlesPageScaleGesture):
(WebKit::WebPage::setPluginScaleFactor): Deleted.
(WebKit::WebPage::pluginDidInstallPDFDocument): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):
(WebKit::WebPage::willStartUserTriggeredZooming):

Canonical link: <a href="https://commits.webkit.org/290293@main">https://commits.webkit.org/290293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f3bffce63e673b1e37dd61051e15016d1c584d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40257 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68931 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26588 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6944 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77302 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36591 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96310 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77804 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77008 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77120 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19042 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21544 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21995 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->