### PR TITLE
[GTK] Fixes invalid DPI-aware font size conversion

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -3966,8 +3966,7 @@ void webkit_settings_set_enable_back_forward_navigation_gestures(WebKitSettings*
  *
  * Convert @pixels to the equivalent value in points.
  *
- * Convert @pixels to the equivalent value in points, based on the current
- * screen DPI. Applications can use this function to convert font size values
+ * Applications can use this function to convert font size values
  * in pixels to font size values in points when getting the font size properties
  * of #WebKitSettings.
  *
@@ -3977,7 +3976,7 @@ void webkit_settings_set_enable_back_forward_navigation_gestures(WebKitSettings*
  */
 guint32 webkit_settings_font_size_to_points(guint32 pixels)
 {
-    return std::round(pixels * 72 / WebCore::fontDPI());
+    return std::round(pixels * 72 / 96);
 }
 
 /**
@@ -3986,8 +3985,7 @@ guint32 webkit_settings_font_size_to_points(guint32 pixels)
  *
  * Convert @points to the equivalent value in pixels.
  *
- * Convert @points to the equivalent value in pixels, based on the current
- * screen DPI. Applications can use this function to convert font size values
+ * Applications can use this function to convert font size values
  * in points to font size values in pixels when setting the font size properties
  * of #WebKitSettings.
  *
@@ -3997,7 +3995,7 @@ guint32 webkit_settings_font_size_to_points(guint32 pixels)
  */
 guint32 webkit_settings_font_size_to_pixels(guint32 points)
 {
-    return std::round(points * WebCore::fontDPI() / 72);
+    return std::round(points * 96 / 72);
 }
 #endif // PLATFORM(GTK)
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -144,7 +144,8 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_minimum_font_size(settings, 7);
     g_assert_cmpuint(webkit_settings_get_minimum_font_size(settings), ==, 7);
 
-    // Test conversion between pixels and points. Use a standard DPI of 96.
+    // Test conversion between pixels and points. It's independent of DPI, and
+    // we're testing that it actually does not change when DPI changes.
     // Set DPI explicitly to avoid the tests failing for users that use a
     // different default DPI. This doesn't affect the system's DPI outside
     // of the tests scope, so we don't need to change it back to the original
@@ -172,11 +173,12 @@ static void testWebKitSettings(Test*, gconstpointer)
         g_assert_cmpuint(webkit_settings_font_size_to_points(webkit_settings_get_default_monospace_font_size(settings)), ==, 12);
 
         // Set DPI to 120. The scaling factor is 120 / 96 == 1.25.
+        // Results should be the same, independent of DPI changes.
         g_object_set(gtkSettings, "gtk-xft-dpi", 120 * 1024, nullptr);
         g_assert_cmpuint(webkit_settings_get_default_font_size(settings), ==, 20);
-        g_assert_cmpuint(webkit_settings_font_size_to_points(webkit_settings_get_default_font_size(settings) * 1.25), ==, 15);
+        g_assert_cmpuint(webkit_settings_font_size_to_points(webkit_settings_get_default_font_size(settings)), ==, 15);
         g_assert_cmpuint(webkit_settings_get_default_monospace_font_size(settings), ==, 16);
-        g_assert_cmpuint(webkit_settings_font_size_to_points(webkit_settings_get_default_monospace_font_size(settings) * 1.25), ==, 12);
+        g_assert_cmpuint(webkit_settings_font_size_to_points(webkit_settings_get_default_monospace_font_size(settings)), ==, 12);
 
         // Set DPI back to 96.
         g_object_set(gtkSettings, "gtk-xft-dpi", 96 * 1024, nullptr);


### PR DESCRIPTION
#### 17ffad119ffb7b61c8d329059f9505a9e77e2d80
<pre>
[GTK] Fixes invalid DPI-aware font size conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=283310">https://bugs.webkit.org/show_bug.cgi?id=283310</a>

Reviewed by Michael Catanzaro.

This DPI canculation was not necessary, because webkit is expecting
&quot;logical pixels&quot; and not &quot;device pixels&quot; for font size.

* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_font_size_to_points):
(webkit_settings_font_size_to_pixels):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):

Co-authored-by: Michael Catanzaro &lt;mcatanzaro@redhat.com&gt;
Canonical link: <a href="https://commits.webkit.org/290464@main">https://commits.webkit.org/290464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8270bfad4c1d330ab6232fd78867399470168685

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69388 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26986 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93126 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7692 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36127 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96951 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77588 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19153 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22040 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20637 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10540 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17323 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22649 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17064 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->