### PR TITLE
Unreviewed, reverting 290161@main (27572b44f54b)

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1114,6 +1114,7 @@ platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
 platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
+platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
 platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -49,7 +49,6 @@
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/BlockObjCExceptions.h>
-#import <wtf/WeakObjCPtr.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/MakeString.h>
 
@@ -66,10 +65,10 @@
 #endif
 
 @interface WebAVStreamDataParserListener : NSObject<AVStreamDataParserOutputHandling> {
-    WeakPtr<WebCore::SourceBufferParserAVFObjC> _parent;
-    WeakObjCPtr<AVStreamDataParser> _parser;
+    WebCore::SourceBufferParserAVFObjC* _parent;
+    AVStreamDataParser* _parser;
 }
-@property (assign) WeakPtr<WebCore::SourceBufferParserAVFObjC> parent;
+@property (assign) WebCore::SourceBufferParserAVFObjC* parent;
 - (id)initWithParser:(AVStreamDataParser*)parser parent:(WebCore::SourceBufferParserAVFObjC*)parent;
 @end
 
@@ -103,43 +102,43 @@
 
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didParseStreamDataAsAsset:(AVAsset *)asset
 {
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
-    Ref { *_parent }->didParseStreamDataAsAsset(asset);
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
+    _parent->didParseStreamDataAsAsset(asset);
 }
 
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didParseStreamDataAsAsset:(AVAsset *)asset withDiscontinuity:(BOOL)discontinuity
 {
     UNUSED_PARAM(discontinuity);
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
-    Ref { *_parent }->didParseStreamDataAsAsset(asset);
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
+    _parent->didParseStreamDataAsAsset(asset);
 }
 
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didFailToParseStreamDataWithError:(NSError *)error
 {
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
-    Ref { *_parent }->didFailToParseStreamDataWithError(error);
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
+    _parent->didFailToParseStreamDataWithError(error);
 }
 
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didProvideMediaData:(CMSampleBufferRef)sample forTrackID:(CMPersistentTrackID)trackID mediaType:(NSString *)nsMediaType flags:(AVStreamDataParserOutputMediaDataFlags)flags
 {
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
-    Ref { *_parent }->didProvideMediaDataForTrackID(trackID, sample, nsMediaType, flags);
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
+    _parent->didProvideMediaDataForTrackID(trackID, sample, nsMediaType, flags);
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)streamDataParserWillProvideContentKeyRequestInitializationData:(AVStreamDataParser *)streamDataParser forTrackID:(CMPersistentTrackID)trackID
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
-    Ref { *_parent }->willProvideContentKeyRequestInitializationDataForTrackID(trackID);
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
+    _parent->willProvideContentKeyRequestInitializationDataForTrackID(trackID);
 }
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didProvideContentKeyRequestInitializationData:(NSData *)initData forTrackID:(CMPersistentTrackID)trackID
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
-    Ref { *_parent }->didProvideContentKeyRequestInitializationDataForTrackID(initData, trackID);
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
+    _parent->didProvideContentKeyRequestInitializationDataForTrackID(initData, trackID);
 }
 
 @end
@@ -151,9 +150,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 @implementation WebAVStreamDataParserWithKeySpecifierListener
 - (void)streamDataParser:(AVStreamDataParser *)streamDataParser didProvideContentKeySpecifier:(AVContentKeySpecifier *)keySpecifier forTrackID:(CMPersistentTrackID)trackID
 {
-    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser.get());
+    ASSERT_UNUSED(streamDataParser, streamDataParser == _parser);
     if ([keySpecifier respondsToSelector:@selector(initializationData)])
-        Ref { *_parent }->didProvideContentKeyRequestSpecifierForTrackID(keySpecifier.initializationData, trackID);
+        _parent->didProvideContentKeyRequestSpecifierForTrackID(keySpecifier.initializationData, trackID);
 }
 @end
 #endif


### PR DESCRIPTION
#### cf34bab6ea92a997fa39b523b096269d9a015fbd
<pre>
Unreviewed, reverting 290161@main (27572b44f54b)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287447">https://bugs.webkit.org/show_bug.cgi?id=287447</a>
<a href="https://rdar.apple.com/144574772">rdar://144574772</a>

REGRESSION(290166@main): [macOS] ASSERTION FAILED: WTF::RawPtrTraits&lt;WTF::DefaultWeakPtrImpl&gt;&gt;::operator*() const

Reverted change:

    Address safer C++ static analysis warnings in SourceBufferParserAVFObjC.mm
    <a href="https://bugs.webkit.org/show_bug.cgi?id=287384">https://bugs.webkit.org/show_bug.cgi?id=287384</a>
    290161@main (27572b44f54b)

Canonical link: <a href="https://commits.webkit.org/290213@main">https://commits.webkit.org/290213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19a68ea0b8430ff8b0cd3b5575671eef81bd9843

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89326 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/8851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94312 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40087 "Failed to checkout and rebase branch from PR 40414") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91377 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/9238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/17095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/40087 "Failed to checkout and rebase branch from PR 40414") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92328 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/9238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/49179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/9238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/39194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/9238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96141 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/16506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/17095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/16762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/76865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/76989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9656 "Failed to checkout and rebase branch from PR 40414") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/13995 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/16520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->