### PR TITLE
[Text Wrapping] Add performance tests for text-wrap-style:pretty.

### DIFF
--- a/PerformanceTests/Layout/TextWrap/text-wrap-style-auto.html
+++ b/PerformanceTests/Layout/TextWrap/text-wrap-style-auto.html
@@ -6,11 +6,11 @@
     </head>
     <style>
         #target {
-        display: none;
-        width: 1000px;
-        text-wrap-style: auto;
-        font-size: 10px;
-        font-family: "Helvetica Neue", Helvetica, Verdana, sans-serif;
+            display: none;
+            width: 1000px;
+            text-wrap-style: auto;
+            font-size: 10px;
+            font-family: "Helvetica Neue", Helvetica, Verdana, sans-serif;
         }
     </style>
     <body>

--- a/PerformanceTests/Layout/TextWrap/text-wrap-style-pretty.html
+++ b/PerformanceTests/Layout/TextWrap/text-wrap-style-pretty.html
@@ -1,14 +1,15 @@
+<!-- webkit-test-runner [ CSSTextWrapPrettyEnabled=true ]-->
 <!DOCTYPE html>
 <html>
     <head>
-        <title>text-wrap-style: balance performance test</title>
+        <title>text-wrap-style: auto performance test</title>
         <script src="../../resources/runner.js"></script>
     </head>
     <style>
         #target {
             display: none;
             width: 1000px;
-            text-wrap-style: balance;
+            text-wrap-style: pretty;
             font-size: 10px;
             font-family: "Helvetica Neue", Helvetica, Verdana, sans-serif;
         }


### PR DESCRIPTION
#### 363bbaad3a38dfadd5f51fb00c4793ef30129f67
<pre>
[Text Wrapping] Add performance tests for text-wrap-style:pretty.
<a href="https://bugs.webkit.org/show_bug.cgi?id=286171">https://bugs.webkit.org/show_bug.cgi?id=286171</a>
&lt;<a href="https://rdar.apple.com/143071848">rdar://143071848</a>&gt;

Reviewed by Alan Baradlay.

This change adds performance tests for text-wrap-style:pretty and will allow
developers to measure relative performance between text-wrap-styles
as well as performance implications of future development.

Canonical link: <a href="https://commits.webkit.org/290287@main">https://commits.webkit.org/290287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f015f378b158cfe331ffa10c328289f4dc3862bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94321 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17105 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68828 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26497 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92337 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49188 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39203 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96150 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16515 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12135 "Found 2 new test failures: fast/dom/crash-with-bad-url.html imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77701 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77000 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20022 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9665 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16529 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16270 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->