### PR TITLE
AX: use constants for accessibility APIs rather than hardcoding strings into the code

### DIFF
--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -101,9 +101,9 @@ void attributedStringSetFont(NSMutableAttributedString *attributedString, CTFont
         [fontAttributes setValue:bridge_cast(postScriptName.get()) forKey:NSAccessibilityFontNameKey];
     auto traits = CTFontGetSymbolicTraits(font);
     if (traits & kCTFontTraitBold)
-        [fontAttributes setValue:@YES forKey:@"AXFontBold"];
+        [fontAttributes setValue:@YES forKey:NSAccessibilityFontBoldAttribute];
     if (traits & kCTFontTraitItalic)
-        [fontAttributes setValue:@YES forKey:@"AXFontItalic"];
+        [fontAttributes setValue:@YES forKey:NSAccessibilityFontItalicAttribute];
 
     [attributedString addAttribute:NSAccessibilityFontTextAttribute value:fontAttributes.get() range:range];
 #endif // PLATFORM(MAC)
@@ -207,20 +207,20 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
     bool didSetHeadingLevel = false;
     for (RefPtr ancestor = this; ancestor; ancestor = ancestor->parentObject()) {
         if (ancestor->hasMarkTag())
-            attributedStringSetNumber(string.get(), @"AXHighlight", @YES, range);
+            attributedStringSetNumber(string.get(), NSAccessibilityHighlightAttribute, @YES, range);
 
         switch (ancestor->roleValue()) {
         case AccessibilityRole::Insertion:
-            attributedStringSetNumber(string.get(), @"AXIsSuggestedInsertion", @YES, range);
+            attributedStringSetNumber(string.get(), NSAccessibilityIsSuggestedInsertionAttribute, @YES, range);
             break;
         case AccessibilityRole::Deletion:
-            attributedStringSetNumber(string.get(), @"AXIsSuggestedDeletion", @YES, range);
+            attributedStringSetNumber(string.get(), NSAccessibilityIsSuggestedDeletionAttribute, @YES, range);
             break;
         case AccessibilityRole::Suggestion:
-            attributedStringSetNumber(string.get(), @"AXIsSuggestion", @YES, range);
+            attributedStringSetNumber(string.get(), NSAccessibilityIsSuggestionAttribute, @YES, range);
             break;
         case AccessibilityRole::Mark:
-            attributedStringSetNumber(string.get(), @"AXHighlight", @YES, range);
+            attributedStringSetNumber(string.get(), NSAccessibilityHighlightAttribute, @YES, range);
             break;
         default:
             break;
@@ -232,7 +232,7 @@ RetainPtr<NSMutableAttributedString> AXCoreObject::createAttributedString(String
         if (!didSetHeadingLevel) {
             if (unsigned level = ancestor->headingLevel()) {
                 didSetHeadingLevel = true;
-                [string.get() addAttribute:@"AXHeadingLevel" value:@(level) range:range];
+                [string.get() addAttribute:NSAccessibilityHeadingLevelAttribute value:@(level) range:range];
             }
         }
     }

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -243,10 +243,10 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
     NSString *macNotification;
     switch (notification) {
     case AXNotification::ActiveDescendantChanged:
-        macNotification = @"AXActiveElementChanged";
+        macNotification = NSAccessibilityActiveElementChangedNotification;
         break;
     case AXNotification::AutocorrectionOccured:
-        macNotification = @"AXAutocorrectionOccurred";
+        macNotification = NSAccessibilityAutocorrectionOccurredNotification;
         break;
     case AXNotification::CurrentStateChanged:
         macNotification = NSAccessibilityCurrentStateChangedNotification;
@@ -255,17 +255,17 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         macNotification = NSAccessibilityFocusedUIElementChangedNotification;
         break;
     case AXNotification::ImageOverlayChanged:
-        macNotification = @"AXImageOverlayChanged";
+        macNotification = NSAccessibilityImageOverlayChangedNotification;
         break;
     case AXNotification::LayoutComplete:
-        macNotification = @"AXLayoutComplete";
+        macNotification = NSAccessibilityLayoutCompleteNotification;
         break;
     case AXNotification::LabelChanged:
         macNotification = NSAccessibilityTitleChangedNotification;
         break;
     case AXNotification::LoadComplete:
     case AXNotification::FrameLoadComplete:
-        macNotification = @"AXLoadComplete";
+        macNotification = NSAccessibilityLoadCompleteNotification;
         // Frame loading events are handled by the UIProcess on macOS to improve reliability.
         // On macOS, before notifications are allowed by AppKit to be sent to clients, you need to have a client (e.g. VoiceOver)
         // register for that notification. Because these new processes appear before VO has a chance to register, it will often
@@ -273,7 +273,7 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         skipSystemNotification = true;
         break;
     case AXNotification::InvalidStatusChanged:
-        macNotification = @"AXInvalidStatusChanged";
+        macNotification = NSAccessibilityInvalidStatusChangedNotification;
         break;
     case AXNotification::SelectedChildrenChanged:
         if (object.isTable() && object.isExposable())
@@ -307,13 +307,13 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         macNotification = NSAccessibilityRowCollapsedNotification;
         break;
     case AXNotification::ElementBusyChanged:
-        macNotification = @"AXElementBusyChanged";
+        macNotification = NSAccessibilityElementBusyChangedNotification;
         break;
     case AXNotification::ExpandedChanged:
-        macNotification = @"AXExpandedChanged";
+        macNotification = NSAccessibilityExpandedChangedNotification;
         break;
     case AXNotification::SortDirectionChanged:
-        macNotification = @"AXSortDirectionChanged";
+        macNotification = NSAccessibilitySortDirectionChangedNotification;
         break;
     case AXNotification::MenuClosed:
         macNotification = (id)kAXMenuClosedNotification;
@@ -323,10 +323,10 @@ void AXObjectCache::postPlatformNotification(AccessibilityObject& object, AXNoti
         macNotification = (id)kAXMenuItemSelectedNotification;
         break;
     case AXNotification::PressDidSucceed:
-        macNotification = @"AXPressDidSucceed";
+        macNotification = NSAccessibilityPressDidSucceedNotification;
         break;
     case AXNotification::PressDidFail:
-        macNotification = @"AXPressDidFail";
+        macNotification = NSAccessibilityPressDidFailNotification;
         break;
     case AXNotification::MenuOpened:
         macNotification = (id)kAXMenuOpenedNotification;
@@ -644,7 +644,7 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(Element*, Element*)
     if (!rootWebArea)
         return;
 
-    [rootWebArea->wrapper() accessibilityPostedNotification:@"AXFocusChanged" userInfo:nil];
+    [rootWebArea->wrapper() accessibilityPostedNotification:NSAccessibilityFocusChangedNotification userInfo:nil];
 }
 
 void AXObjectCache::handleScrolledToAnchor(const Node&)

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -240,7 +240,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 String AccessibilityObject::subrolePlatformString() const
 {
     if (isEmptyGroup(*const_cast<AccessibilityObject*>(this)))
-        return @"AXEmptyGroup";
+        return NSAccessibilityEmptyGroupSubrole;
 
     if (isSecureField())
         return NSAccessibilitySecureTextFieldSubrole;
@@ -500,19 +500,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }
 
-    if ([axRole isEqualToString:@"AXWebArea"])
+    if ([axRole isEqualToString:NSAccessibilityWebAreaRole])
         return AXWebAreaText();
 
-    if ([axRole isEqualToString:@"AXLink"])
+    if ([axRole isEqualToString:NSAccessibilityLinkRole])
         return AXLinkText();
 
-    if ([axRole isEqualToString:@"AXListMarker"])
+    if ([axRole isEqualToString:NSAccessibilityListMarkerRole])
         return AXListMarkerText();
 
-    if ([axRole isEqualToString:@"AXImageMap"])
+    if ([axRole isEqualToString:NSAccessibilityImageMapRole])
         return AXImageMapText();
 
-    if ([axRole isEqualToString:@"AXHeading"])
+    if ([axRole isEqualToString:NSAccessibilityHeadingRole])
         return AXHeadingText();
 
     if ([axRole isEqualToString:NSAccessibilityTextFieldRole]) {
@@ -717,7 +717,7 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::ProgressIndicator, NSAccessibilityProgressIndicatorRole },
         { AccessibilityRole::Meter, NSAccessibilityLevelIndicatorRole },
         { AccessibilityRole::ComboBox, NSAccessibilityComboBoxRole },
-        { AccessibilityRole::DateTime, @"AXDateTimeArea" },
+        { AccessibilityRole::DateTime, NSAccessibilityDateTimeAreaRole },
         { AccessibilityRole::Splitter, NSAccessibilitySplitterRole },
         { AccessibilityRole::Code, NSAccessibilityGroupRole },
         { AccessibilityRole::ColorWell, NSAccessibilityColorWellRole },
@@ -726,10 +726,10 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::TreeGrid, NSAccessibilityTableRole },
         { AccessibilityRole::WebCoreLink, NSAccessibilityLinkRole },
         { AccessibilityRole::ImageMapLink, NSAccessibilityLinkRole },
-        { AccessibilityRole::ImageMap, @"AXImageMap" },
-        { AccessibilityRole::ListMarker, @"AXListMarker" },
-        { AccessibilityRole::WebArea, @"AXWebArea" },
-        { AccessibilityRole::Heading, @"AXHeading" },
+        { AccessibilityRole::ImageMap, NSAccessibilityImageMapRole },
+        { AccessibilityRole::ListMarker, NSAccessibilityListMarkerRole },
+        { AccessibilityRole::WebArea, NSAccessibilityWebAreaRole },
+        { AccessibilityRole::Heading, NSAccessibilityHeadingRole },
         { AccessibilityRole::ListBox, NSAccessibilityListRole },
         { AccessibilityRole::ListBoxOption, NSAccessibilityStaticTextRole },
         { AccessibilityRole::Cell, NSAccessibilityCellRole },
@@ -776,7 +776,7 @@ PlatformRoleMap createPlatformRoleMap()
         { AccessibilityRole::Form, NSAccessibilityGroupRole },
         { AccessibilityRole::Generic, NSAccessibilityGroupRole },
         { AccessibilityRole::SpinButton, NSAccessibilityIncrementorRole },
-        { AccessibilityRole::SpinButtonPart, @"AXIncrementorArrow" },
+        { AccessibilityRole::SpinButtonPart, NSAccessibilityIncrementorArrowRole },
         { AccessibilityRole::Footer, NSAccessibilityGroupRole },
         { AccessibilityRole::ToggleButton, NSAccessibilityCheckBoxRole },
         { AccessibilityRole::Canvas, NSAccessibilityImageRole },

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -29,6 +29,87 @@
 #pragma once
 
 //
+// Roles
+//
+
+#define NSAccessibilityHeadingRole @"AXHeading"
+#define NSAccessibilityDateTimeAreaRole @"AXDateTimeArea"
+#define NSAccessibilityImageMapRole @"AXImageMap"
+#define NSAccessibilityIncrementorArrowRole @"AXIncrementorArrow"
+#define NSAccessibilityListMarkerRole @"AXListMarker"
+#define NSAccessibilityWebAreaRole @"AXWebArea"
+
+//
+// Subroles
+//
+
+#define NSAccessibilityApplicationAlertSubrole @"AXApplicationAlert"
+#define NSAccessibilityApplicationAlertDialogSubrole @"AXApplicationAlertDialog"
+#define NSAccessibilityApplicationDialogSubrole @"AXApplicationDialog"
+#define NSAccessibilityApplicationGroupSubrole @"AXApplicationGroup"
+#define NSAccessibilityApplicationLogSubrole @"AXApplicationLog"
+#define NSAccessibilityApplicationMarqueeSubrole @"AXApplicationMarquee"
+#define NSAccessibilityApplicationStatusSubrole @"AXApplicationStatus"
+#define NSAccessibilityApplicationTimerSubrole @"AXApplicationTimer"
+#define NSAccessibilityAudioSubrole @"AXAudio"
+#define NSAccessibilityCiteStyleGroupSubrole @"AXCiteStyleGroup"
+#define NSAccessibilityCodeStyleGroupSubrole @"AXCodeStyleGroup"
+#define NSAccessibilityContentSeparatorSubrole @"AXContentSeparator"
+#define NSAccessibilityDefinitionSubrole @"AXDefinition"
+#define NSAccessibilityDeleteStyleGroupSubrole @"AXDeleteStyleGroup"
+#define NSAccessibilityDetailsSubrole @"AXDetails"
+#define NSAccessibilityDocumentArticleSubrole @"AXDocumentArticle"
+#define NSAccessibilityDocumentMathSubrole @"AXDocumentMath"
+#define NSAccessibilityDocumentNoteSubrole @"AXDocumentNote"
+#define NSAccessibilityEmptyGroupSubrole @"AXEmptyGroup"
+#define NSAccessibilityFieldsetSubrole @"AXFieldset"
+#define NSAccessibilityFileUploadButtonSubrole @"AXFileUploadButton"
+#define NSAccessibilityFooterSubrole @"AXFooter"
+#define NSAccessibilityInsertStyleGroupSubrole @"AXInsertStyleGroup"
+#define NSAccessibilityKeyboardInputStyleGroupSubrole @"AXKeyboardInputStyleGroup"
+#define NSAccessibilityLandmarkBannerSubrole @"AXLandmarkBanner"
+#define NSAccessibilityLandmarkComplementarySubrole @"AXLandmarkComplementary"
+#define NSAccessibilityLandmarkContentInfoSubrole @"AXLandmarkContentInfo"
+#define NSAccessibilityLandmarkMainSubrole @"AXLandmarkMain"
+#define NSAccessibilityLandmarkNavigationSubrole @"AXLandmarkNavigation"
+#define NSAccessibilityLandmarkRegionSubrole @"AXLandmarkRegion"
+#define NSAccessibilityLandmarkSearchSubrole @"AXLandmarkSearch"
+#define NSAccessibilityMathFenceOperatorSubrole @"AXMathFenceOperator"
+#define NSAccessibilityMathFencedSubrole @"AXMathFenced"
+#define NSAccessibilityMathFractionSubrole @"AXMathFraction"
+#define NSAccessibilityMathIdentifierSubrole @"AXMathIdentifier"
+#define NSAccessibilityMathMultiscriptSubrole @"AXMathMultiscript"
+#define NSAccessibilityMathNumberSubrole @"AXMathNumber"
+#define NSAccessibilityMathOperatorSubrole @"AXMathOperator"
+#define NSAccessibilityMathRootSubrole @"AXMathRoot"
+#define NSAccessibilityMathRowSubrole @"AXMathRow"
+#define NSAccessibilityMathSeparatorOperatorSubrole @"AXMathSeparatorOperator"
+#define NSAccessibilityMathSquareRootSubrole @"AXMathSquareRoot"
+#define NSAccessibilityMathSubscriptSuperscriptSubrole @"AXMathSubscriptSuperscript"
+#define NSAccessibilityMathTableSubrole @"AXMathTable"
+#define NSAccessibilityMathTableCellSubrole @"AXMathTableCell"
+#define NSAccessibilityMathTableRowSubrole @"AXMathTableRow"
+#define NSAccessibilityMathTextSubrole @"AXMathText"
+#define NSAccessibilityMathUnderOverSubrole @"AXMathUnderOver"
+#define NSAccessibilityMeterSubrole @"AXMeter"
+#define NSAccessibilityModelSubrole @"AXModel"
+#define NSAccessibilityPreformattedStyleGroupSubrole @"AXPreformattedStyleGroup"
+#define NSAccessibilityRubyInlineSubrole @"AXRubyInline"
+#define NSAccessibilityRubyTextSubrole @"AXRubyText"
+#define NSAccessibilitySampleStyleGroupSubrole @"AXSampleStyleGroup"
+#define NSAccessibilitySubscriptStyleGroupSubrole @"AXSubscriptStyleGroup"
+#define NSAccessibilitySuggestionSubrole @"AXSuggestion"
+#define NSAccessibilitySummarySubrole @"AXSummary"
+#define NSAccessibilitySuperscriptStyleGroupSubrole @"AXSuperscriptStyleGroup"
+#define NSAccessibilityTabPanelSubrole @"AXTabPanel"
+#define NSAccessibilityTermSubrole @"AXTerm"
+#define NSAccessibilityTimeGroupSubrole @"AXTimeGroup"
+#define NSAccessibilityUserInterfaceTooltipSubrole @"AXUserInterfaceTooltip"
+#define NSAccessibilityVariableStyleGroupSubrole @"AXVariableStyleGroup"
+#define NSAccessibilityVideoSubrole @"AXVideo"
+#define NSAccessibilityWebApplicationSubrole @"AXWebApplication"
+
+//
 // Attributes
 //
 
@@ -38,39 +119,76 @@
 #define NSAccessibilityARIACurrentAttribute @"AXARIACurrent"
 #define NSAccessibilityARIALiveAttribute @"AXARIALive"
 #define NSAccessibilityARIAPosInSetAttribute @"AXARIAPosInSet"
+#define NSAccessibilityARIAPressedIsPresentAttribute @"AXARIAPressedIsPresent"
 #define NSAccessibilityARIARelevantAttribute @"AXARIARelevant"
+#define NSAccessibilityARIARoleAttribute @"AXARIARole"
 #define NSAccessibilityARIARowCountAttribute @"AXARIARowCount"
 #define NSAccessibilityARIARowIndexAttribute @"AXARIARowIndex"
 #define NSAccessibilityARIASetSizeAttribute @"AXARIASetSize"
 #define NSAccessibilityAccessKeyAttribute @"AXAccessKey"
 #define NSAccessibilityActiveElementAttribute @"AXActiveElement"
+#define NSAccessibilityAssociatedPluginParentAttribute @"_AXAssociatedPluginParent"
+#define NSAccessibilityAutocompleteValueAttribute @"AXAutocompleteValue"
+#define NSAccessibilityAutoInteractableAttribute @"AXAutoInteractable"
 #define NSAccessibilityBlockQuoteLevelAttribute @"AXBlockQuoteLevel"
 #define NSAccessibilityBrailleLabelAttribute @"AXBrailleLabel"
 #define NSAccessibilityBrailleRoleDescriptionAttribute @"AXBrailleRoleDescription"
 #define NSAccessibilityCaretBrowsingEnabledAttribute @"AXCaretBrowsingEnabled"
 #define NSAccessibilityChildrenInNavigationOrderAttribute @"AXChildrenInNavigationOrder"
+#define NSAccessibilityClickPointAttribute @"AXClickPoint"
+#define NSAccessibilityControllerForAttribute @"AXControllerFor"
+#define NSAccessibilityControllersAttribute @"AXControllers"
 #define NSAccessibilityDOMClassListAttribute @"AXDOMClassList"
 #define NSAccessibilityDOMIdentifierAttribute @"AXDOMIdentifier"
+#define NSAccessibilityDRTSpeechAttributeAttribute @"AXDRTSpeechAttribute"
+#define NSAccessibilityDateTimeComponentsAttribute @"AXDateTimeComponents"
+#define NSAccessibilityDateTimeComponentsTypeAttribute @"AXDateTimeComponentsType"
 #define NSAccessibilityDatetimeValueAttribute @"AXDateTimeValue"
+#define NSAccessibilityDescribedByAttribute @"AXDescribedBy"
+#define NSAccessibilityDescriptionForAttribute @"AXDescriptionFor"
+#define NSAccessibilityDetailsElementsAttribute @"AXDetailsElements"
+#define NSAccessibilityDetailsForAttribute @"AXDetailsFor"
 #define NSAccessibilityDropEffectsAttribute @"AXDropEffects"
 #define NSAccessibilityEditableAncestorAttribute @"AXEditableAncestor"
 #define NSAccessibilityElementBusyAttribute @"AXElementBusy"
 #define NSAccessibilityEmbeddedImageDescriptionAttribute @"AXEmbeddedImageDescription"
 #define NSAccessibilityEndTextMarkerAttribute @"AXEndTextMarker"
+#define NSAccessibilityEndTextMarkerForTextMarkerRangeAttribute @"_AXEndTextMarkerForTextMarkerRange"
+#define NSAccessibilityErrorMessageElementsAttribute @"AXErrorMessageElements"
+#define NSAccessibilityErrorMessageForAttribute @"AXErrorMessageFor"
 #define NSAccessibilityExpandedTextValueAttribute @"AXExpandedTextValue"
+#define NSAccessibilityFlowFromAttribute @"AXFlowFrom"
+#define NSAccessibilityFlowToAttribute @"AXFlowTo"
 #define NSAccessibilityFocusableAncestorAttribute @"AXFocusableAncestor"
 #define NSAccessibilityGrabbedAttribute @"AXGrabbed"
 #define NSAccessibilityHasDocumentRoleAncestorAttribute @"AXHasDocumentRoleAncestor"
 #define NSAccessibilityHasPopupAttribute @"AXHasPopup"
 #define NSAccessibilityHasWebApplicationAncestorAttribute @"AXHasWebApplicationAncestor"
+#define NSAccessibilityHeadingLevelAttribute @"AXHeadingLevel"
 #define NSAccessibilityHighestEditableAncestorAttribute @"AXHighestEditableAncestor"
 #define NSAccessibilityImageOverlayElementsAttribute @"AXImageOverlayElements"
+#define NSAccessibilityInfoStringForTestingAttribute @"AXInfoStringForTesting"
 #define NSAccessibilityInlineTextAttribute @"AXInlineText"
 #define NSAccessibilityInvalidAttribute @"AXInvalid"
+#define NSAccessibilityIsInCellAttribute @"AXIsInCell"
+#define NSAccessibilityIsInDescriptionListDetailAttribute @"AXIsInDescriptionListDetail"
+#define NSAccessibilityIsInDescriptionListTermAttribute @"AXIsInDescriptionListTerm"
+#define NSAccessibilityIsInTableAttribute @"_AXIsInTable"
+#define NSAccessibilityIsIndeterminateAttribute @"AXIsIndeterminate"
+#define NSAccessibilityIsMultiSelectableAttribute @"AXIsMultiSelectable"
+#define NSAccessibilityIsOnScreenAttribute @"AXIsOnScreen"
+#define NSAccessibilityIsRemoteFrameAttribute @"AXIsRemoteFrame"
 #define NSAccessibilityKeyShortcutsAttribute @"AXKeyShortcutsValue"
+#define NSAccessibilityLabelForAttribute @"AXLabelFor"
+#define NSAccessibilityLabelledByAttribute @"AXLabelledBy"
 #define NSAccessibilityLanguageAttribute @"AXLanguage"
+#define NSAccessibilityLayoutCountAttribute @"AXLayoutCount"
+#define NSAccessibilityLineRectsAndTextAttribute @"AXLineRectsAndText"
 #define NSAccessibilityLinkRelationshipTypeAttribute @"AXLinkRelationshipType"
+#define NSAccessibilityLinkUIElementsAttribute @"AXLinkUIElements"
+#define NSAccessibilityLoadedAttribute @"AXLoaded"
 #define NSAccessibilityLoadingProgressAttribute @"AXLoadingProgress"
+#define NSAccessibilityOwnersAttribute @"AXOwners"
 #define NSAccessibilityOwnsAttribute @"AXOwns"
 #define NSAccessibilityPathAttribute @"AXPath"
 #define NSAccessibilityPopupValueAttribute @"AXPopupValue"
@@ -80,10 +198,20 @@
 #define NSAccessibilitySelectedCellsAttribute @"AXSelectedCells"
 #define NSAccessibilitySelectedTextMarkerRangeAttribute @"AXSelectedTextMarkerRange"
 #define NSAccessibilityStartTextMarkerAttribute @"AXStartTextMarker"
+#define NSAccessibilityStartTextMarkerForTextMarkerRangeAttribute @"_AXStartTextMarkerForTextMarkerRange"
+#define NSAccessibilityStringValueAttribute @"AXStringValue"
+#define NSAccessibilityTableLevelAttribute @"AXTableLevel"
+#define NSAccessibilityTextCompletionAttribute @"AXTextCompletion"
 #define NSAccessibilityTextInputMarkedRangeAttribute @"AXTextInputMarkedRange"
 #define NSAccessibilityTextInputMarkedTextMarkerRangeAttribute @"AXTextInputMarkedTextMarkerRange"
+#define NSAccessibilityTextMarkerDebugDescriptionAttribute @"AXTextMarkerDebugDescription"
+#define NSAccessibilityTextMarkerNodeDebugDescriptionAttribute @"AXTextMarkerNodeDebugDescription"
+#define NSAccessibilityTextMarkerNodeTreeDebugDescriptionAttribute @"AXTextMarkerNodeTreeDebugDescription"
+#define NSAccessibilityTextMarkerRangeDebugDescriptionAttribute @"AXTextMarkerRangeDebugDescription"
+#define NSAccessibilityTextMarkerRangeForNSRangeAttribute @"_AXTextMarkerRangeForNSRange"
 #define NSAccessibilityValueAutofillAvailableAttribute @"AXValueAutofillAvailable"
 #define NSAccessibilityValueAutofillTypeAttribute @"AXValueAutofillType"
+#define NSAccessibilityVisitedAttribute @"AXVisited"
 
 //
 // Parameterized Attributes
@@ -112,6 +240,7 @@
 #define NSAccessibilityPreviousSentenceStartTextMarkerForTextMarkerAttribute @"AXPreviousSentenceStartTextMarkerForTextMarker"
 #define NSAccessibilityPreviousTextMarkerForTextMarkerAttribute @"AXPreviousTextMarkerForTextMarker"
 #define NSAccessibilityPreviousWordStartTextMarkerForTextMarkerAttribute @"AXPreviousWordStartTextMarkerForTextMarker"
+#define NSAccessibilityRangesForSearchPredicateParameterizedAttribute @"AXRangesForSearchPredicate"
 #define NSAccessibilityRightLineTextMarkerRangeForTextMarkerAttribute @"AXRightLineTextMarkerRangeForTextMarker"
 #define NSAccessibilityRightWordTextMarkerRangeForTextMarkerAttribute @"AXRightWordTextMarkerRangeForTextMarker"
 #define NSAccessibilitySentenceTextMarkerRangeForTextMarkerAttribute @"AXSentenceTextMarkerRangeForTextMarker"
@@ -120,11 +249,13 @@
 #define NSAccessibilityStyleTextMarkerRangeForTextMarkerAttribute @"AXStyleTextMarkerRangeForTextMarker"
 #define NSAccessibilityTextMarkerForIndexAttribute @"AXTextMarkerForIndex"
 #define NSAccessibilityTextMarkerForPositionAttribute @"AXTextMarkerForPosition" // FIXME: should be AXTextMarkerForPoint.
+#define NSAccessibilityTextMarkerIsNullParameterizedAttribute @"AXTextMarkerIsNull"
 #define NSAccessibilityTextMarkerIsValidAttribute @"AXTextMarkerIsValid"
 #define NSAccessibilityTextMarkerRangeForLineAttribute @"AXTextMarkerRangeForLine"
 #define NSAccessibilityTextMarkerRangeForTextMarkersAttribute @"AXTextMarkerRangeForTextMarkers"
 #define NSAccessibilityTextMarkerRangeForUIElementAttribute @"AXTextMarkerRangeForUIElement"
 #define NSAccessibilityTextMarkerRangeForUnorderedTextMarkersAttribute @"AXTextMarkerRangeForUnorderedTextMarkers"
+#define NSAccessibilityTextMarkerRangeIsValidParameterizedAttribute @"AXTextMarkerRangeIsValid"
 #define NSAccessibilityUIElementForTextMarkerAttribute @"AXUIElementForTextMarker"
 #define NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute @"AXUIElementsForSearchPredicate"
 
@@ -132,28 +263,50 @@
 // Actions
 //
 
+#define NSAccessibilityDismissAction @"AXDismissAction"
 #define NSAccessibilityScrollToVisibleAction @"AXScrollToVisible"
+#define NSAccessibilitySyncDecrementAction @"AXSyncDecrementAction"
+#define NSAccessibilitySyncIncrementAction @"AXSyncIncrementAction"
+#define NSAccessibilitySyncPressAction @"AXSyncPressAction"
 
 //
 // Attributed string attribute names
 //
 
 #define NSAccessibilityDidSpellCheckAttribute @"AXDidSpellCheck"
-#define NSAccessibilityTextCompletionAttribute @"AXTextCompletion"
+#define NSAccessibilityFontBoldAttribute @"AXFontBold"
+#define NSAccessibilityFontItalicAttribute @"AXFontItalic"
+#define NSAccessibilityHighlightAttribute @"AXHighlight"
+#define NSAccessibilityIsSuggestedInsertionAttribute @"AXIsSuggestedInsertion"
+#define NSAccessibilityIsSuggestedDeletionAttribute @"AXIsSuggestedDeletion"
+#define NSAccessibilityIsSuggestionAttribute @"AXIsSuggestion"
 
 //
 // Notifications
 //
 
+#define NSAccessibilityActiveElementChangedNotification @"AXActiveElementChanged"
+#define NSAccessibilityAutocorrectionOccurredNotification @"AXAutocorrectionOccurred"
 #define NSAccessibilityCurrentStateChangedNotification @"AXCurrentStateChanged"
+#define NSAccessibilityDRTNotificationNotification @"AXDRTNotification"
 #define NSAccessibilityDraggingDestinationDragAcceptedNotification CFSTR("AXDraggingDestinationDragAccepted")
 #define NSAccessibilityDraggingDestinationDragNotAcceptedNotification CFSTR("AXDraggingDestinationDragNotAccepted")
 #define NSAccessibilityDraggingDestinationDropAllowedNotification CFSTR("AXDraggingDestinationDropAllowed")
 #define NSAccessibilityDraggingDestinationDropNotAllowedNotification CFSTR("AXDraggingDestinationDropNotAllowed")
 #define NSAccessibilityDraggingSourceDragBeganNotification CFSTR("AXDraggingSourceDragBegan")
 #define NSAccessibilityDraggingSourceDragEndedNotification CFSTR("AXDraggingSourceDragEnded")
+#define NSAccessibilityElementBusyChangedNotification @"AXElementBusyChanged"
+#define NSAccessibilityExpandedChangedNotification @"AXExpandedChanged"
+#define NSAccessibilityFocusChangedNotification @"AXFocusChanged"
+#define NSAccessibilityImageOverlayChangedNotification @"AXImageOverlayChanged"
+#define NSAccessibilityInvalidStatusChangedNotification @"AXInvalidStatusChanged"
+#define NSAccessibilityLayoutCompleteNotification @"AXLayoutComplete"
 #define NSAccessibilityLiveRegionChangedNotification @"AXLiveRegionChanged"
 #define NSAccessibilityLiveRegionCreatedNotification @"AXLiveRegionCreated"
+#define NSAccessibilityLoadCompleteNotification @"AXLoadComplete"
+#define NSAccessibilityPressDidFailNotification @"AXPressDidFail"
+#define NSAccessibilityPressDidSucceedNotification @"AXPressDidSucceed"
+#define NSAccessibilitySortDirectionChangedNotification @"AXSortDirectionChanged"
 #define NSAccessibilityTextInputMarkingSessionBeganNotification @"AXTextInputMarkingSessionBegan"
 #define NSAccessibilityTextInputMarkingSessionEndedNotification @"AXTextInputMarkingSessionEnded"
 
@@ -172,6 +325,44 @@
 #define NSAccessibilityTextChangeValueLength @"AXTextChangeValueLength"
 #define NSAccessibilityTextChangeValueStartMarker @"AXTextChangeValueStartMarker"
 #define NSAccessibilityTextChangeElement @"AXTextChangeElement"
+
+//
+// For use with NSAccessibilityMisspellingTextMarkerRangeAttribute
+//
+
+#define NSAccessibilityStartTextMarkerRangeParam @"AXStartTextMarkerRange"
+#define NSAccessibilitySpellCheckParam @"AXSpellCheck"
+
+//
+// For use with NSAccessibilityAttributedStringForTextMarkerRangeWithOptionsAttribute
+//
+
+#define NSAccessibilityTextMarkerRangeParam @"AXTextMarkerRange"
+
+//
+// For use with search predicate parameterized attributes, such as:
+//   NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute
+//   NSAccessibilityRangesForSearchPredicateParameterizedAttribute
+//
+
+#define NSAccessibilitySearchCurrentElementKey @"AXStartElement"
+#define NSAccessibilitySearchCurrentRangeKey @"AXStartRange"
+#define NSAccessibilitySearchDirectionKey @"AXDirection"
+#define NSAccessibilityImmediateDescendantsOnlyKey @"AXImmediateDescendantsOnly"
+#define NSAccessibilitySearchResultsLimitKey @"AXResultsLimit"
+#define NSAccessibilitySearchTextKey @"AXSearchText"
+#define NSAccessibilityVisibleOnlyKey @"AXVisibleOnly"
+#define NSAccessibilitySearchIdentifiersKey @"AXSearchKey"
+
+// Values for NSAccessibilitySearchDirectionKey
+#define NSAccessibilitySearchDirectionNext @"AXDirectionNext"
+
+//
+// Used for the return value from NSAccessibilityRangesForSearchPredicateParameterizedAttribute
+//
+
+#define NSAccessibilitySearchResultElementKey @"AXSearchResultElement"
+#define NSAccessibilitySearchResultRangeKey @"AXSearchResultRange"
 
 //
 // For use with NSAccessibilitySelectTextWithCriteriaParameterizedAttribute
@@ -253,7 +444,7 @@
 #define NSAccessibilityTextOperationSmartReplace @"AXTextOperationSmartReplace"
 
 //
-// Math attributes
+// Math-specific attributes
 //
 
 #define NSAccessibilityMathBaseAttribute @"AXMathBase"

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -236,11 +236,6 @@ using namespace WebCore;
 #define NSAccessibilityVisitedLinkSearchKey @"AXVisitedLinkSearchKey"
 #endif
 
-// Search
-#ifndef NSAccessibilityImmediateDescendantsOnly
-#define NSAccessibilityImmediateDescendantsOnly @"AXImmediateDescendantsOnly"
-#endif
-
 static NSArray *convertMathPairsToNSArray(const AccessibilityObject::AccessibilityMathMultiscriptPairs& pairs, NSString *subscriptKey, NSString *superscriptKey)
 {
     return createNSArray(pairs, [&] (auto& pair) {
@@ -797,7 +792,7 @@ static NSDictionary *dictionaryRemovingNonSupportedTypes(NSDictionary *dictionar
         ASSERT(notificationName);
         userInfo = dictionaryRemovingNonSupportedTypes(userInfo);
         NSDictionary *info = [NSDictionary dictionaryWithObjectsAndKeys:notificationName, @"notificationName", userInfo, @"userInfo", nil];
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"AXDRTNotification" object:self userInfo:info];
+        [[NSNotificationCenter defaultCenter] postNotificationName:NSAccessibilityDRTNotificationNotification object:self userInfo:info];
     }
 }
 
@@ -899,14 +894,14 @@ AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(AXCore
     AccessibilitySearchCriteria criteria;
     criteria.anchorObject = &object;
 
-    WebAccessibilityObjectWrapperBase *startElement = [parameter objectForKey:@"AXStartElement"];
-    id startRange = [parameter objectForKey:@"AXStartRange"];
-    NSString *direction = [parameter objectForKey:@"AXDirection"];
-    NSNumber *immediateDescendantsOnly = [parameter objectForKey:NSAccessibilityImmediateDescendantsOnly];
-    NSNumber *resultsLimit = [parameter objectForKey:@"AXResultsLimit"];
-    NSString *searchText = [parameter objectForKey:@"AXSearchText"];
-    NSNumber *visibleOnly = [parameter objectForKey:@"AXVisibleOnly"];
-    id searchKey = [parameter objectForKey:@"AXSearchKey"];
+    WebAccessibilityObjectWrapperBase *startElement = [parameter objectForKey:NSAccessibilitySearchCurrentElementKey];
+    id startRange = [parameter objectForKey:NSAccessibilitySearchCurrentRangeKey];
+    NSString *direction = [parameter objectForKey:NSAccessibilitySearchDirectionKey];
+    NSNumber *immediateDescendantsOnly = [parameter objectForKey:NSAccessibilityImmediateDescendantsOnlyKey];
+    NSNumber *resultsLimit = [parameter objectForKey:NSAccessibilitySearchResultsLimitKey];
+    NSString *searchText = [parameter objectForKey:NSAccessibilitySearchTextKey];
+    NSNumber *visibleOnly = [parameter objectForKey:NSAccessibilityVisibleOnlyKey];
+    id searchKey = [parameter objectForKey:NSAccessibilitySearchIdentifiersKey];
 
     if ([startElement isKindOfClass:[WebAccessibilityObjectWrapperBase class]])
         criteria.startObject = startElement.axBackingObject;
@@ -926,7 +921,7 @@ AccessibilitySearchCriteria accessibilitySearchCriteriaForSearchPredicate(AXCore
 #endif
 
     if ([direction isKindOfClass:[NSString class]])
-        criteria.searchDirection = [direction isEqualToString:@"AXDirectionNext"] ? AccessibilitySearchDirection::Next : AccessibilitySearchDirection::Previous;
+        criteria.searchDirection = [direction isEqualToString:NSAccessibilitySearchDirectionNext] ? AccessibilitySearchDirection::Next : AccessibilitySearchDirection::Previous;
 
     if ([immediateDescendantsOnly isKindOfClass:[NSNumber class]])
         criteria.immediateDescendantsOnly = [immediateDescendantsOnly boolValue];

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -345,7 +345,7 @@ static AccessibilityTextOperation accessibilityTextOperationForParameterizedAttr
 
 static std::pair<AXTextMarkerRange, AccessibilitySearchDirection> misspellingSearchCriteriaForParameterizedAttribute(const NSDictionary *params)
 {
-    id markerRangeRef = [params objectForKey:@"AXStartTextMarkerRange"];
+    id markerRangeRef = [params objectForKey:NSAccessibilityStartTextMarkerRangeParam];
     if (!AXObjectIsTextMarkerRange(markerRangeRef))
         return { };
 
@@ -545,10 +545,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         [additional addObject:NSAccessibilityBrailleRoleDescriptionAttribute];
 
     if (backingObject->detailedByObjects().size())
-        [additional addObject:@"AXDetailsElements"];
+        [additional addObject:NSAccessibilityDetailsElementsAttribute];
 
     if (backingObject->errorMessageObjects().size())
-        [additional addObject:@"AXErrorMessageElements"];
+        [additional addObject:NSAccessibilityErrorMessageElementsAttribute];
 
     if (!backingObject->keyShortcuts().isEmpty())
         [additional addObject:NSAccessibilityKeyShortcutsAttribute];
@@ -605,7 +605,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         NSAccessibilitySelectedTextMarkerRangeAttribute,
         NSAccessibilityStartTextMarkerAttribute,
         NSAccessibilityEndTextMarkerAttribute,
-        @"AXVisited",
+        NSAccessibilityVisitedAttribute,
         NSAccessibilityLinkedUIElementsAttribute,
         NSAccessibilitySelectedAttribute,
         NSAccessibilityBlockQuoteLevelAttribute,
@@ -653,9 +653,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         [tempArray removeObject:NSAccessibilityFocusableAncestorAttribute];
         [tempArray removeObject:NSAccessibilityEditableAncestorAttribute];
         [tempArray removeObject:NSAccessibilityHighestEditableAncestorAttribute];
-        [tempArray addObject:@"AXLinkUIElements"];
-        [tempArray addObject:@"AXLoaded"];
-        [tempArray addObject:@"AXLayoutCount"];
+        [tempArray addObject:NSAccessibilityLinkUIElementsAttribute];
+        [tempArray addObject:NSAccessibilityLoadedAttribute];
+        [tempArray addObject:NSAccessibilityLayoutCountAttribute];
         [tempArray addObject:NSAccessibilityLoadingProgressAttribute];
         [tempArray addObject:NSAccessibilityURLAttribute];
         [tempArray addObject:NSAccessibilityCaretBrowsingEnabledAttribute];
@@ -783,7 +783,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         [tempArray addObject:NSAccessibilityARIARowCountAttribute];
         [tempArray addObject:NSAccessibilitySelectedCellsAttribute];
         [tempArray addObject:NSAccessibilitySelectedChildrenAttribute];
-        [tempArray addObject:@"AXTableLevel"];
+        [tempArray addObject:NSAccessibilityTableLevelAttribute];
         return tempArray;
     }();
     static NeverDestroyed tableRowAttrs = [] {
@@ -1235,12 +1235,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     if (backingObject->isWebArea()) {
-        if ([attributeName isEqualToString:@"AXLinkUIElements"])
+        if ([attributeName isEqualToString:NSAccessibilityLinkUIElementsAttribute])
             return makeNSArray(backingObject->documentLinks());
 
-        if ([attributeName isEqualToString:@"AXLoaded"])
+        if ([attributeName isEqualToString:NSAccessibilityLoadedAttribute])
             return [NSNumber numberWithBool:backingObject->isLoaded()];
-        if ([attributeName isEqualToString:@"AXLayoutCount"])
+        if ([attributeName isEqualToString:NSAccessibilityLayoutCountAttribute])
             return @(backingObject->layoutCount());
         if ([attributeName isEqualToString:NSAccessibilityLoadingProgressAttribute])
             return @(backingObject->loadingProgress());
@@ -1301,7 +1301,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return decrementButton ? decrementButton->wrapper() : nil;
     }
 
-    if ([attributeName isEqualToString: @"AXVisited"])
+    if ([attributeName isEqualToString: NSAccessibilityVisitedAttribute])
         return [NSNumber numberWithBool: backingObject->isVisited()];
 
     if ([attributeName isEqualToString: NSAccessibilityTitleAttribute]) {
@@ -1348,7 +1348,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         );
     }
 
-    if ([attributeName isEqualToString:@"AXDateTimeComponents"])
+    if ([attributeName isEqualToString:NSAccessibilityDateTimeComponentsAttribute])
         return @(convertToAXFDateTimeComponents(backingObject->dateTimeComponentsType()));
 
     if ([attributeName isEqualToString:(NSString *)kAXMenuItemMarkCharAttribute]) {
@@ -1391,7 +1391,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityPathAttribute])
         return [self path];
 
-    if ([attributeName isEqualToString:@"AXLineRectsAndText"]) {
+    if ([attributeName isEqualToString:NSAccessibilityLineRectsAndTextAttribute]) {
         return Accessibility::retrieveAutoreleasedValueFromMainThread<NSArray *>([protectedSelf = retainPtr(self)] () -> RetainPtr<NSArray> {
             return protectedSelf.get().lineRectsAndText;
         });
@@ -1629,7 +1629,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([attributeName isEqualToString:NSAccessibilityBlockQuoteLevelAttribute])
         return @(backingObject->blockquoteLevel());
-    if ([attributeName isEqualToString:@"AXTableLevel"])
+    if ([attributeName isEqualToString:NSAccessibilityTableLevelAttribute])
         return @(backingObject->tableLevel());
 
     if ([attributeName isEqualToString: NSAccessibilityLinkedUIElementsAttribute])
@@ -1797,11 +1797,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return createNSArray(backingObject->classList()).autorelease();
 
     // This allows us to connect to a plugin that creates a shadow node for editing (like PDFs).
-    if ([attributeName isEqualToString:@"_AXAssociatedPluginParent"])
+    if ([attributeName isEqualToString:NSAccessibilityAssociatedPluginParentAttribute])
         return [self _associatedPluginParentWith:backingObject];
 
     // This used to be a testing-only attribute, but unfortunately some ATs do actually request it.
-    if ([attributeName isEqualToString:@"AXDRTSpeechAttribute"])
+    if ([attributeName isEqualToString:NSAccessibilityDRTSpeechAttributeAttribute])
         return [self baseAccessibilitySpeechHint];
 
     if ([attributeName isEqualToString:NSAccessibilityPopupValueAttribute])
@@ -1816,13 +1816,13 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityHasWebApplicationAncestorAttribute])
         return [NSNumber numberWithBool:backingObject->hasWebApplicationAncestor()];
 
-    if ([attributeName isEqualToString:@"AXIsInDescriptionListDetail"])
+    if ([attributeName isEqualToString:NSAccessibilityIsInDescriptionListDetailAttribute])
         return [NSNumber numberWithBool:backingObject->isInDescriptionListDetail()];
 
-    if ([attributeName isEqualToString:@"AXIsInDescriptionListTerm"])
+    if ([attributeName isEqualToString:NSAccessibilityIsInDescriptionListTermAttribute])
         return [NSNumber numberWithBool:backingObject->isInDescriptionListTerm()];
 
-    if ([attributeName isEqualToString:@"AXDetailsElements"])
+    if ([attributeName isEqualToString:NSAccessibilityDetailsElementsAttribute])
         return makeNSArray(backingObject->detailedByObjects());
 
     if ([attributeName isEqualToString:NSAccessibilityBrailleLabelAttribute])
@@ -1834,7 +1834,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attributeName isEqualToString:NSAccessibilityRelativeFrameAttribute])
         return [NSValue valueWithRect:(NSRect)backingObject->relativeFrame()];
 
-    if ([attributeName isEqualToString:@"AXErrorMessageElements"]) {
+    if ([attributeName isEqualToString:NSAccessibilityErrorMessageElementsAttribute]) {
         // Only expose error messages for objects in an invalid state.
         // https://www.w3.org/TR/wai-aria-1.2/#aria-errormessage
         if (backingObject->invalidStatus() == "false"_s)
@@ -1869,7 +1869,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     }
 
     // VoiceOver property to ignore certain groups.
-    if ([attributeName isEqualToString:@"AXAutoInteractable"])
+    if ([attributeName isEqualToString:NSAccessibilityAutoInteractableAttribute])
         return @(backingObject->isRemoteFrame());
 
     if (AXObjectCache::clientIsInTestMode())
@@ -1881,80 +1881,80 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
 {
     ASSERT_WITH_MESSAGE(AXObjectCache::clientIsInTestMode(), "Should be used for testing only, not for AT clients.");
 
-    if ([attributeName isEqualToString:@"AXARIARole"])
+    if ([attributeName isEqualToString:NSAccessibilityARIARoleAttribute])
         return backingObject->computedRoleString();
 
-    if ([attributeName isEqualToString:@"AXStringValue"])
+    if ([attributeName isEqualToString:NSAccessibilityStringValueAttribute])
         return backingObject->stringValue();
 
-    if ([attributeName isEqualToString:@"AXDateTimeComponentsType"])
+    if ([attributeName isEqualToString:NSAccessibilityDateTimeComponentsTypeAttribute])
         return [NSNumber numberWithUnsignedShort:(uint8_t)backingObject->dateTimeComponentsType()];
 
-    if ([attributeName isEqualToString:@"AXControllers"])
+    if ([attributeName isEqualToString:NSAccessibilityControllersAttribute])
         return makeNSArray(backingObject->controllers());
 
-    if ([attributeName isEqualToString:@"AXControllerFor"])
+    if ([attributeName isEqualToString:NSAccessibilityControllerForAttribute])
         return makeNSArray(backingObject->controlledObjects());
 
-    if ([attributeName isEqualToString:@"AXDescribedBy"])
+    if ([attributeName isEqualToString:NSAccessibilityDescribedByAttribute])
         return makeNSArray(backingObject->describedByObjects());
 
-    if ([attributeName isEqualToString:@"AXDescriptionFor"])
+    if ([attributeName isEqualToString:NSAccessibilityDescriptionForAttribute])
         return makeNSArray(backingObject->descriptionForObjects());
 
-    if ([attributeName isEqualToString:@"AXDetailsFor"])
+    if ([attributeName isEqualToString:NSAccessibilityDetailsForAttribute])
         return makeNSArray(backingObject->detailsForObjects());
 
-    if ([attributeName isEqualToString:@"AXErrorMessageFor"])
+    if ([attributeName isEqualToString:NSAccessibilityErrorMessageForAttribute])
         return makeNSArray(backingObject->errorMessageForObjects());
 
-    if ([attributeName isEqualToString:@"AXFlowFrom"])
+    if ([attributeName isEqualToString:NSAccessibilityFlowFromAttribute])
         return makeNSArray(backingObject->flowFromObjects());
 
-    if ([attributeName isEqualToString:@"AXFlowTo"])
+    if ([attributeName isEqualToString:NSAccessibilityFlowToAttribute])
         return makeNSArray(backingObject->flowToObjects());
 
-    if ([attributeName isEqualToString:@"AXLabelledBy"])
+    if ([attributeName isEqualToString:NSAccessibilityLabelledByAttribute])
         return makeNSArray(backingObject->labeledByObjects());
 
-    if ([attributeName isEqualToString:@"AXLabelFor"])
+    if ([attributeName isEqualToString:NSAccessibilityLabelForAttribute])
         return makeNSArray(backingObject->labelForObjects());
 
-    if ([attributeName isEqualToString:@"AXOwners"])
+    if ([attributeName isEqualToString:NSAccessibilityOwnersAttribute])
         return makeNSArray(backingObject->owners());
 
-    if ([attributeName isEqualToString:@"AXIsInCell"])
+    if ([attributeName isEqualToString:NSAccessibilityIsInCellAttribute])
         return [NSNumber numberWithBool:backingObject->isInCell()];
 
-    if ([attributeName isEqualToString:@"AXARIAPressedIsPresent"])
+    if ([attributeName isEqualToString:NSAccessibilityARIAPressedIsPresentAttribute])
         return [NSNumber numberWithBool:backingObject->pressedIsPresent()];
 
-    if ([attributeName isEqualToString:@"AXAutocompleteValue"])
+    if ([attributeName isEqualToString:NSAccessibilityAutocompleteValueAttribute])
         return backingObject->autoCompleteValue();
 
-    if ([attributeName isEqualToString:@"AXClickPoint"])
+    if ([attributeName isEqualToString:NSAccessibilityClickPointAttribute])
         return [NSValue valueWithPoint:backingObject->clickPoint()];
 
-    if ([attributeName isEqualToString:@"AXIsIndeterminate"])
+    if ([attributeName isEqualToString:NSAccessibilityIsIndeterminateAttribute])
         return [NSNumber numberWithBool:backingObject->isIndeterminate()];
 
-    if ([attributeName isEqualToString:@"AXIsMultiSelectable"])
+    if ([attributeName isEqualToString:NSAccessibilityIsMultiSelectableAttribute])
         return [NSNumber numberWithBool:backingObject->isMultiSelectable()];
 
-    if ([attributeName isEqualToString:@"AXIsOnScreen"])
+    if ([attributeName isEqualToString:NSAccessibilityIsOnScreenAttribute])
         return [NSNumber numberWithBool:backingObject->isOnScreen()];
 
-    if ([attributeName isEqualToString:@"_AXIsInTable"]) {
+    if ([attributeName isEqualToString:NSAccessibilityIsInTableAttribute]) {
         auto* table = Accessibility::findAncestor(*backingObject, false, [&] (const auto& ancestor) {
             return ancestor.isTable();
         });
         return [NSNumber numberWithBool:!!table];
     }
 
-    if ([attributeName isEqualToString:@"AXIsRemoteFrame"])
+    if ([attributeName isEqualToString:NSAccessibilityIsRemoteFrameAttribute])
         return [NSNumber numberWithBool:backingObject->isRemoteFrame()];
 
-    if ([attributeName isEqualToString:@"AXInfoStringForTesting"])
+    if ([attributeName isEqualToString:NSAccessibilityInfoStringForTestingAttribute])
         return backingObject->infoStringForTesting();
 
     return nil;
@@ -1978,10 +1978,10 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
     else
         return nil;
 
-    if ([attribute isEqualToString:@"AXTextMarkerIsNull"])
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerIsNullParameterizedAttribute])
         return [NSNumber numberWithBool:AXTextMarker(markerRef).isNull()];
 
-    if ([attribute isEqualToString:@"AXTextMarkerRangeIsValid"]) {
+    if ([attribute isEqualToString:NSAccessibilityTextMarkerRangeIsValidParameterizedAttribute]) {
         AXTextMarkerRange markerRange { markerRangeRef };
         return [NSNumber numberWithBool:markerRange.start().isValid() && markerRange.end().isValid()];
     }
@@ -2114,7 +2114,7 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
         }
     } else {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        callback([hitTestResult accessibilityAttributeValue:@"AXInfoStringForTesting"]);
+        callback([hitTestResult accessibilityAttributeValue:NSAccessibilityInfoStringForTestingAttribute]);
         ALLOW_DEPRECATED_DECLARATIONS_END
     }
 }
@@ -2430,13 +2430,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
     if ([action isEqualToString:NSAccessibilityPressAction])
         [self accessibilityPerformPressAction];
-    else if ([action isEqualToString:@"AXSyncPressAction"]) {
+    else if ([action isEqualToString:NSAccessibilitySyncPressAction]) {
         // Used in layout tests, so that we don't have to wait for the async press action.
         [self _accessibilityPerformPressAction];
-    }
-    else if ([action isEqualToString:@"AXSyncIncrementAction"])
+    } else if ([action isEqualToString:NSAccessibilitySyncIncrementAction])
         [self _accessibilityPerformIncrementAction];
-    else if ([action isEqualToString:@"AXSyncDecrementAction"])
+    else if ([action isEqualToString:NSAccessibilitySyncDecrementAction])
         [self _accessibilityPerformDecrementAction];
     else if ([action isEqualToString:NSAccessibilityShowMenuAction])
         [self accessibilityPerformShowMenuAction];
@@ -2446,7 +2445,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         [self accessibilityPerformDecrementAction];
     else if ([action isEqualToString:NSAccessibilityScrollToVisibleAction])
         [self accessibilityScrollToVisible];
-    else if ([action isEqualToString:@"AXDismissAction"])
+    else if ([action isEqualToString:NSAccessibilityDismissAction])
         backingObject->performDismissActionIgnoringResult();
     else if (AXObjectCache::clientIsInTestMode() && [action isEqualToString:@"AXLogTrees"])
         [self _accessibilityPrintTrees];
@@ -2995,7 +2994,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         return createNSArray(operationResult).autorelease();
     }
 
-    if ([attribute isEqualToString:@"AXRangesForSearchPredicate"]) {
+    if ([attribute isEqualToString:NSAccessibilityRangesForSearchPredicateParameterizedAttribute]) {
         auto criteria = accessibilitySearchCriteriaForSearchPredicate(*backingObject, dictionary);
         if (criteria.searchKeys.size() == 1 && criteria.searchKeys[0] == AccessibilitySearchKey::MisspelledWord) {
             // Request for the next/previous misspelling.
@@ -3008,8 +3007,8 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
                 return nil;
 
             RetainPtr result = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:
-                object->wrapper(), @"AXSearchResultElement",
-                textMarkerRange->platformData().bridgingAutorelease(), @"AXSearchResultRange",
+                object->wrapper(), NSAccessibilitySearchResultElementKey,
+                textMarkerRange->platformData().bridgingAutorelease(), NSAccessibilitySearchResultRangeKey,
                 nil]);
             return [[[NSArray alloc] initWithObjects:result.get(), nil] autorelease];
         }
@@ -3331,12 +3330,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
         if (dictionary) {
             AXTextMarkerRangeRef textMarkerRange = nil;
-            id parameter = [dictionary objectForKey:@"AXTextMarkerRange"];
+            id parameter = [dictionary objectForKey:NSAccessibilityTextMarkerRangeParam];
             if (AXObjectIsTextMarkerRange(parameter))
                 textMarkerRange = (AXTextMarkerRangeRef)parameter;
 
             auto spellCheck = AXCoreObject::SpellCheck::No;
-            parameter = [dictionary objectForKey:@"AXSpellCheck"];
+            parameter = [dictionary objectForKey:NSAccessibilitySpellCheckParam];
             if ([parameter isKindOfClass:[NSNumber class]] && [parameter boolValue])
                 spellCheck = AXCoreObject::SpellCheck::Yes;
             return attributedStringForTextMarkerRange(*backingObject, textMarkerRange, spellCheck);


### PR DESCRIPTION
#### 7bfcab80374a45e733ed06eef88d59716d451683
<pre>
AX: use constants for accessibility APIs rather than hardcoding strings into the code
<a href="https://bugs.webkit.org/show_bug.cgi?id=287486">https://bugs.webkit.org/show_bug.cgi?id=287486</a>
<a href="https://rdar.apple.com/144621410">rdar://144621410</a>

Reviewed by Tyler Wilcock.

Replace hardcoded strings of the form @&quot;AX...&quot; with constants defined in CocoaAccessibilityConstants.h

* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::attributedStringSetFont):
(WebCore::AXCoreObject::createAttributedString const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::postPlatformNotification):
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):
(WebCore::AccessibilityObject::rolePlatformDescription const):
(WebCore::Accessibility::createPlatformRoleMap):
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase accessibilityPostedNotification:userInfo:]):
(accessibilitySearchCriteriaForSearchPredicate):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(misspellingSearchCriteriaForParameterizedAttribute):
(-[WebAccessibilityObjectWrapper _additionalAccessibilityAttributeNames:]):
(-[WebAccessibilityObjectWrapper ALLOW_DEPRECATED_IMPLEMENTATIONS_END]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:]):
(attributeValueForTesting):
(parameterizedAttributeValueForTesting):
(-[WebAccessibilityObjectWrapper _accessibilityHitTestResolvingRemoteFrame:callback:]):
(-[WebAccessibilityObjectWrapper accessibilityPerformAction:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):

Canonical link: <a href="https://commits.webkit.org/290342@main">https://commits.webkit.org/290342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60c509a348ca0e48ebb9cdc2b15e9f5361104ecf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9483 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68988 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26640 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49353 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7014 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35759 "Found 2 new test failures: media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39440 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16749 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12301 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77874 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17004 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77175 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19080 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9916 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22076 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19954 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->