### PR TITLE
[WGSL] @size should only be allowed on members with creation-fixed footprint

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/repro_144542199-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/repro_144542199-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/repro_144542199.html
+++ b/LayoutTests/fast/webgpu/nocrash/repro_144542199.html
@@ -1,0 +1,160 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+// START
+adapter0 = await navigator.gpu.requestAdapter();
+device0 = await adapter0.requestDevice();
+veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage', hasDynamicOffset : false}},
+]});
+buffer2 = device0.createBuffer({
+  size : 23908,
+  usage :
+      GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM
+});
+pipelineLayout1 = device0.createPipelineLayout(
+    {bindGroupLayouts : [ veryExplicitBindGroupLayout0 ]});
+
+    videoFrame0 = new VideoFrame(new ArrayBuffer(16), {
+  codedWidth : 2,
+  codedHeight : 2,
+  format : 'BGRA',
+  timestamp : 0,
+  colorSpace : {}
+});
+shaderModule0 = device0.createShaderModule({
+  code : ` requires unrestricted_pointer_parameters;
+              fn unconst_u32(v: u32) -> u32 {
+            return v;
+            }
+              struct FragmentOutput0 {
+              @align(8) @size(160) f0: array<bool>}
+              fn unconst_i32(v: i32) -> i32 {
+            return v;
+            }
+              @group(0) @binding(0) var<storage, read_write> buffer11: T7;
+              var<private> vp0: bool = bool();
+              var<workgroup> vw0: vec4i;
+              struct T3 {
+              @align(32) @size(160) f0: atomic<u32>}
+              struct T7 {
+              @size(96) f0: atomic<u32>,   @align(32) @size(64) f1: array<u32>}
+              fn unconst_f16(v: f16) -> f16 {
+            return v;
+            }
+
+              struct T2 {
+              @size(160) f0: array<atomic<i32>, 3>}
+              fn unconst_f32(v: f32) -> f32 {
+            return v;
+            }
+              @must_use  fn fn0(a0: ptr<storage, array<u32>, read_write>, a1: array<array<array<bool, 1>, 1>, 13>) -> array<array<i32, 1>, 3> {
+              var out: array<array<i32, 1>, 3>;
+              var vf0bool = a1[12][u32(a1[unconst_u32(263193016)][unconst_u32(138045565)][0])][unconst_u32(2604852460)];
+              (*a0)[(1404641704)] = (*a0)[arrayLength(&(*a0))];
+              return out;
+            }
+              
+              @compute @workgroup_size(6, 1, 1) fn compute0() {
+              _ = fn0(&(*&buffer11).f1, array(array(array(bool(vw0[0]))), array(array(bool(vw0[2]))), array(array(bool(vw0[2]))), array(array(bool(vw0[3]))), array(array(bool(vw0[1]))), array(array(bool(vw0.w))), array(array(bool(vw0.y))), array(array(bool(vw0.a))), array(array(bool(vw0[3]))), array(array(bool(vw0[2]))), array(array(bool(vw0[1]))), array(array(bool(vw0[3]))), array(array(bool(vw0[2])))));
+            }
+             `,
+});
+
+let commandEncoder29 = device0.createCommandEncoder();
+let computePassEncoder25 = commandEncoder29.beginComputePass();
+try {
+} catch {
+}
+let externalTexture1 = device0.importExternalTexture({source : videoFrame0});
+let pipeline7 = device0.createComputePipeline(
+    {layout : pipelineLayout1, compute : {module : shaderModule0}});
+try {
+  computePassEncoder25.setPipeline(pipeline7);
+} catch {
+}
+let bindGroup23 = device0.createBindGroup({
+  layout : veryExplicitBindGroupLayout0,
+  entries : [
+    {binding : 0, resource : {buffer : buffer2}},
+  ],
+});
+try {
+  computePassEncoder25.setBindGroup(0, bindGroup23);
+} catch {
+}
+try {
+  computePassEncoder25.dispatchWorkgroups(1);
+  computePassEncoder25.end();
+} catch {
+}
+let commandBuffer1 = commandEncoder29.finish();
+try {
+  device0.queue.submit([ commandBuffer1 ]);
+} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -406,8 +406,13 @@ void AttributeValidator::visit(AST::StructureMember& member)
             continue;
 
         if (auto* sizeAttribute = dynamicDowncast<AST::SizeAttribute>(attribute)) {
-            // FIXME: check that the member type must have creation-fixed footprint.
             m_hasSizeOrAlignmentAttributes = true;
+
+            if (!member.type().inferredType()->hasCreationFixedFootprint()) {
+                error(attribute.span(), "@size can only be applied to members that have a type with a size that is fully determined at shader creation time."_s);
+                continue;
+            }
+
             // https://gpuweb.github.io/cts/standalone/?q=webgpu:shader,validation,parse,attribute:expressions:value=%22override%22;*
             auto& constantValue = sizeAttribute->size().constantValue();
             if (!constantValue) {


### PR DESCRIPTION
#### 1a858a70092a0da3e01de5109e57f2fd53c80c9f
<pre>
[WGSL] @size should only be allowed on members with creation-fixed footprint
<a href="https://bugs.webkit.org/show_bug.cgi?id=287487">https://bugs.webkit.org/show_bug.cgi?id=287487</a>
<a href="https://rdar.apple.com/144542199">rdar://144542199</a>

Reviewed by Mike Wyrzykowski.

A check was missing in AttributeValidator that the member @size was applied to
must have creation-fixed footprint [1].

[1]: <a href="https://www.w3.org/TR/WGSL/#size-attr">https://www.w3.org/TR/WGSL/#size-attr</a>

* LayoutTests/fast/webgpu/nocrash/repro_144542199-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/repro_144542199.html: Added.
* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):

Canonical link: <a href="https://commits.webkit.org/290275@main">https://commits.webkit.org/290275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10752b14e134180cf3cf898582f5f0b66bdf6533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40093 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68824 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81088 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49184 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/88833 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35473 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39200 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77203 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96147 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16512 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12131 "Found 60 new test failures: animations/3d/animate-to-transform-perpective-to-none.html fast/forms/single-line-text-with-line-height.html fast/scrolling/latching/scroll-div-no-latching.html fast/text/emoji-gender-fe0f-6.html fast/writing-mode/logical-height-after-clear.html http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77698 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76879 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/76997 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19032 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21429 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20032 "Found 6 new test failures: http/tests/webarchive/cross-origin-stylesheet-crash.html http/tests/webarchive/test-css-url-encoding-shift-jis.html http/tests/webarchive/test-css-url-encoding-utf-8.html http/tests/webarchive/test-css-url-encoding.html http/tests/webarchive/test-preload-resources.html media/media-vp8-hiddenframes.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->