### PR TITLE
Make network process wait web processes to exit before deleting data

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -49,7 +49,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
     DestroySession(PAL::SessionID sessionID) -> ()
 
     FetchWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, OptionSet<WebKit::WebsiteDataFetchOption> fetchOptions) -> (struct WebKit::WebsiteData websiteData)
-    DeleteWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, WallTime modifiedSince) -> ()
+    DeleteWebsiteData(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, WallTime modifiedSince, HashSet<WebCore::ProcessIdentifier> activeWebProcesses) -> ()
     DeleteWebsiteDataForOrigins(PAL::SessionID sessionID, OptionSet<WebKit::WebsiteDataType> websiteDataTypes, Vector<WebCore::SecurityOriginData> origins, Vector<String> cookieHostNames, Vector<String> HSTSCacheHostNames, Vector<WebCore::RegistrableDomain> registrableDomains) -> ()
     RenameOriginInWebsiteData(PAL::SessionID sessionID, WebCore::SecurityOriginData oldOrigin, WebCore::SecurityOriginData newOrigin, OptionSet<WebKit::WebsiteDataType> websiteDataTypes) -> ()
     WebsiteDataOriginDirectoryForTesting(PAL::SessionID sessionID, struct WebCore::ClientOrigin origin, OptionSet<WebKit::WebsiteDataType> websiteDataType) -> (String directory)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -432,9 +432,9 @@ void NetworkProcessProxy::fetchWebsiteData(PAL::SessionID sessionID, OptionSet<W
     sendWithAsyncReply(Messages::NetworkProcess::FetchWebsiteData(sessionID, dataTypes, fetchOptions), WTFMove(completionHandler));
 }
 
-void NetworkProcessProxy::deleteWebsiteData(PAL::SessionID sessionID, OptionSet<WebsiteDataType> dataTypes, WallTime modifiedSince, CompletionHandler<void()>&& completionHandler)
+void NetworkProcessProxy::deleteWebsiteData(PAL::SessionID sessionID, OptionSet<WebsiteDataType> dataTypes, WallTime modifiedSince, const HashSet<WebCore::ProcessIdentifier>& identifiers, CompletionHandler<void()>&& completionHandler)
 {
-    sendWithAsyncReply(Messages::NetworkProcess::DeleteWebsiteData(sessionID, dataTypes, modifiedSince), WTFMove(completionHandler));
+    sendWithAsyncReply(Messages::NetworkProcess::DeleteWebsiteData(sessionID, dataTypes, modifiedSince, identifiers), WTFMove(completionHandler));
 }
 
 void NetworkProcessProxy::deleteWebsiteDataForOrigins(PAL::SessionID sessionID, OptionSet<WebsiteDataType> dataTypes, const Vector<WebCore::SecurityOriginData>& origins, const Vector<String>& cookieHostNames, const Vector<String>& HSTSCacheHostNames, const Vector<RegistrableDomain>& registrableDomains, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -143,7 +143,7 @@ public:
     void addAllowedFirstPartyForCookies(WebProcessProxy&, const WebCore::RegistrableDomain& firstPartyForCookies, LoadedWebArchive, CompletionHandler<void()>&&);
 
     void fetchWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, CompletionHandler<void(WebsiteData)>&&);
-    void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, CompletionHandler<void()>&& completionHandler);
+    void deleteWebsiteData(PAL::SessionID, OptionSet<WebsiteDataType>, WallTime modifiedSince, const HashSet<WebCore::ProcessIdentifier>&, CompletionHandler<void()>&&);
     void deleteWebsiteDataForOrigins(PAL::SessionID, OptionSet<WebKit::WebsiteDataType>, const Vector<WebCore::SecurityOriginData>& origins, const Vector<String>& cookieHostNames, const Vector<String>& HSTSCacheHostNames, const Vector<RegistrableDomain>&, CompletionHandler<void()>&&);
     void renameOriginInWebsiteData(PAL::SessionID, const WebCore::SecurityOriginData&, const WebCore::SecurityOriginData&, OptionSet<WebsiteDataType>, CompletionHandler<void()>&&);
     void websiteDataOriginDirectoryForTesting(PAL::SessionID, WebCore::ClientOrigin&&, OptionSet<WebsiteDataType>, CompletionHandler<void(const String&)>&&);

--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -82,6 +82,14 @@ bool WebProcessCache::canCacheProcess(WebProcessProxy& process) const
         return false;
     }
 
+    if (RefPtr websiteDataStore = process.websiteDataStore()) {
+        // Network process might wait for this web process to exit before clearing data.
+        if (websiteDataStore->isRemovingData()) {
+            WEBPROCESSCACHE_RELEASE_LOG("canCacheProcess: Not caching process because its website data store is removing data", process.processID());
+            return false;
+        }
+    }
+
     if (MemoryPressureHandler::singleton().isUnderMemoryPressure()) {
         WEBPROCESSCACHE_RELEASE_LOG("canCacheProcess: Not caching process because we are under memory pressure", process.processID());
         return false;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -680,7 +680,7 @@ void WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess(Remo
     }
 
     // Prioritize the requesting WebProcess for running the service worker.
-    if (!remoteWorkerProcessProxy && !s_useSeparateServiceWorkerProcess && requestingProcess) {
+    if (!remoteWorkerProcessProxy && !s_useSeparateServiceWorkerProcess && requestingProcess && requestingProcess->state() != WebProcessProxy::State::Terminated) {
         if (requestingProcess->websiteDataStore() == websiteDataStore && requestingProcess->site() == site)
             useProcessForRemoteWorkers(*requestingProcess);
     }
@@ -1657,6 +1657,18 @@ void WebProcessPool::terminateAllWebContentProcesses(ProcessTerminationReason re
     Vector<Ref<WebProcessProxy>> processes = m_processes;
     for (Ref process : processes)
         process->requestTermination(reason);
+}
+
+void WebProcessPool::terminateServiceWorkersForSession(PAL::SessionID sessionID)
+{
+    Ref protectedThis { *this };
+    Vector<Ref<WebProcessProxy>> serviceWorkerProcesses;
+    remoteWorkerProcesses().forEach([&](auto& process) {
+        if (process.isRunningServiceWorkers() && process.sessionID() == sessionID)
+            serviceWorkerProcesses.append(process);
+    });
+    for (Ref serviceWorkerProcess : serviceWorkerProcesses)
+        serviceWorkerProcess->disableRemoteWorkers(RemoteWorkerType::ServiceWorker);
 }
 
 void WebProcessPool::terminateServiceWorkers()

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -335,6 +335,7 @@ public:
     void sendNetworkProcessPrepareToSuspendForTesting(CompletionHandler<void()>&&);
     void sendNetworkProcessWillSuspendImminentlyForTesting();
     void sendNetworkProcessDidResume();
+    void terminateServiceWorkersForSession(PAL::SessionID);
     void terminateServiceWorkers();
 
     void setShouldMakeNextWebProcessLaunchFailForTesting(bool value) { m_shouldMakeNextWebProcessLaunchFailForTesting = value; }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1547,6 +1547,10 @@ void WebProcess::deleteWebsiteData(OptionSet<WebsiteDataType> websiteDataTypes, 
 
         CrossOriginPreflightResultCache::singleton().clear();
     }
+
+    if (websiteDataTypes.contains(WebsiteDataType::ResourceLoadStatistics))
+        clearResourceLoadStatistics();
+
     completionHandler();
 }
 


### PR DESCRIPTION
#### 77fc477a6eedabe4679b2f88496e837673b901e3
<pre>
Make network process wait web processes to exit before deleting data
<a href="https://bugs.webkit.org/show_bug.cgi?id=287491">https://bugs.webkit.org/show_bug.cgi?id=287491</a>
<a href="https://rdar.apple.com/144626633">rdar://144626633</a>

Reviewed by Chris Dumez.

In the case where clients close all web views before deleting website data, sometimes they notice data still exists in
next fetch. This is not because data is not removed, but data is populated after deletion, as the current implementation
does not wait until pages to fully close (and network requests to finish) before deletion. To fix this, now we make
network process wait web processes to exit before it deletes data. This is implemented by making UI process include
active web process identifiers in the delete data request sent to network process. For web process that&apos;s not active,
network process will wait for them to exit before starting deletion. To avoid waiting indefinitely, the wait will time
out after 3s and deletion will start anyways.

Also, to ensure inactive web processes (process that has no active page) will exit, during the website data deletion
process, UI process kill service worker processes, clear web process cache and disable web process cache.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::removeNetworkConnectionToWebProcess):
(WebKit::NetworkProcess::performDeleteWebsiteDataTask):
(WebKit::NetworkProcess::deleteWebsiteData):
(WebKit::NetworkProcess::deleteWebsiteDataImpl):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::deleteWebsiteData):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::canCacheProcess const):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::establishRemoteWorkerContextConnectionToNetworkProcess):
(WebKit::WebProcessPool::terminateServiceWorkersForSession):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::computeWebProcessAccessTypeForDataRemoval):
(WebKit::computeWebProcessAccessTypeForDataRemovalWithRecords):
(WebKit::WebsiteDataStore::activeWebProcesses const):
(WebKit::WebsiteDataStore::removeDataInNetworkProcess):
(WebKit::WebsiteDataStore::removeData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::isRemovingData const):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::deleteWebsiteData):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::log):
(TestWebKitAPI::installServiceWorker):
(TestWebKitAPI::addEventListener):
(TestWebKitAPI::(WKWebsiteDataStore, RemoveDataWaitUntilWebProcessesExit)):
(TestWebKitAPI::TEST(WKWebsiteDataStore, FetchNonPersistentCredentials)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, FetchPersistentCredentials)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, RemoveNonPersistentCredentials)): Deleted.
(TestWebKitAPI::TEST(WebKit, SettingNonPersistentDataStorePathsThrowsException)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, FetchPersistentWebStorage)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, FetchNonPersistentWebStorage)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, SessionSetCount)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, ReferenceCycle)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, ClearCustomDataStoreNoWebViews)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, DoNotCreateDefaultDataStore)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, DefaultHSTSStorageDirectory)): Deleted.
(TestWebKitAPI::createWebsiteDataStoreAndPrepare): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, DataStoreWithIdentifierAndPushPartition)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifier)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierRemoveCredentials)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, RemoveDataStoreWithIdentifierErrorWhenInUse)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, ListIdentifiers)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStorePrivate, FetchWithSize)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, DataStoreForNilIdentifier)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, DataStoreForEmptyIdentifier)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatio)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, OriginQuotaRatioInvalidValue)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatio)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithResourceLoadStatisticsEnabled)): Deleted.
(TestWebKitAPI::htmlStringForTotalQuotaRatioTest): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioWithPersistedDomain)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, TotalQuotaRatioInvalidValue)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, QuotaRatioDefaultValue)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStoreConfiguration, StandardVolumeCapacity)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStorePrivate, CompletionHandlerForRemovalFromNetworkProcess)): Deleted.
(TestWebKitAPI::TEST(WKWebsiteDataStore, DoNotLogNetworkConnectionsInEphemeralSessions)): Deleted.

Canonical link: <a href="https://commits.webkit.org/290386@main">https://commits.webkit.org/290386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee0b71c58807e94b8513ca68578b982b555e1178

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89787 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94809 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91839 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69160 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26773 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7163 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39693 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96610 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16974 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12462 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78053 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77341 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19102 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21777 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10151 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22306 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16726 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20178 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18509 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->