### PR TITLE
Web Extension icon errors are duplicated in errors array.

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm
@@ -292,7 +292,7 @@ void WebExtension::recordError(Ref<API::Error> error)
 
     // Only the first occurrence of each error is recorded in the array. This prevents duplicate errors,
     // such as repeated "resource not found" errors, from being included multiple times.
-    if (m_errors.contains(error))
+    if (m_errors.containsIf([&](auto& existingError) { return existingError->localizedDescription() == error->localizedDescription(); }))
         return;
 
     [wrapper() willChangeValueForKey:@"errors"];

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.cpp
@@ -1930,7 +1930,7 @@ RefPtr<WebCore::Icon> WebExtension::actionIcon(WebCore::FloatSize size)
 
         if (RefPtr result = bestIconForManifestKey(*actionObject, defaultIconManifestKey, size, m_actionIconsCache, Error::InvalidActionIcon, localizedErrorDescription))
             return result;
-        }
+    }
 
     return icon(size);
 }


### PR DESCRIPTION
#### b83c037519e94862ad4f0f39c85cfc8c2b17f8b1
<pre>
Web Extension icon errors are duplicated in errors array.
<a href="https://webkit.org/b/287497">https://webkit.org/b/287497</a>
<a href="https://rdar.apple.com/144623162">rdar://144623162</a>

Reviewed by Brian Weinstein.

Correct how duplicate errors are avoided now that they are stored in a Vector
of API::Error objects and not an NSArray of NSError objects.

Added a regression test.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionCocoa.mm:
(WebKit::WebExtension::recordError): Compare descriptions.
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::actionIcon): Drive-by whitespace fix.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtension.mm:
(TestWebKitAPI::TEST(WKWebExtension, IconErrorsOnce)): Added.

Canonical link: <a href="https://commits.webkit.org/290269@main">https://commits.webkit.org/290269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f46174829207b16ebf8c63b3e7ebb1be2f994834

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44192 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91404 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68839 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26514 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49200 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6855 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35485 "Found 4 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39221 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96168 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77711 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16789 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76892 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77012 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9684 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14031 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16547 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21858 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16288 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19739 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->