### PR TITLE
Non-unified build fixes: SerializationContext edition

### DIFF
--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -24,6 +24,7 @@
 
 #include "CSSLayerBlockRule.h"
 #include "CSSMarkup.h"
+#include "CSSSerializationContext.h"
 #include "CSSStyleSheet.h"
 #include "MediaList.h"
 #include "MediaQueryParser.h"

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -44,6 +44,7 @@
 #include "CSSParser.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserOptions.h"
+#include "CSSSerializationContext.h"
 #include "CalculationCategory.h"
 #include "CalculationValue.h"
 #include "Logging.h"

--- a/Source/WebCore/dom/SpatialBackdropSource.cpp
+++ b/Source/WebCore/dom/SpatialBackdropSource.cpp
@@ -17,8 +17,9 @@
  * Boston, MA 02110-1301, USA.
  */
 
-#if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
 #include "config.h"
+
+#if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
 #include "SpatialBackdropSource.h"
 
 namespace WebCore {

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
+#include "BoxExtents.h"
 #include "EventTrackingRegions.h"
 #include "FrameIdentifier.h"
 #include "LayerHostingContextIdentifier.h"

--- a/Source/WebCore/style/values/color/StyleCurrentColor.cpp
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "StyleCurrentColor.h"
 
+#include "CSSSerializationContext.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/values/color/StyleCurrentColor.h
+++ b/Source/WebCore/style/values/color/StyleCurrentColor.h
@@ -29,6 +29,11 @@
 #include <wtf/Forward.h>
 
 namespace WebCore {
+
+namespace CSS {
+struct SerializationContext;
+}
+
 namespace Style {
 
 struct CurrentColor {


### PR DESCRIPTION
#### 183f726261eb29a69953ca00cda8ad88b99a083c
<pre>
Non-unified build fixes: SerializationContext edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=287499">https://bugs.webkit.org/show_bug.cgi?id=287499</a>

Unreviewed build fix.

Missing the CSSSerializationContext includes and a drive-by
BoxExtents missing include.

* Source/WebCore/css/CSSImportRule.cpp:
* Source/WebCore/css/calc/CSSCalcValue.cpp:
* Source/WebCore/dom/SpatialBackdropSource.cpp:
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/style/values/color/StyleCurrentColor.cpp:
* Source/WebCore/style/values/color/StyleCurrentColor.h:

Canonical link: <a href="https://commits.webkit.org/290238@main">https://commits.webkit.org/290238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd8518f728931912e24995290c0c7640241cf4cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9268 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17158 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26509 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49212 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35486 "Found 4 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html svg/as-image/img-preserveAspectRatio-support-2.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39224 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96171 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16536 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77718 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77019 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21444 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9687 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16550 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16291 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19742 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18072 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->