### PR TITLE
Address some of the Safer CPP warnings in DNSResolveQueueCFNet.cpp

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		465F34932CD824AF000963B1 /* ObjCRuntimeExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */; };
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
+		468EAFD42D5B1E37005069CF /* SocketPOSIX.h in Headers */ = {isa = PBXBuildFile; fileRef = 468EAFD32D5B1E37005069CF /* SocketPOSIX.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B4C53C2D4F2D0A00BAA3FE /* NSStringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46BEB6EB22FFE24900269867 /* RefCounted.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 46BEB6E922FFDDD500269867 /* RefCounted.cpp */; };
@@ -1246,6 +1247,7 @@
 		465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCRuntimeExtras.mm; sourceTree = "<group>"; };
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
 		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
+		468EAFD32D5B1E37005069CF /* SocketPOSIX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SocketPOSIX.h; sourceTree = "<group>"; };
 		46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParsingUtilities.h; sourceTree = "<group>"; };
 		46B4C53B2D4F2D0A00BAA3FE /* NSStringExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSStringExtras.h; sourceTree = "<group>"; };
 		46BA9EAB1F4CD61E009A2BBC /* CompletionHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CompletionHandler.h; sourceTree = "<group>"; };
@@ -2096,6 +2098,7 @@
 				EB2C86D8267B275C0052CB9A /* CPUTimePOSIX.cpp */,
 				A331D96621F24ABD009F02AA /* FileSystemPOSIX.cpp */,
 				A3EE5C3921FFAC5E00FABD61 /* OSAllocatorPOSIX.cpp */,
+				468EAFD32D5B1E37005069CF /* SocketPOSIX.h */,
 				A32D8FA421FFFAB400780662 /* ThreadingPOSIX.cpp */,
 			);
 			path = posix;
@@ -3622,6 +3625,7 @@
 				DD3DC92F27A4BF8E007E5B61 /* SixCharacterHash.h in Headers */,
 				FA0C387B2BEAD56B00583842 /* SmallMap.h in Headers */,
 				DD3DC8DE27A4BF8E007E5B61 /* SmallSet.h in Headers */,
+				468EAFD42D5B1E37005069CF /* SocketPOSIX.h in Headers */,
 				DDF3076727C086CD006A526F /* SoftLinking.h in Headers */,
 				DD3DC8D727A4BF8E007E5B61 /* SoftLinking.h in Headers */,
 				DD3DC91F27A4BF8E007E5B61 /* SortedArrayMap.h in Headers */,

--- a/Source/WTF/wtf/posix/SocketPOSIX.h
+++ b/Source/WTF/wtf/posix/SocketPOSIX.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sys/socket.h>
+#include <wtf/Compiler.h>
+#include <wtf/Function.h>
+#include <wtf/TypeCasts.h>
+
+namespace WTF {
+
+inline bool isIPV4SocketAddress(const struct sockaddr& socket)
+{
+    return socket.sa_family == AF_INET;
+}
+
+inline const struct sockaddr_in* dynamicCastToIPV4SocketAddress(const struct sockaddr& socket)
+{
+    if (isIPV4SocketAddress(socket))
+        SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast<const struct sockaddr_in*>(&socket);
+    return nullptr;
+}
+
+inline const struct sockaddr_in& asIPV4SocketAddress(const struct sockaddr& socket)
+{
+    RELEASE_ASSERT(isIPV4SocketAddress(socket));
+    SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const struct sockaddr_in*>(&socket);
+}
+
+inline bool initializeIPV4SocketAddress(sockaddr_storage& storage, NOESCAPE const Function<bool(sockaddr_in&)>& initialize)
+{
+    zeroBytes(storage);
+    SUPPRESS_MEMORY_UNSAFE_CAST auto& address = *reinterpret_cast<struct sockaddr_in*>(&storage);
+    if (!initialize(address))
+        return false;
+    storage.ss_family = AF_INET;
+    return true;
+}
+
+inline bool isIPV6SocketAddress(const struct sockaddr& socket)
+{
+    return socket.sa_family == AF_INET6;
+}
+
+inline const struct sockaddr_in6* dynamicCastToIPV6SocketAddress(const struct sockaddr& socket)
+{
+    if (isIPV6SocketAddress(socket))
+        SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast<const struct sockaddr_in6*>(&socket);
+    return nullptr;
+}
+
+inline const struct sockaddr_in6& asIPV6SocketAddress(const struct sockaddr& socket)
+{
+    RELEASE_ASSERT(isIPV6SocketAddress(socket));
+    SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<const struct sockaddr_in6*>(&socket);
+}
+
+inline bool initializeIPV6SocketAddress(sockaddr_storage& storage, NOESCAPE const Function<bool(sockaddr_in6&)>& initialize)
+{
+    zeroBytes(storage);
+    SUPPRESS_MEMORY_UNSAFE_CAST auto& address = *reinterpret_cast<struct sockaddr_in6*>(&storage);
+    if (!initialize(address))
+        return false;
+    storage.ss_family = AF_INET6;
+    return true;
+}
+
+inline struct sockaddr& asSocketAddress(sockaddr_storage& storage)
+{
+    SUPPRESS_MEMORY_UNSAFE_CAST return *reinterpret_cast<struct sockaddr*>(&storage);
+}
+
+} // namespace WTF
+
+using WTF::asIPV4SocketAddress;
+using WTF::asIPV6SocketAddress;
+using WTF::asSocketAddress;
+using WTF::dynamicCastToIPV4SocketAddress;
+using WTF::dynamicCastToIPV6SocketAddress;
+using WTF::initializeIPV4SocketAddress;
+using WTF::initializeIPV6SocketAddress;
+using WTF::isIPV4SocketAddress;
+using WTF::isIPV6SocketAddress;

--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -126,7 +126,6 @@ platform/mac/SerializedPlatformDataCueMac.mm
 platform/mac/WebCoreFullScreenWindow.mm
 platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
 platform/network/BlobResourceHandle.cpp
-platform/network/cf/DNSResolveQueueCFNet.cpp
 rendering/BidiRun.cpp
 rendering/BidiRun.h
 rendering/RenderAncestorIterator.h

--- a/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp
@@ -39,6 +39,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/cf/VectorCF.h>
+#include <wtf/posix/SocketPOSIX.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -100,10 +101,10 @@ static std::optional<IPAddress> extractIPAddress(const struct sockaddr* address)
 {
     if (!address)
         return std::nullopt;
-    if (address->sa_family == AF_INET)
-        return IPAddress { reinterpret_cast<const struct sockaddr_in*>(address)->sin_addr };
-    if (address->sa_family == AF_INET6)
-        return IPAddress { reinterpret_cast<const struct sockaddr_in6*>(address)->sin6_addr };
+    if (auto* addressV4 = dynamicCastToIPV4SocketAddress(*address))
+        return IPAddress { addressV4->sin_addr };
+    if (auto* addressV6 = dynamicCastToIPV6SocketAddress(*address))
+        return IPAddress { addressV6->sin6_addr };
     ASSERT_NOT_REACHED();
     return std::nullopt;
 }

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -40,6 +40,7 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/cocoa/SpanCocoa.h>
+#include <wtf/posix/SocketPOSIX.h>
 
 namespace WebKit {
 
@@ -186,10 +187,11 @@ static inline bool isNat64IPAddress(const rtc::IPAddress& ip)
     std::unique_ptr<struct ifaddrs> toBeFreed(interfaces);
 
     for (auto* interface = interfaces; interface; interface = interface->ifa_next) {
-        if (interface->ifa_addr->sa_family != AF_INET)
+        auto* address = dynamicCastToIPV4SocketAddress(*interface->ifa_addr);
+        if (!address)
             continue;
 
-        rtc::IPAddress interfaceAddress { reinterpret_cast<sockaddr_in*>(interface->ifa_addr)->sin_addr };
+        rtc::IPAddress interfaceAddress { address->sin_addr };
         if (ip != interfaceAddress)
             continue;
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -44,6 +44,7 @@
 #import <wtf/Scope.h>
 #import <wtf/WeakRandom.h>
 #import <wtf/cocoa/VectorCocoa.h>
+#import <wtf/posix/SocketPOSIX.h>
 #import <wtf/text/MakeString.h>
 #import <pal/cocoa/WebPrivacySoftLink.h>
 
@@ -432,11 +433,11 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 
 inline static std::optional<WebCore::IPAddress> ipAddress(const struct sockaddr* address)
 {
-    if (address->sa_family == AF_INET)
-        return WebCore::IPAddress { reinterpret_cast<const sockaddr_in*>(address)->sin_addr };
+    if (auto* addressV4 = dynamicCastToIPV4SocketAddress(*address))
+        return WebCore::IPAddress { addressV4->sin_addr };
 
-    if (address->sa_family == AF_INET6)
-        return WebCore::IPAddress { reinterpret_cast<const sockaddr_in6*>(address)->sin6_addr };
+    if (auto* addressV6 = dynamicCastToIPV6SocketAddress(*address))
+        return WebCore::IPAddress { addressV6->sin6_addr };
 
     return std::nullopt;
 }

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -2,9 +2,7 @@ AutomationProtocolObjects.h
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/cocoa/WebSocketTaskCocoa.mm
 NetworkProcess/webrtc/NetworkRTCMonitor.cpp
-NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
 Platform/cocoa/CocoaHelpers.mm
-Platform/cocoa/WebPrivacyHelpers.mm
 Shared/API/APIArray.h
 Shared/API/APIDictionary.h
 Shared/API/c/WKSharedAPICast.h
@@ -13,7 +11,6 @@ Shared/API/c/cf/WKURLCF.mm
 Shared/APIWebArchive.mm
 Shared/Cocoa/WKNSURL.mm
 Shared/Cocoa/WKObject.h
-Shared/RTCNetwork.cpp
 Shared/UserData.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKDownload.mm

--- a/Source/WebKit/Shared/RTCNetwork.cpp
+++ b/Source/WebKit/Shared/RTCNetwork.cpp
@@ -24,12 +24,13 @@
  */
 
 #include "config.h"
+
+#if USE(LIBWEBRTC)
 #include "RTCNetwork.h"
 
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/StdLibExtras.h>
-
-#if USE(LIBWEBRTC)
+#include <wtf/posix/SocketPOSIX.h>
 
 namespace WebKit {
 
@@ -131,10 +132,10 @@ IPAddress::IPAddress(const struct sockaddr& address)
 {
     switch (address.sa_family) {
     case AF_INET6:
-        value = fromIPv6Address(reinterpret_cast<const sockaddr_in6*>(&address)->sin6_addr);
+        value = fromIPv6Address(asIPV6SocketAddress(address).sin6_addr);
         break;
     case AF_INET:
-        value = reinterpret_cast<const sockaddr_in*>(&address)->sin_addr.s_addr;
+        value = asIPV4SocketAddress(address).sin_addr.s_addr;
         break;
     case AF_UNSPEC:
         value = UnspecifiedFamily { };


### PR DESCRIPTION
#### ff08cabb2102fb7af646608a942999bd03f94e44
<pre>
Address some of the Safer CPP warnings in DNSResolveQueueCFNet.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287469">https://bugs.webkit.org/show_bug.cgi?id=287469</a>

Reviewed by Darin Adler.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/posix/SocketPOSIX.h: Added.
(WTF::isIPV4SocketAddress):
(WTF::dynamicCastToIPV4SocketAddress):
(WTF::asIPV4SocketAddress):
(WTF::isIPV6Socket):
(WTF::dynamicCastToIPV6SocketAddress):
(WTF::asIPV6SocketAddress):
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::extractIPAddress):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::gatherNetworkMap):
(WebKit::connectToRemoteAddress):
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::isNat64IPAddress):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ipAddress):
* Source/WebKit/Shared/RTCNetwork.cpp:
(WebKit::RTC::Network::IPAddress::IPAddress):

Canonical link: <a href="https://commits.webkit.org/290259@main">https://commits.webkit.org/290259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b8862f877a70a305f7ccdddf57e1a2dfed74ae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89458 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17264 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7192 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49277 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39331 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82256 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96278 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88233 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16639 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77099 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19024 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21525 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9790 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16653 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/21962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110726 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16394 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26545 "Found 5 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->