### PR TITLE
Table row background-images fill the corresponding cells

### DIFF
--- a/LayoutTests/fast/table/row-background-image-span-expected.html
+++ b/LayoutTests/fast/table/row-background-image-span-expected.html
@@ -1,0 +1,93 @@
+<html>
+<head>
+<title>Row background image span</title>
+<style>* { box-sizing: border-box }
+caption { caption-side: bottom; font-family: sans-serif; font-size: smaller; text-align: left; margin-top: 16px }</style>
+</head>
+<body>
+    <p>A repeating background image applied to a table row should cover the whole area of contained cells, even if those cells span multiple rows, since this is how background colors behave. Also, rounded borders apply to cells, and row backgrounds are restricted to cell contents. If a cell spans multiple rows or columns, rounding should apply at the relevant <em>cell</em> corners.</p>
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>1. Row background color</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background-color: black"></td>
+            <td style="width: 60px; height: 120px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>2. Row repeating solid gradient (should equal #1)</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background-color: black"></td>
+            <td style="width: 60px; height: 120px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>3. Row repeating gradient</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background: repeat top/30px 30px border-box linear-gradient(to bottom, royalblue 0, black 100%)"></td>
+            <td style="width: 60px; height: 120px; background: repeat top/30px 30px linear-gradient(to bottom, royalblue 0, black 100%)" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>4. Row non-repeating gradient should not span to second row</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; background-color: black"></td>
+            <td style="width: 60px; height: 60px; background-color: black"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 60px"></td>
+        </tr>
+    </table>
+</div>
+
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>5. Row background color with rounded corners</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px; background-color: black"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>6. Repeating solid gradient with rounded corners (should equal #5)</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px; background-color: black"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px; background-color: black" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>7. Non-repeating solid gradient with rounded corners</caption>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px; background-color: black"></td>
+            <td style="width: 60px; height: 60px; border-radius: 10px; border-bottom-left-radius: 0; border-bottom-right-radius: 0; background-color: black"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/table/row-background-image-span.html
+++ b/LayoutTests/fast/table/row-background-image-span.html
@@ -1,0 +1,92 @@
+<html>
+<head>
+<meta name="fuzzy" content="maxDifference=0-67; totalPixels=0-15000" />
+<title>Row background image span</title>
+<style>* { box-sizing: border-box }
+caption { caption-side: bottom; font-family: sans-serif; font-size: smaller; text-align: left; margin-top: 16px }</style>
+</head>
+<body>
+    <p>A repeating background image applied to a table row should cover the whole area of contained cells, even if those cells span multiple rows, since this is how background colors behave. Also, rounded borders apply to cells, and row backgrounds are restricted to cell contents. If a cell spans multiple rows or columns, rounding should apply at the relevant <em>cell</em> corners.</p>
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>1. Row background color</caption>
+        <tr style="background-color: black">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>2. Row repeating solid gradient (should equal #1)</caption>
+        <tr style="background: repeat top/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>3. Row repeating gradient</caption>
+        <tr style="background: repeat top/30px 30px linear-gradient(to bottom, royalblue 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>4. Row non-repeating gradient should not span to second row</caption>
+        <tr style="background: no-repeat top/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+            <td style="width: 60px; height: 120px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua"></td>
+        </tr>
+    </table>
+</div>
+
+<div style="display: flex; flex-wrap: wrap; align-items: start; gap: 10px">
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>5. Row background color with rounded corners</caption>
+        <tr style="background-color: black">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>6. Repeating solid gradient with rounded corners (should equal #5)</caption>
+        <tr style="background: repeat center/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+
+    <table style="width: 120px; border-spacing: 0; margin-bottom: 1em">
+        <caption>7. Non-repeating solid gradient with rounded corners</caption>
+        <tr style="background: no-repeat center/100% 100% linear-gradient(to bottom, black 0, black 100%)">
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+            <td style="width: 60px; height: 120px; border-radius: 10px" rowspan="2"></td>
+        </tr>
+        <tr>
+            <td style="width: 60px; height: 60px; border: 5px dashed aqua; border-radius: 10px"></td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -147,13 +147,13 @@ void BackgroundPainter::paintFillLayers(const Color& color, const FillLayer& fil
     auto baseBgColorUsage = BaseBackgroundColorUse;
 
     if (shouldDrawBackgroundInSeparateBuffer) {
-        paintFillLayer(color, *layers.last(), rect, bleedAvoidance, { }, { }, op, backgroundObject, BaseBackgroundColorOnly);
+        paintFillLayer(color, *layers.last(), rect, bleedAvoidance, { }, op, backgroundObject, BaseBackgroundColorOnly);
         baseBgColorUsage = BaseBackgroundColorSkip;
         context.beginTransparencyLayer(1);
     }
 
     for (auto& layer : makeReversedRange(layers))
-        paintFillLayer(color, *layer, rect, bleedAvoidance, { }, { }, op, backgroundObject, baseBgColorUsage);
+        paintFillLayer(color, *layer, rect, bleedAvoidance, { }, op, backgroundObject, baseBgColorUsage);
 
     if (shouldDrawBackgroundInSeparateBuffer)
         context.endTransparencyLayer();
@@ -170,7 +170,7 @@ static void applyBoxShadowForBackground(GraphicsContext& context, const RenderSt
 }
 
 void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLayer, const LayoutRect& rect,
-    BleedAvoidance bleedAvoidance, const InlineIterator::InlineBoxIterator& inlineBoxIterator, const LayoutRect& backgroundImageStrip, CompositeOperator op, RenderElement* backgroundObject, BaseBackgroundColorUsage baseBgColorUsage) const
+    BleedAvoidance bleedAvoidance, const InlineIterator::InlineBoxIterator& inlineBoxIterator, CompositeOperator op, RenderElement* backgroundObject, BaseBackgroundColorUsage baseBgColorUsage) const
 {
     GraphicsContext& context = m_paintInfo.context();
 
@@ -186,7 +186,7 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
 
     bool hasRoundedBorder = style.hasBorderRadius()
         && (closedEdges.start(style.writingMode()) || closedEdges.end(style.writingMode()));
-    bool clippedWithLocalScrolling = m_renderer.hasNonVisibleOverflow() && bgLayer.attachment() == FillAttachment::LocalBackground;
+    bool clippedWithLocalScrolling = m_renderer.hasNonVisibleOverflow() && bgLayer.attachment() == FillAttachment::LocalBackground && !m_imageRect;
     bool isBorderFill = layerClip == FillBox::BorderBox;
     bool isRoot = m_renderer.isDocumentElementRenderer();
 
@@ -474,10 +474,9 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
 
     // no progressive loading of the background image
     if (!baseBgColorOnly && shouldPaintBackgroundImage) {
-        // Multiline inline boxes paint like the image was one long strip spanning lines. The backgroundImageStrip is this fictional rectangle.
-        auto imageRect = backgroundImageStrip.isEmpty() ? scrolledPaintRect : backgroundImageStrip;
-        auto paintOffset = backgroundImageStrip.isEmpty() ? rect.location() : backgroundImageStrip.location();
-        auto geometry = calculateBackgroundImageGeometry(m_renderer, m_paintInfo.paintContainer, bgLayer, paintOffset, imageRect, m_overrideOrigin);
+        // m_imageRect, if provided, is used for sizing the image. It is set for table rows and for inline boxes (multiline inline boxes paint like the image was one long strip spanning lines).
+        auto paintOffset = m_imageRect ? m_imageRect->location() : rect.location();
+        auto geometry = calculateBackgroundImageGeometry(m_renderer, m_paintInfo.paintContainer, bgLayer, paintOffset, scrolledPaintRect, m_imageRect);
 
         auto& clientForBackgroundImage = backgroundObject ? *backgroundObject : m_renderer;
         bgImage->setContainerContextForRenderer(clientForBackgroundImage, geometry.tileSizeWithoutPixelSnapping, m_renderer.style().usedZoom());
@@ -550,7 +549,7 @@ static void pixelSnapBackgroundImageGeometryForPainting(LayoutRect& destinationR
     destinationRect = LayoutRect(snapRectToDevicePixels(destinationRect, scaleFactor));
 }
 
-BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(const RenderBoxModelObject& renderer, const RenderLayerModelObject* paintContainer, const FillLayer& fillLayer, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin)
+BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(const RenderBoxModelObject& renderer, const RenderLayerModelObject* paintContainer, const FillLayer& fillLayer, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, const std::optional<LayoutRect>& imageRect)
 {
     auto& view = renderer.view();
 
@@ -563,19 +562,18 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
     bool isTransformed = renderer.isTransformed() || (enclosingLayer && enclosingLayer->hasTransformedAncestor());
     bool fixedAttachment = fillLayer.attachment() == FillAttachment::FixedBackground && !isTransformed;
 
-    LayoutRect destinationRect(borderBoxRect);
+    LayoutRect destinationRect(imageRect.value_or(borderBoxRect));
     float deviceScaleFactor = renderer.document().deviceScaleFactor();
     if (!fixedAttachment) {
         LayoutUnit right;
         LayoutUnit bottom;
         // Scroll and Local.
-        auto fillLayerOrigin = overrideOrigin.value_or(fillLayer.origin());
-        if (fillLayerOrigin != FillBox::BorderBox) {
+        if (fillLayer.origin() != FillBox::BorderBox && !imageRect) {
             left = renderer.borderLeft();
             right = renderer.borderRight();
             top = renderer.borderTop();
             bottom = renderer.borderBottom();
-            if (fillLayerOrigin == FillBox::ContentBox) {
+            if (fillLayer.origin() == FillBox::ContentBox) {
                 left += renderer.paddingLeft();
                 right += renderer.paddingRight();
                 top += renderer.paddingTop();
@@ -595,7 +593,7 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
                 top += (renderer.marginTop() - extendedBackgroundRect.y());
             }
         } else {
-            positioningAreaSize = borderBoxRect.size() - LayoutSize(left + right, top + bottom);
+            positioningAreaSize = destinationRect.size() - LayoutSize(left + right, top + bottom);
             positioningAreaSize = LayoutSize(snapRectToDevicePixels(LayoutRect(paintOffset, positioningAreaSize), deviceScaleFactor).size());
         }
     } else {
@@ -722,11 +720,19 @@ BackgroundImageGeometry BackgroundPainter::calculateBackgroundImageGeometry(cons
     }
 
     if (fixedAttachment) {
-        LayoutPoint attachmentPoint = borderBoxRect.location();
+        LayoutPoint attachmentPoint = imageRect.value_or(borderBoxRect).location();
         phase.expand(std::max<LayoutUnit>(attachmentPoint.x() - destinationRect.x(), 0), std::max<LayoutUnit>(attachmentPoint.y() - destinationRect.y(), 0));
     }
 
-    destinationRect.intersect(borderBoxRect);
+    if (imageRect) {
+        destinationRect.intersect(*imageRect);
+        // expand repeating background to cover whole borderBoxRect in repeat directions
+        if (backgroundRepeatX == FillRepeat::Repeat)
+            destinationRect.unite({ borderBoxRect.x(), destinationRect.y(), borderBoxRect.width(), destinationRect.height() });
+        if (backgroundRepeatY == FillRepeat::Repeat)
+            destinationRect.unite({ destinationRect.x(), borderBoxRect.y(), destinationRect.width(), borderBoxRect.height() });
+    } else
+        destinationRect.intersect(borderBoxRect);
 
     auto tileSizeWithoutPixelSnapping = tileSize;
     pixelSnapBackgroundImageGeometryForPainting(destinationRect, tileSize, phase, spaceSize, deviceScaleFactor);

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -66,17 +66,17 @@ public:
     BackgroundPainter(RenderBoxModelObject&, const PaintInfo&);
 
     void setOverrideClip(FillBox overrideClip) { m_overrideClip = overrideClip; }
-    void setOverrideOrigin(FillBox overrideOrigin) { m_overrideOrigin = overrideOrigin; }
+    void setImageRect(const LayoutRect& imageRect) { m_imageRect = imageRect; }
 
     void paintBackground(const LayoutRect&, BleedAvoidance) const;
 
     void paintFillLayers(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, CompositeOperator, RenderElement* backgroundObject = nullptr) const;
-    void paintFillLayer(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, const InlineIterator::InlineBoxIterator&, const LayoutRect& backgroundImageStrip = { }, CompositeOperator = CompositeOperator::SourceOver, RenderElement* backgroundObject = nullptr, BaseBackgroundColorUsage = BaseBackgroundColorUse) const;
+    void paintFillLayer(const Color&, const FillLayer&, const LayoutRect&, BleedAvoidance, const InlineIterator::InlineBoxIterator&, CompositeOperator = CompositeOperator::SourceOver, RenderElement* backgroundObject = nullptr, BaseBackgroundColorUsage = BaseBackgroundColorUse) const;
 
     void paintBoxShadow(const LayoutRect&, const RenderStyle&, ShadowStyle, RectEdges<bool> closedEdges = { true, true, true, true }) const;
 
     static bool paintsOwnBackground(const RenderBoxModelObject&);
-    static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin = std::nullopt);
+    static BackgroundImageGeometry calculateBackgroundImageGeometry(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const FillLayer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, const std::optional<LayoutRect>& imageRect = std::nullopt);
     static void clipRoundedInnerRect(GraphicsContext&, const FloatRoundedRect& clipRect);
     static bool boxShadowShouldBeAppliedToBackground(const RenderBoxModelObject&, const LayoutPoint& paintOffset, BleedAvoidance, const InlineIterator::InlineBoxIterator&);
 
@@ -91,7 +91,7 @@ private:
     RenderBoxModelObject& m_renderer;
     const PaintInfo& m_paintInfo;
     std::optional<FillBox> m_overrideClip;
-    std::optional<FillBox> m_overrideOrigin;
+    std::optional<LayoutRect> m_imageRect;
 };
 
 }

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -308,14 +308,14 @@ void InlineBoxPainter::paintFillLayer(const Color& color, const FillLayer& fillL
     BackgroundPainter backgroundPainter { renderer(), m_paintInfo };
 
     if (!hasFillImageOrBorderRadious || !m_inlineBox.isSplit() || m_isRootInlineBox) {
-        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, { }, op);
+        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, op);
         return;
     }
 
     if (renderer().style().boxDecorationBreak() == BoxDecorationBreak::Clone) {
         GraphicsContextStateSaver stateSaver(m_paintInfo.context());
         m_paintInfo.context().clip({ rect.location(), m_inlineBox.visualRectIgnoringBlockDirection().size() });
-        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, { }, op);
+        backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, op);
         return;
     }
 
@@ -346,10 +346,11 @@ void InlineBoxPainter::paintFillLayer(const Color& color, const FillLayer& fillL
         isHorizontal() ? totalLogicalWidth : LayoutUnit(m_inlineBox.visualRectIgnoringBlockDirection().width()),
         isHorizontal() ? LayoutUnit(m_inlineBox.visualRectIgnoringBlockDirection().height()) : totalLogicalWidth
     };
+    backgroundPainter.setImageRect(backgroundImageStrip);
 
     GraphicsContextStateSaver stateSaver(m_paintInfo.context());
     m_paintInfo.context().clip(FloatRect { rect });
-    backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, backgroundImageStrip, op);
+    backgroundPainter.paintFillLayer(color, fillLayer, rect, BleedAvoidance::None, m_inlineBox, op);
 }
 
 void InlineBoxPainter::paintBoxShadow(ShadowStyle shadowStyle, const LayoutRect& paintRect)

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1378,50 +1378,41 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
     if (!tableElt->collapseBorders() && style().emptyCells() == EmptyCell::Hide && !firstChild())
         return;
 
-    const auto& style = backgroundObject->style();
-    auto& bgLayer = style.backgroundLayers();
+    const auto& bgStyle = backgroundObject->style();
+    auto& bgLayer = bgStyle.backgroundLayers();
 
-    auto color = style.visitedDependentColor(CSSPropertyBackgroundColor);
+    auto color = bgStyle.visitedDependentColor(CSSPropertyBackgroundColor);
     if (!bgLayer.hasImage() && !color.isVisible())
         return;
 
-    color = style.colorByApplyingColorFilter(color);
+    color = bgStyle.colorByApplyingColorFilter(color);
 
-    LayoutPoint adjustedPaintOffset = paintOffset;
+    LayoutRect fillRect { paintOffset, size() };
     if (backgroundObject != this)
-        adjustedPaintOffset.moveBy(location());
+        fillRect.moveBy(location());
 
-    // Background images attached to the row or row group must span the row
-    // or row group. Draw them at the backgroundObject's dimensions, but
-    // clipped to this cell.
-    // FIXME: This should also apply to columns and column groups.
-    bool paintBackgroundObject = backgroundObject != this && bgLayer.hasImage() && !is<RenderTableCol>(backgroundObject);
-    // We have to clip here because the background would paint
-    // on top of the borders otherwise. This only matters for cells and rows.
-    bool shouldClip = paintBackgroundObject || (backgroundObject->hasLayer() && (backgroundObject == this || backgroundObject == parent()) && tableElt->collapseBorders());
-    GraphicsContextStateSaver stateSaver(paintInfo.context(), shouldClip);
-    if (paintBackgroundObject)
-        paintInfo.context().clip({ adjustedPaintOffset, size() });
-    else if (shouldClip) {
-        LayoutRect clipRect(adjustedPaintOffset.x() + borderLeft(), adjustedPaintOffset.y() + borderTop(),
-            width() - borderLeft() - borderRight(), height() - borderTop() - borderBottom());
-        paintInfo.context().clip(clipRect);
-    }
-    LayoutRect fillRect;
-    if (paintBackgroundObject) {
-        if (auto* tableSectionRenderer = dynamicDowncast<RenderTableSection>(backgroundObject))
-            fillRect = backgroundRectForSection(*tableSectionRenderer, *tableElt);
-        else
-            fillRect = backgroundRectForRow(*backgroundObject, *tableElt);
-        fillRect.moveBy(backgroundPaintOffset);
-    } else
-        fillRect = LayoutRect { adjustedPaintOffset, size() };
-    auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     BackgroundPainter painter { *this, paintInfo };
     if (backgroundObject != this) {
         painter.setOverrideClip(FillBox::BorderBox);
-        painter.setOverrideOrigin(FillBox::BorderBox);
+        // Background images attached to the row or row group must span the
+        // row or row group. Draw them as sized for that element, but clipped
+        // to this cell.
+        // FIXME: This should also apply to columns and column groups.
+        if (bgLayer.hasImage() && !is<RenderTableCol>(backgroundObject)) {
+            LayoutRect imageRect;
+            if (auto* tableSectionRenderer = dynamicDowncast<RenderTableSection>(backgroundObject))
+                imageRect = backgroundRectForSection(*tableSectionRenderer, *tableElt);
+            else
+                imageRect = backgroundRectForRow(*backgroundObject, *tableElt);
+            imageRect.moveBy(backgroundPaintOffset);
+            painter.setImageRect(imageRect);
+        }
     }
+    if (backgroundObject->hasLayer() && (backgroundObject == this || backgroundObject == parent()) && tableElt->collapseBorders()) {
+        // Shrink the drawn area to account for collapsed borders (cell and row only)
+        fillRect.contract(borderWidths());
+    }
+    auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
     painter.paintFillLayers(color, bgLayer, fillRect, BleedAvoidance::None, compositeOp, backgroundObject);
 }
 


### PR DESCRIPTION
<pre>
Table row background-images fill the corresponding cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=287503">https://bugs.webkit.org/show_bug.cgi?id=287503</a>

Reviewed by NOBODY (OOPS!).

A table row background-image "covers exactly the full area of
all cells that originate in the row, even if they span outside
the row, but this difference in area does not affect background
image positioning." (CSS 2.1) Ensure that row (or column or
section) background-images expand to fill the cell area when
appropriate by explicitly enlarging the painted area. Also
apply the correct rounded corners: they must restrict the *cell*
dimensions, not the row (or column or section) dimensions.

Unlike prior code, this always paints the cell rectangle, but
supplies a separate rectangle for image sizing purposes. This
subsumes the `backgroundImageStrip` functionality used
for inline backgrounds.

* LayoutTests/fast/table/row-background-image-span.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayers const):
(WebCore::BackgroundPainter::paintFillLayer const):
Remove `backgroundImageStrip` parameter in favor of `m_imageRect`.
(WebCore::BackgroundPainter::calculateBackgroundImageGeometry):
Size according to `imageRect` when provided. Expand results to
`destinationRect` for repeated backgrounds.
* Source/WebCore/rendering/BackgroundPainter.h:
(WebCore::BackgroundPainter::setImageRect): New function.
(WebCore::BackgroundPainter::setOverrideOrigin): Deleted.
* Source/WebCore/rendering/InlineBoxPainter.cpp:
(WebCore::InlineBoxPainter::paintFillLayer): Use `setImageRect`.
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):
Use `setImageRect` to compute image dimensions, but always paint
`fillRect` (the cell rectangle).
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c37459fb02ed40df12afc57460a4c031ce93cfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/99472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/19122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/9375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/104603 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/50074 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/101513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/19410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/27555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75710 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32811 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/102479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/56069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/14573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7802 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/49433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/84499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106961 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/26586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/19400 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84670 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26948 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/86022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/84188 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/6558 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/20358 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/26526 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/31727 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/26346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/29659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27913 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->