### PR TITLE
REGRESSION( SequoiaC ): [ Debug SequoiaC+ ] TestWebKitAPI.WKWebViewCandidateTests.ShouldNotRequestCandidatesInPasswordField is a constant timeout

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm
@@ -83,7 +83,8 @@ static NSString *GetDocumentScrollTopJSExpression = @"document.body.scrollTop";
 - (void)insertCandidatesAndWaitForResponse:(NSString *)replacementString range:(NSRange)range
 {
     _isDoneWaitingForCandidate = false;
-    [self _handleAcceptedCandidate:[[TestCandidate alloc] initWithReplacementString:replacementString inRange:range]];
+    RetainPtr candidate = adoptNS([[TestCandidate alloc] initWithReplacementString:replacementString inRange:range]);
+    [self _handleAcceptedCandidate:candidate.get()];
     TestWebKitAPI::Util::run(&_isDoneWaitingForCandidate);
 }
 
@@ -213,42 +214,36 @@ TEST(WKWebViewCandidateTests, ShouldNotRequestCandidatesInPasswordField)
     [wkWebView waitForMessage:@"loaded"];
     [wkWebView _forceRequestCandidates];
 
-    dispatch_async(dispatch_get_main_queue(), ^()
-    {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [wkWebView mouseDownAtPoint:NSMakePoint(400, 150) simulatePressure:YES];
     });
     [wkWebView waitForMessage:@"password-focused"];
-
-    [wkWebView typeString:@"foo" inputMessage:@"password-input"];
+    [wkWebView insertText:@"foo"];
+    [wkWebView waitForNextPresentationUpdate];
     EXPECT_FALSE([wkWebView _shouldRequestCandidates]);
 
     NSString *passwordFieldValue = [wkWebView stringByEvaluatingJavaScript:@"document.querySelector('#password').value"];
-    EXPECT_STREQ(passwordFieldValue.UTF8String, "foo");
+    EXPECT_WK_STREQ(passwordFieldValue, "foo");
 }
-
-#if USE(APPLE_INTERNAL_SDK)
 
 TEST(WKWebViewCandidateTests, ShouldRequestCandidatesInTextField)
 {
-    auto wkWebView = adoptNS([[CandidateTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
+    RetainPtr wkWebView = adoptNS([[CandidateTestWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600)]);
     [wkWebView loadTestPageNamed:@"text-and-password-inputs"];
     [wkWebView waitForMessage:@"loaded"];
     [wkWebView _forceRequestCandidates];
 
-    dispatch_async(dispatch_get_main_queue(), ^()
-    {
+    dispatch_async(dispatch_get_main_queue(), ^{
         [wkWebView mouseDownAtPoint:NSMakePoint(400, 450) simulatePressure:YES];
     });
     [wkWebView waitForMessage:@"text-focused"];
-
-    [wkWebView typeString:@"bar" inputMessage:@"text-input"];
+    [wkWebView insertText:@"bar"];
+    [wkWebView waitForNextPresentationUpdate];
     EXPECT_TRUE([wkWebView _shouldRequestCandidates]);
 
     NSString *textFieldValue = [wkWebView stringByEvaluatingJavaScript:@"document.querySelector('#text').value"];
-    EXPECT_STREQ(textFieldValue.UTF8String, "bar");
+    EXPECT_WK_STREQ(textFieldValue, "bar");
 }
-
-#endif
 
 TEST(WKWebViewCandidateTests, CandidateRectForEmptyParagraph)
 {


### PR DESCRIPTION
#### b1b8f97614b709797b226fd438d6d18e28c4fd50
<pre>
REGRESSION( SequoiaC ): [ Debug SequoiaC+ ] TestWebKitAPI.WKWebViewCandidateTests.ShouldNotRequestCandidatesInPasswordField is a constant timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=287496">https://bugs.webkit.org/show_bug.cgi?id=287496</a>
<a href="https://rdar.apple.com/144628446">rdar://144628446</a>

Reviewed by Abrar Rahman Protyasha.

Adjust several API tests to be more robust when inserting text; rather than sending synthesized key
events to insert text into editable fields, we instead use `-insertText:` and wait for the next
presentation update to achieve the same effect. These tests don&apos;t actually depend on key events
(just inserting text via editing commands), so `-insertText:` is sufficient.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewCandidateTests.mm:
(-[CandidateTestWebView insertCandidatesAndWaitForResponse:range:]):
(TEST(WKWebViewCandidateTests, ShouldNotRequestCandidatesInPasswordField)):
(TEST(WKWebViewCandidateTests, ShouldRequestCandidatesInTextField)):

Canonical link: <a href="https://commits.webkit.org/290241@main">https://commits.webkit.org/290241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2747fe802756a82223e3d2e5dcd40f1d8b5c81d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40135 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68858 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7127 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49218 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6872 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39242 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96189 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16555 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77728 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77032 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21457 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9705 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16568 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19760 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->