### PR TITLE
Hit-testing an element does not take the mask-image's bounds into account

### DIFF
--- a/LayoutTests/css3/masking/mask-image-hit-test-children-outside-parent-bounds-expected.txt
+++ b/LayoutTests/css3/masking/mask-image-hit-test-children-outside-parent-bounds-expected.txt
@@ -1,0 +1,11 @@
+Test whether the bounds of the mask-image of an element are taken into account when hit-testing it's children.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.elementFromPoint(b.x, b.y).localName is "div"
+PASS document.elementFromPoint(b.x + 96, b.y + 96).localName is "html"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/css3/masking/mask-image-hit-test-children-outside-parent-bounds.html
+++ b/LayoutTests/css3/masking/mask-image-hit-test-children-outside-parent-bounds.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hit testing of children outside of the bounds of parent's mask-image</title>
+    <script src="../../resources/js-test.js"></script>
+    <style>
+      .parent {
+          mask-image: linear-gradient(white, white);
+          width: 64px;
+          height: 64px;
+      }
+
+      .child {
+          width: 128px;
+          height: 128px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="parent">
+      <div class="child"></div>
+    </div>
+
+    <script>
+      description("Test whether the bounds of the mask-image of an element are taken into account when hit-testing it's children.");
+
+      let b = document.querySelector(".parent").getBoundingClientRect();
+      shouldBeEqualToString("document.elementFromPoint(b.x, b.y).localName", "div");
+      shouldBeEqualToString("document.elementFromPoint(b.x + 96, b.y + 96).localName", "html");
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1562,6 +1562,18 @@ bool RenderBox::hitTestBorderRadius(const HitTestLocation& hitTestLocation, cons
     return hitTestLocation.intersects(borderShape.deprecatedRoundedRect());
 }
 
+bool RenderBox::hitTestMask(const HitTestLocation& hitTestLocation, const LayoutPoint& accumulatedOffset) const
+{
+    if (isRenderView() || !hasMask())
+        return true;
+
+    LayoutPoint adjustedLocation = accumulatedOffset + location();
+    LayoutRect maskRect = maskClipRect(LayoutPoint());
+    maskRect.moveBy(adjustedLocation);
+
+    return hitTestLocation.intersects(maskRect);
+}
+
 bool RenderBox::nodeAtPoint(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction action)
 {
     LayoutPoint adjustedLocation = accumulatedOffset + location();
@@ -1586,6 +1598,9 @@ bool RenderBox::nodeAtPoint(const HitTestRequest& request, HitTestResult& result
             return false;
 
         if (!hitTestBorderRadius(locationInContainer, accumulatedOffset))
+            return false;
+
+        if (!hitTestMask(locationInContainer, accumulatedOffset))
             return false;
 
         updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
@@ -1966,7 +1981,7 @@ void RenderBox::paintMaskImages(const PaintInfo& paintInfo, const LayoutRect& pa
         paintInfo.context().endTransparencyLayer();
 }
 
-LayoutRect RenderBox::maskClipRect(const LayoutPoint& paintOffset)
+LayoutRect RenderBox::maskClipRect(const LayoutPoint& paintOffset) const
 {
     const NinePieceImage& maskBorder = style().maskBorder();
     if (maskBorder.image()) {

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -267,6 +267,7 @@ public:
     bool hitTestVisualOverflow(const HitTestLocation&, const LayoutPoint& accumulatedOffset) const;
     bool hitTestClipPath(const HitTestLocation&, const LayoutPoint& accumulatedOffset) const;
     bool hitTestBorderRadius(const HitTestLocation&, const LayoutPoint& accumulatedOffset) const;
+    bool hitTestMask(const HitTestLocation&, const LayoutPoint& accumulatedOffset) const;
 
     LayoutUnit minPreferredLogicalWidth() const override;
     LayoutUnit maxPreferredLogicalWidth() const override;
@@ -492,7 +493,7 @@ public:
         return true;
     }
 
-    LayoutRect maskClipRect(const LayoutPoint& paintOffset);
+    LayoutRect maskClipRect(const LayoutPoint& paintOffset) const;
 
     VisiblePosition positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4603,8 +4603,11 @@ RenderLayer::HitLayer RenderLayer::hitTestLayer(RenderLayer* rootLayer, RenderLa
 
     auto offsetFromRoot = offsetFromAncestor(rootLayer);
     // FIXME: We need to correctly hit test the clip-path when we have a RenderInline too.
-    if (auto* rendererBox = this->renderBox(); rendererBox && !rendererBox->hitTestClipPath(hitTestLocation, toLayoutPoint(offsetFromRoot - toLayoutSize(rendererLocation()))))
-        return { };
+    if (auto* rendererBox = this->renderBox(); rendererBox) {
+        auto layoutPoint = toLayoutPoint(offsetFromRoot - toLayoutSize(rendererLocation()));
+        if (!rendererBox->hitTestClipPath(hitTestLocation, layoutPoint) || !rendererBox->hitTestMask(hitTestLocation, layoutPoint))
+            return { };
+    }
 
     // Begin by walking our list of positive layers from highest z-index down to the lowest z-index.
     auto hitLayer = hitTestList(positiveZOrderLayers(), rootLayer, request, result, hitTestRect, hitTestLocation, localTransformState.get(), zOffsetForDescendantsPtr, depthSortDescendants);


### PR DESCRIPTION
#### 9b9e0441ab2fe4a1a2f1024ddbe63f11a5d87d2b
<pre>
Hit-testing an element does not take the mask-image&apos;s bounds into account
<a href="https://bugs.webkit.org/show_bug.cgi?id=287510">https://bugs.webkit.org/show_bug.cgi?id=287510</a>

Reviewed by NOBODY (OOPS!).

Add a method to RenderBox, `hitTestMask`, allowing it&apos;s mask&apos;s bounds
to be hit tested, and take that into account when hit-testing a
RenderBox, if applicable. This avoids cursor events being dispatched
to masked-out portions of children of an element with a `mask-image`,
for instance. This behaviour appears not to be specified by
CSS-MASKING-1, but is consistent with what both Blink and Gecko
implement, and probably makes more sense from an user&apos;s perspective
either way.

* LayoutTests/css3/masking/mask-image-hit-test-children-outside-parent-bounds-expected.txt: Added.
* LayoutTests/css3/masking/mask-image-hit-test-children-outside-parent-bounds.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hitTestMask const):

Add a method to hit test the RenderBox&apos;s mask&apos;s bounds, similar to
the border radius test immediately above.

(WebCore::RenderBox::maskClipRect const):
(WebCore::RenderBox::maskClipRect): Deleted.

Made `this` const, so we can make `hitTestMask`&apos;s `this` const as well

(WebCore::RenderBox::nodeAtPoint):

Take the mask&apos;s bounds into account when deciding whether a given hit
has hit the current RenderBox.

* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::hitTestLayer):

Likewise, for children of a given layer.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b9e0441ab2fe4a1a2f1024ddbe63f11a5d87d2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91437 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68866 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7139 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81179 "Found 3 new API test failures: TestWebKitAPI.PrivateClickMeasurement.EphemeralWithAttributedBundleIdentifier, TestWebKitAPI.PrivateClickMeasurement.Basic, TestWebKitAPI.PrivateClickMeasurement.DestinationClickFraudPrevention (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49226 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6884 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35561 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16567 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12190 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77042 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20100 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9717 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21891 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16321 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19772 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->