### PR TITLE
[webkitbugspy] git-webkit fails with AttributeError if a tracked bug is not found when cc-ing

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -671,20 +671,34 @@ class Tracker(GenericTracker):
             if user_to_cc:
                 keyword_to_add = 'InRadar'
             elif comment_to_make:
-                tracked_bug = issue.references[0] if issue.references else '?'
-                sys.stderr.write("{} already CCed '{}' and tracking a different bug\n".format(
-                    self.radar_importer.name,
-                    tracked_bug,
-                ))
-                response = webkitcorepy.Terminal.choose(
-                    f'Double-check you have the correct bug ({issue.link}).\nWould you like to overwrite {tracked_bug.link} with {radar.link}?',
-                    options=('Yes', 'Skip CC', 'Exit'), default='Exit',
-                )
-                if response == 'Skip CC':
-                    print(f'Skipping CC for {issue.link}')
-                    return None
-                if response == 'No':
-                    raise ValueError('Radar is tracking a different bug')
+                tracked_bug = issue.references[0] if issue.references else None
+                if tracked_bug:
+                    sys.stderr.write("{} already CCed '{}' and tracking a different bug\n".format(
+                        self.radar_importer.name,
+                        tracked_bug,
+                    ))
+                    response = webkitcorepy.Terminal.choose(
+                        f'Double-check you have the correct bug ({issue.link}).\nWould you like to overwrite {tracked_bug.link} with {radar.link}?',
+                        options=('Yes', 'Skip CC', 'Exit'), default='Exit',
+                    )
+                    if response == 'Skip CC':
+                        print(f'Skipping CC for {issue.link}')
+                        return None
+                    if response == 'No':
+                        raise ValueError('Radar is tracking a different bug')
+                else:
+                    sys.stderr.write("{} already CCed but no Radar was imported\n".format(
+                        self.radar_importer.name,
+                    ))
+                    response = webkitcorepy.Terminal.choose(
+                        f'Would you like to CC {radar.link}?',
+                        options=('Yes', 'Skip CC', 'Exit'), default='Exit',
+                    )
+                    if response == 'Skip CC':
+                        print(f'Skipping CC for {issue.link}')
+                        return None
+                    if response == 'No':
+                        raise ValueError("Radar Importer is already CC'd")
                 user_to_cc = True  # Ensure that the user override is respected even if 'InRadar' is applied
 
         did_modify_cc = False


### PR DESCRIPTION
#### a6b08a2a7b335f8a2debe54eb78a850dfbc8d34b
<pre>
[webkitbugspy] git-webkit fails with AttributeError if a tracked bug is not found when cc-ing
<a href="https://bugs.webkit.org/show_bug.cgi?id=287517">https://bugs.webkit.org/show_bug.cgi?id=287517</a>
<a href="https://rdar.apple.com/144640536">rdar://144640536</a>

Reviewed by Jonathan Bedard.

A possible edge case is when the Radar Importer is CC&apos;d on a bug but it is slow to respond
and there is no radar associated with the bug. Then, a user tries to manually CC a radar through
git-webkit. Our tooling will believe there&apos;s already a radar associated when there isn&apos;t.

We shouldn&apos;t output &apos;?&apos; in place of a radar and rather catch this case and verify
that the user intended to CC the radar. (Another possibility is to silently CC the radar without
asking, since this is technically correct if we discount race conditions with the importer.)

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.cc_radar):

Canonical link: <a href="https://commits.webkit.org/291529@main">https://commits.webkit.org/291529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a5f32399f7e2faf89ba58950a78b223cb4279a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40154 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91443 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68870 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26545 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81161 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49230 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/88893 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35544 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39260 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96207 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77740 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76958 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77046 "Found 1 new API test failure: /WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/new-window-policy (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20089 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9723 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14904 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16586 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16327 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->