### PR TITLE
[visionOS] Fix the drag preview of the <model> element

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -94,6 +94,8 @@ public:
 
     std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier() const;
 
+    std::optional<PlatformLayerIdentifier> layerID() const;
+
 #if ENABLE(MODEL_PROCESS)
     RefPtr<ModelContext> modelContext() const;
 
@@ -173,7 +175,6 @@ private:
     void deleteModelPlayer();
 
     RefPtr<GraphicsLayer> graphicsLayer() const;
-    std::optional<PlatformLayerIdentifier> layerID() const;
 
     HTMLModelElement& readyPromiseResolve();
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1422,6 +1422,11 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
             item.title = titleAttribute.isEmpty() ? link->innerText() : titleAttribute.string();
             item.url = frame.document()->completeURL(link->getAttribute(HTMLNames::hrefAttr));
         }
+
+#if ENABLE(MODEL_PROCESS)
+        if (RefPtr modelElement = dynamicDowncast<HTMLModelElement>(state.source); modelElement && m_dragSourceAction.contains(DragSourceAction::Model))
+            item.modelLayerID = modelElement->layerID();
+#endif
     }
     client().startDrag(WTFMove(item), *state.dataTransfer, mainFrame.get());
     // DragClient::startDrag can cause our Page to dispear, deallocating |this|.

--- a/Source/WebCore/platform/DragItem.h
+++ b/Source/WebCore/platform/DragItem.h
@@ -31,6 +31,7 @@
 #include "IntPoint.h"
 #include "IntRect.h"
 #include "PasteboardWriterData.h"
+#include "PlatformLayerIdentifier.h"
 #include "PromisedAttachmentInfo.h"
 
 namespace WebCore {
@@ -51,6 +52,10 @@ struct DragItem final {
     bool containsSelection { false };
 
     PromisedAttachmentInfo promisedAttachmentInfo;
+
+#if ENABLE(MODEL_PROCESS)
+    Markable<PlatformLayerIdentifier> modelLayerID;
+#endif
 
     PasteboardWriterData data { };
 };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7576,6 +7576,9 @@ struct WebCore::DragItem {
     WebCore::IntRect dragPreviewFrameInRootViewCoordinates;
     bool containsSelection;
     WebCore::PromisedAttachmentInfo promisedAttachmentInfo;
+#if ENABLE(MODEL_PROCESS)
+    Markable<WebCore::PlatformLayerIdentifier> modelLayerID;
+#endif
     [NotSerialized] WebCore::PasteboardWriterData data;
 };
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -227,6 +227,10 @@ enum class TapHandlingResult : uint8_t;
 - (void)_updatePageLoadObserverState NS_DIRECT;
 #endif
 
+#if ENABLE(MODEL_PROCESS)
+- (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView;
+#endif
+
 @end
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3891,6 +3891,13 @@ static bool isLockdownModeWarningNeeded()
     _overriddenZoomScaleParameters = std::nullopt;
 }
 
+#if ENABLE(MODEL_PROCESS)
+- (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView
+{
+    [_contentView _willInvalidateDraggedModelWithContainerView:containerView];
+}
+#endif
+
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WKWebViewIOSInternalAdditionsAfter.mm>)
 #import <WebKitAdditions/WKWebViewIOSInternalAdditionsAfter.mm>
 #endif

--- a/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.h
@@ -28,6 +28,7 @@
 #if PLATFORM(IOS_FAMILY) && ENABLE(MODEL_PROCESS)
 
 #import <WebCore/ModelContext.h>
+#import <WebCore/PlatformLayerIdentifier.h>
 #import <wtf/RefCounted.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/UniqueRef.h>
@@ -51,6 +52,8 @@ public:
     virtual ~ModelPresentationManagerProxy();
 
     RetainPtr<WKPageHostedModelView> setUpModelView(Ref<WebCore::ModelContext>);
+    RetainPtr<UIView> startDragForModel(const WebCore::PlatformLayerIdentifier&);
+    void doneWithCurrentDragSession();
     void invalidateModel(const WebCore::PlatformLayerIdentifier&);
     void invalidateAllModels();
 
@@ -69,6 +72,7 @@ private:
     ModelPresentation& ensureModelPresentation(Ref<WebCore::ModelContext>, const WebPageProxy&);
 
     HashMap<WebCore::PlatformLayerIdentifier, UniqueRef<ModelPresentation>> m_modelPresentations;
+    HashSet<WebCore::PlatformLayerIdentifier> m_activelyDraggedModelLayerIDs;
     WeakPtr<WebPageProxy> m_page;
 };
 

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.h
@@ -48,7 +48,8 @@ namespace WebKit {
 struct DragSourceState {
     OptionSet<WebCore::DragSourceAction> action;
     CGRect dragPreviewFrameInRootViewCoordinates { CGRectZero };
-    RetainPtr<UIImage> image;
+    using DragPreviewContentType = std::variant<RetainPtr<UIImage>, RetainPtr<UIView>>;
+    DragPreviewContentType dragPreviewContent;
     std::optional<WebCore::TextIndicatorData> indicatorData;
     std::optional<WebCore::Path> visiblePath;
     String linkTitle;
@@ -70,7 +71,7 @@ public:
     // These helper methods are unique to UIDragInteraction.
     void prepareForDragSession(id <UIDragSession>, dispatch_block_t completionHandler);
     void dragSessionWillBegin();
-    void stageDragItem(const WebCore::DragItem&, UIImage *);
+    void stageDragItem(const WebCore::DragItem&, DragSourceState::DragPreviewContentType);
     bool hasStagedDragSource() const;
     const DragSourceState& stagedDragSource() const { return m_stagedDragSource.value(); }
     enum class DidBecomeActive : bool { No, Yes };

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -965,6 +965,10 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
 
+#if ENABLE(MODEL_PROCESS)
+- (void)_willInvalidateDraggedModelWithContainerView:(UIView *)containerView;
+#endif
+
 @end
 
 @interface WKContentView (WKTesting)

--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -44,6 +44,7 @@
 #import <UIKit/UIKeyboardPreferencesController.h>
 #import <UIKit/UIKeyboard_Private.h>
 #import <UIKit/UIPress_Private.h>
+#import <UIKit/UIRemoteView.h>
 #import <UIKit/UIResponder_Private.h>
 #import <UIKit/UIScreen_Private.h>
 #import <UIKit/UIScrollEvent_Private.h>

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		51FA14312AF5BAE00003ACD1 /* IPCSerialization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51FA14302AF5BAE00003ACD1 /* IPCSerialization.mm */; };
 		520BCF4C141EB09E00937EA8 /* WebArchive_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 520BCF4A141EB09E00937EA8 /* WebArchive_Bundle.cpp */; };
 		5245178721B9F57B0082CB34 /* RenderingProgressPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 52D5D6BE21B9F1B20046ABA6 /* RenderingProgressPlugIn.mm */; };
+		524A93202D5AB3A600D566F1 /* simple-model-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 524A931F2D5AB3A600D566F1 /* simple-model-page.html */; };
 		52D673EE1AFB127300FA19FE /* WKPageCopySessionStateWithFiltering.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52D673EC1AFB126800FA19FE /* WKPageCopySessionStateWithFiltering.cpp */; };
 		52E5CE4914D21EAB003B2BD8 /* ParentFrame_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 52E5CE4814D21EAB003B2BD8 /* ParentFrame_Bundle.cpp */; };
 		5311BD5E1EA9490E00525281 /* ThreadMessages.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5311BD5D1EA9490D00525281 /* ThreadMessages.cpp */; };
@@ -1993,6 +1994,7 @@
 				A17C46EA2C98E54B0023F3C7 /* simple-form.html in Copy Resources */,
 				A17C46EB2C98E54B0023F3C7 /* simple-iframe.html in Copy Resources */,
 				A17C46EC2C98E54B0023F3C7 /* simple-image-overlay.html in Copy Resources */,
+				524A93202D5AB3A600D566F1 /* simple-model-page.html in Copy Resources */,
 				A17C46ED2C98E54B0023F3C7 /* simple-responsive-page.html in Copy Resources */,
 				A17C46EE2C98E54B0023F3C7 /* simple-tall.html in Copy Resources */,
 				A17C46EF2C98E54B0023F3C7 /* simple.html in Copy Resources */,
@@ -2745,6 +2747,7 @@
 		520BCF4A141EB09E00937EA8 /* WebArchive_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebArchive_Bundle.cpp; sourceTree = "<group>"; };
 		520BCF4B141EB09E00937EA8 /* WebArchive.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebArchive.cpp; sourceTree = "<group>"; };
 		521D1B7227713E80003900C5 /* web-authentication-get-assertion-hid-internal-uv-pin-fallback.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "web-authentication-get-assertion-hid-internal-uv-pin-fallback.html"; sourceTree = "<group>"; };
+		524A931F2D5AB3A600D566F1 /* simple-model-page.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "simple-model-page.html"; sourceTree = "<group>"; };
 		524BBC9B19DF3714002F1AF1 /* file-with-video.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "file-with-video.html"; sourceTree = "<group>"; };
 		524BBC9C19DF377A002F1AF1 /* WKPageIsPlayingAudio.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKPageIsPlayingAudio.cpp; sourceTree = "<group>"; };
 		524BBCA019E30C63002F1AF1 /* test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.mp4; sourceTree = "<group>"; };
@@ -5938,6 +5941,7 @@
 				C0ADBE8412FCA6B600D2C129 /* simple-form.html */,
 				33DC890E1419539300747EF7 /* simple-iframe.html */,
 				F4EC8093260D2E620010311D /* simple-image-overlay.html */,
+				524A931F2D5AB3A600D566F1 /* simple-model-page.html */,
 				F460F668261262C70064F2B6 /* simple-responsive-page.html */,
 				BCAA485514A021640088FAC4 /* simple-tall.html */,
 				BC909778125571AB00083756 /* simple.html */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/simple-model-page.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/simple-model-page.html
@@ -1,0 +1,7 @@
+<model>
+    <source src='cube.usdz'>
+</model>
+<script>
+    document.querySelector('model').addEventListener('load', event => window.webkit.messageHandlers.modelLoading.postMessage('LOADED'));
+    document.querySelector('model').ready.then((result) => window.webkit.messageHandlers.modelLoading.postMessage('READY'));
+</script>

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -112,6 +112,7 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 @property (nonatomic, strong) NSArray *externalItemProviders;
 @property (nonatomic, readonly) UIDropProposal *lastKnownDropProposal;
 
+@property (nonatomic, copy) void(^dragProgressMidPointReachedBlock)(void);
 @property (nonatomic, copy) BOOL(^showCustomActionSheetBlock)(_WKActivatedElementInfo *);
 @property (nonatomic, copy) NSArray *(^convertItemProvidersBlock)(NSItemProvider *, NSArray *, NSDictionary *);
 @property (nonatomic, copy) NSArray *(^overridePerformDropBlock)(id <UIDropSession>);

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -658,6 +658,11 @@ IGNORE_WARNINGS_END
         return;
     }
 
+    if (_currentProgress >= 0.5 && _dragProgressMidPointReachedBlock) {
+        _dragProgressMidPointReachedBlock();
+        _dragProgressMidPointReachedBlock = nil;
+    }
+
     _lastKnownDragCaretRect = [_webView _dragCaretRect];
     _currentProgress += progressIncrementStep;
     CGPoint locationInWindow = self._currentLocation;


### PR DESCRIPTION
#### 676b1c75b77ea731918213ca6853ff55aaccec61
<pre>
[visionOS] Fix the drag preview of the &lt;model&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=287525">https://bugs.webkit.org/show_bug.cgi?id=287525</a>
<a href="https://rdar.apple.com/141165213">rdar://141165213</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

For UITargetedDragPreview to capture the snapshot of a view
with entity-based content properly, we need to pass the _UIRemoteView
hosting the model content directly when constructing the UITargetedDragPreview.
To do that, we need to pass the model element’s PlatformLayerIdentifier
in the DragItem, so we can use it to retrieve the _UIRemoteView hosting
the model entity from ModelPresentationManagerProxy in the UI process
to stage the drag session with.
In DragDropInteractionState::createDragPreviewInternal(), if the drag
preview content is the _UIRemoteView rather than an image, create the
UITargetedDragPreview with that view directly.

Handle the edge case where the model element is removed while
it’s being dragged by adding it to the WKContentView’s drag previews
container view.

* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::doSystemDrag):
If the dragged element is an HTMLModelElement, save off its
PlatformLayerIdentifier in the DragItem.
* Source/WebCore/platform/DragItem.h:
Include the model element’s PlatformLayerIdentifier
in the DragItem struct.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _willInvalidateDraggedModelWithContainerView:]):
* Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Model/ModelPresentationManagerProxy.mm:
(WebKit::ModelPresentationManagerProxy::startDragForModel):
Add the dragged model’s layer identifier to m_activelyDraggedModelLayerIDs.
Return the _UIRemoteView hosting the model entity.
(WebKit::ModelPresentationManagerProxy::doneWithCurrentDragSession):
Clear m_activelyDraggedModelLayerIDs.
(WebKit::ModelPresentationManagerProxy::invalidateModel):
If the model layer being removed is currently being dragged, call
-[WKWebView _willInvalidateDraggedModelWithContainerView:] with the
model container view so it can be re-parented to the window’s
view hierarchy.
* Source/WebKit/UIProcess/ios/DragDropInteractionState.h:
DragSourceState now stores content with the DragPreviewContentType
which is either a UIImage or a UIView.
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::shouldUseDragImageToCreatePreviewForDragSource):
(WebKit::DragDropInteractionState::previewForCancelling):
The UITargetedDragPreview’s view is the _UIRemoteView’s that’s
already in the remote layer tree’s view hierarchy if the dragged
element is a model element. Only add UITargetedDragPreview’s view
to m_previewViewsForDragCancel if its superview is the preview container.
(WebKit::DragDropInteractionState::createDragPreviewInternal const):
If the drag preview content is a UIView (which is the case for a
dragged model), create a UITargetedDragPreview with that UIView.
(WebKit::DragDropInteractionState::stageDragItem):
(WebKit::DragDropInteractionState::updatePreviewsForActiveDragSources):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _startDrag:item:]):
If the dragged item has a model layer identifier, stage the drag
item with the _UIRemoteView returned from the page’s ModelPresentationManagerProxy.
(-[WKContentView cleanUpDragSourceSessionState]):
Clear the dragged models tracked in ModelPresentationManagerProxy.
(-[WKContentView _willInvalidateDraggedModelWithContainerView:]):
This is called when the dragged model is being removed from the document.
We need to keep its container view in the window by hiding it and
adding it to the WKContentView’s _dragPreviewContainerView.
* Source/WebKit/UIProcess/ios/WKPageHostedModelView.mm:
(-[WKPageHostedModelView init]):
Add some nil checks which are needed for TestWebKitAPI model drag
and drop tests.
* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/simple-model-page.html: Added.
Simple test page with a model. Posts messages when the model is
loaded and when it’s ready.
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(-[ModelLoadingMessageHandler userContentController:didReceiveScriptMessage:]):
Teach ModelLoadingMessageHandler to catch both the model loaded
event and the model ready event.
(TestWebKitAPI::TEST(DragAndDropTests, CanStartDragOnModel)):
Update test to load the new simple-model-page.html.
(TestWebKitAPI::TEST(DragAndDropTests, CheckModelDragPreview)):
Simulate the dragging of a model element and verify that the resulting
UITargetedDragPreview’s view is a _UIRemoteView. In the middle of the
drag, remove the model from the document and make sure the _UIRemoteView
is still in the window’s view hierarchy. We have to test this scenario
while the drag is still in progress because the page’s drag preview
container view gets removed from the window at the end of the drag session.
* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[DragAndDropSimulator _advanceProgress]):
Call _dragProgressMidPointReachedBlock if it&apos;s set when the
drag progress has passed the midway point.

Canonical link: <a href="https://commits.webkit.org/290437@main">https://commits.webkit.org/290437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d504b3db9e00e70fbd6308a548717d6771aaa48d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89986 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40759 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69280 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26889 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81633 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49637 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7307 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39893 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96812 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17174 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78261 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17430 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77475 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21933 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20517 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10368 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17184 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22509 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20377 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18708 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->