### PR TITLE
Add support for CoreIPCNSURLCredentialType::ClientCertificate

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h
@@ -51,6 +51,7 @@ enum class CoreIPCNSURLCredentialType : uint8_t {
     Password,
     ServerTrust,
     KerberosTicket,
+    ClientCertificate,
     XMobileMeAuthToken,
     OAuth2
 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm
@@ -156,6 +156,9 @@ CoreIPCNSURLCredential::CoreIPCNSURLCredential(NSURLCredential *credential)
         case kURLCredentialOAuth2:
             m_data.type = CoreIPCNSURLCredentialType::OAuth2;
             break;
+        case kURLCredentialClientCertificate:
+            m_data.type = CoreIPCNSURLCredentialType::ClientCertificate;
+            break;
         default:
             ASSERT_NOT_REACHED();
             m_data.type = CoreIPCNSURLCredentialType::Password;
@@ -245,6 +248,9 @@ RetainPtr<id> CoreIPCNSURLCredential::toID() const
                 [flags setObject: flagPair.second.toID().get() forKey:flagPair.first.toID().get()];
             [dict setObject:flags.get() forKey:@"flags"];
         }
+        break;
+    case CoreIPCNSURLCredentialType::ClientCertificate:
+        [dict setObject:@(kURLCredentialClientCertificate) forKey:@"type"];
         break;
     case CoreIPCNSURLCredentialType::XMobileMeAuthToken:
         [dict setObject:@(kURLCredentialXMobileMeAuthToken) forKey:@"type"];

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.serialization.in
@@ -36,6 +36,7 @@ header: "CoreIPCNSURLCredential.h"
     Password,
     ServerTrust,
     KerberosTicket,
+    ClientCertificate,
     XMobileMeAuthToken,
     OAuth2
 };


### PR DESCRIPTION
#### 84c6f16ce6744f46dfdb2adb29bd22a0a89f8fd2
<pre>
Add support for CoreIPCNSURLCredentialType::ClientCertificate
<a href="https://bugs.webkit.org/show_bug.cgi?id=287528">https://bugs.webkit.org/show_bug.cgi?id=287528</a>
<a href="https://rdar.apple.com/144634274">rdar://144634274</a>

Reviewed by Sihui Liu.

* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.mm:
(WebKit::CoreIPCNSURLCredential::CoreIPCNSURLCredential):
(WebKit::CoreIPCNSURLCredential::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLCredential.serialization.in:

Canonical link: <a href="https://commits.webkit.org/290313@main">https://commits.webkit.org/290313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254815178cc4afc5d240f9147982c67746889ad6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40186 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68887 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6904 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39290 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96237 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16603 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77758 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77065 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19067 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21494 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9753 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16616 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->