### PR TITLE
Adopt more smart pointers in PlatformCAFilters, DecodedDataDocumentParser

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -555,7 +555,6 @@ dom/CustomElementRegistry.cpp
 dom/DOMImplementation.cpp
 dom/DataTransfer.cpp
 dom/DataTransferItemList.cpp
-dom/DecodedDataDocumentParser.cpp
 dom/Document.cpp
 dom/DocumentFontLoader.cpp
 dom/DocumentFragment.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -630,7 +630,6 @@ platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/TileGrid.cpp
-platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
 platform/graphics/coretext/ComplexTextControllerCoreText.mm

--- a/Source/WebCore/dom/DecodedDataDocumentParser.cpp
+++ b/Source/WebCore/dom/DecodedDataDocumentParser.cpp
@@ -43,7 +43,7 @@ void DecodedDataDocumentParser::appendBytes(DocumentWriter& writer, std::span<co
     if (data.empty())
         return;
 
-    String decoded = writer.decoder().decode(data);
+    String decoded = writer.protectedDecoder()->decode(data);
     if (decoded.isEmpty())
         return;
 
@@ -53,7 +53,7 @@ void DecodedDataDocumentParser::appendBytes(DocumentWriter& writer, std::span<co
 
 void DecodedDataDocumentParser::flush(DocumentWriter& writer)
 {
-    String remainingData = writer.decoder().flush();
+    String remainingData = writer.protectedDecoder()->flush();
     if (remainingData.isEmpty())
         return;
 

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -295,6 +295,11 @@ TextResourceDecoder& DocumentWriter::decoder()
     return *m_decoder;
 }
 
+Ref<TextResourceDecoder> DocumentWriter::protectedDecoder()
+{
+    return decoder();
+}
+
 void DocumentWriter::reportDataReceived()
 {
     ASSERT(m_decoder);

--- a/Source/WebCore/loader/DocumentWriter.h
+++ b/Source/WebCore/loader/DocumentWriter.h
@@ -62,6 +62,8 @@ public:
     const String& mimeType() const { return m_mimeType; }
     void setMIMEType(const String& type) { m_mimeType = type; }
 
+    Ref<TextResourceDecoder> protectedDecoder();
+
     // Exposed for DocumentParser::appendBytes.
     TextResourceDecoder& decoder();
     void reportDataReceived();

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm
@@ -129,13 +129,13 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
     ASSERT(presentationModifierCount(*canonicalFilters));
 
     for (size_t i = 0; i < numberOfCanonicalFilters; ++i) {
-        auto& canonicalFilterOperation = (*canonicalFilters)[i].get();
-        auto& initialFilterOperation = i < numberOfInitialFilters ? initialFilters[i].get() : passthroughFilter(canonicalFilterOperation.type());
-        ASSERT(canonicalFilterOperation.type() == initialFilterOperation.type());
+        Ref canonicalFilterOperation = (*canonicalFilters)[i].get();
+        Ref initialFilterOperation = i < numberOfInitialFilters ? initialFilters[i].get() : passthroughFilter(canonicalFilterOperation->type());
+        ASSERT(canonicalFilterOperation->type() == initialFilterOperation->type());
 
         auto filterName = makeString("filter_"_s, i);
 
-        auto type = initialFilterOperation.type();
+        auto type = initialFilterOperation->type();
         switch (type) {
         case FilterOperation::Type::Default:
         case FilterOperation::Type::Reference:
@@ -143,11 +143,11 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
             ASSERT_NOT_REACHED();
             break;
         case FilterOperation::Type::DropShadow: {
-            const auto& dropShadowOperation = downcast<DropShadowFilterOperation>(initialFilterOperation);
-            auto size = CGSizeMake(dropShadowOperation.x(), dropShadowOperation.y());
+            const Ref dropShadowOperation = downcast<DropShadowFilterOperation>(initialFilterOperation);
+            auto size = CGSizeMake(dropShadowOperation->x(), dropShadowOperation->y());
             presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowOffset" initialValue:[NSValue value:&size withObjCType:@encode(CGSize)] additive:NO group:group.get()]) });
-            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowColor" initialValue:(id) cachedCGColor(dropShadowOperation.color()).autorelease() additive:NO group:group.get()]) });
-            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowRadius" initialValue:@(dropShadowOperation.stdDeviation()) additive:NO group:group.get()]) });
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowColor" initialValue:(id) cachedCGColor(dropShadowOperation->color()).autorelease() additive:NO group:group.get()]) });
+            presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:@"shadowRadius" initialValue:@(dropShadowOperation->stdDeviation()) additive:NO group:group.get()]) });
             continue;
         }
         case FilterOperation::Type::Grayscale:
@@ -159,7 +159,7 @@ void PlatformCAFilters::presentationModifiers(const FilterOperations& initialFil
         case FilterOperation::Type::Brightness:
         case FilterOperation::Type::Contrast:
         case FilterOperation::Type::Blur: {
-            auto keyValueName = makeString("filters."_s, filterName, '.', animatedFilterPropertyName(initialFilterOperation.type()));
+            auto keyValueName = makeString("filters."_s, filterName, '.', animatedFilterPropertyName(initialFilterOperation->type()));
             presentationModifiers.append({ type, adoptNS([[CAPresentationModifier alloc] initWithKeyPath:keyValueName initialValue:filterValueForOperation(initialFilterOperation).get() additive:NO group:group.get()]) });
             continue;
         }
@@ -183,20 +183,20 @@ void PlatformCAFilters::updatePresentationModifiers(const FilterOperations& filt
     size_t filterIndex = 0;
     auto numberOfFilters = filters.size();
     for (size_t i = 0; i < presentationModifiers.size(); ++i) {
-        auto& filterOperation = filterIndex < numberOfFilters ? *filters.at(filterIndex) : passthroughFilter(presentationModifiers[i].first);
+        Ref filterOperation = filterIndex < numberOfFilters ? *filters.at(filterIndex) : passthroughFilter(presentationModifiers[i].first);
         ++filterIndex;
-        switch (filterOperation.type()) {
+        switch (filterOperation->type()) {
         case FilterOperation::Type::Default:
         case FilterOperation::Type::Reference:
         case FilterOperation::Type::None:
             ASSERT_NOT_REACHED();
             return;
         case FilterOperation::Type::DropShadow: {
-            const auto& dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
-            auto size = CGSizeMake(dropShadowOperation.x(), dropShadowOperation.y());
+            const Ref dropShadowOperation = downcast<DropShadowFilterOperation>(filterOperation);
+            auto size = CGSizeMake(dropShadowOperation->x(), dropShadowOperation->y());
             [presentationModifiers[i].second.get() setValue:[NSValue value:&size withObjCType:@encode(CGSize)]];
-            [presentationModifiers[i + 1].second.get() setValue:(id) cachedCGColor(dropShadowOperation.color()).autorelease()];
-            [presentationModifiers[i + 2].second.get() setValue:@(dropShadowOperation.stdDeviation())];
+            [presentationModifiers[i + 1].second.get() setValue:(id) cachedCGColor(dropShadowOperation->color()).autorelease()];
+            [presentationModifiers[i + 2].second.get() setValue:@(dropShadowOperation->stdDeviation())];
             i += 2;
             continue;
         }


### PR DESCRIPTION
#### 8ddea9e10c63b1c3d6e7938cc25bb38a54786fbf
<pre>
Adopt more smart pointers in PlatformCAFilters, DecodedDataDocumentParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=287529">https://bugs.webkit.org/show_bug.cgi?id=287529</a>
<a href="https://rdar.apple.com/144652225">rdar://144652225</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/DecodedDataDocumentParser.cpp:
(WebCore::DecodedDataDocumentParser::appendBytes):
(WebCore::DecodedDataDocumentParser::flush):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::protectedDecoder):
* Source/WebCore/loader/DocumentWriter.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCAFiltersCocoa.mm:
(WebCore::PlatformCAFilters::presentationModifiers):
(WebCore::PlatformCAFilters::updatePresentationModifiers):

Canonical link: <a href="https://commits.webkit.org/290333@main">https://commits.webkit.org/290333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb56ccdab89753d504e9de2edbc41d54ad07ba98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17365 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68984 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92560 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81277 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7004 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35661 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39432 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96379 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12300 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77856 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77171 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9908 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14075 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22068 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16495 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19946 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->