### PR TITLE
REGRESSION(283286.393@safari-7620-branch): Crash in `PageOverlayController::uninstallPageOverlay`

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -539,6 +539,9 @@ Page::~Page()
     if (RefPtr scrollingCoordinator = m_scrollingCoordinator)
         scrollingCoordinator->pageDestroyed();
 
+    if (m_resourceUsageOverlay)
+        m_resourceUsageOverlay->detachFromPage();
+
     checkedBackForward()->close();
     if (!isUtilityPage())
         BackForwardCache::singleton().removeAllItemsForPage(*this);

--- a/Source/WebCore/page/ResourceUsageOverlay.h
+++ b/Source/WebCore/page/ResourceUsageOverlay.h
@@ -63,6 +63,8 @@ public:
     void platformDraw(CGContextRef);
 #endif
 
+    void detachFromPage() { m_page.clear(); }
+
     static const int normalWidth = 570;
     static const int normalHeight = 180;
 


### PR DESCRIPTION
#### 379956fc242a6bad0a3d8d665398834a25c22e7a
<pre>
REGRESSION(283286.393@safari-7620-branch): Crash in `PageOverlayController::uninstallPageOverlay`
<a href="https://bugs.webkit.org/show_bug.cgi?id=283832">https://bugs.webkit.org/show_bug.cgi?id=283832</a>
<a href="https://rdar.apple.com/140529810">rdar://140529810</a>

Reviewed by Chris Dumez.

283286.393@safari-7620-branch made the ResourceUsageOverlay destructor access the page it was holding
instead of the page held by the page’s mainframe. This was a behavior change because the page destructor
nulls the page held by the mainframe, so we would not try to uninstall the overlay if page destruction
has begun.

This change clears the page held by ResourceUsageOverlay in the page’s destructor to avoid uninstalling
the overlay during page destruction.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::~Page):
* Source/WebCore/page/ResourceUsageOverlay.h:

Originally-landed-as: 283286.535@safari-7620-branch (6bfd37a9ea77). <a href="https://rdar.apple.com/144654097">rdar://144654097</a>
Canonical link: <a href="https://commits.webkit.org/290254@main">https://commits.webkit.org/290254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37835e1202135e9c6691062be433ec8ecc89ecc5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8950 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68890 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49250 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35545 "Found 5 new test failures: editing/undo/redo-reapply-edit-command-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-queued-navigations.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39293 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77265 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96272 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16606 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77095 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21496 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9756 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16619 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21930 "Found 1 new failure in page/Page.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->