### PR TITLE
[JSC] Add core semantics of import defer

### DIFF
--- a/JSTests/modules/import-defer-1-1-cycle.js
+++ b/JSTests/modules/import-defer-1-1-cycle.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+import "./import-defer-1-1-cycle/a.js";

--- a/JSTests/modules/import-defer-1-1-cycle/a.js
+++ b/JSTests/modules/import-defer-1-1-cycle/a.js
@@ -1,0 +1,9 @@
+// a.js
+
+import "./b.js";
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;

--- a/JSTests/modules/import-defer-1-1-cycle/b.js
+++ b/JSTests/modules/import-defer-1-1-cycle/b.js
@@ -1,0 +1,6 @@
+// b.js
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-1-1-cycle/c.js
+++ b/JSTests/modules/import-defer-1-1-cycle/c.js
@@ -1,0 +1,9 @@
+// c.js
+
+import "./d.js";
+import "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-1-1-cycle/d.js
+++ b/JSTests/modules/import-defer-1-1-cycle/d.js
@@ -1,0 +1,6 @@
+// d.js
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-1-1-cycle/e.js
+++ b/JSTests/modules/import-defer-1-1-cycle/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+await 0;
+
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-1-cycle.js
+++ b/JSTests/modules/import-defer-1-cycle.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+import "./import-defer-1-cycle/a.js";

--- a/JSTests/modules/import-defer-1-cycle/a.js
+++ b/JSTests/modules/import-defer-1-cycle/a.js
@@ -1,0 +1,8 @@
+// a.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;

--- a/JSTests/modules/import-defer-1-cycle/c.js
+++ b/JSTests/modules/import-defer-1-cycle/c.js
@@ -1,0 +1,8 @@
+// c.js
+
+import "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-1-cycle/e.js
+++ b/JSTests/modules/import-defer-1-cycle/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;
+
+await 0;
+
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-2-1-deferred-cycle.js
+++ b/JSTests/modules/import-defer-2-1-deferred-cycle.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+import "./import-defer-2-1-deferred-cycle/a.js";

--- a/JSTests/modules/import-defer-2-1-deferred-cycle/a.js
+++ b/JSTests/modules/import-defer-2-1-deferred-cycle/a.js
@@ -1,0 +1,9 @@
+// a.js
+
+import "./b.js";
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;

--- a/JSTests/modules/import-defer-2-1-deferred-cycle/b.js
+++ b/JSTests/modules/import-defer-2-1-deferred-cycle/b.js
@@ -1,0 +1,6 @@
+// b.js
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-2-1-deferred-cycle/c.js
+++ b/JSTests/modules/import-defer-2-1-deferred-cycle/c.js
@@ -1,0 +1,6 @@
+// c.js
+
+import "./d.js";
+import "./e.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-2-1-deferred-cycle/d.js
+++ b/JSTests/modules/import-defer-2-1-deferred-cycle/d.js
@@ -1,0 +1,3 @@
+// d.js
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-2-1-deferred-cycle/e.js
+++ b/JSTests/modules/import-defer-2-1-deferred-cycle/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;
+
+await 0;
+
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-2-1-force-evaluation.js
+++ b/JSTests/modules/import-defer-2-1-force-evaluation.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-2-1-force-evaluation/a.js";

--- a/JSTests/modules/import-defer-2-1-force-evaluation/a.js
+++ b/JSTests/modules/import-defer-2-1-force-evaluation/a.js
@@ -1,0 +1,11 @@
+// a.js
+
+import "./b.js";
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+ns.c;

--- a/JSTests/modules/import-defer-2-1-force-evaluation/b.js
+++ b/JSTests/modules/import-defer-2-1-force-evaluation/b.js
@@ -1,0 +1,6 @@
+// b.js
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-2-1-force-evaluation/c.js
+++ b/JSTests/modules/import-defer-2-1-force-evaluation/c.js
@@ -1,0 +1,11 @@
+// c.js
+
+import "./d.js";
+import "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;
+
+export const c = 1;

--- a/JSTests/modules/import-defer-2-1-force-evaluation/d.js
+++ b/JSTests/modules/import-defer-2-1-force-evaluation/d.js
@@ -1,0 +1,6 @@
+// d.js
+
+var global = (Function("return this"))();
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-2-1-force-evaluation/e.js
+++ b/JSTests/modules/import-defer-2-1-force-evaluation/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;
+
+await 0;
+
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-2-deferred-cycle.js
+++ b/JSTests/modules/import-defer-2-deferred-cycle.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+import "./import-defer-2-deferred-cycle/a.js";

--- a/JSTests/modules/import-defer-2-deferred-cycle/a.js
+++ b/JSTests/modules/import-defer-2-deferred-cycle/a.js
@@ -1,0 +1,8 @@
+// a.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-2-deferred-cycle/c.js
+++ b/JSTests/modules/import-defer-2-deferred-cycle/c.js
@@ -1,0 +1,5 @@
+// c.js
+
+import "./e.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-2-deferred-cycle/e.js
+++ b/JSTests/modules/import-defer-2-deferred-cycle/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-2-force-evaluation.js
+++ b/JSTests/modules/import-defer-2-force-evaluation.js
@@ -1,0 +1,4 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+import "./import-defer-2-force-evaluation/a.js";

--- a/JSTests/modules/import-defer-2-force-evaluation/a.js
+++ b/JSTests/modules/import-defer-2-force-evaluation/a.js
@@ -1,0 +1,10 @@
+// a.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;
+
+ns.c;

--- a/JSTests/modules/import-defer-2-force-evaluation/c.js
+++ b/JSTests/modules/import-defer-2-force-evaluation/c.js
@@ -1,0 +1,10 @@
+// c.js
+
+import "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+export const c = 1;

--- a/JSTests/modules/import-defer-2-force-evaluation/e.js
+++ b/JSTests/modules/import-defer-2-force-evaluation/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-3-1-force-evaluation.js
+++ b/JSTests/modules/import-defer-3-1-force-evaluation.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-3-1-force-evaluation/a.js";

--- a/JSTests/modules/import-defer-3-1-force-evaluation/a.js
+++ b/JSTests/modules/import-defer-3-1-force-evaluation/a.js
@@ -1,0 +1,11 @@
+// a.js
+
+import "./b.js";
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+ns.c;

--- a/JSTests/modules/import-defer-3-1-force-evaluation/b.js
+++ b/JSTests/modules/import-defer-3-1-force-evaluation/b.js
@@ -1,0 +1,6 @@
+// b.js
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-3-1-force-evaluation/c.js
+++ b/JSTests/modules/import-defer-3-1-force-evaluation/c.js
@@ -1,0 +1,11 @@
+// c.js
+
+import "./d.js";
+import "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;
+
+export const c = 1;

--- a/JSTests/modules/import-defer-3-1-force-evaluation/d.js
+++ b/JSTests/modules/import-defer-3-1-force-evaluation/d.js
@@ -1,0 +1,6 @@
+// d.js
+
+var global = (Function("return this"))();
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-3-1-force-evaluation/e.js
+++ b/JSTests/modules/import-defer-3-1-force-evaluation/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;
+
+await 0;
+
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-3-1-indirect-cycle.js
+++ b/JSTests/modules/import-defer-3-1-indirect-cycle.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-3-1-indirect-cycle/a.js";

--- a/JSTests/modules/import-defer-3-1-indirect-cycle/a.js
+++ b/JSTests/modules/import-defer-3-1-indirect-cycle/a.js
@@ -1,0 +1,9 @@
+// a.js
+
+import "./b.js";
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;

--- a/JSTests/modules/import-defer-3-1-indirect-cycle/b.js
+++ b/JSTests/modules/import-defer-3-1-indirect-cycle/b.js
@@ -1,0 +1,6 @@
+// b.js
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-3-1-indirect-cycle/c.js
+++ b/JSTests/modules/import-defer-3-1-indirect-cycle/c.js
@@ -1,0 +1,6 @@
+// c.js
+
+import "./d.js";
+import "./e.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-3-1-indirect-cycle/d.js
+++ b/JSTests/modules/import-defer-3-1-indirect-cycle/d.js
@@ -1,0 +1,3 @@
+// d.js
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-3-1-indirect-cycle/e.js
+++ b/JSTests/modules/import-defer-3-1-indirect-cycle/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;
+
+await 0;
+
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-3-force-evaluation.js
+++ b/JSTests/modules/import-defer-3-force-evaluation.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-3-force-evaluation/a.js";

--- a/JSTests/modules/import-defer-3-force-evaluation/a.js
+++ b/JSTests/modules/import-defer-3-force-evaluation/a.js
@@ -1,0 +1,10 @@
+// a.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;
+
+ns.c;

--- a/JSTests/modules/import-defer-3-force-evaluation/c.js
+++ b/JSTests/modules/import-defer-3-force-evaluation/c.js
@@ -1,0 +1,10 @@
+// c.js
+
+import "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+export const c = 1;

--- a/JSTests/modules/import-defer-3-force-evaluation/e.js
+++ b/JSTests/modules/import-defer-3-force-evaluation/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-3-indirect-cycle.js
+++ b/JSTests/modules/import-defer-3-indirect-cycle.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-3-indirect-cycle/a.js";

--- a/JSTests/modules/import-defer-3-indirect-cycle/a.js
+++ b/JSTests/modules/import-defer-3-indirect-cycle/a.js
@@ -1,0 +1,8 @@
+// a.js
+
+import defer * as ns from "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-3-indirect-cycle/c.js
+++ b/JSTests/modules/import-defer-3-indirect-cycle/c.js
@@ -1,0 +1,5 @@
+// c.js
+
+import "./e.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-3-indirect-cycle/e.js
+++ b/JSTests/modules/import-defer-3-indirect-cycle/e.js
@@ -1,0 +1,14 @@
+// e.js
+
+import defer * as ns from "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-4-both-imports.js
+++ b/JSTests/modules/import-defer-4-both-imports.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-4-both-imports/a.js";

--- a/JSTests/modules/import-defer-4-both-imports/a.js
+++ b/JSTests/modules/import-defer-4-both-imports/a.js
@@ -1,0 +1,10 @@
+// a.js
+
+import defer * as ns from "./b.js";
+import "./c.js";
+import "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-4-both-imports/b.js
+++ b/JSTests/modules/import-defer-4-both-imports/b.js
@@ -1,0 +1,6 @@
+// b.js
+
+var global = (Function("return this"))();
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-4-both-imports/c.js
+++ b/JSTests/modules/import-defer-4-both-imports/c.js
@@ -1,0 +1,6 @@
+// c.js
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-5-force-evaluation-b-a/a.js";

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a/a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a/a.js
@@ -1,0 +1,10 @@
+// a.js
+
+import defer * as ns from "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;
+
+ns.b;

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a/b.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a/b.js
@@ -1,0 +1,10 @@
+// b.js
+
+import "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 6)
+  throw new Error(`bad value ${global.count}`);
+global.count = 7;
+
+export const b = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a/c.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a/c.js
@@ -1,0 +1,14 @@
+// c.js
+
+import "./d.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+await 0;
+
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a/d.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a/d.js
@@ -1,0 +1,8 @@
+// d.js
+
+import defer * as ns from "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a/e.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a/e.js
@@ -1,0 +1,5 @@
+// e.js
+
+import "./f.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-5-force-evaluation-b-a/f.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-b-a/f.js
@@ -1,0 +1,14 @@
+// f.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-5-force-evaluation-e-a-b-a/a.js";

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/a.js
@@ -1,0 +1,11 @@
+// a.js
+
+import defer * as ns from "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;
+
+global.nsE.e;
+ns.b;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/b.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/b.js
@@ -1,0 +1,10 @@
+// b.js
+
+import "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 7)
+  throw new Error(`bad value ${global.count}`);
+global.count = 8;
+
+export const b = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/c.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/c.js
@@ -1,0 +1,14 @@
+// c.js
+
+import "./d.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+await 0;
+
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/d.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/d.js
@@ -1,0 +1,10 @@
+// d.js
+
+import defer * as ns from "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;
+
+global.nsE = ns;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/e.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/e.js
@@ -1,0 +1,10 @@
+// e.js
+
+import "./f.js";
+
+var global = (Function("return this"))();
+if (global.count !== 6)
+  throw new Error(`bad value ${global.count}`);
+global.count = 7;
+
+export const e = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/f.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/f.js
@@ -1,0 +1,14 @@
+// f.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-5-force-evaluation-e-d-b-a/a.js";

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/a.js
@@ -1,0 +1,10 @@
+// a.js
+
+import defer * as ns from "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 6)
+  throw new Error(`bad value ${global.count}`);
+global.count = 7;
+
+ns.b;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/b.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/b.js
@@ -1,0 +1,10 @@
+// b.js
+
+import "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 7)
+  throw new Error(`bad value ${global.count}`);
+global.count = 8;
+
+export const b = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/c.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/c.js
@@ -1,0 +1,14 @@
+// c.js
+
+import "./d.js";
+
+var global = (Function("return this"))();
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;
+
+await 0;
+
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/d.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/d.js
@@ -1,0 +1,10 @@
+// d.js
+
+import defer * as ns from "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;
+
+ns.e;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/e.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/e.js
@@ -1,0 +1,10 @@
+// e.js
+
+import "./f.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+export const e = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/f.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/f.js
@@ -1,0 +1,14 @@
+// f.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-5-force-evaluation-e-d/a.js";

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d/a.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d/a.js
@@ -1,0 +1,8 @@
+// a.js
+
+import defer * as ns from "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 6)
+  throw new Error(`bad value ${global.count}`);
+global.count = 7;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d/b.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d/b.js
@@ -1,0 +1,5 @@
+// b.js
+
+import "./c.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d/c.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d/c.js
@@ -1,0 +1,14 @@
+// c.js
+
+import "./d.js";
+
+var global = (Function("return this"))();
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;
+
+await 0;
+
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d/d.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d/d.js
@@ -1,0 +1,10 @@
+// d.js
+
+import defer * as ns from "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;
+
+ns.e;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d/e.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d/e.js
@@ -1,0 +1,10 @@
+// e.js
+
+import "./f.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+export const e = 1;

--- a/JSTests/modules/import-defer-5-force-evaluation-e-d/f.js
+++ b/JSTests/modules/import-defer-5-force-evaluation-e-d/f.js
@@ -1,0 +1,14 @@
+// f.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-5-multiple-async.js
+++ b/JSTests/modules/import-defer-5-multiple-async.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-5-multiple-async/a.js";

--- a/JSTests/modules/import-defer-5-multiple-async/a.js
+++ b/JSTests/modules/import-defer-5-multiple-async/a.js
@@ -1,0 +1,8 @@
+// a.js
+
+import defer * as ns from "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 5)
+  throw new Error(`bad value ${global.count}`);
+global.count = 6;

--- a/JSTests/modules/import-defer-5-multiple-async/b.js
+++ b/JSTests/modules/import-defer-5-multiple-async/b.js
@@ -1,0 +1,5 @@
+// b.js
+
+import "./c.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-5-multiple-async/c.js
+++ b/JSTests/modules/import-defer-5-multiple-async/c.js
@@ -1,0 +1,14 @@
+// c.js
+
+import "./d.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+await 0;
+
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-5-multiple-async/d.js
+++ b/JSTests/modules/import-defer-5-multiple-async/d.js
@@ -1,0 +1,8 @@
+// d.js
+
+import defer * as ns from "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-5-multiple-async/e.js
+++ b/JSTests/modules/import-defer-5-multiple-async/e.js
@@ -1,0 +1,5 @@
+// e.js
+
+import "./f.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-5-multiple-async/f.js
+++ b/JSTests/modules/import-defer-5-multiple-async/f.js
@@ -1,0 +1,14 @@
+// f.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-6-force-eval-order.js
+++ b/JSTests/modules/import-defer-6-force-eval-order.js
@@ -1,0 +1,2 @@
+//@ requireOptions("--useImportDefer=1")
+import "./import-defer-6-force-eval-order/a.js";

--- a/JSTests/modules/import-defer-6-force-eval-order/a.js
+++ b/JSTests/modules/import-defer-6-force-eval-order/a.js
@@ -1,0 +1,14 @@
+// a.js
+
+import defer * as ns from "./b.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;
+
+ns.b;
+
+if (global.count !== 4)
+  throw new Error(`bad value ${global.count}`);
+global.count = 5;

--- a/JSTests/modules/import-defer-6-force-eval-order/b.js
+++ b/JSTests/modules/import-defer-6-force-eval-order/b.js
@@ -1,0 +1,10 @@
+// b.js
+
+import "./c.js";
+
+var global = (Function("return this"))();
+if (global.count !== 3)
+  throw new Error(`bad value ${global.count}`);
+global.count = 4;
+
+export let b;

--- a/JSTests/modules/import-defer-6-force-eval-order/c.js
+++ b/JSTests/modules/import-defer-6-force-eval-order/c.js
@@ -1,0 +1,14 @@
+// c.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-6-force-eval-order/d.js
+++ b/JSTests/modules/import-defer-6-force-eval-order/d.js
@@ -1,0 +1,8 @@
+// d.js
+
+import defer * as ns from "./e.js";
+
+var global = (Function("return this"))();
+if (global.count !== 2)
+  throw new Error(`bad value ${global.count}`);
+global.count = 3;

--- a/JSTests/modules/import-defer-6-force-eval-order/e.js
+++ b/JSTests/modules/import-defer-6-force-eval-order/e.js
@@ -1,0 +1,5 @@
+// e.js
+
+import "./f.js";
+
+throw new Error(`deferred module should never be executed`);

--- a/JSTests/modules/import-defer-6-force-eval-order/f.js
+++ b/JSTests/modules/import-defer-6-force-eval-order/f.js
@@ -1,0 +1,14 @@
+// f.js
+
+import "./a.js";
+
+var global = (Function("return this"))();
+if (global.count !== undefined)
+  throw new Error(`bad value ${global.count}`);
+global.count = 1;
+
+await 0;
+
+if (global.count !== 1)
+  throw new Error(`bad value ${global.count}`);
+global.count = 2;

--- a/JSTests/modules/import-defer-basic.js
+++ b/JSTests/modules/import-defer-basic.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-basic/1.js";
+
+shouldBe(global.count, 0);
+
+aNs.foo();
+
+shouldBe(global.count, 1);

--- a/JSTests/modules/import-defer-basic/1.js
+++ b/JSTests/modules/import-defer-basic/1.js
@@ -1,0 +1,6 @@
+var global = (Function("return this"))();
+global.count++;
+
+export function foo() {
+  // Called to trigger deferred module execution
+}

--- a/JSTests/modules/import-defer-basic/2.js
+++ b/JSTests/modules/import-defer-basic/2.js
@@ -1,0 +1,2 @@
+import defer * as aNs from "./a.js";
+//aNs.foo();

--- a/JSTests/modules/import-defer-default.js
+++ b/JSTests/modules/import-defer-default.js
@@ -1,0 +1,5 @@
+import { shouldBe } from "./resources/assert.js"
+
+import defer from "./import-defer-default/foo.js";
+
+shouldBe(defer, "foo");

--- a/JSTests/modules/import-defer-default/foo.js
+++ b/JSTests/modules/import-defer-default/foo.js
@@ -1,0 +1,1 @@
+export default "foo";

--- a/JSTests/modules/import-defer-defineownproperty.js
+++ b/JSTests/modules/import-defer-defineownproperty.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe, shouldThrow } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-basic/1.js";
+
+shouldBe(global.count, 0);
+
+Object.defineProperty(aNs, "foo", { });
+
+shouldBe(global.count, 1);

--- a/JSTests/modules/import-defer-deleteproperty.js
+++ b/JSTests/modules/import-defer-deleteproperty.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe, shouldThrow } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-basic/1.js";
+
+shouldBe(global.count, 0);
+
+shouldThrow(() => delete aNs.foo, "TypeError: Unable to delete property.");
+
+shouldBe(global.count, 1);

--- a/JSTests/modules/import-defer-getownproperty.js
+++ b/JSTests/modules/import-defer-getownproperty.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-basic/1.js";
+
+shouldBe(global.count, 0);
+
+Object.getOwnPropertyDescriptor(aNs, "foo");
+
+shouldBe(global.count, 1);

--- a/JSTests/modules/import-defer-hasproperty.js
+++ b/JSTests/modules/import-defer-hasproperty.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-basic/1.js";
+
+shouldBe(global.count, 0);
+
+"foo" in aNs;
+
+shouldBe(global.count, 1);

--- a/JSTests/modules/import-defer-ownpropertykeys.js
+++ b/JSTests/modules/import-defer-ownpropertykeys.js
@@ -1,0 +1,13 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe, shouldThrow } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-basic/1.js";
+
+shouldBe(global.count, 0);
+
+Object.keys(aNs);
+
+shouldBe(global.count, 1);

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete.js
@@ -1,0 +1,3 @@
+//@ requireOptions("--useImportDefer=1")
+
+import "./import-defer-ready-for-sync-execution-cycle-delete/d.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/a.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/a.js
@@ -1,0 +1,1 @@
+import "./b.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/b.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/b.js
@@ -1,0 +1,1 @@
+import "./c.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/c.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/c.js
@@ -1,0 +1,2 @@
+import "./d.js";
+import "./b.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/d.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/d.js
@@ -1,0 +1,7 @@
+import { shouldThrow } from "../resources/assert.js";
+
+import defer * as ns from "./a.js";
+
+shouldThrow(() => { delete ns.foo; }, "TypeError: Unable to evaluate deferred module import");
+
+await 3;

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys.js
@@ -1,0 +1,3 @@
+//@ requireOptions("--useImportDefer=1")
+
+import "./import-defer-ready-for-sync-execution-cycle-keys/d.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/a.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/a.js
@@ -1,0 +1,1 @@
+import "./b.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/b.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/b.js
@@ -1,0 +1,1 @@
+import "./c.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/c.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/c.js
@@ -1,0 +1,2 @@
+import "./d.js";
+import "./b.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/d.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/d.js
@@ -1,0 +1,7 @@
+import { shouldThrow } from "../resources/assert.js";
+
+import defer * as ns from "./a.js";
+
+shouldThrow(() => { Object.getOwnPropertyNames(ns); }, "TypeError: Unable to evaluate deferred module import");
+
+await 3;

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle.js
@@ -1,0 +1,3 @@
+//@ requireOptions("--useImportDefer=1")
+
+import "./import-defer-ready-for-sync-execution-cycle/d.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle/a.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle/a.js
@@ -1,0 +1,1 @@
+import "./b.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle/b.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle/b.js
@@ -1,0 +1,1 @@
+import "./c.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle/c.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle/c.js
@@ -1,0 +1,2 @@
+import "./d.js";
+import "./b.js";

--- a/JSTests/modules/import-defer-ready-for-sync-execution-cycle/d.js
+++ b/JSTests/modules/import-defer-ready-for-sync-execution-cycle/d.js
@@ -1,0 +1,7 @@
+import { shouldThrow } from "../resources/assert.js";
+
+import defer * as ns from "./a.js";
+
+shouldThrow(() => { ns.foo; }, "TypeError: Unable to evaluate deferred module import");
+
+await 3;

--- a/JSTests/modules/import-defer-then.js
+++ b/JSTests/modules/import-defer-then.js
@@ -1,0 +1,19 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe, shouldThrow } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+global.count = 0;
+
+import defer * as aNs from "./import-defer-then/export-then.js";
+
+shouldBe(global.count, 0);
+
+shouldBe(aNs.then, undefined);
+shouldBe(Object.getOwnPropertyDescriptor(aNs, "then"), undefined);
+shouldThrow(() => Object.defineProperty(aNs, "then", { }), "TypeError: Attempting to define property on object that is not extensible.");
+shouldThrow(() => aNs.then = "foo", "TypeError: Attempted to assign to readonly property.");
+shouldBe(delete aNs.then, true);
+shouldBe(Object.keys(aNs).length, 0);
+shouldBe("then" in aNs, false);
+
+shouldBe(global.count, 0);

--- a/JSTests/modules/import-defer-then/export-then.js
+++ b/JSTests/modules/import-defer-then/export-then.js
@@ -1,0 +1,1 @@
+export let then = 42;

--- a/JSTests/modules/import-defer-tla.js
+++ b/JSTests/modules/import-defer-tla.js
@@ -1,0 +1,21 @@
+//@ requireOptions("--useImportDefer=1")
+import { shouldBe } from "./resources/assert.js"
+
+var global = (Function("return this"))();
+
+import "./import-defer-tla/b.js";
+import defer * as c from "./import-defer-tla/c.js";
+
+shouldBe(global.bEvaluated, 1);
+shouldBe(global.cEvaluated, undefined);
+shouldBe(global.dEvaluated, 1);
+shouldBe(global.eEvaluated, 1);
+shouldBe(global.fEvaluated, undefined);
+
+shouldBe(c.value, 2);
+
+shouldBe(global.bEvaluated, 1);
+shouldBe(global.cEvaluated, 1);
+shouldBe(global.dEvaluated, 1);
+shouldBe(global.eEvaluated, 1);
+shouldBe(global.fEvaluated, 1);

--- a/JSTests/modules/import-defer-tla/b.js
+++ b/JSTests/modules/import-defer-tla/b.js
@@ -1,0 +1,4 @@
+// b.js
+
+var global = (Function("return this"))();
+global.bEvaluated = (global.bEvaluated || 0) + 1;

--- a/JSTests/modules/import-defer-tla/c.js
+++ b/JSTests/modules/import-defer-tla/c.js
@@ -1,0 +1,9 @@
+// c.js
+
+import "./d.js";
+import "./f.js";
+
+var global = (Function("return this"))();
+global.cEvaluated = (global.cEvaluated || 0) + 1;
+
+export let value = 2;

--- a/JSTests/modules/import-defer-tla/d.js
+++ b/JSTests/modules/import-defer-tla/d.js
@@ -1,0 +1,8 @@
+// d.js
+
+var global = (Function("return this"))();
+global.dEvaluated = (global.dEvaluated || 0) + 1;
+
+import "./e.js";
+
+await 0;

--- a/JSTests/modules/import-defer-tla/e.js
+++ b/JSTests/modules/import-defer-tla/e.js
@@ -1,0 +1,4 @@
+// e.js
+
+var global = (Function("return this"))();
+global.eEvaluated = (global.eEvaluated || 0) + 1;

--- a/JSTests/modules/import-defer-tla/f.js
+++ b/JSTests/modules/import-defer-tla/f.js
@@ -1,0 +1,4 @@
+// f.js
+
+var global = (Function("return this"))();
+global.fEvaluated = (global.fEvaluated || 0) + 1;

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -9,13 +9,13 @@ flags:
   json-parse-with-source: useJSONSourceTextAccess
   iterator-sequencing: useIteratorSequencing
   explicit-resource-management: useExplicitResourceManagement
+  import-defer: useImportDefer
 skip:
   features:
     - callable-boundary-realms
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
     - source-phase-imports
-    - import-defer
   paths:
     - test/built-ins/Temporal/Instant/prototype/toZonedDateTimeISO
     - test/built-ins/Temporal/Now/plainDateISO
@@ -41,6 +41,7 @@ skip:
     - test/intl402/Temporal/PlainTime
     - test/intl402/Temporal/PlainYearMonth
     - test/intl402/Temporal/ZonedDateTime
+    - test/language/expressions/dynamic-import/import-defer
     - test/staging/Intl402
     - test/staging/JSON
     - test/staging/Temporal
@@ -388,3 +389,127 @@ skip:
     - test/built-ins/Temporal/PlainTime/prototype/since/argument-zoneddatetime-negative-epochnanoseconds.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-balance-negative-time-units.js
     - test/built-ins/Temporal/PlainTime/prototype/until/argument-zoneddatetime-negative-epochnanoseconds.js
+
+    # Dynamic import.defer not supported yet
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/catch/nested-else-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/top-level-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/catch/nested-block-labeled-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-arrow-function-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-else-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-with-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-block-labeled-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-if-braceless-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-do-while-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/catch/nested-while-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-if-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/catch/nested-block-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-function-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-gen-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-function-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-arrow-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-do-while-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-function-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-arrow-function-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-async-gen-return-await-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/catch/nested-if-import-catch-import-defer-specifier-tostring-abrupt-rejects.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-gen-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/top-level-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-function-return-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-assignment-expression-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-do-while-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-await-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-function-return-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-assignment-expression-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-block-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-return-await-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-arrow-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-return-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-async-arrow-function-return-await-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-while-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-expression-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-with-expression-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-arrow-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-block-labeled-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-with-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-function-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-if-braceless-import-defer-empty-str-is-valid-assign-expr.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-arrow-function-await-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/valid/nested-else-braceless-import-defer-script-code-valid.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-gen-await-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-else-braceless-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-function-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-await-import-defer-no-rest-param.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-async-function-return-await-import-defer-no-new-call-expression.js
+    - test/language/expressions/dynamic-import/syntax/invalid/top-level-import-defer-assignment-expr-not-optional.js
+    - test/language/expressions/dynamic-import/syntax/invalid/nested-while-import-defer-no-rest-param.js
+    - test/language/import/import-defer/deferred-namespace-object/identity.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1284,6 +1284,18 @@ test/language/identifiers/start-unicode-16.0.0-escaped.js:
 test/language/identifiers/start-unicode-16.0.0.js:
   default: "SyntaxError: Invalid character '\\u1c89'"
   strict mode: "SyntaxError: Invalid character '\\u1c89'"
+test/language/import/import-defer/deferred-namespace-object/exotic-object-behavior.js:
+  module: 'Test262Error: descriptor should be writable'
+test/language/import/import-defer/errors/get-self-while-defer-evaluating/main.js:
+  module: 'Test262Error: ns.foo while evaluating throws a TypeError'
+test/language/import/import-defer/errors/module-throws/defer-import-after-evaluation.js:
+  module: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Evaluation errors are thrown for modules evaluated before getting the deferred namespace Expected SameValue(«[object Object]», «undefined») to be true'
+test/language/import/import-defer/errors/module-throws/third-party-evaluation-after-defer-import.js:
+  module: 'Test262:AsyncTestFailure:Test262Error: Test262Error: Evaluation errors are thrown for modules evaluated after getting the deferred namespace Expected SameValue(«[object Object]», «undefined») to be true'
+test/language/import/import-defer/errors/module-throws/trigger-evaluation.js:
+  module: 'Test262Error: Evaluation errors are thrown for already evaluated modules Expected SameValue(«[object Object]», «undefined») to be true'
+test/language/import/import-defer/evaluation-top-level-await/flattening-order/main.js:
+  module: 'Test262Error: Actual [1, 2.1.1 start, 2.1.1 end, 2.2.1, 2.2 start, 2.2 end, 3, 4.1 start, 4.1 end, 5] and expected [1, 2.1.1 start, 2.2.1, 2.2 start, 3, 5, 2.1.1 end, 2.2 end, 4.1 start, 4.1 end, 5] should have the same contents. '
 test/language/module-code/top-level-await/async-module-does-not-block-sibling-modules.js:
   module: 'Test262Error: Expected SameValue(«true», «false») to be true'
 test/language/statements/async-generator/yield-star-promise-not-unwrapped.js:

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -79,6 +79,8 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_ModuleSatisfy.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Status::Satisfy)));
     m_ModuleLink.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Status::Link)));
     m_ModuleReady.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Status::Ready)));
+    m_ModulePhaseDefer.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Phase::Defer)));
+    m_ModulePhaseEvaluation.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Phase::Evaluation)));
     m_promiseRejectionReject.set(m_vm, jsNumber(static_cast<unsigned>(JSPromiseRejectionOperation::Reject)));
     m_promiseRejectionHandle.set(m_vm, jsNumber(static_cast<unsigned>(JSPromiseRejectionOperation::Handle)));
     m_promiseStatePending.set(m_vm, jsNumber(static_cast<unsigned>(JSPromise::Status::Pending)));

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -139,6 +139,8 @@ enum class LinkTimeConstant : int32_t;
     macro(ModuleSatisfy) \
     macro(ModuleLink) \
     macro(ModuleReady) \
+    macro(ModulePhaseDefer) \
+    macro(ModulePhaseEvaluation) \
     macro(promiseRejectionReject) \
     macro(promiseRejectionHandle) \
     macro(promiseStatePending) \

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.cpp
@@ -40,11 +40,13 @@ ModuleAnalyzer::ModuleAnalyzer(JSGlobalObject* globalObject, const Identifier& m
 {
 }
 
-void ModuleAnalyzer::appendRequestedModule(const Identifier& specifier, RefPtr<ScriptFetchParameters>&& attributes)
+void ModuleAnalyzer::appendRequestedModule(const Identifier& specifier, JSModuleRecord::ModulePhase phase, RefPtr<ScriptFetchParameters>&& attributes)
 {
-    auto result = m_requestedModules.add(specifier.impl());
-    if (result.isNewEntry)
-        moduleRecord()->appendRequestedModule(specifier, WTFMove(attributes));
+    auto result = m_requestedModules.add(specifier.impl(), static_cast<int>(phase));
+    if (result.isNewEntry || result.iterator->value == static_cast<int>(JSModuleRecord::ModulePhase::Defer)) {
+        moduleRecord()->appendRequestedModule(specifier, phase, WTFMove(attributes));
+        m_requestedModules.set(specifier.impl(), static_cast<int>(phase));
+    }
 }
 
 void ModuleAnalyzer::exportVariable(ModuleProgramNode& moduleProgramNode, const RefPtr<UniquedStringImpl>& localName, const VariableEnvironmentEntry& variable)

--- a/Source/JavaScriptCore/parser/ModuleAnalyzer.h
+++ b/Source/JavaScriptCore/parser/ModuleAnalyzer.h
@@ -26,11 +26,11 @@
 #pragma once
 
 #include "ErrorType.h"
+#include "JSModuleRecord.h"
 #include "Nodes.h"
 
 namespace JSC {
 
-class JSModuleRecord;
 class SourceCode;
 class ScriptFetchParameters;
 
@@ -46,7 +46,7 @@ public:
 
     JSModuleRecord* moduleRecord() { return m_moduleRecord; }
 
-    void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&);
+    void appendRequestedModule(const Identifier&, JSModuleRecord::ModulePhase, RefPtr<ScriptFetchParameters>&&);
 
     void fail(std::tuple<ErrorType, String>&& errorMessage) { m_errorMessage = errorMessage; }
 
@@ -55,7 +55,7 @@ private:
 
     VM& m_vm;
     JSModuleRecord* m_moduleRecord;
-    IdentifierSet m_requestedModules;
+    IdentifierMap m_requestedModules;
     std::tuple<ErrorType, String> m_errorMessage;
 };
 

--- a/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
+++ b/Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp
@@ -83,7 +83,8 @@ bool ImportDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
         return false;
     }
 
-    analyzer.appendRequestedModule(m_moduleName->moduleName(), WTFMove(result.value()));
+    auto phase = m_type == ImportType::Normal ? JSModuleRecord::ModulePhase::Evaluation : JSModuleRecord::ModulePhase::Defer;
+    analyzer.appendRequestedModule(m_moduleName->moduleName(), phase, WTFMove(result.value()));
     for (auto* specifier : m_specifierList->specifiers()) {
         analyzer.moduleRecord()->addImportEntry(JSModuleRecord::ImportEntry {
             specifier->importedName() == analyzer.vm().propertyNames->timesIdentifier
@@ -91,6 +92,7 @@ bool ImportDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
             m_moduleName->moduleName(),
             specifier->importedName(),
             specifier->localName(),
+            phase,
         });
     }
     return true;
@@ -104,7 +106,7 @@ bool ExportAllDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
         return false;
     }
 
-    analyzer.appendRequestedModule(m_moduleName->moduleName(), WTFMove(result.value()));
+    analyzer.appendRequestedModule(m_moduleName->moduleName(), JSModuleRecord::ModulePhase::Evaluation, WTFMove(result.value()));
     analyzer.moduleRecord()->addStarExportEntry(m_moduleName->moduleName());
     return true;
 }
@@ -128,7 +130,7 @@ bool ExportNamedDeclarationNode::analyzeModule(ModuleAnalyzer& analyzer)
             return false;
         }
 
-        analyzer.appendRequestedModule(m_moduleName->moduleName(), WTFMove(result.value()));
+        analyzer.appendRequestedModule(m_moduleName->moduleName(), JSModuleRecord::ModulePhase::Evaluation, WTFMove(result.value()));
     }
 
     for (auto* specifier : m_specifierList->specifiers()) {

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -90,11 +90,13 @@ public:
     };
 
     enum class ImportEntryType { Single, Namespace };
+    enum class ModulePhase { Evaluation, Defer };
     struct ImportEntry {
         ImportEntryType type;
         Identifier moduleRequest;
         Identifier importName;
         Identifier localName;
+        ModulePhase phase;
     };
 
     typedef WTF::ListHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> OrderedIdentifierSet;
@@ -103,12 +105,13 @@ public:
 
     struct ModuleRequest {
         RefPtr<UniquedStringImpl> m_specifier;
+        ModulePhase m_phase;
         RefPtr<ScriptFetchParameters> m_attributes;
     };
 
     DECLARE_EXPORT_INFO;
 
-    void appendRequestedModule(const Identifier&, RefPtr<ScriptFetchParameters>&&);
+    void appendRequestedModule(const Identifier&, ModulePhase, RefPtr<ScriptFetchParameters>&&);
     void addStarExportEntry(const Identifier&);
     void addImportEntry(const ImportEntry&);
     void addExportEntry(const ExportEntry&);
@@ -141,7 +144,7 @@ public:
 
     AbstractModuleRecord* hostResolveImportedModule(JSGlobalObject*, const Identifier& moduleName);
 
-    JSModuleNamespaceObject* getModuleNamespace(JSGlobalObject*);
+    JSModuleNamespaceObject* getModuleNamespace(JSGlobalObject*, ModulePhase);
     
     JSModuleEnvironment* moduleEnvironment()
     {
@@ -205,6 +208,7 @@ private:
     WriteBarrier<JSMap> m_dependenciesMap;
     
     WriteBarrier<JSModuleNamespaceObject> m_moduleNamespaceObject;
+    WriteBarrier<JSModuleNamespaceObject> m_moduleDeferredNamespaceObject;
 
     WriteBarrier<JSModuleEnvironment> m_moduleEnvironment;
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.h
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.h
@@ -55,6 +55,11 @@ public:
         Ready,
     };
 
+    enum Phase {
+        Evaluation = 1,
+        Defer,
+    };
+
     static JSModuleLoader* create(JSGlobalObject* globalObject, VM& vm, Structure* structure)
     {
         JSModuleLoader* object = new (NotNull, allocateCell<JSModuleLoader>(vm)) JSModuleLoader(vm, structure);
@@ -84,7 +89,7 @@ public:
     JSValue evaluateNonVirtual(JSGlobalObject*, JSValue key, JSValue moduleRecord, JSValue scriptFetcher, JSValue sentValue, JSValue resumeMode);
 
     // Utility functions.
-    JSModuleNamespaceObject* getModuleNamespaceObject(JSGlobalObject*, JSValue moduleRecord);
+    JSModuleNamespaceObject* getModuleNamespaceObject(JSGlobalObject*, JSValue moduleRecord, JSValue phase);
     JSArray* dependencyKeysIfEvaluated(JSGlobalObject*, JSValue key);
 
 private:

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
@@ -45,10 +45,10 @@ public:
         return vm.moduleNamespaceObjectSpace<mode>();
     }
 
-    static JSModuleNamespaceObject* create(JSGlobalObject* globalObject, Structure* structure, AbstractModuleRecord* moduleRecord, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&& resolutions)
+    static JSModuleNamespaceObject* create(JSGlobalObject* globalObject, Structure* structure, AbstractModuleRecord* moduleRecord, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&& resolutions, bool isDeferred)
     {
         VM& vm = getVM(globalObject);
-        JSModuleNamespaceObject* object = new (NotNull, allocateCell<JSModuleNamespaceObject>(vm)) JSModuleNamespaceObject(vm, structure);
+        JSModuleNamespaceObject* object = new (NotNull, allocateCell<JSModuleNamespaceObject>(vm)) JSModuleNamespaceObject(vm, structure, isDeferred);
         object->finishCreation(globalObject, moduleRecord, WTFMove(resolutions));
         return object;
     }
@@ -69,10 +69,13 @@ public:
     AbstractModuleRecord* moduleRecord() { return m_moduleRecord.get(); }
 
 private:
-    JS_EXPORT_PRIVATE JSModuleNamespaceObject(VM&, Structure*);
+    JS_EXPORT_PRIVATE JSModuleNamespaceObject(VM&, Structure*, bool);
     JS_EXPORT_PRIVATE void finishCreation(JSGlobalObject*, AbstractModuleRecord*, Vector<std::pair<Identifier, AbstractModuleRecord::Resolution>>&&);
     DECLARE_VISIT_CHILDREN;
     bool getOwnPropertySlotCommon(JSGlobalObject*, PropertyName, PropertySlot&);
+    void ensureDeferredNamespaceEvaluation(JSGlobalObject*);
+    bool isSymbolLikeNamespaceKey(VM&, PropertyName);
+    bool moduleExportsListContains(JSGlobalObject*, RefPtr<UniquedStringImpl>);
 
     struct ExportEntry {
         Identifier localName;
@@ -84,6 +87,7 @@ private:
     ExportMap m_exports;
     FixedVector<Identifier> m_names;
     WriteBarrier<AbstractModuleRecord> m_moduleRecord;
+    bool m_isDeferred;
 
     friend size_t cellSize(JSCell*);
 };

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.h
@@ -61,6 +61,8 @@ public:
     const VariableEnvironment& declaredVariables() const { return m_declaredVariables; }
     const VariableEnvironment& lexicalVariables() const { return m_lexicalVariables; }
 
+    bool readyForSyncExecution(JSGlobalObject*);
+
 private:
     JSModuleRecord(VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&, CodeFeatures);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -319,12 +319,13 @@ JSWebAssemblyInstance* JSWebAssemblyInstance::tryCreate(VM& vm, Structure* insta
             auto fieldName = Identifier::fromString(vm, makeAtomString(import.field));
             auto result = specifiers.add(moduleName.impl());
             if (result.isNewEntry)
-                moduleRecord->appendRequestedModule(moduleName, nullptr);
+                moduleRecord->appendRequestedModule(moduleName, WebAssemblyModuleRecord::ModulePhase::Evaluation, nullptr);
             moduleRecord->addImportEntry(WebAssemblyModuleRecord::ImportEntry {
                 WebAssemblyModuleRecord::ImportEntryType::Single,
                 moduleName,
                 fieldName,
                 Identifier::fromUid(PrivateName(PrivateName::Description, "WebAssemblyImportName"_s)),
+                WebAssemblyModuleRecord::ModulePhase::Evaluation,
             });
         }
         ASSERT(moduleRecord->importEntries().size() == moduleInformation.imports.size());


### PR DESCRIPTION
#### 76b9ea94098a0a52860f9c98d8feec6f0f01f7a8
<pre>
[JSC] Add core semantics of import defer

<a href="https://bugs.webkit.org/show_bug.cgi?id=286272">https://bugs.webkit.org/show_bug.cgi?id=286272</a>

Reviewed by NOBODY (OOPS!).

Implements the semantics of `import defer` along with deferred namespace
objects. The proposal semantics can be found at:

  <a href="https://github.com/tc39/proposal-defer-import-eval/">https://github.com/tc39/proposal-defer-import-eval/</a>

This doesn&apos;t include the dynamic form `import.defer()` yet. There are a few
limitations of the implementation that mostly stem from other bugs in the
module loader. The following test262 tests do not pass yet and have
test expectations set:

  - import-defer/errors/module-throws/trigger-evaluation.js
  - import-defer/errors/module-throws/defer-import-after-evaluation.js
  - import-defer/errors/module-throws/third-party-evaluation-after-defer-import.js
    (because JSC does not store and re-throw module eval errors)
  - import-defer/errors/get-other-while-evaluating-async
  - import-defer/errors/get-other-while-dep-evaluating-async
    (in debug mode, due to a assertion that can be triggered already in JSC)
  - import-defer/evaluation-top-level-await/flattening-order
    (due to async module behavior in JSC)
  - import-defer/deferred-namespace-object/exotic-object-behavior.js
  - import-defer/errors/get-self-while-defer-evaluating/main.js
  - import-defer/errors/resolution-error/import-defer-of-missing-module-fails.js:
    (These tests fail temporarily due to upstream test bugs,
     should get fixed after test262 gets updated)

Many of these issues will be fixed by the general module refactoring for
the following bug: <a href="https://bugs.webkit.org/show_bug.cgi?id=242740">https://bugs.webkit.org/show_bug.cgi?id=242740</a>

* JSTests/modules/import-defer-1-1-cycle.js: Added.
* JSTests/modules/import-defer-1-1-cycle/a.js: Added.
* JSTests/modules/import-defer-1-1-cycle/b.js: Added.
* JSTests/modules/import-defer-1-1-cycle/c.js: Added.
* JSTests/modules/import-defer-1-1-cycle/d.js: Added.
* JSTests/modules/import-defer-1-1-cycle/e.js: Added.
* JSTests/modules/import-defer-1-cycle.js: Added.
* JSTests/modules/import-defer-1-cycle/a.js: Added.
* JSTests/modules/import-defer-1-cycle/c.js: Added.
* JSTests/modules/import-defer-1-cycle/e.js: Added.
* JSTests/modules/import-defer-2-1-deferred-cycle.js: Added.
* JSTests/modules/import-defer-2-1-deferred-cycle/a.js: Added.
* JSTests/modules/import-defer-2-1-deferred-cycle/b.js: Added.
* JSTests/modules/import-defer-2-1-deferred-cycle/c.js: Added.
* JSTests/modules/import-defer-2-1-deferred-cycle/d.js: Added.
* JSTests/modules/import-defer-2-1-deferred-cycle/e.js: Added.
* JSTests/modules/import-defer-2-1-force-evaluation.js: Added.
* JSTests/modules/import-defer-2-1-force-evaluation/a.js: Added.
* JSTests/modules/import-defer-2-1-force-evaluation/b.js: Added.
* JSTests/modules/import-defer-2-1-force-evaluation/c.js: Added.
* JSTests/modules/import-defer-2-1-force-evaluation/d.js: Added.
* JSTests/modules/import-defer-2-1-force-evaluation/e.js: Added.
* JSTests/modules/import-defer-2-deferred-cycle.js: Added.
* JSTests/modules/import-defer-2-deferred-cycle/a.js: Added.
* JSTests/modules/import-defer-2-deferred-cycle/c.js: Added.
* JSTests/modules/import-defer-2-deferred-cycle/e.js: Added.
* JSTests/modules/import-defer-2-force-evaluation.js: Added.
* JSTests/modules/import-defer-2-force-evaluation/a.js: Added.
* JSTests/modules/import-defer-2-force-evaluation/c.js: Added.
* JSTests/modules/import-defer-2-force-evaluation/e.js: Added.
* JSTests/modules/import-defer-3-1-force-evaluation.js: Added.
* JSTests/modules/import-defer-3-1-force-evaluation/a.js: Added.
* JSTests/modules/import-defer-3-1-force-evaluation/b.js: Added.
* JSTests/modules/import-defer-3-1-force-evaluation/c.js: Added.
* JSTests/modules/import-defer-3-1-force-evaluation/d.js: Added.
* JSTests/modules/import-defer-3-1-force-evaluation/e.js: Added.
* JSTests/modules/import-defer-3-1-indirect-cycle.js: Added.
* JSTests/modules/import-defer-3-1-indirect-cycle/a.js: Added.
* JSTests/modules/import-defer-3-1-indirect-cycle/b.js: Added.
* JSTests/modules/import-defer-3-1-indirect-cycle/c.js: Added.
* JSTests/modules/import-defer-3-1-indirect-cycle/d.js: Added.
* JSTests/modules/import-defer-3-1-indirect-cycle/e.js: Added.
* JSTests/modules/import-defer-3-force-evaluation.js: Added.
* JSTests/modules/import-defer-3-force-evaluation/a.js: Added.
* JSTests/modules/import-defer-3-force-evaluation/c.js: Added.
* JSTests/modules/import-defer-3-force-evaluation/e.js: Added.
* JSTests/modules/import-defer-3-indirect-cycle.js: Added.
* JSTests/modules/import-defer-3-indirect-cycle/a.js: Added.
* JSTests/modules/import-defer-3-indirect-cycle/c.js: Added.
* JSTests/modules/import-defer-3-indirect-cycle/e.js: Added.
* JSTests/modules/import-defer-4-both-imports.js: Added.
* JSTests/modules/import-defer-4-both-imports/a.js: Added.
* JSTests/modules/import-defer-4-both-imports/b.js: Added.
* JSTests/modules/import-defer-4-both-imports/c.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a/a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a/b.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a/c.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a/d.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a/e.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-b-a/f.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/b.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/c.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/d.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/e.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-a-b-a/f.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/b.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/c.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/d.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/e.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d-b-a/f.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d/a.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d/b.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d/c.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d/d.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d/e.js: Added.
* JSTests/modules/import-defer-5-force-evaluation-e-d/f.js: Added.
* JSTests/modules/import-defer-5-multiple-async.js: Added.
* JSTests/modules/import-defer-5-multiple-async/a.js: Added.
* JSTests/modules/import-defer-5-multiple-async/b.js: Added.
* JSTests/modules/import-defer-5-multiple-async/c.js: Added.
* JSTests/modules/import-defer-5-multiple-async/d.js: Added.
* JSTests/modules/import-defer-5-multiple-async/e.js: Added.
* JSTests/modules/import-defer-5-multiple-async/f.js: Added.
* JSTests/modules/import-defer-6-force-eval-order.js: Added.
* JSTests/modules/import-defer-6-force-eval-order/a.js: Added.
* JSTests/modules/import-defer-6-force-eval-order/b.js: Added.
* JSTests/modules/import-defer-6-force-eval-order/c.js: Added.
* JSTests/modules/import-defer-6-force-eval-order/d.js: Added.
* JSTests/modules/import-defer-6-force-eval-order/e.js: Added.
* JSTests/modules/import-defer-6-force-eval-order/f.js: Added.
* JSTests/modules/import-defer-basic.js: Added.
* JSTests/modules/import-defer-basic/1.js: Added.
(export.foo):
* JSTests/modules/import-defer-basic/2.js: Added.
* JSTests/modules/import-defer-default.js: Added.
* JSTests/modules/import-defer-default/foo.js: Added.
* JSTests/modules/import-defer-defineownproperty.js: Added.
* JSTests/modules/import-defer-deleteproperty.js: Added.
* JSTests/modules/import-defer-getownproperty.js: Added.
* JSTests/modules/import-defer-hasproperty.js: Added.
* JSTests/modules/import-defer-ownpropertykeys.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/a.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/b.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/c.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-delete/d.js: Added.
(shouldThrow):
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/a.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/b.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/c.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle-keys/d.js: Added.
(shouldThrow):
* JSTests/modules/import-defer-ready-for-sync-execution-cycle.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle/a.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle/b.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle/c.js: Added.
* JSTests/modules/import-defer-ready-for-sync-execution-cycle/d.js: Added.
(shouldThrow):
* JSTests/modules/import-defer-then.js: Added.
* JSTests/modules/import-defer-then/export-then.js: Added.
* JSTests/modules/import-defer-tla.js: Added.
* JSTests/modules/import-defer-tla/b.js: Added.
* JSTests/modules/import-defer-tla/c.js: Added.
* JSTests/modules/import-defer-tla/d.js: Added.
* JSTests/modules/import-defer-tla/e.js: Added.
* JSTests/modules/import-defer-tla/f.js: Added.
* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/ModuleLoader.js:
(linkTimeConstant.newRegistryEntry):
(visibility.PrivateRecursive.requestSatisfyUtil):
(visibility.PrivateRecursive.link):
(visibility.PrivateRecursive.moduleEvaluation):
(visibility.PrivateRecursive.async asyncModuleEvaluation):
(visibility.PrivateRecursive.async asyncModuleDeferredEvaluation):
(visibility.PrivateRecursive.async requestImportModule):
(visibility.PrivateRecursive.dependencyKeysIfEvaluated):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/parser/ModuleAnalyzer.cpp:
(JSC::ModuleAnalyzer::appendRequestedModule):
* Source/JavaScriptCore/parser/ModuleAnalyzer.h:
* Source/JavaScriptCore/parser/NodesAnalyzeModule.cpp:
(JSC::ImportDeclarationNode::analyzeModule):
(JSC::ExportAllDeclarationNode::analyzeModule):
(JSC::ExportNamedDeclarationNode::analyzeModule):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::visitChildrenImpl):
(JSC::AbstractModuleRecord::appendRequestedModule):
(JSC::AbstractModuleRecord::getModuleNamespace):
(JSC::AbstractModuleRecord::dump):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::finishCreation):
(JSC::JSModuleLoader::getModuleNamespaceObject):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSModuleLoader.h:
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.cpp:
(JSC::JSModuleNamespaceObject::JSModuleNamespaceObject):
(JSC::JSModuleNamespaceObject::finishCreation):
(JSC::JSModuleNamespaceObject::ensureDeferredNamespaceEvaluation):
(JSC::JSModuleNamespaceObject::isSymbolLikeNamespaceKey):
(JSC::JSModuleNamespaceObject::getOwnPropertySlotCommon):
(JSC::JSModuleNamespaceObject::moduleExportsListContains):
(JSC::JSModuleNamespaceObject::deleteProperty):
(JSC::JSModuleNamespaceObject::deletePropertyByIndex):
(JSC::JSModuleNamespaceObject::getOwnPropertyNames):
(JSC::JSModuleNamespaceObject::defineOwnProperty):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h:
* Source/JavaScriptCore/runtime/JSModuleRecord.cpp:
(JSC::JSModuleRecord::instantiateDeclarations):
(JSC::JSModuleRecord::evaluate):
(JSC::JSModuleRecord::readyForSyncExecution):
* Source/JavaScriptCore/runtime/JSModuleRecord.h:
* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::tryCreate):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76b9ea94098a0a52860f9c98d8feec6f0f01f7a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/103750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/23452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/13772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/108941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/54402 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/23848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/31998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/78832 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/106756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/18510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/93592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59166 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/18313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11641 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/53778 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/96425 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/88083 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/111330 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/102361 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/30906 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/22788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/87829 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/31267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/89793 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/87481 "Found 101 new API test failures: /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, /TestWebKit:WebKit.InjectedBundleInitializationUserDataCallbackWins, /TestWebKit:WebKit.GeolocationBasicWithHighAccuracy, /WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, /TestWebKit:WebKit.ForceRepaint, /TestWebKit:WebKit.PendingAPIRequestURL, /WebKitGTK/TestUIClient:/webkit/WebKitWebView/mediaKeySystem-permission-requests, /TestWebKit:WebKit.PreventEmptyUserAgent, /TestWebKit:WebKit2.ProvisionalURLAfterWillSendRequestCallback, /WebKitGTK/TestDownloads:/webkit/Downloads/contex-menu-download-actions ... (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/32361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/25263 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/30834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/36137 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/125994 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/30628 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/34881 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/33963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/32189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->