### PR TITLE
Adopt more smart pointers in APIContentRuleListStore.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -79,7 +79,6 @@ Shared/WebImage.cpp
 Shared/WebMemorySampler.cpp
 Shared/graphics/ImageBufferSet.cpp
 UIProcess/API/APIAttachment.cpp
-UIProcess/API/APIContentRuleListStore.cpp
 UIProcess/API/APIDownloadClient.h
 UIProcess/API/APIHTTPCookieStore.cpp
 UIProcess/API/APIInspectorExtension.cpp

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -80,6 +80,10 @@ public:
     void invalidateContentRuleListHeader(const WTF::String& identifier);
     void getContentRuleListSource(WTF::String&& identifier, CompletionHandler<void(WTF::String)>);
 
+    Ref<WTF::ConcurrentWorkQueue> protectedCompileQueue();
+    Ref<WTF::WorkQueue> protectedReadQueue();
+    Ref<WTF::WorkQueue> protectedRemoveQueue();
+
 private:
     WTF::String defaultStorePath();
 


### PR DESCRIPTION
#### ec7c72daf7b9d3ad3a829eac3f7beb2da7d87028
<pre>
Adopt more smart pointers in APIContentRuleListStore.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287534">https://bugs.webkit.org/show_bug.cgi?id=287534</a>
<a href="https://rdar.apple.com/144655779">rdar://144655779</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::ContentRuleListStore::lookupContentRuleListFile):
(API::ContentRuleListStore::getAvailableContentRuleListIdentifiers):
(API::ContentRuleListStore::compileContentRuleListFile):
(API::ContentRuleListStore::removeContentRuleListFile):
(API::ContentRuleListStore::getContentRuleListSource):
(API::ContentRuleListStore::protectedCompileQueue):
(API::ContentRuleListStore::protectedReadQueue):
(API::ContentRuleListStore::protectedRemoveQueue):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:

Canonical link: <a href="https://commits.webkit.org/290332@main">https://commits.webkit.org/290332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28440b1dc2517339249f6ff2da6f09054753fc7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8954 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94416 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40193 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17234 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68895 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26559 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49255 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6906 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39297 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36536 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77766 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77075 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20086 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9760 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14074 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16623 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21934 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16364 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->