### PR TITLE
Add caret positioning tests for vertical-rl mode

### DIFF
--- a/LayoutTests/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 82,60,20,1
+Click at 5, 5 for left above first line : 42,20,25,1
+Click at 5, 275 for right above first line : 42,20,25,1
+Click at 25, 5 for left of first line : 42,32,25,1
+Click at 25, 275 for right of first line : 62,248,20,1
+Click at 45, 5 for left of second line : 82,60,20,1
+Click at 45, 275 for right of second line : 82,176,20,1
+Click at 65, 5 for left of third line : 82,176,20,1
+Click at 65, 275 for right of third line : 82,176,20,1
+Click at 85, 5 for left of fourth line : 102,80,20,1
+Click at 85, 275 for right of fourth line : 121,100,19,1
+Click at 105, 5 for left of fifth line : 141,120,20,1
+Click at 105, 275 for right of fifth line : 141,260,20,1
+Click at 125, 5 for left of sixth line : 161,140,20,1
+Click at 125, 275 for right of sixth line : 161,200,20,1
+Click at 145, 5 for left of seventh line : 161,140,20,1
+Click at 145, 275 for right of seventh line : 161,200,20,1
+Click at 170, 5 for left below last line : 161,200,20,1
+Click at 170, 275 for right below last line : 161,200,20,1
+Click at 25, 30 for inside first root inline fragment : 42,32,25,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 141,120,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 62,40,20,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 82,60,20,1
+Click at 85, 220 for inside unfragmented non-root inline : 102,225,20,1

--- a/LayoutTests/editing/caret/caret-position-vertical-rl.html
+++ b/LayoutTests/editing/caret/caret-position-vertical-rl.html
@@ -1,0 +1,124 @@
+<html>
+<style>
+#test {
+    writing-mode: vertical-rl;
+    /* If this test ends up being flaky, consider using Ahem. But it's more rigorous not to. */
+    outline: solid gray 1px;
+    padding: 1em;
+    width: 10em;
+    height: 20ch;
+    font: 20px/1 monospace;
+    background: /* Create a 10px grid to help with debugging. */
+        repeating-linear-gradient(transparent 0em 9px, #FC88 9px 10px),
+        repeating-linear-gradient(to left, transparent 0px 9px, #FC88 9px 10px);
+}
+span {
+    border: 1px solid aqua;
+}
+</style>
+
+<div id=test contenteditable>
+This is a test <span id=first>of writingsideways in vertical text</span><br>
+with multiline <span id=second>text</span> and alongwordthat'slong andanotherword.
+</div>
+
+<hr>
+
+<ul id="console"></ul>
+
+<script src="../../resources/ui-helper.js"></script>
+<script>
+
+var test = document.getElementById('test');
+var first = document.getElementById('first');
+var second = document.getElementById('second');
+
+var testRightEdge = test.offsetLeft + test.offsetWidth;
+var testTopEdge = test.offsetTop;
+var measure = test.offsetHeight;
+
+function stringifyCaret(caretRect) {
+    // Convert to LTR-relative coords and stringify
+    return -(caretRect.x - testRightEdge) + ","
+        + (caretRect.y - testTopEdge) + ","
+        + caretRect.width + ","
+        + caretRect.height;
+}
+
+function log(str) {
+    var li = document.createElement("li");
+    li.appendChild(document.createTextNode(str));
+    var console = document.getElementById("console");
+    console.appendChild(li);
+}
+
+function testCaretPosition(testID, element)
+{
+    element.focus();
+    var caretRect = window.internals.absoluteCaretBounds();
+    log(testID + " : " + stringifyCaret(caretRect));
+}
+
+async function clickInTest(target, blockCoord, inlineCoord)
+{
+    if (window.eventSender) {
+        await UIHelper.activateAt(testRightEdge - blockCoord, testTopEdge + inlineCoord);
+    }
+    else {
+        log("FAIL: could not send click event");
+    }
+}
+
+// To make it easier to reason about individual tests, this test method
+// accepts click coordinates in LTR-relative terms. See helper functions for conversion.
+async function testCaretClick(testID, blockCoord, inlineCoord, element)
+{
+    await clickInTest(element, blockCoord, inlineCoord);
+    testCaretPosition("Click at " + blockCoord + ", " + inlineCoord + " for " + testID, element);
+}
+
+async function runTest()
+{
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    // Tests for bugs that are oddly specific and hard to describe
+    window.getSelection().collapse(first.firstChild, 24);
+    await testCaretPosition("Bug 286961", first);
+
+    // Check caret insertion
+    await testCaretClick("left above first line", 5, 5, test);
+    await testCaretClick("right above first line", 5, measure - 5, test);
+
+    await testCaretClick("left of first line", 25, 5, test);
+    await testCaretClick("right of first line", 25, measure - 5, test);
+    await testCaretClick("left of second line", 45, 5, test);
+    await testCaretClick("right of second line", 45, measure - 5, test);
+    await testCaretClick("left of third line", 65, 5, test);
+    await testCaretClick("right of third line", 65, measure - 5, test);
+    await testCaretClick("left of fourth line", 85, 5, test);
+    await testCaretClick("right of fourth line", 85, measure - 5, test);
+    await testCaretClick("left of fifth line", 105, 5, test);
+    await testCaretClick("right of fifth line", 105, measure - 5, test);
+    await testCaretClick("left of sixth line", 125, 5, test);
+    await testCaretClick("right of sixth line", 125, measure - 5, test);
+    await testCaretClick("left of seventh line", 145, 5, test);
+    await testCaretClick("right of seventh line", 145, measure - 5, test);
+
+    await testCaretClick("left below last line", 170, 5, test);
+    await testCaretClick("right below last line", 170, measure - 5, test);
+
+    await testCaretClick("inside first root inline fragment", 25, 30, test);
+    await testCaretClick("inside middle fragment of root inline fragment", 125, 30, test);
+    await testCaretClick("inside middle fragment of non-root inline fragment", 45, 30, first);
+    await testCaretClick("inside last fragment of non-root inline fragment", 65, 30, first);
+    await testCaretClick("inside unfragmented non-root inline", 85, measure - 60, second);
+
+    testRunner.notifyDone();
+}
+
+runTest();
+
+</script>

--- a/LayoutTests/platform/ios/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/ios/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 81,60,20,2
+Click at 5, 5 for left above first line : 41,20,23,2
+Click at 5, 275 for right above first line : 41,20,23,2
+Click at 25, 5 for left of first line : 41,20,23,2
+Click at 25, 275 for right of first line : 81,60,20,2
+Click at 45, 5 for left of second line : 81,60,20,2
+Click at 45, 275 for right of second line : 81,175,20,2
+Click at 65, 5 for left of third line : 81,175,20,2
+Click at 65, 275 for right of third line : 81,175,20,2
+Click at 85, 5 for left of fourth line : 101,80,20,2
+Click at 85, 275 for right of fourth line : 140,120,20,2
+Click at 105, 5 for left of fifth line : 140,120,20,2
+Click at 105, 275 for right of fifth line : 160,140,20,2
+Click at 125, 5 for left of sixth line : 160,140,20,2
+Click at 125, 275 for right of sixth line : 160,199,20,2
+Click at 145, 5 for left of seventh line : 160,140,20,2
+Click at 145, 275 for right of seventh line : 160,199,20,2
+Click at 170, 5 for left below last line : 160,199,20,2
+Click at 170, 275 for right below last line : 160,199,20,2
+Click at 25, 30 for inside first root inline fragment : 41,20,23,2
+Click at 125, 30 for inside middle fragment of root inline fragment : 248,-8,0,0
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 248,-8,0,0
+Click at 65, 30 for inside last fragment of non-root inline fragment : 248,-8,0,0
+Click at 85, 220 for inside unfragmented non-root inline : 101,249,20,2

--- a/LayoutTests/platform/mac-ventura/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/mac-ventura/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 82,60,20,1
+Click at 5, 5 for left above first line : 42,20,25,1
+Click at 5, 275 for right above first line : 42,20,25,1
+Click at 25, 5 for left of first line : 42,32,25,1
+Click at 25, 275 for right of first line : 62,248,20,1
+Click at 45, 5 for left of second line : 82,60,20,1
+Click at 45, 275 for right of second line : 82,176,20,1
+Click at 65, 5 for left of third line : 82,176,20,1
+Click at 65, 275 for right of third line : 82,176,20,1
+Click at 85, 5 for left of fourth line : 102,80,20,1
+Click at 85, 275 for right of fourth line : 121,100,19,1
+Click at 105, 5 for left of fifth line : 141,120,20,1
+Click at 105, 275 for right of fifth line : 141,260,20,1
+Click at 125, 5 for left of sixth line : 161,140,20,1
+Click at 125, 275 for right of sixth line : 161,200,20,1
+Click at 145, 5 for left of seventh line : 161,140,20,1
+Click at 145, 275 for right of seventh line : 161,200,20,1
+Click at 170, 5 for left below last line : 161,200,20,1
+Click at 170, 275 for right below last line : 161,200,20,1
+Click at 25, 30 for inside first root inline fragment : 42,32,25,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 141,120,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 62,40,20,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 82,60,20,1
+Click at 85, 220 for inside unfragmented non-root inline : 102,225,20,1

--- a/LayoutTests/platform/mac/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/mac/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 82,60,20,2
+Click at 5, 5 for left above first line : 42,20,25,2
+Click at 5, 275 for right above first line : 42,20,25,2
+Click at 25, 5 for left of first line : 42,31,25,2
+Click at 25, 275 for right of first line : 62,247,20,2
+Click at 45, 5 for left of second line : 82,60,20,2
+Click at 45, 275 for right of second line : 82,175,20,2
+Click at 65, 5 for left of third line : 82,175,20,2
+Click at 65, 275 for right of third line : 82,175,20,2
+Click at 85, 5 for left of fourth line : 102,80,20,2
+Click at 85, 275 for right of fourth line : 121,100,19,2
+Click at 105, 5 for left of fifth line : 141,120,20,2
+Click at 105, 275 for right of fifth line : 141,259,20,2
+Click at 125, 5 for left of sixth line : 161,140,20,2
+Click at 125, 275 for right of sixth line : 161,199,20,2
+Click at 145, 5 for left of seventh line : 161,140,20,2
+Click at 145, 275 for right of seventh line : 161,199,20,2
+Click at 170, 5 for left below last line : 161,199,20,2
+Click at 170, 275 for right below last line : 161,199,20,2
+Click at 25, 30 for inside first root inline fragment : 42,31,25,2
+Click at 125, 30 for inside middle fragment of root inline fragment : 141,120,20,2
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 62,40,20,2
+Click at 65, 30 for inside last fragment of non-root inline fragment : 82,60,20,2
+Click at 85, 220 for inside unfragmented non-root inline : 102,224,20,2

--- a/LayoutTests/platform/win/editing/caret/caret-position-vertical-rl-expected.txt
+++ b/LayoutTests/platform/win/editing/caret/caret-position-vertical-rl-expected.txt
@@ -1,0 +1,26 @@
+This is a test of writingsideways in vertical text
+with multiline text and alongwordthat'slong andanotherword.
+Bug 286961 : 82,60,20,1
+Click at 5, 5 for left above first line : 42,32,25,1
+Click at 5, 275 for right above first line : 62,248,20,1
+Click at 25, 5 for left of first line : 42,32,25,1
+Click at 25, 275 for right of first line : 62,248,20,1
+Click at 45, 5 for left of second line : 82,60,20,1
+Click at 45, 275 for right of second line : 82,176,20,1
+Click at 65, 5 for left of third line : 82,176,20,1
+Click at 65, 275 for right of third line : 82,176,20,1
+Click at 85, 5 for left of fourth line : 102,80,20,1
+Click at 85, 275 for right of fourth line : 121,100,19,1
+Click at 105, 5 for left of fifth line : 141,120,20,1
+Click at 105, 275 for right of fifth line : 141,260,20,1
+Click at 125, 5 for left of sixth line : 161,140,20,1
+Click at 125, 275 for right of sixth line : 161,200,20,1
+Click at 145, 5 for left of seventh line : 161,140,20,1
+Click at 145, 275 for right of seventh line : 161,200,20,1
+Click at 170, 5 for left below last line : 161,140,20,1
+Click at 170, 275 for right below last line : 161,200,20,1
+Click at 25, 30 for inside first root inline fragment : 42,32,25,1
+Click at 125, 30 for inside middle fragment of root inline fragment : 141,120,20,1
+Click at 45, 30 for inside middle fragment of non-root inline fragment : 62,40,20,1
+Click at 65, 30 for inside last fragment of non-root inline fragment : 82,60,20,1
+Click at 85, 220 for inside unfragmented non-root inline : 102,225,20,1


### PR DESCRIPTION
#### 584a7141320672a3426e2b8141909911d548013c
<pre>
Add caret positioning tests for vertical-rl mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=287533">https://bugs.webkit.org/show_bug.cgi?id=287533</a>
<a href="https://rdar.apple.com/144655091">rdar://144655091</a>

Reviewed by Alan Baradlay.

This tests caret positioning in response to clicks within and outside
split and unsplit root and non-root inline boxes.

* LayoutTests/editing/caret/caret-position-vertical-rl-expected.txt: Added.
* LayoutTests/editing/caret/caret-position-vertical-rl.html: Added.
* LayoutTests/platform/ios/editing/caret/caret-position-vertical-rl-expected.txt: Added.
* LayoutTests/platform/mac-ventura/editing/caret/caret-position-vertical-rl-expected.txt: Added.
* LayoutTests/platform/mac/editing/caret/caret-position-vertical-rl-expected.txt: Added.
* LayoutTests/platform/win/editing/caret/caret-position-vertical-rl-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/290324@main">https://commits.webkit.org/290324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfd901ed5f9c114ad29bbfab052742f40f75b78d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40397 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69026 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26673 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92631 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81332 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49390 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7052 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39503 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77404 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96450 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16812 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77900 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17068 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77220 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20234 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9979 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14069 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16566 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20017 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->