### PR TITLE
Add support for image-rendering keywords `high-quality` and `smooth`

### DIFF
--- a/LayoutTests/fast/css/image-rendering-parsing-expected.txt
+++ b/LayoutTests/fast/css/image-rendering-parsing-expected.txt
@@ -7,6 +7,12 @@ PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.C
 PASS div.style.getPropertyValue('image-rendering') is "auto"
 PASS getComputedStyle(div).getPropertyValue('image-rendering') is "auto"
 PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.CSS_PRIMITIVE_VALUE
+PASS div.style.getPropertyValue('image-rendering') is "smooth"
+PASS getComputedStyle(div).getPropertyValue('image-rendering') is "smooth"
+PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.CSS_PRIMITIVE_VALUE
+PASS div.style.getPropertyValue('image-rendering') is "high-quality"
+PASS getComputedStyle(div).getPropertyValue('image-rendering') is "high-quality"
+PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.CSS_PRIMITIVE_VALUE
 PASS div.style.getPropertyValue('image-rendering') is "crisp-edges"
 PASS getComputedStyle(div).getPropertyValue('image-rendering') is "crisp-edges"
 PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.CSS_PRIMITIVE_VALUE
@@ -20,10 +26,10 @@ PASS div.style.getPropertyValue('image-rendering') is "-webkit-optimize-contrast
 PASS getComputedStyle(div).getPropertyValue('image-rendering') is "crisp-edges"
 PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.CSS_PRIMITIVE_VALUE
 PASS div.style.getPropertyValue('image-rendering') is "optimizespeed"
-PASS getComputedStyle(div).getPropertyValue('image-rendering') is "optimizespeed"
+PASS getComputedStyle(div).getPropertyValue('image-rendering') is "crisp-edges"
 PASS div.style.getPropertyCSSValue('image-rendering').cssValueType is CSSValue.CSS_PRIMITIVE_VALUE
 PASS div.style.getPropertyValue('image-rendering') is "optimizequality"
-PASS getComputedStyle(div).getPropertyValue('image-rendering') is "optimizequality"
+PASS getComputedStyle(div).getPropertyValue('image-rendering') is "smooth"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/image-rendering-parsing.html
+++ b/LayoutTests/fast/css/image-rendering-parsing.html
@@ -23,12 +23,14 @@ function testImageRendering(value, computedValue)
 }
 
 testImageRendering('auto', 'auto');
+testImageRendering('smooth', 'smooth');
+testImageRendering('high-quality', 'high-quality');
 testImageRendering('crisp-edges', 'crisp-edges');
 testImageRendering('pixelated', 'pixelated');
 testImageRendering('-webkit-crisp-edges', 'crisp-edges');
 testImageRendering('-webkit-optimize-contrast', 'crisp-edges');
-testImageRendering('optimizeSpeed', 'optimizespeed');
-testImageRendering('optimizeQuality', 'optimizequality');
+testImageRendering('optimizeSpeed', 'crisp-edges');
+testImageRendering('optimizeQuality', 'smooth');
 
 successfullyParsed = true;
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-rendering-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-rendering-computed-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Property image-rendering value 'auto'
-FAIL Property image-rendering value 'smooth' assert_true: 'smooth' is a supported value for image-rendering. expected true got false
-FAIL Property image-rendering value 'high-quality' assert_true: 'high-quality' is a supported value for image-rendering. expected true got false
+PASS Property image-rendering value 'smooth'
+PASS Property image-rendering value 'high-quality'
 PASS Property image-rendering value 'crisp-edges'
 PASS Property image-rendering value 'pixelated'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-rendering-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-rendering-valid-expected.txt
@@ -1,7 +1,7 @@
 
 PASS e.style['image-rendering'] = "auto" should set the property value
-FAIL e.style['image-rendering'] = "smooth" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['image-rendering'] = "high-quality" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['image-rendering'] = "smooth" should set the property value
+PASS e.style['image-rendering'] = "high-quality" should set the property value
 PASS e.style['image-rendering'] = "crisp-edges" should set the property value
 PASS e.style['image-rendering'] = "pixelated" should set the property value
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1966,14 +1966,14 @@ constexpr CSSValueID toCSSValueID(ImageRendering imageRendering)
     switch (imageRendering) {
     case ImageRendering::Auto:
         return CSSValueAuto;
+    case ImageRendering::Smooth:
+        return CSSValueSmooth;
+    case ImageRendering::HighQuality:
+        return CSSValueHighQuality;
     case ImageRendering::CrispEdges:
         return CSSValueCrispEdges;
     case ImageRendering::Pixelated:
         return CSSValuePixelated;
-    case ImageRendering::OptimizeSpeed:
-        return CSSValueOptimizeSpeed;
-    case ImageRendering::OptimizeQuality:
-        return CSSValueOptimizeQuality;
     }
     ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
     return CSSValueInvalid;
@@ -1984,16 +1984,18 @@ template<> constexpr ImageRendering fromCSSValueID(CSSValueID valueID)
     switch (valueID) {
     case CSSValueAuto:
         return ImageRendering::Auto;
+    case CSSValueSmooth:
+    case CSSValueOptimizeQuality:
+        return ImageRendering::Smooth;
+    case CSSValueHighQuality:
+        return ImageRendering::HighQuality;
     case CSSValueWebkitOptimizeContrast:
     case CSSValueCrispEdges:
     case CSSValueWebkitCrispEdges:
+    case CSSValueOptimizeSpeed:
         return ImageRendering::CrispEdges;
     case CSSValuePixelated:
         return ImageRendering::Pixelated;
-    case CSSValueOptimizeSpeed:
-        return ImageRendering::OptimizeSpeed;
-    case CSSValueOptimizeQuality:
-        return ImageRendering::OptimizeQuality;
     default:
         break;
     }

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3811,14 +3811,8 @@
             "inherited": true,
             "values": [
                 "auto",
-                {
-                    "value": "smooth",
-                    "status": "unimplemented"
-                },
-                {
-                    "value": "high-quality",
-                    "status": "unimplemented"
-                },
+                "smooth",
+                "high-quality",
                 "pixelated",
                 "crisp-edges",
                 {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1216,6 +1216,8 @@ off
 // auto
 // optimizeSpeed (deprecated)
 optimizeQuality // ( deprecated)
+// smooth
+high-quality
 crisp-edges
 pixelated
 -webkit-crisp-edges

--- a/Source/WebCore/rendering/ImageQualityController.cpp
+++ b/Source/WebCore/rendering/ImageQualityController.cpp
@@ -104,13 +104,13 @@ void ImageQualityController::restartTimer()
 std::optional<InterpolationQuality> ImageQualityController::interpolationQualityFromStyle(const RenderStyle& style)
 {
     switch (style.imageRendering()) {
-    case ImageRendering::OptimizeSpeed:
-        return InterpolationQuality::Low;
+    case ImageRendering::Smooth:
+        return InterpolationQuality::Default;
+    case ImageRendering::HighQuality:
+        return InterpolationQuality::High;
     case ImageRendering::CrispEdges:
     case ImageRendering::Pixelated:
         return InterpolationQuality::DoNotInterpolate;
-    case ImageRendering::OptimizeQuality:
-        return InterpolationQuality::Default; // FIXME: CSS 3 Images says that optimizeQuality should behave like 'auto', but that prevents authors from overriding this low quality rendering behavior.
     case ImageRendering::Auto:
         break;
     }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -880,12 +880,18 @@ void RenderLayerBacking::updateContentsScalingFilters(const RenderStyle& style)
     auto minificationFilter = GraphicsLayer::ScalingFilter::Linear;
     auto magnificationFilter = GraphicsLayer::ScalingFilter::Linear;
     switch (style.imageRendering()) {
+    case ImageRendering::HighQuality:
+        minificationFilter = GraphicsLayer::ScalingFilter::Trilinear;
+        magnificationFilter = GraphicsLayer::ScalingFilter::Trilinear;
+        break;
     case ImageRendering::CrispEdges:
     case ImageRendering::Pixelated:
         // FIXME: In order to match other code-paths, we treat these the same.
         minificationFilter = GraphicsLayer::ScalingFilter::Nearest;
         magnificationFilter = GraphicsLayer::ScalingFilter::Nearest;
         break;
+    case ImageRendering::Smooth:
+    case ImageRendering::Auto:
     default:
         break;
     }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -648,8 +648,8 @@ TextStream& operator<<(TextStream& ts, ImageRendering imageRendering)
 {
     switch (imageRendering) {
     case ImageRendering::Auto: ts << "auto"; break;
-    case ImageRendering::OptimizeSpeed: ts << "optimizeSpeed"; break;
-    case ImageRendering::OptimizeQuality: ts << "optimizeQuality"; break;
+    case ImageRendering::Smooth: ts << "smooth"; break;
+    case ImageRendering::HighQuality: ts << "highQuality"; break;
     case ImageRendering::CrispEdges: ts << "crispEdges"; break;
     case ImageRendering::Pixelated: ts << "pixelated"; break;
     }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -980,8 +980,8 @@ enum class TextWrapStyle : uint8_t {
 
 enum class ImageRendering : uint8_t {
     Auto = 0,
-    OptimizeSpeed,
-    OptimizeQuality,
+    Smooth,
+    HighQuality,
     CrispEdges,
     Pixelated
 };


### PR DESCRIPTION
#### a5eaa828437eae73bba70ae8055c75ea796cd1fe
<pre>
Add support for image-rendering keywords `high-quality` and `smooth`
<a href="https://bugs.webkit.org/show_bug.cgi?id=287535">https://bugs.webkit.org/show_bug.cgi?id=287535</a>

Reviewed by NOBODY (OOPS!).

Adds support for the keywords `high-quality` and `smooth` for the
`image-rendering` CSS property. Also updates the  mappings of legacy
values `optimizeQuality` and `optimizeSpeed` to map to `smooth` and
`crisp-edges` respectively as the spec requires.

* LayoutTests/fast/css/image-rendering-parsing-expected.txt:
* LayoutTests/fast/css/image-rendering-parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-rendering-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/parsing/image-rendering-valid-expected.txt:
    - Updated tests and results.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
    - Update mappings.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
    - Add the new keywords.

* Source/WebCore/rendering/ImageQualityController.cpp:
    - Map `smooth` to ImageQuality::Default and `high-quality` to `ImageQuality::High`.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
    - Map `smooth` to the default linear scaling and `high-quality` to the highest quality trilinear.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5eaa828437eae73bba70ae8055c75ea796cd1fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94421 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17239 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68905 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26575 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49266 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6919 "Found 8 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml.html imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/css/cssom/cssom-getPropertyValue-common-checks.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35574 "Found 6 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77276 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36576 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16615 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12223 "Found 4 new test failures: http/tests/pdf/linearized-pdf-in-display-none-iframe.html imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77778 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77088 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21513 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20112 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/image-rendering.html imported/w3c/web-platform-tests/svg/painting/inheritance.svg imported/w3c/web-platform-tests/svg/painting/parsing/image-rendering-computed.svg (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9765 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21939 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16369 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19820 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->