### PR TITLE
Remove WebCoreDecompressionSession queue management.

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h
@@ -73,7 +73,6 @@ class VideoMediaSampleRenderer;
 class VideoTrackPrivate;
 class AudioTrackPrivateMediaSourceAVFObjC;
 class VideoTrackPrivateMediaSourceAVFObjC;
-class WebCoreDecompressionSession;
 class SharedBuffer;
 
 struct TrackInfo;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -51,7 +51,6 @@
 #import "VideoMediaSampleRenderer.h"
 #import "VideoTrackPrivateMediaSourceAVFObjC.h"
 #import "WebAVSampleBufferListener.h"
-#import "WebCoreDecompressionSession.h"
 #import "WebSampleBufferVideoRendering.h"
 #import <AVFoundation/AVAssetTrack.h>
 #import <JavaScriptCore/TypedArrayInlines.h>

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -71,7 +71,6 @@ class VideoFrame;
 class VideoMediaSampleRenderer;
 class VideoLayerManagerObjC;
 class VideoTrackPrivateWebM;
-class WebCoreDecompressionSession;
 
 class MediaPlayerPrivateWebM
     : public MediaPlayerPrivateInterface

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -53,7 +53,6 @@
 #import "VideoLayerManagerObjC.h"
 #import "VideoMediaSampleRenderer.h"
 #import "VideoTrackPrivateWebM.h"
-#import "WebCoreDecompressionSession.h"
 #import "WebMResourceClient.h"
 #import "WebSampleBufferVideoRendering.h"
 #import <AVFoundation/AVFoundation.h>

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,23 +30,16 @@
 #include "ProcessIdentity.h"
 #include <CoreMedia/CMTime.h>
 #include <atomic>
-#include <wtf/Deque.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
 #include <wtf/MediaTime.h>
-#include <wtf/MonotonicTime.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WorkQueue.h>
 
-typedef CFTypeRef CMBufferRef;
-typedef const struct __CFArray * CFArrayRef;
-typedef struct opaqueCMBufferQueue *CMBufferQueueRef;
 typedef struct opaqueCMSampleBuffer *CMSampleBufferRef;
-typedef struct OpaqueCMTimebase* CMTimebaseRef;
-typedef signed long CMItemCount;
 typedef struct __CVBuffer *CVPixelBufferRef;
 typedef struct __CVBuffer *CVImageBufferRef;
 typedef UInt32 VTDecodeInfoFlags;
@@ -57,130 +50,54 @@ namespace WebCore {
 class VideoDecoder;
 struct PlatformVideoColorSpace;
 
-class WEBCORE_EXPORT WebCoreDecompressionSession : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCoreDecompressionSession> {
+class WebCoreDecompressionSession : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<WebCoreDecompressionSession> {
 public:
     static Ref<WebCoreDecompressionSession> createOpenGL() { return adoptRef(*new WebCoreDecompressionSession(OpenGL)); }
     static Ref<WebCoreDecompressionSession> createRGB() { return adoptRef(*new WebCoreDecompressionSession(RGB)); }
 
-    ~WebCoreDecompressionSession();
-    void invalidate();
-    bool isInvalidated() const { return m_invalidated; }
+    WEBCORE_EXPORT ~WebCoreDecompressionSession();
+    WEBCORE_EXPORT void invalidate();
 
-    void enqueueSample(CMSampleBufferRef, bool displaying = true);
-    bool isReadyForMoreMediaData() const;
-    void requestMediaDataWhenReady(Function<void()>&&);
-    void stopRequestingMediaData();
-    void notifyWhenHasAvailableVideoFrame(Function<void()>&&);
-
-    RetainPtr<CVPixelBufferRef> decodeSampleSync(CMSampleBufferRef);
+    WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> decodeSampleSync(CMSampleBufferRef);
 
     using DecodingPromise = NativePromise<RetainPtr<CMSampleBufferRef>, OSStatus>;
-    Ref<DecodingPromise> decodeSample(CMSampleBufferRef, bool displaying);
-
-    void setTimebase(CMTimebaseRef);
-    RetainPtr<CMTimebaseRef> timebase() const;
-
-    enum ImageForTimeFlags { ExactTime, AllowEarlier, AllowLater };
-    RetainPtr<CVPixelBufferRef> imageForTime(const MediaTime&, ImageForTimeFlags = ExactTime);
-    void flush();
-
-    void setErrorListener(Function<void(OSStatus)>&&);
-    void removeErrorListener();
-
-    unsigned totalVideoFrames() const { return m_totalVideoFrames; }
-    unsigned droppedVideoFrames() const { return m_droppedVideoFrames; }
-    unsigned corruptedVideoFrames() const { return m_corruptedVideoFrames; }
-    MediaTime totalFrameDelay() const { return m_totalFrameDelay; }
-
-    bool hardwareDecoderEnabled() const { return m_hardwareDecoderEnabled; }
-    void setHardwareDecoderEnabled(bool enabled) { m_hardwareDecoderEnabled = enabled; }
+    WEBCORE_EXPORT Ref<DecodingPromise> decodeSample(CMSampleBufferRef, bool displaying);
+    WEBCORE_EXPORT void flush();
 
     void setResourceOwner(const ProcessIdentity& resourceOwner) { m_resourceOwner = resourceOwner; }
-
-    static RetainPtr<CMBufferQueueRef> createBufferQueue();
 
 private:
     enum Mode {
         OpenGL,
         RGB,
     };
-    WebCoreDecompressionSession(Mode);
+    WEBCORE_EXPORT explicit WebCoreDecompressionSession(Mode);
 
     RetainPtr<VTDecompressionSessionRef> ensureDecompressionSessionForSample(CMSampleBufferRef);
 
-    void setTimebaseWithLockHeld(CMTimebaseRef);
-    void enqueueCompressedSample(CMSampleBufferRef, bool displaying, uint32_t flushId);
     Ref<DecodingPromise> decodeSampleInternal(CMSampleBufferRef, bool displaying);
-    void enqueueDecodedSample(CMSampleBufferRef);
-    void maybeDecodeNextSample();
     void handleDecompressionOutput(bool displaying, OSStatus, VTDecodeInfoFlags, CVImageBufferRef, CMTime presentationTimeStamp, CMTime presentationDuration);
-    RetainPtr<CVPixelBufferRef> getFirstVideoFrame();
-    void resetAutomaticDequeueTimer();
-    void automaticDequeue();
-    bool shouldDecodeSample(CMSampleBufferRef, bool displaying);
     void assignResourceOwner(CVImageBufferRef);
 
-    static CMTime getDecodeTime(CMBufferRef, void* refcon);
-    static CMTime getPresentationTime(CMBufferRef, void* refcon);
-    static CMTime getDuration(CMBufferRef, void* refcon);
-    static CFComparisonResult compareBuffers(CMBufferRef buf1, CMBufferRef buf2, void* refcon);
-    void maybeBecomeReadyForMoreMediaData();
-
-    void resetQosTier();
-    void increaseQosTier();
-    void decreaseQosTier();
-    void updateQosWithDecodeTimeStatistics(double ratio);
-
-    bool isUsingVideoDecoder(CMSampleBufferRef) const;
     Ref<MediaPromise> initializeVideoDecoder(FourCharCode, std::span<const uint8_t>, const std::optional<PlatformVideoColorSpace>&);
-
-    static const CMItemCount kMaximumCapacity = 120;
-    static const CMItemCount kHighWaterMark = 60;
-    static const CMItemCount kLowWaterMark = 15;
+    bool isInvalidated() const { return m_invalidated; }
 
     Mode m_mode;
     mutable Lock m_lock;
     RetainPtr<VTDecompressionSessionRef> m_decompressionSession WTF_GUARDED_BY_LOCK(m_lock);
-    RetainPtr<CMBufferQueueRef> m_producerQueue;
-    RetainPtr<CMTimebaseRef> m_timebase WTF_GUARDED_BY_LOCK(m_lock);
     const Ref<WorkQueue> m_decompressionQueue;
-    const Ref<WorkQueue> m_enqueingQueue;
-    OSObjectPtr<dispatch_source_t> m_timerSource WTF_GUARDED_BY_LOCK(m_lock);
-    Function<void()> m_notificationCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
-    Function<void()> m_hasAvailableFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
-    Function<void(RetainPtr<CMSampleBufferRef>&&)> m_newDecodedFrameCallback WTF_GUARDED_BY_CAPABILITY(mainThread);
-    RetainPtr<CFArrayRef> m_qosTiers WTF_GUARDED_BY_LOCK(m_lock);
-    int m_currentQosTier WTF_GUARDED_BY_LOCK(m_lock) { 0 };
-    std::atomic<unsigned> m_framesSinceLastQosCheck { 0 };
-    double m_decodeRatioMovingAverage { 0 };
 
     std::atomic<uint32_t> m_flushId { 0 };
-    std::atomic<bool> m_isUsingVideoDecoder { true };
     RefPtr<VideoDecoder> m_videoDecoder WTF_GUARDED_BY_LOCK(m_lock);
     bool m_videoDecoderCreationFailed { false };
-    std::atomic<bool> m_decodePending { false };
     struct PendingDecodeData {
-        MonotonicTime startTime;
         bool displaying { false };
     };
     std::optional<PendingDecodeData> m_pendingDecodeData WTF_GUARDED_BY_CAPABILITY(m_decompressionQueue.get());
-    // A VideoDecoder can't process more than one request at a time.
-    // Handle the case should the DecompressionSession be used even if isReadyForMoreMediaData() returned false;
-    Deque<std::tuple<RetainPtr<CMSampleBufferRef>, bool, uint32_t>> m_pendingSamples WTF_GUARDED_BY_CAPABILITY(m_decompressionQueue.get());
-    bool m_isDecodingSample WTF_GUARDED_BY_CAPABILITY(m_decompressionQueue.get()) { false };
     RetainPtr<CMSampleBufferRef> m_lastDecodedSample WTF_GUARDED_BY_CAPABILITY(m_decompressionQueue.get());
     OSStatus m_lastDecodingError WTF_GUARDED_BY_CAPABILITY(m_decompressionQueue.get()) { noErr };
 
-    Function<void(OSStatus)> m_errorListener WTF_GUARDED_BY_CAPABILITY(mainThread);
-
     std::atomic<bool> m_invalidated { false };
-    std::atomic<bool> m_hardwareDecoderEnabled { true };
-    std::atomic<int> m_framesBeingDecoded { 0 };
-    std::atomic<unsigned> m_totalVideoFrames { 0 };
-    std::atomic<unsigned> m_droppedVideoFrames { 0 };
-    std::atomic<unsigned> m_corruptedVideoFrames { 0 };
-    std::atomic<bool> m_deliverDecodedFrames { false };
-    MediaTime m_totalFrameDelay;
 
     ProcessIdentity m_resourceOwner;
 };


### PR DESCRIPTION
#### 6c992def912e01b0fb737224cae08fb323b729a4
<pre>
Remove WebCoreDecompressionSession queue management.
<a href="https://bugs.webkit.org/show_bug.cgi?id=283565">https://bugs.webkit.org/show_bug.cgi?id=283565</a>
<a href="https://rdar.apple.com/140417110">rdar://140417110</a>

Reviewed by Jer Noble.

Remove no longer used code.
Frame queue management is now done in the VideoMediaSampleRenderer and
a WebCoreDecompressionSession is only ever used to decode a single frame
at a time.

No change in observable behaviour. Covered by existing tests.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.h: Remove unused forward declaration
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm: Remove unused header.
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h: Remove unused forward declaration
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm: Remove unused header.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WTF::CFTypeTrait&lt;CMSampleBufferRef&gt;::typeID): Move code from WebCoreDecompressionSession
(WebCore::getDecodeTime): Move code from WebCoreDecompressionSession
(WebCore::getPresentationTime): Move code from WebCoreDecompressionSession
(WebCore::getDuration): Move code from WebCoreDecompressionSession
(WebCore::compareBuffers): Move code from WebCoreDecompressionSession
(WebCore::createBufferQueue): Move code from WebCoreDecompressionSession
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreDecompressionSession.mm:
(WebCore::WebCoreDecompressionSession::WebCoreDecompressionSession):
(WebCore::WebCoreDecompressionSession::invalidate):
(WebCore::WebCoreDecompressionSession::ensureDecompressionSessionForSample):
(WebCore::WebCoreDecompressionSession::decodeSampleInternal):
(WebCore::WebCoreDecompressionSession::handleDecompressionOutput):
(WebCore::WebCoreDecompressionSession::flush):
(WTF::CFTypeTrait&lt;CMSampleBufferRef&gt;::typeID): Deleted.
(WebCore::WebCoreDecompressionSession::setTimebase): Deleted.
(WebCore::WebCoreDecompressionSession::setTimebaseWithLockHeld): Deleted.
(WebCore::WebCoreDecompressionSession::timebase const): Deleted.
(WebCore::WebCoreDecompressionSession::maybeBecomeReadyForMoreMediaData): Deleted.
(WebCore::WebCoreDecompressionSession::createBufferQueue): Deleted.
(WebCore::WebCoreDecompressionSession::enqueueSample): Deleted.
(WebCore::WebCoreDecompressionSession::shouldDecodeSample): Deleted.
(WebCore::WebCoreDecompressionSession::enqueueCompressedSample): Deleted.
(WebCore::WebCoreDecompressionSession::maybeDecodeNextSample): Deleted.
(WebCore::WebCoreDecompressionSession::setErrorListener): Deleted.
(WebCore::WebCoreDecompressionSession::removeErrorListener): Deleted.
(WebCore::WebCoreDecompressionSession::getFirstVideoFrame): Deleted.
(WebCore::WebCoreDecompressionSession::automaticDequeue): Deleted.
(WebCore::WebCoreDecompressionSession::enqueueDecodedSample): Deleted.
(WebCore::WebCoreDecompressionSession::isReadyForMoreMediaData const): Deleted.
(WebCore::WebCoreDecompressionSession::requestMediaDataWhenReady): Deleted.
(WebCore::WebCoreDecompressionSession::stopRequestingMediaData): Deleted.
(WebCore::WebCoreDecompressionSession::notifyWhenHasAvailableVideoFrame): Deleted.
(WebCore::WebCoreDecompressionSession::imageForTime): Deleted.
(WebCore::WebCoreDecompressionSession::getDecodeTime): Deleted.
(WebCore::WebCoreDecompressionSession::getPresentationTime): Deleted.
(WebCore::WebCoreDecompressionSession::getDuration): Deleted.
(WebCore::WebCoreDecompressionSession::compareBuffers): Deleted.
(WebCore::WebCoreDecompressionSession::resetQosTier): Deleted.
(WebCore::WebCoreDecompressionSession::increaseQosTier): Deleted.
(WebCore::WebCoreDecompressionSession::decreaseQosTier): Deleted.
(WebCore::WebCoreDecompressionSession::updateQosWithDecodeTimeStatistics): Deleted.

Canonical link: <a href="https://commits.webkit.org/290307@main">https://commits.webkit.org/290307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/002d2a53ea07d3ace7b59f2af2b8da156919fa17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89435 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/8960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91486 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68898 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26564 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6915 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35553 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77272 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96250 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77771 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/76968 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77080 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19064 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9766 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21940 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16370 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->