### PR TITLE
Adopt more smart pointers in WebPageProxy (part 8)

### DIFF
--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -496,6 +496,7 @@ public:
 
 #if ENABLE(CONTENT_EXTENSIONS)
     WebCore::ResourceMonitorThrottler& resourceMonitorThrottler();
+    Ref<WebCore::ResourceMonitorThrottler> protectedResourceMonitorThrottler() { return resourceMonitorThrottler(); }
     void resetResourceMonitorThrottlerForTesting();
 #endif
 


### PR DESCRIPTION
#### 494eb6ccd44d9183a838f6c32b077dc0524a4e5f
<pre>
Adopt more smart pointers in WebPageProxy (part 8)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287545">https://bugs.webkit.org/show_bug.cgi?id=287545</a>
<a href="https://rdar.apple.com/144670800">rdar://144670800</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.
Adding WebPageProxy back to the skip list until analyzer is updated with
false positive fixes.

Fix some new issues as well.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::showDigitalCredentialsPicker):
(WebKit::WebPageProxy::dismissDigitalCredentialsPicker):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::requestAttachmentIcon):
(WebKit::WebPageProxy::shouldOffloadIFrameForHost const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::protectedResourceMonitorThrottler):

Canonical link: <a href="https://commits.webkit.org/290330@main">https://commits.webkit.org/290330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d42cc540b360f0026fd2fffa8bdfa5639908d99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40362 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49373 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7031 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39468 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12328 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77884 "Found 1 new test failure: imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/video-tag.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77114 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77200 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9944 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14073 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16790 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18313 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->