### PR TITLE
Adopt more smart pointers in ExecutableAllocator.cpp

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -87,7 +87,6 @@
 ./inspector/remote/cocoa/RemoteInspectorCocoa.mm
 ./interpreter/Interpreter.cpp
 ./jit/BaselineJITPlan.cpp
-./jit/ExecutableAllocator.cpp
 ./jit/GCAwareJITStubRoutine.cpp
 ./jit/ICStats.cpp
 ./jit/ICStats.h

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1344,6 +1344,7 @@ void dumpJITMemory(const void* dst, const void* src, size_t size)
     static size_t offset WTF_GUARDED_BY_LOCK(dumpJITMemoryLock) = 0;
     static bool needsToFlush WTF_GUARDED_BY_LOCK(dumpJITMemoryLock) = false;
     static LazyNeverDestroyed<Ref<WorkQueue>> flushQueue;
+    static auto flushQueueSingleton = []() { return flushQueue.get(); };
     struct DumpJIT {
         static void flush() WTF_REQUIRES_LOCK(dumpJITMemoryLock)
         {
@@ -1364,7 +1365,7 @@ void dumpJITMemory(const void* dst, const void* src, size_t size)
                 return;
 
             needsToFlush = true;
-            flushQueue.get()->dispatchAfter(Seconds(Options::dumpJITMemoryFlushInterval()), [] {
+            flushQueueSingleton()->dispatchAfter(Seconds(Options::dumpJITMemoryFlushInterval()), [] {
                 Locker locker { dumpJITMemoryLock };
                 if (!needsToFlush)
                     return;


### PR DESCRIPTION
#### 4e626ce31dd8d23f47f75ca2bc4a4d7d0dec8520
<pre>
Adopt more smart pointers in ExecutableAllocator.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287547">https://bugs.webkit.org/show_bug.cgi?id=287547</a>
<a href="https://rdar.apple.com/144671298">rdar://144671298</a>

Reviewed by Chris Dumez.

Smart pointer adoption as per the static analyzer.
Fixing the following failure:
<a href="https://build.webkit.org/results/Apple-Sequoia-Safer-CPP-Checks/290239@main%20(1908)/scan-build-output/StaticAnalyzer/JavaScriptCore/StaticAnalyzerReports/report-ExecutableAllocator.cpp-enqueueFlush-5-943468.html#EndPath">https://build.webkit.org/results/Apple-Sequoia-Safer-CPP-Checks/290239@main%20(1908)/scan-build-output/StaticAnalyzer/JavaScriptCore/StaticAnalyzerReports/report-ExecutableAllocator.cpp-enqueueFlush-5-943468.html#EndPath</a>

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::dumpJITMemory):

Canonical link: <a href="https://commits.webkit.org/290305@main">https://commits.webkit.org/290305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e450309838d513e9c251ba96af0b6d5e623ee1a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89593 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94585 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40360 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26660 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92594 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49372 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39466 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82391 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96413 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88368 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16775 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77197 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19060 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21633 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9942 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16788 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/110861 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16529 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26571 "Found 10 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->