### PR TITLE
Address safer CPP warnings in NetworkRTCMonitor.cpp

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp
@@ -266,8 +266,11 @@ static std::optional<RTCNetwork::IPAddress> getSocketLocalAddress(int socket, bo
 {
     sockaddr_storage localAddressStorage;
     zeroBytes(localAddressStorage);
-    socklen_t localAddressStorageLength = sizeof(sockaddr_storage);
-    if (::getsockname(socket, reinterpret_cast<sockaddr*>(&localAddressStorage), &localAddressStorageLength) < 0) {
+
+    auto& localAddress = asSocketAddress(localAddressStorage);
+    socklen_t localAddressStorageLength = sizeof(localAddress);
+
+    if (::getsockname(socket, &localAddress, &localAddressStorageLength) < 0) {
         RELEASE_LOG_ERROR(WebRTC, "getDefaultIPAddress getsockname failed, useIPv4=%d", useIPv4);
         return { };
     }
@@ -278,7 +281,7 @@ static std::optional<RTCNetwork::IPAddress> getSocketLocalAddress(int socket, bo
         return { };
     }
 
-    return RTCNetwork::IPAddress { *reinterpret_cast<const struct sockaddr*>(&localAddressStorage) };
+    return RTCNetwork::IPAddress { localAddress };
 }
 
 static std::optional<RTCNetwork::IPAddress> getDefaultIPAddress(bool useIPv4)

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,7 +1,6 @@
 AutomationProtocolObjects.h
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/cocoa/WebSocketTaskCocoa.mm
-NetworkProcess/webrtc/NetworkRTCMonitor.cpp
 Platform/cocoa/CocoaHelpers.mm
 Shared/API/APIArray.h
 Shared/API/APIDictionary.h


### PR DESCRIPTION
#### ec36d10f1269f15f08954114c1747b88f11556a0
<pre>
Address safer CPP warnings in NetworkRTCMonitor.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287548">https://bugs.webkit.org/show_bug.cgi?id=287548</a>
<a href="https://rdar.apple.com/144674613">rdar://144674613</a>

Reviewed by Chris Dumez.

We can use the new functions introduced by 290259@main to
fix the unsafe casting failures.

* Source/WebKit/NetworkProcess/webrtc/NetworkRTCMonitor.cpp:
(WebKit::getSocketLocalAddress):
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/290302@main">https://commits.webkit.org/290302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75a6968957fcafde317237a10bd1733fa5fbfc0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40259 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17298 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26587 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81209 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49298 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6945 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39365 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77303 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96312 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12247 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77803 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77119 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9824 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14053 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16687 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/21998 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16428 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19879 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->