### PR TITLE
[CSS-anchor-position-1] Fine-grained invalidation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7591,7 +7591,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-fa
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-composited-scrolling-006.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-fixedpos.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-012.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-to-sticky-004.html [ ImageOnlyFailure ]

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2751,10 +2751,6 @@ void Document::resolveStyle(ResolveStyleType type)
                 documentElement->invalidateStyleForSubtree();
         }
 
-        // FIXME: Be smarter about invalidation for anchor positioning.
-        // This simply repeats the entire anchor-positioning process.
-        styleScope().clearAnchorPositioningState();
-
         Style::TreeResolver resolver(*this, WTFMove(m_pendingRenderTreeUpdate));
         auto styleUpdate = resolver.resolve();
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2625,6 +2625,11 @@ void Element::invalidateForQueryContainerSizeChange()
     setElementStateFlag(ElementStateFlag::NeedsUpdateQueryContainerDependentStyle);
 }
 
+void Element::invalidateForAnchorRectChange()
+{
+    Node::invalidateStyle(Style::Validity::ElementInvalid);
+}
+
 void Element::invalidateForResumingQueryContainerResolution()
 {
     setChildNeedsStyleRecalc();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -775,6 +775,7 @@ public:
     void invalidateStyleForAnimation();
     void invalidateStyleForSubtreeInternal();
     void invalidateForQueryContainerSizeChange();
+    void invalidateForAnchorRectChange();
     void invalidateForResumingQueryContainerResolution();
     void invalidateForResumingAnchorPositionedElementResolution();
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -158,8 +158,8 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
     if (view().hasOneRef())
         return;
 
-    Style::Scope::QueryContainerUpdateContext queryContainerUpdateContext;
-    while (document() && document()->styleScope().updateQueryContainerState(queryContainerUpdateContext)) {
+    Style::Scope::LayoutDependencyUpdateContext layoutDependencyUpdateContext;
+    while (document() && document()->styleScope().invalidateForLayoutDependencies(layoutDependencyUpdateContext)) {
         document()->updateStyleIfNeeded();
 
         if (!needsLayout())

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1641,7 +1641,7 @@ const Element* RenderElement::defaultAnchor() const
     auto defaultAnchorLookupResult = anchoringState.anchorElements.find(anchorName->name);
     if (defaultAnchorLookupResult == anchoringState.anchorElements.end())
         return nullptr;
-    return &defaultAnchorLookupResult->value.get();
+    return defaultAnchorLookupResult->value.get();
 }
 
 const RenderElement* RenderElement::defaultAnchorRenderer() const

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -53,7 +53,7 @@ enum class AnchorPositionResolutionStage : uint8_t {
     Positioned,
 };
 
-using AnchorElements = HashMap<AtomString, WeakRef<Element, WeakPtrImplWithEventTargetData>>;
+using AnchorElements = HashMap<AtomString, WeakPtr<Element, WeakPtrImplWithEventTargetData>>;
 
 struct AnchorPositionedState {
     WTF_MAKE_TZONE_ALLOCATED(AnchorPositionedState);
@@ -103,6 +103,9 @@ public:
     static void updateSnapshottedScrollOffsets(Document&);
 
     static LayoutRect computeAnchorRectRelativeToContainingBlock(CheckedRef<const RenderBoxModelObject> anchorBox, const RenderBlock& containingBlock);
+
+    using AnchorToAnchorPositionedMap = SingleThreadWeakHashMap<const RenderBoxModelObject, Vector<Ref<Element>>>;
+    static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(Document&);
 
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -924,15 +924,20 @@ bool Scope::isForUserAgentShadowTree() const
     return m_shadowRoot && m_shadowRoot->mode() == ShadowRootMode::UserAgent;
 }
 
-bool Scope::updateQueryContainerState(QueryContainerUpdateContext& context)
+bool Scope::invalidateForLayoutDependencies(LayoutDependencyUpdateContext& context)
+{
+    return invalidateForContainerDependencies(context) || invalidateForAnchorDependencies(context);
+}
+
+bool Scope::invalidateForContainerDependencies(LayoutDependencyUpdateContext& context)
 {
     ASSERT(!m_shadowRoot);
 
     if (!m_document->renderView())
         return false;
 
-    auto previousStates = WTFMove(m_queryContainerStates);
-    m_queryContainerStates.clear();
+    auto previousQueryContainerDimensions = WTFMove(m_queryContainerDimensionsOnLastUpdate);
+    m_queryContainerDimensionsOnLastUpdate.clear();
 
     Vector<CheckedPtr<Element>> containersToInvalidate;
 
@@ -960,18 +965,62 @@ bool Scope::updateQueryContainerState(QueryContainerUpdateContext& context)
             RELEASE_ASSERT_NOT_REACHED();
         };
 
-        auto it = previousStates.find(*containerElement);
-        bool changed = it == previousStates.end() || sizeChanged(it->value);
+        auto it = previousQueryContainerDimensions.find(*containerElement);
+        bool changed = it == previousQueryContainerDimensions.end() || sizeChanged(it->value);
         // Protect against unstable layout by invalidating only once per container.
         if (changed && context.invalidatedContainers.add(*containerElement).isNewEntry)
             containersToInvalidate.append(containerElement);
-        m_queryContainerStates.add(*containerElement, size);
+        m_queryContainerDimensionsOnLastUpdate.add(*containerElement, size);
     }
 
     for (auto& toInvalidate : containersToInvalidate)
         toInvalidate->invalidateForQueryContainerSizeChange();
 
     return !containersToInvalidate.isEmpty();
+}
+
+bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& context)
+{
+    ASSERT(!m_shadowRoot);
+
+    if (!m_document->renderView())
+        return false;
+
+    auto previousAnchorRects = WTFMove(m_anchorRectsOnLastUpdate);
+    m_anchorRectsOnLastUpdate.clear();
+
+    Vector<CheckedRef<Element>> anchoredElementsToInvalidate;
+
+    if (m_document->renderView()->anchors().isEmptyIgnoringNullReferences())
+        return false;
+
+    auto anchorMap = AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap(m_document);
+
+    for (auto& anchorRenderer : m_document->renderView()->anchors()) {
+        auto rect = anchorRenderer.absoluteBoundingBoxRect();
+
+        m_anchorRectsOnLastUpdate.add(anchorRenderer, rect);
+
+        auto it = previousAnchorRects.find(anchorRenderer);
+        bool changed = it == previousAnchorRects.end() || it->value != rect;
+        if (!changed)
+            continue;
+
+        auto anchoredElements = anchorMap.getOptional(anchorRenderer);
+        if (!anchoredElements)
+            continue;
+
+        for (auto& anchoredElement : *anchoredElements) {
+            if (!context.invalidatedAnchorPositioned.add(anchoredElement.get()).isNewEntry)
+                continue;
+            anchoredElementsToInvalidate.append(anchoredElement);
+        }
+    }
+
+    for (auto& toInvalidate : anchoredElementsToInvalidate)
+        toInvalidate->invalidateForAnchorRectChange();
+
+    return !anchoredElementsToInvalidate.isEmpty();
 }
 
 const MatchResult* Scope::cachedMatchResult(const Element& element)
@@ -1033,16 +1082,23 @@ Element* hostForScopeOrdinal(const Element& element, ScopeOrdinal scopeOrdinal)
     return host;
 }
 
-void Scope::clearAnchorPositioningState()
+void Scope::resetAnchorPositioningStateBeforeStyleResolution()
 {
-    for (auto keyAndValue : m_anchorPositionedStates) {
-        CheckedRef element = keyAndValue.key;
-        if (auto* renderer = dynamicDowncast<RenderBox>(element->renderer()); renderer && renderer->layer())
-            renderer->layer()->clearSnapshottedScrollOffsetForAnchorPositioning();
-        keyAndValue.key.invalidateStyle();
+    // FIXME: Move this transient state to TreeResolver.
+    for (auto elementAndState : m_anchorPositionedStates) {
+        elementAndState.value->anchorNames.clear();
+        elementAndState.value->stage = AnchorPositionResolutionStage::Initial;
     }
+}
 
-    m_anchorPositionedStates.clear();
+void Scope::updateAnchorPositioningStateAfterStyleResolution()
+{
+    AnchorPositionEvaluator::updateSnapshottedScrollOffsets(m_document);
+
+    m_anchorPositionedStates.removeIf([](auto& elementAndState) {
+        // Remove if we have no anchors after initial resolution.
+        return elementAndState.value->stage != AnchorPositionResolutionStage::Initial && elementAndState.value->anchorNames.isEmpty();
+    });
 }
 
 }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -75,9 +75,14 @@ TreeResolver::TreeResolver(Document& document, std::unique_ptr<Update> update)
     : m_document(document)
     , m_update(WTFMove(update))
 {
+    // FIXME: Move transient state to TreeResolver similar to QueryContainerState.
+    m_document->styleScope().resetAnchorPositioningStateBeforeStyleResolution();
 }
 
-TreeResolver::~TreeResolver() = default;
+TreeResolver::~TreeResolver()
+{
+    m_document->styleScope().updateAnchorPositioningStateAfterStyleResolution();
+}
 
 TreeResolver::Scope::Scope(Document& document, Update& update)
     : resolver(document.styleScope().resolver())


### PR DESCRIPTION
#### 5daa772e687cbea74995e542e6412ffb7bddb1f3
<pre>
[CSS-anchor-position-1] Fine-grained invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=287552">https://bugs.webkit.org/show_bug.cgi?id=287552</a>
<a href="https://rdar.apple.com/144681624">rdar://144681624</a>

Reviewed by Alan Baradlay.

Track when anchors move and invalidate anchored element style only when needed.
Before this we just invalidated all anchored elements unconditionally.

* LayoutTests/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateForAnchorRectChange):

Add a style invalidation function for this.

* Source/WebCore/dom/Element.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets):

Take care to also clear the offsets if they are not being applied.

(WebCore::Style::AnchorPositionEvaluator::makeAnchorPositionedForAnchorMap):

Make a reverse map.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForLayoutDependencies):
(WebCore::Style::Scope::invalidateForContainerDependencies):
(WebCore::Style::Scope::invalidateForAnchorDependencies):

Track the positions of anchors, invalidate if they have moved.

(WebCore::Style::Scope::resetAnchorPositioningStateBeforeStyleResolution):

Reset the transient state only.

(WebCore::Style::Scope::updateAchorPositioningStateAfterStyleResolution):

Update the snapshotted offsets.
Get rid of items that are not anchored anymore.

(WebCore::Style::Scope::updateQueryContainerState): Deleted.
(WebCore::Style::Scope::clearAnchorPositioningState): Deleted.
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::TreeResolver):
(WebCore::Style::TreeResolver::~TreeResolver):

Canonical link: <a href="https://commits.webkit.org/290291@main">https://commits.webkit.org/290291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f403110295534fa8a3c72cddd94c7adf89d85c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44413 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17360 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68985 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26642 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81278 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49350 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35662 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39427 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96374 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77853 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77081 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77168 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19046 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21608 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9903 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16749 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16490 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19941 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18272 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->