### PR TITLE
[Glib] Fix build on non-Linux platforms

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -274,7 +274,7 @@ void ProcessLauncher::launchProcess()
     m_processID = g_ascii_strtoll(processIdStr, nullptr, 0);
     RELEASE_ASSERT(m_processID);
 
-    RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, this, serverSocket = WTFMove(webkitSocketPair.server)] {
+    RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, this, serverSocket = WTFMove(webkitSocketPair.server)] mutable {
         didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
     });
 #endif


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=285806

2d331cef5d1c ("Address static analysis warnings related to RunLoop") updated the non-Linux code, but missed adding "mutable" there like it did for the common part, leading to the following error:

```
In file included from /build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/FastMalloc.h:26,
                 from /build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/TZoneMalloc.h:35,
                 from /build/webkit2gtk-2.47.4/Source/WebKit/WebKit2Prefix.h:67,
                 from <command-line>:
/build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp: In lambda function: /build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h:1502:58: error: binding reference of type ‘WTF::UnixFileDescriptor&&’ to ‘std::remove_reference<const WTF::UnixFileDescriptor&>::type’ {aka ‘const WTF::UnixFileDescriptor’} discards qualifiers
 1502 | #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
/build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:278:78: note: in expansion of macro ‘WTFMove’
  278 |         didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
      |                                                                              ^~~~~~~
In file included from /build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:28,
                 from /build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:28:
/build/webkit2gtk-2.47.4/Source/WebKit/Platform/IPC/Connection.h:273:50: note:   initializing argument 1 of ‘IPC::Connection::Identifier::Identifier(WTF::UnixFileDescriptor&&)’
  273 |         explicit Identifier(UnixFileDescriptor&& fd)
      |                             ~~~~~~~~~~~~~~~~~~~~~^~
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h: In instantiation of ‘constexpr typename std::remove_reference<_Arg>::type&& std::move(T&&) [with WTF::CheckMoveParameterTag <anonymous> = WTF::CheckMoveParameter; T = const WTF::UnixFileDescriptor&; typename remove_reference<_Arg>::type = const WTF::UnixFileDescriptor]’:
/build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:278:78:   required from here
 1502 | #define WTFMove(value) std::move<WTF::CheckMoveParameter>(value)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h:923:51: error: static assertion failed: T is const qualified.
  923 |     static_assert(!is_const<NonRefQualifiedType>::value, "T is const qualified.");
      |                                                   ^~~~~
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h:923:51: note: ‘!(bool)std::integral_constant<bool, true>::value’ evaluates to false
ninja: build stopped: subcommand failed.
```

* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp: (WebKit::ProcessLauncher::launchProcess):

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d94c9bd033f28eb2dcc3bc707a1924c9de97eda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44369 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/40279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17318 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/94504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/40279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92513 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94504 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/6961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39385 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36618 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96332 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16694 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16949 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/21562 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9851 "The change is no longer eligible for processing.") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16707 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Running compile-webkit") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16448 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19899 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->