### PR TITLE
[Glib] Fix build on non-Linux platforms

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -274,7 +274,7 @@ void ProcessLauncher::launchProcess()
     m_processID = g_ascii_strtoll(processIdStr, nullptr, 0);
     RELEASE_ASSERT(m_processID);
 
-    RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, this, serverSocket = WTFMove(webkitSocketPair.server)] {
+    RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, this, serverSocket = WTFMove(webkitSocketPair.server)] mutable {
         didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
     });
 #endif


### PR DESCRIPTION
#### 757540b9d7838ceea18a36c1c3a22d20d5ad3ef6
<pre>
[Glib] Fix build on non-Linux platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=285806">https://bugs.webkit.org/show_bug.cgi?id=285806</a>

Reviewed by Michael Catanzaro

2d331cef5d1c (&quot;Address static analysis warnings related to RunLoop&quot;)
updated the non-Linux code, but missed adding &quot;mutable&quot; there like it
did for the common part, leading to the following error:

In file included from /build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/FastMalloc.h:26,
                 from /build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/TZoneMalloc.h:35,
                 from /build/webkit2gtk-2.47.4/Source/WebKit/WebKit2Prefix.h:67,
                 from &lt;command-line&gt;:
/build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp: In lambda function:
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h:1502:58: error: binding reference of type ‘WTF::UnixFileDescriptor&amp;&amp;’ to ‘std::remove_reference&lt;const WTF::UnixFileDescriptor&amp;&gt;::type’ {aka ‘const WTF::UnixFileDescriptor’} discards qualifiers
 1502 | #define WTFMove(value) std::move&lt;WTF::CheckMoveParameter&gt;(value)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
/build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:278:78: note: in expansion of macro ‘WTFMove’
  278 |         didFinishLaunchingProcess(m_processID, IPC::Connection::Identifier { WTFMove(serverSocket) });
      |                                                                              ^~~~~~~
In file included from /build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:28,
                 from /build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:28:
/build/webkit2gtk-2.47.4/Source/WebKit/Platform/IPC/Connection.h:273:50: note:   initializing argument 1 of ‘IPC::Connection::Identifier::Identifier(WTF::UnixFileDescriptor&amp;&amp;)’
  273 |         explicit Identifier(UnixFileDescriptor&amp;&amp; fd)
      |                             ~~~~~~~~~~~~~~~~~~~~~^~
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h: In instantiation of ‘constexpr typename std::remove_reference&lt;_Arg&gt;::type&amp;&amp; std::move(T&amp;&amp;) [with WTF::CheckMoveParameterTag &lt;anonymous&gt; = WTF::CheckMoveParameter; T = const WTF::UnixFileDescriptor&amp;; typename remove_reference&lt;_Arg&gt;::type = const WTF::UnixFileDescriptor]’:
/build/webkit2gtk-2.47.4/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:278:78:   required from here
 1502 | #define WTFMove(value) std::move&lt;WTF::CheckMoveParameter&gt;(value)
      |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h:923:51: error: static assertion failed: T is const qualified.
  923 |     static_assert(!is_const&lt;NonRefQualifiedType&gt;::value, &quot;T is const qualified.&quot;);
      |                                                   ^~~~~
/build/webkit2gtk-2.47.4/build-soup3/WTF/Headers/wtf/StdLibExtras.h:923:51: note: ‘!(bool)std::integral_constant&lt;bool, true&gt;::value’ evaluates to false
ninja: build stopped: subcommand failed.

* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):

Canonical link: <a href="https://commits.webkit.org/291283@main">https://commits.webkit.org/291283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41784b517c7426cec27602e1c7b5446455570cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42789 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20262 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70734 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28199 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9193 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8911 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42121 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79233 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99289 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14285 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79748 "Found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79006 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23548 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12333 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24483 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19004 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->