### PR TITLE
[scroll-animations] "Removing/inserting element with attaching timeline" WPT test is failing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt
@@ -5,7 +5,7 @@ PASS Inner timeline does not interfere with outer timeline
 PASS Deferred timeline with two attachments
 PASS Dynamically re-attaching
 PASS Dynamically detaching
-FAIL Removing/inserting element with attaching timeline assert_equals: expected "0px" but got "100px"
+PASS Removing/inserting element with attaching timeline
 PASS Ancestor attached element becoming display:none/block
 FAIL A deferred timeline appearing dynamically in the ancestor chain assert_equals: expected "100px" but got "0px"
 PASS Animations prefer non-deferred timelines

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -88,6 +88,7 @@ public:
     void unregisterNamedTimelinesAssociatedWithElement(const Styleable&);
     void removePendingOperationsForCSSAnimation(const CSSAnimation&);
     void documentDidResolveStyle();
+    void styleableWasRemoved(const Styleable&);
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
@@ -116,6 +117,7 @@ private:
     Vector<TimelineMapAttachOperation> m_pendingAttachOperations;
     Vector<std::pair<TimelineScope, WeakStyleable>> m_timelineScopeEntries;
     UncheckedKeyHashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
+    HashSet<Ref<ScrollTimeline>> m_removedTimelines;
 
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     std::unique_ptr<AcceleratedEffectStackUpdater> m_acceleratedEffectStackUpdater;

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -294,6 +294,8 @@ void Styleable::animationWasRemoved(WebAnimation& animation) const
 void Styleable::elementWasRemoved() const
 {
     cancelStyleOriginatedAnimations();
+    if (CheckedPtr timelinesController = element.protectedDocument()->timelinesController())
+        timelinesController->styleableWasRemoved(*this);
 }
 
 void Styleable::willChangeRenderer() const


### PR DESCRIPTION
#### 897d1cdb792517153e7f3a00fe5657ebc4c15175
<pre>
[scroll-animations] &quot;Removing/inserting element with attaching timeline&quot; WPT test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=287561">https://bugs.webkit.org/show_bug.cgi?id=287561</a>

Reviewed by Dean Jackson.

When an element is disconnected from the document, we must make sure that any style-originated
timeline that was created due to a `scroll-timeline-name` or `view-timeline-name` property set
on that element is unregistered and that animations associated with that timeline are re-evaluated.

Currently, the method `AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement()`
is already called when an element is disconnected from the document by virtue of the render tree
teardown calling into `Styleable::cancelStyleOriginatedAnimations()`. But that method simply removes
the timelines originated from that element from the name-to-timeline map.

We need to also ensure that the associated animations are re-evaluated, so we add a new method
`AnimationTimelinesController::styleableWasRemoved()` called when an element is removed, via
`Styleable::elementWasRemoved()`, and make sure to update the animations associated with the
affected timeline&apos;s name. To that end, we collect the removed timelines in a new `m_removedTimelines`
set so that we may process the timelines removed in `unregisterNamedTimelinesAssociatedWithElement()`
once the element is removed from the DOM (since `unregisterNamedTimelinesAssociatedWithElement()`
is called first).

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/timeline-scope-expected.txt:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::documentDidResolveStyle):
(WebCore::AnimationTimelinesController::unregisterNamedTimelinesAssociatedWithElement):
(WebCore::AnimationTimelinesController::styleableWasRemoved):
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::elementWasRemoved const):

Canonical link: <a href="https://commits.webkit.org/290337@main">https://commits.webkit.org/290337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0df1c853060073432346bcf8b291397be1b39696

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94715 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17528 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92723 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/49465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/39619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/96542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16904 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/96542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17160 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/96542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/21727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10074 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14079 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16917 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16658 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->