### PR TITLE
[GLib] Implement run-webkit-app script

### DIFF
--- a/Tools/Scripts/run-webkit-app
+++ b/Tools/Scripts/run-webkit-app
@@ -34,6 +34,12 @@ use FindBin;
 use lib $FindBin::Bin;
 use webkitdirs;
 
+if (isLinux()) {
+    my $scriptsDir = relativeScriptsDir();
+    exec "$scriptsDir/../glib/run-webkit-app.py", @ARGV;
+    exit;
+}
+
 printHelpAndExitForRunAndDebugWebKitAppIfNeeded();
 
 setConfiguration();

--- a/Tools/glib/run-webkit-app.py
+++ b/Tools/glib/run-webkit-app.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 Igalia S.L.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Library General Public
+# License as published by the Free Software Foundation; either
+# version 2 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Library General Public License for more details.
+#
+# You should have received a copy of the GNU Library General Public License
+# along with this library; see the file COPYING.LIB.  If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+# Boston, MA 02110-1301, USA.
+
+import argparse
+import os
+from os import path
+import subprocess
+import sys
+
+sys.path.append(path.abspath(path.join(path.dirname(__file__), '..', 'Scripts')))
+
+from webkitpy.common.host import Host
+from webkitpy.common.webkit_finder import WebKitFinder
+
+
+def get_default_configuration(output_dir):
+    try:
+        with open(path.join(output_dir, 'Configuration')) as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description='run-webkit-app runs an executable with a specific build of WebKit')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--release', action='store_const', dest='configuration', const='Release')
+    group.add_argument('--debug', action='store_const', dest='configuration', const='Debug')
+    parser.add_argument('executable', nargs=argparse.REMAINDER)
+    options = parser.parse_args(sys.argv[1:])
+
+    host = Host()
+    finder = WebKitFinder(host.filesystem)
+    output_dir = finder.path_from_webkit_outputdir()
+    subdir = options.configuration or get_default_configuration(output_dir)
+
+    if not os.environ.get('WEBKIT_BUILD_USE_SYSTEM_LIBRARIES', 0):
+        sys.exit('ERROR: This command is not supported when using flatpak.')
+
+    if not options.executable:
+        parser.print_help()
+        print('')
+        sys.exit('ERROR: An executable is required.')
+
+    if not subdir:
+        sys.exit('ERROR: You must specify either --debug/--release or set it with `set-webkit-configuration`.')
+
+    build_dir = path.join(output_dir, 'GTK', subdir)
+
+    env = os.environ.copy()
+
+    libdir = path.join(build_dir, 'lib')
+    env['WEBKIT_EXEC_PATH'] = path.join(build_dir, 'bin')
+    env['WEBKIT_INJECTED_BUNDLE_PATH'] = libdir
+    if 'LD_LIBRARY_PATH' in env:
+        env['LD_LIBRARY_PATH'] = ':'.join((libdir, env['LD_LIBRARY_PATH']))
+    else:
+        env['LD_LIBRARY_PATH'] = libdir
+
+    proc = subprocess.run(options.executable, env=env)
+    sys.exit(proc.returncode)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
#### c9cbd9212869b9defd01d281f630e0585e36705c
<pre>
[GLib] Implement run-webkit-app script
<a href="https://bugs.webkit.org/show_bug.cgi?id=287562">https://bugs.webkit.org/show_bug.cgi?id=287562</a>

Reviewed by Philippe Normand.

This allows easily testing a host application against a webkit build.

* Tools/Scripts/run-webkit-app:
* Tools/glib/run-webkit-app.py: Added.
(get_default_configuration):
(main):

Canonical link: <a href="https://commits.webkit.org/290270@main">https://commits.webkit.org/290270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddd0c837ff4c3897e5764d536496a46935f79f7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89530 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40297 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/68966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26619 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81246 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49332 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6978 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77332 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96350 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77838 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77154 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21578 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9873 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14032 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16725 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16466 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19917 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->