### PR TITLE
[GStreamer][WebRTC] Configure send/receive buffer sizes on ICE transport

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
@@ -65,6 +65,13 @@ void GStreamerIceTransportBackend::iceTransportChanged()
 
     g_object_get(m_backend.get(), "transport", &m_iceTransport.outPtr(), nullptr);
 
+    // Setting same libnice socket size options as LibWebRTC. 1MB for incoming streams and 256Kb for outgoing streams.
+    if (gstObjectHasProperty(GST_OBJECT_CAST(m_iceTransport.get()), "receive-buffer-size"))
+        g_object_set(m_iceTransport.get(), "receive-buffer-size", 1048576, nullptr);
+
+    if (gstObjectHasProperty(GST_OBJECT_CAST(m_iceTransport.get()), "send-buffer-size"))
+        g_object_set(m_iceTransport.get(), "send-buffer-size", 262144, nullptr);
+
     g_signal_connect_swapped(m_iceTransport.get(), "notify::state", G_CALLBACK(+[](GStreamerIceTransportBackend* backend) {
         backend->stateChanged();
     }), this);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -1684,7 +1684,7 @@ void configureVideoRTPDepayloader(GstElement* element)
         g_object_set(element, "wait-for-keyframe", TRUE, nullptr);
 }
 
-static bool gstObjectHasProperty(GstObject* gstObject, const char* name)
+bool gstObjectHasProperty(GstObject* gstObject, const char* name)
 {
     return g_object_class_find_property(G_OBJECT_GET_CLASS(gstObject), name);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -313,6 +313,7 @@ void configureVideoDecoderForHarnessing(const GRefPtr<GstElement>&);
 void configureMediaStreamVideoDecoder(GstElement*);
 void configureVideoRTPDepayloader(GstElement*);
 
+bool gstObjectHasProperty(GstObject*, const char* name);
 bool gstObjectHasProperty(GstElement*, const char* name);
 bool gstObjectHasProperty(GstPad*, const char* name);
 


### PR DESCRIPTION
#### 912331d6d1a9f7ae07c7f87d344dcc71026abc7e
<pre>
[GStreamer][WebRTC] Configure send/receive buffer sizes on ICE transport
<a href="https://bugs.webkit.org/show_bug.cgi?id=287556">https://bugs.webkit.org/show_bug.cgi?id=287556</a>

Reviewed by Xabier Rodriguez-Calvar.

The 1MB value for incoming streams should help reducing packet loss at very high/bursty receive
rates. See also:
<a href="https://source.chromium.org/chromium/_/webrtc/src/+/2514dd7a20f187ce230e0d00a24b5fd33d29e0f2">https://source.chromium.org/chromium/_/webrtc/src/+/2514dd7a20f187ce230e0d00a24b5fd33d29e0f2</a>

The 256K value for outgoing streams also maps current LibWebRTC, see also:
<a href="https://source.chromium.org/chromium/_/webrtc/src/+/031ebc42e633d2b9b1e0b5dd2ee676800bf86807">https://source.chromium.org/chromium/_/webrtc/src/+/031ebc42e633d2b9b1e0b5dd2ee676800bf86807</a>

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp:
(WebCore::GStreamerIceTransportBackend::iceTransportChanged):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::gstObjectHasProperty):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:

Canonical link: <a href="https://commits.webkit.org/290393@main">https://commits.webkit.org/290393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/369805e42dc224eb074191f9c694313388885c97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40296 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9445 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26621 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/6977 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35668 "Found 3 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html http/tests/xmlhttprequest/cross-origin-cookie-storage.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77331 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96349 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77159 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19106 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20188 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9872 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16724 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22037 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18247 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->