### PR TITLE
REGRESSION(289503@main): www.business-standard.com audio player is cut off

### DIFF
--- a/LayoutTests/media/modern-media-controls/audio/audio-controls-metrics-content-box-expected.txt
+++ b/LayoutTests/media/modern-media-controls/audio/audio-controls-metrics-content-box-expected.txt
@@ -1,0 +1,12 @@
+Testing the <audio> controls metrics.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS defaultAudio.getBoundingClientRect().width is 270
+PASS defaultAudio.getBoundingClientRect().height is 51
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/audio/audio-controls-metrics-content-box.html
+++ b/LayoutTests/media/modern-media-controls/audio/audio-controls-metrics-content-box.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../../../resources/js-test-pre.js"></script>
+<body>
+<style>
+    audio {
+        box-model: content-box;
+        padding: 10px;
+    }
+</style>
+<script type="text/javascript">
+
+description("Testing the <code>&lt;audio></code> controls metrics.");
+
+const defaultAudio = document.body.appendChild(document.createElement("audio"));
+defaultAudio.controls = true;
+
+shouldBe("defaultAudio.getBoundingClientRect().width", "270");
+shouldBe("defaultAudio.getBoundingClientRect().height", "51");
+
+debug("");
+defaultAudio.remove();
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -33,6 +33,7 @@
     height: var(--inline-controls-bar-height);
     min-width: 44px !important;
     min-height: var(--inline-controls-bar-height) !important;
+    box-sizing: content-box !important;
 }
 
 * {


### PR DESCRIPTION
#### 7eb463a782c516d7ce373f1215d8f9e8997eb3b3
<pre>
REGRESSION(289503@main): www.business-standard.com audio player is cut off
<a href="https://rdar.apple.com/144633668">rdar://144633668</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287565">https://bugs.webkit.org/show_bug.cgi?id=287565</a>

Reviewed by Simon Fraser.

The business-standard.com site set a padding on the &lt;audio&gt; elements it inserts into
its articles, but also sets `box-sizing:border-box` on those elements. In combination
with the UA rule requiring a specific height for those elements, this causes the content
area of those elements to be reduced and clipped.

Set a UA rule for audio elements such that the element&apos;s `box-sizing:` is set to
`content-box`, which ensures the content area of the element will always be visible.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.css:
(:host(audio)):

Canonical link: <a href="https://commits.webkit.org/290407@main">https://commits.webkit.org/290407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df77191ea51c5fb5b5b3c7d77a199dfdeefcff9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89758 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91810 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92759 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7434 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81454 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49493 "Found 3 new API test failures: /TestWTF:WTF_EnumTraits.EnumMinMax, /TestWTF:WTF_EnumTraits.EnumNameValid, /TestWTF:WTF_EnumTraits.EnumNameSignedValues (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7156 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35834 "Found 9 new test failures: fast/html/process-end-tag-for-inbody-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fullscreen/empty-anonymous-block-continuation-crash.html fullscreen/full-screen-request-removed.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39660 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77995 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77320 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19117 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20345 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10119 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16953 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22277 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20146 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->