### PR TITLE
REGRESSION:(289950@main)[macOS]: http/tests/webarchive tests are a flaky failures with image failures(failure in EWS)

### DIFF
--- a/LayoutTests/http/tests/webarchive/cross-origin-stylesheet-crash.html
+++ b/LayoutTests/http/tests/webarchive/cross-origin-stylesheet-crash.html
@@ -1,6 +1,9 @@
 <html>
 <head>
 <script>
+if (window.internals)
+    internals.clearMemoryCache();
+
 if (window.testRunner)
     testRunner.dumpDOMAsWebArchive();
 </script>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-expected.txt
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-expected.txt
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WebMainResource</key>
+	<dict>
+		<key>WebResourceData</key>
+		<string>&lt;html&gt;&lt;head&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-no-charset.css"&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-shift-jis.css"&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-utf-8.css"&gt;
+&lt;script&gt;
+if (window.internals)
+    internals.clearMemoryCache();
+
+if (window.testRunner)
+    testRunner.dumpDOMAsWebArchive();
+&lt;/script&gt;
+&lt;/head&gt;
+&lt;body&gt;
+&lt;div&gt;
+Test for &lt;a href="https://bugs.webkit.org/show_bug.cgi?id=11850"&gt;Bug 11850:
+Webarchive fails to save images referenced in CSS&lt;/a&gt;
+&lt;/div&gt;
+&lt;div&gt;&lt;p&gt;This test makes sure that the URL in the shift-jis encoded CSS file is encoded properly in the webarchive.&lt;/p&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?img-src-no-charset-%88%9F&lt;/tt&gt; query string for &amp;lt;img&amp;gt; tag with no document charset: &lt;div class="styled"&gt;&lt;img src="resources/apple.gif?img-src-no-charset-ˆŸ"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-no-charset-%88%9F&lt;/tt&gt; query string for CSS url() with no CSS charset: &lt;div class="styled background-no-charset"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-shift-jis-%88%9F&lt;/tt&gt; query string for CSS url() with shift-jis CSS charset: &lt;div class="styled background-shift-jis"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-utf-8-%E4%BA%9C&lt;/tt&gt; query string for CSS url() with utf-8 CSS charset: &lt;div class="styled background-utf-8"&gt;&lt;/div&gt;&lt;/div&gt;
+
+
+&lt;/body&gt;&lt;/html&gt;</string>
+		<key>WebResourceFrameName</key>
+		<string></string>
+		<key>WebResourceMIMEType</key>
+		<string>text/html</string>
+		<key>WebResourceTextEncodingName</key>
+		<string>UTF-8</string>
+		<key>WebResourceURL</key>
+		<string>http://127.0.0.1:8000/webarchive/test-css-url-encoding.html</string>
+	</dict>
+	<key>WebSubresources</key>
+	<array>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%CB%86%C5%B8</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%CB%86%C5%B8</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-utf-8-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-utf-8-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?img-src-no-charset-%88%9F</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?img-src-no-charset-%88%9F</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			ZGl2LnN0eWxlZCB7CiAgICBib3JkZXI6IDFweCBzb2xpZCBibGFj
+			azsKICAgIGRpc3BsYXk6IGlubGluZS1ibG9jazsKICAgIGhlaWdo
+			dDogNjRweDsKfQpkaXYuYmFja2dyb3VuZC1uby1jaGFyc2V0IHsK
+			ICAgIHdpZHRoOiA1MnB4OwogICAgYmFja2dyb3VuZC1pbWFnZTog
+			dXJsKGFwcGxlLmdpZj9jc3MtdXJsLW5vLWNoYXJzZXQtiJ8pOwp9
+			Cg==
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-no-charset.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>196</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>196</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-no-charset.css</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>div.styled {
+    border: 1px solid black;
+    display: inline-block;
+    height: 64px;
+}
+div.background-shift-jis {
+    width: 52px;
+    background-image: url(apple.gif?css-url-shift-jis-亜);
+}
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-shift-jis.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>194</string>
+					<key>Content-Type</key>
+					<string>text/css;charset=shift-jis</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>194</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+				<key>textEncodingName</key>
+				<string>shift-jis</string>
+			</dict>
+			<key>WebResourceTextEncodingName</key>
+			<string>shift-jis</string>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-shift-jis.css</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>div.styled {
+    border: 1px solid black;
+    display: inline-block;
+    height: 64px;
+}
+div.background-utf-8 {
+    width: 52px;
+    background-image: url(apple.gif?css-url-utf-8-亜);
+}
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-utf-8.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>190</string>
+					<key>Content-Type</key>
+					<string>text/css;charset=utf-8</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>190</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+				<key>textEncodingName</key>
+				<string>utf-8</string>
+			</dict>
+			<key>WebResourceTextEncodingName</key>
+			<string>utf-8</string>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-utf-8.css</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis-expected.txt
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis-expected.txt
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WebMainResource</key>
+	<dict>
+		<key>WebResourceData</key>
+		<string>&lt;html&gt;&lt;head&gt;
+&lt;meta http-equiv="Content-Type" content="text/html;charset=shift-jis"&gt;
+&lt;!-- "?shift-jis" works around Bug 22952 when run after test-css-url-encoding-utf-8.html --&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-no-charset.css?shift-jis"&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-shift-jis.css"&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-utf-8.css"&gt;
+&lt;script&gt;
+if (window.internals)
+    internals.clearMemoryCache();
+
+if (window.testRunner)
+    testRunner.dumpDOMAsWebArchive();
+&lt;/script&gt;
+&lt;/head&gt;
+&lt;body&gt;
+&lt;div&gt;
+Test for &lt;a href="https://bugs.webkit.org/show_bug.cgi?id=11850"&gt;Bug 11850:
+Webarchive fails to save images referenced in CSS&lt;/a&gt;
+&lt;/div&gt;
+&lt;div&gt;&lt;p&gt;This test makes sure that the URL in the shift-jis encoded CSS file is encoded properly in the webarchive.&lt;/p&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?img-src-shift-jis-%88%9F&lt;/tt&gt; query string for &amp;lt;img&amp;gt; tag with shift-jis document charset: &lt;div class="styled"&gt;&lt;img src="resources/apple.gif?img-src-shift-jis-亜"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-no-charset-%88%9F&lt;/tt&gt; query string for CSS url() with no CSS charset: &lt;div class="styled background-no-charset"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-shift-jis-%88%9F&lt;/tt&gt; query string for CSS url() with shift-jis CSS charset: &lt;div class="styled background-shift-jis"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-utf-8-%E4%BA%9C&lt;/tt&gt; query string for CSS url() with utf-8 CSS charset: &lt;div class="styled background-utf-8"&gt;&lt;/div&gt;&lt;/div&gt;
+
+
+&lt;/body&gt;&lt;/html&gt;</string>
+		<key>WebResourceFrameName</key>
+		<string></string>
+		<key>WebResourceMIMEType</key>
+		<string>text/html</string>
+		<key>WebResourceTextEncodingName</key>
+		<string>UTF-8</string>
+		<key>WebResourceURL</key>
+		<string>http://127.0.0.1:8000/webarchive/test-css-url-encoding-shift-jis.html</string>
+	</dict>
+	<key>WebSubresources</key>
+	<array>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-utf-8-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-utf-8-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?img-src-shift-jis-%88%9F</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?img-src-shift-jis-%88%9F</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			ZGl2LnN0eWxlZCB7CiAgICBib3JkZXI6IDFweCBzb2xpZCBibGFj
+			azsKICAgIGRpc3BsYXk6IGlubGluZS1ibG9jazsKICAgIGhlaWdo
+			dDogNjRweDsKfQpkaXYuYmFja2dyb3VuZC1uby1jaGFyc2V0IHsK
+			ICAgIHdpZHRoOiA1MnB4OwogICAgYmFja2dyb3VuZC1pbWFnZTog
+			dXJsKGFwcGxlLmdpZj9jc3MtdXJsLW5vLWNoYXJzZXQtiJ8pOwp9
+			Cg==
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-no-charset.css?shift-jis</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>196</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>196</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-no-charset.css?shift-jis</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>div.styled {
+    border: 1px solid black;
+    display: inline-block;
+    height: 64px;
+}
+div.background-shift-jis {
+    width: 52px;
+    background-image: url(apple.gif?css-url-shift-jis-亜);
+}
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-shift-jis.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>194</string>
+					<key>Content-Type</key>
+					<string>text/css;charset=shift-jis</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>194</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+				<key>textEncodingName</key>
+				<string>shift-jis</string>
+			</dict>
+			<key>WebResourceTextEncodingName</key>
+			<string>shift-jis</string>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-shift-jis.css</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>div.styled {
+    border: 1px solid black;
+    display: inline-block;
+    height: 64px;
+}
+div.background-utf-8 {
+    width: 52px;
+    background-image: url(apple.gif?css-url-utf-8-亜);
+}
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-utf-8.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>190</string>
+					<key>Content-Type</key>
+					<string>text/css;charset=utf-8</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>190</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+				<key>textEncodingName</key>
+				<string>utf-8</string>
+			</dict>
+			<key>WebResourceTextEncodingName</key>
+			<string>utf-8</string>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-utf-8.css</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis.html
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis.html
@@ -6,6 +6,9 @@
 <link rel="stylesheet" type="text/css" href="resources/test-shift-jis.css">
 <link rel="stylesheet" type="text/css" href="resources/test-utf-8.css">
 <script>
+if (window.internals)
+    internals.clearMemoryCache();
+
 if (window.testRunner)
     testRunner.dumpDOMAsWebArchive();
 </script>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8-expected.txt
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8-expected.txt
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WebMainResource</key>
+	<dict>
+		<key>WebResourceData</key>
+		<string>&lt;html&gt;&lt;head&gt;
+&lt;meta http-equiv="content-type" content="text/html; charset=utf-8"&gt;
+&lt;!-- "?utf-8" works around Bug 22952 when run after test-css-url-encoding-shift-jis.html --&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-no-charset.css?utf-8"&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-shift-jis.css"&gt;
+&lt;link rel="stylesheet" type="text/css" href="resources/test-utf-8.css"&gt;
+&lt;script&gt;
+if (window.internals)
+    internals.clearMemoryCache();
+
+if (window.testRunner)
+    testRunner.dumpDOMAsWebArchive();
+&lt;/script&gt;
+&lt;/head&gt;
+&lt;body&gt;
+&lt;div&gt;
+Test for &lt;a href="https://bugs.webkit.org/show_bug.cgi?id=11850"&gt;Bug 11850:
+Webarchive fails to save images referenced in CSS&lt;/a&gt;
+&lt;/div&gt;
+&lt;div&gt;&lt;p&gt;This test makes sure that the URL in the shift-jis encoded CSS file is encoded properly in the webarchive.&lt;/p&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?img-src-utf-8-%E4%BA%9C&lt;/tt&gt; query string for &amp;lt;img&amp;gt; tag with utf-8 document charset: &lt;div class="styled"&gt;&lt;img src="resources/apple.gif?img-src-utf-8-亜"&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-no-charset-%EF%BF%BD%EF%BF%BD&lt;/tt&gt; query string for CSS url() with no CSS charset: &lt;div class="styled background-no-charset"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-shift-jis-%88%9F&lt;/tt&gt; query string for CSS url() with shift-jis CSS charset: &lt;div class="styled background-shift-jis"&gt;&lt;/div&gt;&lt;/div&gt;
+&lt;div&gt;Expected &lt;tt&gt;?css-url-utf-8-%E4%BA%9C&lt;/tt&gt; query string for CSS url() with utf-8 CSS charset: &lt;div class="styled background-utf-8"&gt;&lt;/div&gt;&lt;/div&gt;
+
+
+&lt;/div&gt;&lt;/body&gt;&lt;/html&gt;</string>
+		<key>WebResourceFrameName</key>
+		<string></string>
+		<key>WebResourceMIMEType</key>
+		<string>text/html</string>
+		<key>WebResourceTextEncodingName</key>
+		<string>UTF-8</string>
+		<key>WebResourceURL</key>
+		<string>http://127.0.0.1:8000/webarchive/test-css-url-encoding-utf-8.html</string>
+	</dict>
+	<key>WebSubresources</key>
+	<array>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%EF%BF%BD%EF%BF%BD</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-no-charset-%EF%BF%BD%EF%BF%BD</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-shift-jis-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-utf-8-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?css-url-utf-8-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			R0lGODlhNABAAMQfAGJiYvLz9ImKitvb2/39/cnJyaSkpOPj49TU
+			1MHBwbW1terq7Lu7u/X19uXm5+3u7+fo6eDg4e/w8t7e3/n5+RcX
+			F87Oz/f398fHx9fX16+vr9HR0fDw8Pj4+MzMzAAAACH5BAEAAB8A
+			LAAAAAA0AEAAQAX/4CeOZGme5iFUlYC+cCwKD7FAxxElAiTDnATA
+			cCEYj8aABiBIDCIbjQCgqBEojUCjQSEEpoXTAUCQLB4PiZoTaG/f
+			jcuFgj1kBrnIZDLoDzIIgRsTAgYmBk8TEQ4OEGdpbBQLDAUQEA55
+			e32AGxsWHh4FBRgJCQgFAhQoCwIDlgsSFxyFOnt8foAInp+jpQkM
+			wArCGsQaCg0KBgEoDwAAHoHRgroW1aEYpL7A28LDxcUGGgalhi8I
+			AAgYoOvrn5/soL2lwcThEBQAAz/7JxYAXVcCPNjggp/BEwIYOHNm
+			wMHBErMSEMgCR47FC3EwwnlzocOFBxMy3NHkp88EBwU///gjcKCR
+			o0cPOEhwM6fDgUGWMuHKtQvUBgBhThhQ4CBCSwhoJDToQKxljlq4
+			BPHCNo+bggXEXnwZMNMAupJ/ckm9RvUXg27dvqllkEFADxMQAKir
+			Zs3Du1CiRpX1ZfasN3EGAlsYIIADv3MCDnBowKEAQwSGSRzAMEVA
+			BIwTmCB4yHkEQQMACQDY0LmzgAlXZF0ac6D0QwUJOAxAkMArgAyu
+			T3gQ5zYwBh8jBmhgoG9EBgYG3BbSQHpfBAEKjHSYTt3jxQ4BH3DB
+			2EaLnAYLIgC6EyGuBhMDyDSI2X3jlu8Vay7480TPrU250p8n0SrA
+			SzQxsTGTFu9hF4B45WESgf8e+EWzy0/NlTBOeDk0AtNMcVAQQCcH
+			5LTgLSJJ9c4ooQiwjFAI7GGUhWkE0AFWv+GQB4N/6OJJPNnMY0EA
+			ACyAgmMSLIKUBBxQgEoGRX0IIk8j5hiMNwxQkBAKDAhgxgMdeCBX
+			BGCJFGInvMhj1V/fJMCjmSVEAEBcAFiQS4jS9HSNNk+mpZZaBmAw
+			WgmZUeNJJ4DWJUqOdI6JZ2DjEHKiCRwEBg88BbCTl15O+lUPoo3u
+			94MCAERAijrx+NQHBuIo4EGNgBRQigcRdAFAArl9EAAbBnWgRayl
+			ObCEiQQIECGu+2i5gBEaxgUcsDJk1sAVtp4xJbIy6JkdJhBAB63/
+			DCstoOAGXhV3LQxeubWQZd/+kBBDuF17AKcAaDDAAuEp1G4GDZiA
+			gBRMYODAAgdYYBsD+zjgFUAUVGedERf8NO49AQ2YkX85ZNDuCyoU
+			cEVGBlunEUVbuBHHdBwcMNtIfkwQFwYlUMDDRA5v9B18FRUMHn22
+			gBUWIZp+QEGeBKShRnceu5cRHbLdodNO0aSngAlV2vCIBD4PSOB7
+			c0hidCb31TgNDyfEdcElLz3Cwdgt07HAHY0crbWN7iiQUgluN7Di
+			K2eQ3cYcFwywQYcy0ggnmLx48FNrQllQ1FGvxIQhBQ+o0wgmUIU1
+			Fl7YbEBZByggskeFjiQVAAUQKFDJ/2p5REUNjlSx1dYFmWOgh5Bi
+			azhcTlhvMpZedMIm2q8kuE1h5zNRkMxJM97HJI65D7NBBz2ekNkD
+			LZ0hQQeEJZAkjbafPmdVdhKDQAMAEC5hAg8g9XlyeNRs+o1kVeWX
+			AncywDwD9ZKQmSMBLDAEl13ydCPu3CPTnRKgPwP4aARVuoBjEBGW
+			8fivSdkYE/zudCcPCMADvUOXNOIEJtQVCi0CxFN6HlCCKgFqA4II
+			1F0A6L46kQlRgRkDBk0ghV3Q5YYQxAahtvGkb8DQgM94gWPuAoq6
+			xCMvGKDUDl8YmOigIwYyjNSjpriOQUXQUpfilwAc8gMhZCABc8Hh
+			NSJlgTkOgoIUZykG+UQTFIMohBEIKGN9BmCbQgRmCq+awAIwgh0b
+			vMo1C6hNZfJ0wBdMwG29KQAJy/WtEAAAO1BvbG9udXMK
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>image/gif</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>image/gif</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?img-src-utf-8-%E4%BA%9C</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>1476</string>
+					<key>Content-Type</key>
+					<string>image/gif</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>1476</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/apple.gif?img-src-utf-8-%E4%BA%9C</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<data>
+			ZGl2LnN0eWxlZCB7CiAgICBib3JkZXI6IDFweCBzb2xpZCBibGFj
+			azsKICAgIGRpc3BsYXk6IGlubGluZS1ibG9jazsKICAgIGhlaWdo
+			dDogNjRweDsKfQpkaXYuYmFja2dyb3VuZC1uby1jaGFyc2V0IHsK
+			ICAgIHdpZHRoOiA1MnB4OwogICAgYmFja2dyb3VuZC1pbWFnZTog
+			dXJsKGFwcGxlLmdpZj9jc3MtdXJsLW5vLWNoYXJzZXQtiJ8pOwp9
+			Cg==
+			</data>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-no-charset.css?utf-8</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>196</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>196</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-no-charset.css?utf-8</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>div.styled {
+    border: 1px solid black;
+    display: inline-block;
+    height: 64px;
+}
+div.background-shift-jis {
+    width: 52px;
+    background-image: url(apple.gif?css-url-shift-jis-亜);
+}
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-shift-jis.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>194</string>
+					<key>Content-Type</key>
+					<string>text/css;charset=shift-jis</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>194</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+				<key>textEncodingName</key>
+				<string>shift-jis</string>
+			</dict>
+			<key>WebResourceTextEncodingName</key>
+			<string>shift-jis</string>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-shift-jis.css</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>div.styled {
+    border: 1px solid black;
+    display: inline-block;
+    height: 64px;
+}
+div.background-utf-8 {
+    width: 52px;
+    background-image: url(apple.gif?css-url-utf-8-亜);
+}
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-utf-8.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>190</string>
+					<key>Content-Type</key>
+					<string>text/css;charset=utf-8</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>190</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+				<key>textEncodingName</key>
+				<string>utf-8</string>
+			</dict>
+			<key>WebResourceTextEncodingName</key>
+			<string>utf-8</string>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-utf-8.css</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8.html
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8.html
@@ -6,6 +6,9 @@
 <link rel="stylesheet" type="text/css" href="resources/test-shift-jis.css">
 <link rel="stylesheet" type="text/css" href="resources/test-utf-8.css">
 <script>
+if (window.internals)
+    internals.clearMemoryCache();
+
 if (window.testRunner)
     testRunner.dumpDOMAsWebArchive();
 </script>

--- a/LayoutTests/http/tests/webarchive/test-css-url-encoding.html
+++ b/LayoutTests/http/tests/webarchive/test-css-url-encoding.html
@@ -4,6 +4,9 @@
 <link rel="stylesheet" type="text/css" href="resources/test-shift-jis.css">
 <link rel="stylesheet" type="text/css" href="resources/test-utf-8.css">
 <script>
+if (window.internals)
+    internals.clearMemoryCache();
+
 if (window.testRunner)
     testRunner.dumpDOMAsWebArchive();
 </script>

--- a/LayoutTests/http/tests/webarchive/test-preload-resources-expected.txt
+++ b/LayoutTests/http/tests/webarchive/test-preload-resources-expected.txt
@@ -1,0 +1,306 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WebMainResource</key>
+	<dict>
+		<key>WebResourceData</key>
+		<string>&lt;html&gt;&lt;head&gt;
+
+&lt;link rel="stylesheet" type="text/css" href="resources/test-preload-resources.css"&gt;
+&lt;link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?1" title="green"&gt;
+&lt;link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?2" title="blue"&gt;
+&lt;link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?3" title="yellow"&gt;
+&lt;link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?4" title="pink"&gt;
+&lt;link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?5" title="purple"&gt;
+&lt;link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?6" title="gray"&gt;
+
+&lt;script&gt;
+if (window.internals)
+    internals.clearMemoryCache();
+
+if (window.testRunner)
+    testRunner.dumpDOMAsWebArchive();
+&lt;/script&gt;
+
+&lt;/head&gt;&lt;body&gt;
+&lt;div&gt;
+Test for &lt;a href="https://bugs.webkit.org/show_bug.cgi?id=22466"&gt;Bug 22466:
+REGRESSION (35867): Many resources missing when saving webarchive of webkit.org&lt;/a&gt;
+&lt;/div&gt;
+&lt;p&gt;Some resources are missing when saving this page as a webarchive.&lt;/p&gt;
+
+&lt;/body&gt;&lt;/html&gt;</string>
+		<key>WebResourceFrameName</key>
+		<string></string>
+		<key>WebResourceMIMEType</key>
+		<string>text/html</string>
+		<key>WebResourceTextEncodingName</key>
+		<string>UTF-8</string>
+		<key>WebResourceURL</key>
+		<string>http://127.0.0.1:8000/webarchive/test-preload-resources.html</string>
+	</dict>
+	<key>WebSubresources</key>
+	<array>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?1</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?1</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?2</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?2</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?3</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?3</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?4</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?4</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?5</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?5</string>
+		</dict>
+		<dict>
+			<key>WebResourceData</key>
+			<string>/* test-preload-resources.css */
+</string>
+			<key>WebResourceMIMEType</key>
+			<string>text/css</string>
+			<key>WebResourceResponse</key>
+			<dict>
+				<key>MIMEType</key>
+				<string>text/css</string>
+				<key>URL</key>
+				<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?6</string>
+				<key>allHeaderFields</key>
+				<dict>
+					<key>Accept-Ranges</key>
+					<string>bytes</string>
+					<key>Content-Length</key>
+					<string>33</string>
+					<key>Content-Type</key>
+					<string>text/css</string>
+					<key>Date</key>
+					<string>Sun, 16 Nov 2008 17:00:00 GMT</string>
+					<key>Etag</key>
+					<string>"301925-21-45c7d72d3e780"</string>
+					<key>Last-Modified</key>
+					<string>Sun, 16 Nov 2008 16:55:00 GMT</string>
+					<key>Server</key>
+					<string>Apache/2.2.9 (Unix) mod_ssl/2.2.9 OpenSSL/0.9.7l PHP/5.2.6</string>
+				</dict>
+				<key>expectedContentLength</key>
+				<integer>33</integer>
+				<key>statusCode</key>
+				<integer>200</integer>
+			</dict>
+			<key>WebResourceURL</key>
+			<string>http://127.0.0.1:8000/webarchive/resources/test-preload-resources.css?6</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/LayoutTests/http/tests/webarchive/test-preload-resources.html
+++ b/LayoutTests/http/tests/webarchive/test-preload-resources.html
@@ -9,6 +9,9 @@
 <link rel="alternate stylesheet" type="text/css" href="resources/test-preload-resources.css?6" title="gray">
 
 <script>
+if (window.internals)
+    internals.clearMemoryCache();
+
 if (window.testRunner)
     testRunner.dumpDOMAsWebArchive();
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1962,10 +1962,3 @@ webkit.org/b/287122 [ Ventura+ ] imported/w3c/web-platform-tests/html/capability
 
 # rdar://141631699 ([ macOS wk2 arm64 ] Multiple fast/css/webkit-named-image/apple-pay-logo-white/* tests are failing on EWS.)
 [ arm64 ] fast/css/webkit-named-image/apple-pay-logo-white [ Skip ]
-
-# webkit.org/b/287509 REGRESSION:(289950@main?)[macOS]: http/tests/webarchive tests are a flaky failures with image failures(failure in EWS)
-http/tests/webarchive/cross-origin-stylesheet-crash.html [ Pass ImageOnlyFailure ]
-http/tests/webarchive/test-css-url-encoding-shift-jis.html [ Pass ImageOnlyFailure ]
-http/tests/webarchive/test-css-url-encoding-utf-8.html [ Pass ImageOnlyFailure ]
-http/tests/webarchive/test-css-url-encoding.html [ Pass ImageOnlyFailure ]
-http/tests/webarchive/test-preload-resources.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/mac/http/tests/webarchive/cross-origin-stylesheet-crash-expected.txt
+++ b/LayoutTests/platform/mac/http/tests/webarchive/cross-origin-stylesheet-crash-expected.txt
@@ -7,6 +7,9 @@
 		<key>WebResourceData</key>
 		<string>&lt;html&gt;&lt;head&gt;
 &lt;script&gt;
+if (window.internals)
+    internals.clearMemoryCache();
+
 if (window.testRunner)
     testRunner.dumpDOMAsWebArchive();
 &lt;/script&gt;


### PR DESCRIPTION
#### e11a47ee2628ebd5ee07512170534d8609da0141
<pre>
REGRESSION:(289950@main)[macOS]: http/tests/webarchive tests are a flaky failures with image failures(failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287509">https://bugs.webkit.org/show_bug.cgi?id=287509</a>
<a href="https://rdar.apple.com/144639388">rdar://144639388</a>

Reviewed by Ryosuke Niwa.

In 289950@main, we started to capture some memory-cached files in webarchive, which helps ensure high fidelity of the
result. This change makes webarchive content less deterministic -- it will be dependent on what is availalbe in memory
cache. And this causes webarhive tests to be flaky because we compare the running result with a fixed content. To fix
the flakiness, now we clear memory cache before running the webarchive tests.

* LayoutTests/http/tests/webarchive/cross-origin-stylesheet-crash.html:
* LayoutTests/http/tests/webarchive/test-css-url-encoding-expected.txt: Added.
* LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis-expected.txt: Added.
* LayoutTests/http/tests/webarchive/test-css-url-encoding-shift-jis.html:
* LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8-expected.txt: Added.
* LayoutTests/http/tests/webarchive/test-css-url-encoding-utf-8.html:
* LayoutTests/http/tests/webarchive/test-css-url-encoding.html:
* LayoutTests/http/tests/webarchive/test-preload-resources-expected.txt: Added.
* LayoutTests/http/tests/webarchive/test-preload-resources.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/http/tests/webarchive/cross-origin-stylesheet-crash-expected.txt:

Canonical link: <a href="https://commits.webkit.org/290309@main">https://commits.webkit.org/290309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4c432d158f84f61cfb71b85c257c7d73153b191

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40318 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9467 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26633 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49345 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7005 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35655 "Found 5 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html http/tests/webarchive/cross-origin-stylesheet-crash.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36656 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96371 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16733 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12293 "Found 1 new test failure: fast/events/event-handler-detached-document.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77849 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77172 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19063 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9900 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16746 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16487 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->