### PR TITLE
Add Page Visibility API iframe Site Isolation Test

### DIFF
--- a/LayoutTests/http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe-expected.txt
@@ -1,0 +1,10 @@
+This test checks the onvisibilitychange event handler attribute in an iframe.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data.text is "visibility change triggered"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html
@@ -1,0 +1,30 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+
+<!DOCTYPE html>
+<html>
+<body onload="startTest()">
+<iframe id="iframeTest" src="http://localhost:8000/site-isolation/resources/page-visibility-iframe-send-onvisibility-change-back.html"></iframe>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+description("This test checks the onvisibilitychange event handler attribute in an iframe.");
+
+var jsTestIsAsync = true;
+
+function startTest() {
+    if (!window.testRunner)
+        return;
+    
+    window.addEventListener("message", function(event) {
+        shouldBeEqualToString("event.data.text", "visibility change triggered");
+        finishJSTest();
+    }, false);
+
+    if (window.testRunner)
+        testRunner.setPageVisibility("hidden");
+
+    testRunner.waitUntilDone();
+}
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/page-visibility-iframe-send-onvisibility-change-back.html
+++ b/LayoutTests/http/tests/site-isolation/resources/page-visibility-iframe-send-onvisibility-change-back.html
@@ -1,0 +1,7 @@
+<html>
+<script>
+    document.addEventListener("visibilitychange", (event) => {
+        window.parent.postMessage({ text: "visibility change triggered" }, "*");
+    });
+</script>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7709,3 +7709,5 @@ webkit.org/b/288694 [ Debug arm64 ] fast/multicol/body-stuck-with-dirty-bit-with
 webkit.org/b/288888 [ arm64 ] compositing/contents-format/deep-color-backing-store.html [ Failure ]
 
 webkit.org/b/288896 editing/caret/caret-position-vertical-rl.html [ Failure ]
+
+webkit.org/b/287569 http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html [ Timeout ]


### PR DESCRIPTION
#### fc84bdd750e19392c947e21685b02f64b36e8e88
<pre>
Add Page Visibility API iframe Site Isolation Test
<a href="https://bugs.webkit.org/show_bug.cgi?id=287569">https://bugs.webkit.org/show_bug.cgi?id=287569</a>
<a href="https://rdar.apple.com/problem/144710517">rdar://problem/144710517</a>

Reviewed by Alex Christensen.

Add test case to ensure that the page visibility api test works when in a remote iframe under site isolation.

On iOS, the `testRunner.setPageVisibility(&quot;hidden&quot;);` api is not working w/ or w/o site isolation, which
is causing the test to fail.

* LayoutTests/http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/page-visibility-onvisibilitychange-in-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/page-visibility-iframe-send-onvisibility-change-back.html: Added.
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/291497@main">https://commits.webkit.org/291497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78dcbad526d4b8b6ce8962721b37b2cb1da62eab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43603 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96079 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51495 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1861 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100103 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20129 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80194 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20381 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79495 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19738 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24039 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1357 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13222 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20113 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23260 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->