### PR TITLE
Adopt more smart pointers in PendingScript.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -12,7 +12,6 @@ css/query/MediaQueryFeatures.cpp
 dom/Document.cpp
 dom/Element.cpp
 dom/MouseRelatedEvent.cpp
-dom/PendingScript.cpp
 dom/ViewTransition.cpp
 editing/CompositeEditCommand.cpp
 editing/Editor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -600,7 +600,6 @@ dom/NodeList.h
 dom/NodeRareData.h
 dom/NodeWithIndex.h
 dom/Observable.cpp
-dom/PendingScript.cpp
 dom/Position.cpp
 dom/PositionIterator.cpp
 dom/PositionIterator.h

--- a/Source/WebCore/dom/PendingScript.cpp
+++ b/Source/WebCore/dom/PendingScript.cpp
@@ -66,8 +66,8 @@ PendingScript::~PendingScript()
 void PendingScript::notifyClientFinished()
 {
     Ref<PendingScript> protectedThis(*this);
-    if (m_client)
-        m_client->notifyFinished(*this);
+    if (CheckedPtr client = m_client)
+        client->notifyFinished(*this);
 }
 
 void PendingScript::notifyFinished(LoadableScript&)
@@ -77,12 +77,14 @@ void PendingScript::notifyFinished(LoadableScript&)
 
 bool PendingScript::isLoaded() const
 {
-    return m_loadableScript && m_loadableScript->isLoaded();
+    RefPtr loadableScript = m_loadableScript;
+    return loadableScript && loadableScript->isLoaded();
 }
 
 bool PendingScript::hasError() const
 {
-    return m_loadableScript && m_loadableScript->hasError();
+    RefPtr loadableScript = m_loadableScript;
+    return loadableScript && loadableScript->hasError();
 }
 
 void PendingScript::setClient(PendingScriptClient& client)


### PR DESCRIPTION
#### 87b68aff2c8316988d43b66df6059164b47f73b0
<pre>
Adopt more smart pointers in PendingScript.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287570">https://bugs.webkit.org/show_bug.cgi?id=287570</a>
<a href="https://rdar.apple.com/144713608">rdar://144713608</a>

Reviewed by NOBODY (OOPS!).

Smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/PendingScript.cpp:
(WebCore::PendingScript::notifyClientFinished):
(WebCore::PendingScript::isLoaded const):
(WebCore::PendingScript::hasError const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87b68aff2c8316988d43b66df6059164b47f73b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40328 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17367 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/68982 "Failure limit exceed. At least found 258 new test failures: fast/dom/Window/property-access-on-cached-window-after-frame-removed.html fast/parser/iframe-onload-document-close-with-external-script-2.html fast/parser/iframe-onload-document-close-with-external-script-3.html fast/parser/iframe-onload-document-close-with-external-script.html http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/fullscreen/fullscreen-feature-policy.html http/tests/priority-hints/script-module-initial-load.html http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html http/wpt/import-maps/data-driven/resolving-data-url-prefix.html http/wpt/import-maps/data-driven/resolving-empty-import-map.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7270 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49347 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7001 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35670 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39434 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96381 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16743 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12298 "Found 60 new test failures: fast/css/pseudo-cache-stale.html fast/css/pseudo-default-basics.html fast/css/pseudo-element-selector-scrollbar-hover.html fast/css/pseudo-element-specificity.html fast/css/pseudo-element-updates-on-empty.html fast/css/pseudo-focus-within-basics.html fast/css/pseudo-focus-within-inside-shadow-dom.html fast/css/pseudo-focus-within-style-sharing-1.html fast/css/pseudo-focus-within-style-sharing-2.html fast/css/pseudo-in-range-on-disabled-input-basics.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77855 "Failure limit exceed. At least found 268 new test failures: fast/dom/HTMLAnchorElement/anchor-download-unset.html fast/dom/HTMLAnchorElement/anchor-nodownload.html fast/dom/Window/property-access-on-cached-window-after-frame-removed.html fast/parser/iframe-onload-document-close-with-external-script-2.html fast/parser/iframe-onload-document-close-with-external-script-3.html fast/parser/iframe-onload-document-close-with-external-script.html http/tests/IndexedDB/collect-IDB-objects.https.html http/tests/fullscreen/fullscreen-feature-policy.html http/tests/priority-hints/script-module-initial-load.html http/tests/security/contentSecurityPolicy/1.1/module-scriptnonce-blocked.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/16998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77088 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77170 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9910 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16756 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22070 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18279 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->