### PR TITLE
[iOS] fast/events/ios/contenteditable-autocapitalize.html is a flaky failure

### DIFF
--- a/LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word.html
+++ b/LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word.html
@@ -24,13 +24,7 @@ addEventListener("load", async () => {
     const afterEndOfWord = { x : 250, y : rect.top + rect.height / 2 };
 
     await UIHelper.activateAndWaitForInputSessionAt(afterEndOfWord.x, afterEndOfWord.y);
-
-    for (let character of [..."Testign"]) {
-        await UIHelper.callFunctionAndWaitForEvent(async () => {
-            await UIHelper.typeCharacter(character);
-            await UIHelper.ensurePresentationUpdate();
-        }, editor, "input");
-    }
+    await UIHelper.typeCharacters("Testign");
     testPassed("Typed 'Testign'");
 
     await UIHelper.applyAutocorrection("Testing", "Testign", true);

--- a/LayoutTests/editing/input/cocoa/autocorrect-off.html
+++ b/LayoutTests/editing/input/cocoa/autocorrect-off.html
@@ -29,11 +29,7 @@
         if (window.testRunner)
             await UIHelper.activateElementAndWaitForInputSession(element);
 
-        for (let character of [...stringToType]) {
-            await UIHelper.callFunctionAndWaitForEvent(() => {
-                return window.testRunner ? UIHelper.typeCharacter(character) : Promise.resolve();
-            }, element, "input");
-        }
+        await UIHelper.typeCharacters(stringToType);
 
         element.blur();
 

--- a/LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period.html
+++ b/LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period.html
@@ -22,10 +22,7 @@ addEventListener("load", async () => {
     editor = document.querySelector(".editor");
     await UIHelper.activateElementAndWaitForInputSession(editor);
 
-    await UIHelper.callFunctionAndWaitForEvent(async () => {
-        await UIHelper.typeCharacter(" ");
-        await UIHelper.ensurePresentationUpdate();
-    }, editor, "keyup");
+    await UIHelper.typeCharacters(" ", "keyup");
 
     await UIHelper.applyAutocorrection(".", " ");
     await shouldBecomeEqual("editor.textContent", "'Hi.'");

--- a/LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area.html
+++ b/LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area.html
@@ -28,13 +28,7 @@ addEventListener("load", async () => {
 
     const textarea = document.querySelector("textarea");
     await UIHelper.activateElementAndWaitForInputSession(textarea);
-
-    for (let character of [..."hello"]) {
-        await UIHelper.callFunctionAndWaitForEvent(async () => {
-            await UIHelper.typeCharacter(character);
-            await UIHelper.ensurePresentationUpdate();
-        }, textarea, "keyup");
-    }
+    await UIHelper.typeCharacters("hello", "keyup");
 
     updateCountBefore = await UIHelper.keyboardUpdateForChangedSelectionCount();
     textarea.value = "";

--- a/LayoutTests/editing/selection/ios/extend-selection-with-inline-predictions.html
+++ b/LayoutTests/editing/selection/ios/extend-selection-with-inline-predictions.html
@@ -29,14 +29,7 @@ addEventListener("load", async () => {
     description("This test verifies that selecting backwards after typing with inline predictions does not cause a crash. This test requires WebKitTestRunner.");
 
     await UIHelper.activateElementAndWaitForInputSession(document.getElementById("target"));
-
-    for (let character of [..."i want to c"]) {
-        await UIHelper.callFunctionAndWaitForEvent(async () => {
-            await UIHelper.typeCharacter(character);
-            await UIHelper.ensurePresentationUpdate();
-        }, document.body, "keyup");
-    }
-
+    await UIHelper.typeCharacters("i want to c", "keyup", document.body);
     await UIHelper.setInlinePrediction("elebrate");
     await UIHelper.ensurePresentationUpdate();
 

--- a/LayoutTests/fast/events/ios/contenteditable-autocapitalize.html
+++ b/LayoutTests/fast/events/ios/contenteditable-autocapitalize.html
@@ -17,10 +17,7 @@
                 editable.autocapitalize = autocapitalizeType;
 
                 await UIHelper.activateElementAndWaitForInputSession(editable);
-                await UIHelper.typeCharacter("t");
-                await UIHelper.ensurePresentationUpdate();
-                await UIHelper.typeCharacter("o");
-                await UIHelper.ensurePresentationUpdate();
+                await UIHelper.typeCharacters("to");
 
                 if (expectedTextContent === editable.textContent)
                     testPassed(`With autocapitalize: ${autocapitalizeType}, the output is: "${editable.textContent}"`);

--- a/LayoutTests/fast/forms/ios/autocapitalize-words.html
+++ b/LayoutTests/fast/forms/ios/autocapitalize-words.html
@@ -23,8 +23,7 @@ description("This test verifies that typing in editable areas with autocapitaliz
 async function typeStringInElement(element, string)
 {
     await UIHelper.activateElementAndWaitForInputSession(element);
-    for (const character of [...string])
-        await UIHelper.callFunctionAndWaitForEvent(() => UIHelper.typeCharacter(character), element, "input");
+    await UIHelper.typeCharacters(string);
     element.blur();
     await UIHelper.waitForKeyboardToHide();
 }

--- a/LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html
+++ b/LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html
@@ -16,13 +16,8 @@ async function runTest()
     await UIHelper.activateElementAndWaitForInputSession(input);
     await UIHelper.toggleCapsLock();
 
-    await UIHelper.callFunctionAndWaitForEvent(async () => {
-        await UIHelper.keyDown("a");
-    }, input, "keyup");
-
-    await UIHelper.callFunctionAndWaitForEvent(async () => {
-        await UIHelper.keyDown("\b");
-    }, input, "keyup");
+    await UIHelper.typeCharacters("a", "keyup");
+    await UIHelper.typeCharacters("\b", "keyup");
 
     await UIHelper.ensureStablePresentationUpdate();
     internals.startTrackingRepaints();

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2297,6 +2297,16 @@ window.UIHelper = class UIHelper {
             testRunner.runUIScript("uiController.keyboardUpdateForChangedSelectionCount", resolve);
         });
     }
+
+    static async typeCharacters(stringToType, waitForEvent = "input", eventTarget = null) {
+        for (let character of [...stringToType]) {
+            await UIHelper.callFunctionAndWaitForEvent(async () => {
+                if (window.testRunner)
+                    await UIHelper.typeCharacter(character);
+                await UIHelper.ensurePresentationUpdate();
+            }, eventTarget || document.activeElement, waitForEvent);
+        }
+    }
 }
 
 UIHelper.EventStreamBuilder = class {


### PR DESCRIPTION
#### 058abd3f4442ff5468c490ef859910560c730813
<pre>
[iOS] fast/events/ios/contenteditable-autocapitalize.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=287578">https://bugs.webkit.org/show_bug.cgi?id=287578</a>
<a href="https://rdar.apple.com/144713635">rdar://144713635</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

This iOS layout test sometimes fails, with the following test output:

```
-PASS With autocapitalize: none, the output is: &quot;to&quot;
+FAIL With autocapitalize: none, the output is: &quot;t&quot; (expected &quot;to&quot;)
```

...which suggests that we occasionally fail to wait for `o` to be typed after focusing the text
field for the first time. Other (similar) tests that attempt to type a sequence of characters on iOS
are robust against this, by waiting for either the `input` or `keyup` event to be handled after
typing each key, before moving on with the rest of the test.

To fix this, we extract this technique for waiting on a DOM event before typing the next character
into a new `UIHelper` method, and deploy this new helper method in various tests (including the
flaky test in this bug) to avoid code duplication.

* LayoutTests/editing/caret/ios/place-caret-after-autocorrected-word.html:
* LayoutTests/editing/input/cocoa/autocorrect-off.html:
* LayoutTests/editing/input/ios/autocorrection-replaces-space-with-period.html:
* LayoutTests/editing/input/ios/invalidate-text-entry-context-when-clearing-text-area.html:
* LayoutTests/editing/selection/ios/extend-selection-with-inline-predictions.html:
* LayoutTests/fast/events/ios/contenteditable-autocapitalize.html:
* LayoutTests/fast/forms/ios/autocapitalize-words.html:
* LayoutTests/fast/repaint/placeholder-after-caps-lock-hidden.html:
* LayoutTests/resources/ui-helper.js:

Introduce the new test helper (`typeCharacters`).

(window.UIHelper.async typeCharacters):
(window.UIHelper):
(UIHelper.EventStreamBuilder.prototype._reset): Deleted.
(UIHelper.EventStreamBuilder.prototype.begin): Deleted.
(UIHelper.EventStreamBuilder.prototype.wait): Deleted.
(UIHelper.EventStreamBuilder.prototype.move): Deleted.
(UIHelper.EventStreamBuilder.prototype.end): Deleted.
(UIHelper.EventStreamBuilder.prototype.takeResult): Deleted.

Canonical link: <a href="https://commits.webkit.org/290306@main">https://commits.webkit.org/290306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3291406d3420fdb8483ea5138452c151cf1c671c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40350 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26654 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7025 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39456 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96403 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16765 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17020 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77103 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77196 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19061 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21625 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9932 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16778 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16519 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->