### PR TITLE
[css-anchor-position-1] Allow anchor-size() in sizing/margin properties specified in animation keyframes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7624,7 +7624,6 @@ imported/w3c/web-platform-tests/css/css-anchor-position/position-visibility-remo
 
 # timeouts
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-js-expose.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-animation.html [ Skip ]
 
 # -- End: Anchor Positioning -- #
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-animation-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Animation with anchor-size() assert_equals: expected 150 but got 0
+PASS Animation with anchor-size()
 

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -314,14 +314,17 @@ void BlendingKeyframes::updatePropertiesMetadata(const StyleProperties& properti
             m_containsCSSVariableReferences = true;
 
         if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(cssValue)) {
+            auto propertyID = propertyReference.id();
             auto valueId = primitiveValue->valueID();
+
             if (valueId == CSSValueInherit)
-                m_propertiesSetToInherit.add(propertyReference.id());
+                m_propertiesSetToInherit.add(propertyID);
             else if (valueId == CSSValueCurrentcolor)
-                m_propertiesSetToCurrentColor.add(propertyReference.id());
-            else if (!m_usesRelativeFontWeight && propertyReference.id() == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
+                m_propertiesSetToCurrentColor.add(propertyID);
+            else if (!m_usesRelativeFontWeight && propertyID == CSSPropertyFontWeight && (valueId == CSSValueBolder || valueId == CSSValueLighter))
                 m_usesRelativeFontWeight = true;
-            if (CSSProperty::isInsetProperty(propertyReference.id())) {
+
+            if (Style::AnchorPositionEvaluator::propertyAllowsAnchorFunction(propertyID) || Style::AnchorPositionEvaluator::propertyAllowsAnchorSizeFunction(propertyID)) {
                 auto dependencies = cssValue->computedStyleDependencies();
                 if (dependencies.anchors)
                     m_usesAnchorFunctions = true;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -451,6 +451,11 @@ RefPtr<Element> AnchorPositionEvaluator::findAnchorAndAttemptResolution(const Bu
     return anchorElement;
 }
 
+bool AnchorPositionEvaluator::propertyAllowsAnchorFunction(CSSPropertyID propertyID)
+{
+    return CSSProperty::isInsetProperty(propertyID);
+}
+
 std::optional<double> AnchorPositionEvaluator::evaluate(const BuilderState& builderState, std::optional<ScopedName> elementName, Side side)
 {
     auto propertyID = builderState.cssPropertyID();
@@ -459,7 +464,7 @@ std::optional<double> AnchorPositionEvaluator::evaluate(const BuilderState& buil
     // https://drafts.csswg.org/css-anchor-position-1/#anchor-valid
     auto isValidAnchor = [&] {
         // It’s being used in an inset property...
-        if (!CSSProperty::isInsetProperty(propertyID))
+        if (!propertyAllowsAnchorFunction(propertyID))
             return false;
 
         // ...on an absolutely-positioned element.
@@ -563,6 +568,11 @@ static BoxAxis anchorSizeDimensionToPhysicalDimension(AnchorSizeDimension dimens
     return BoxAxis::Horizontal;
 }
 
+bool AnchorPositionEvaluator::propertyAllowsAnchorSizeFunction(CSSPropertyID propertyID)
+{
+    return CSSProperty::isSizingProperty(propertyID) || CSSProperty::isInsetProperty(propertyID) || CSSProperty::isMarginProperty(propertyID);
+}
+
 std::optional<double> AnchorPositionEvaluator::evaluateSize(const BuilderState& builderState, std::optional<ScopedName> elementName, std::optional<AnchorSizeDimension> dimension)
 {
     auto propertyID = builderState.cssPropertyID();
@@ -570,7 +580,7 @@ std::optional<double> AnchorPositionEvaluator::evaluateSize(const BuilderState& 
 
     auto isValidAnchorSize = [&] {
         // It’s being used in a sizing property, an inset property, or a margin property...
-        if (!CSSProperty::isSizingProperty(propertyID) && !CSSProperty::isInsetProperty(propertyID) && !CSSProperty::isMarginProperty(propertyID))
+        if (!propertyAllowsAnchorSizeFunction(propertyID))
             return false;
 
         // ...on an absolutely-positioned element.

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -42,6 +42,8 @@ class LayoutRect;
 class RenderBlock;
 class RenderBoxModelObject;
 
+enum CSSPropertyID : uint16_t;
+
 namespace Style {
 
 class BuilderState;
@@ -95,7 +97,10 @@ public:
     static RefPtr<Element> findAnchorAndAttemptResolution(const BuilderState&, std::optional<ScopedName> elementName);
 
     using Side = std::variant<CSSValueID, double>;
+    static bool propertyAllowsAnchorFunction(CSSPropertyID);
     static std::optional<double> evaluate(const BuilderState&, std::optional<ScopedName> elementName, Side);
+
+    static bool propertyAllowsAnchorSizeFunction(CSSPropertyID);
     static std::optional<double> evaluateSize(const BuilderState&, std::optional<ScopedName> elementName, std::optional<AnchorSizeDimension>);
 
     static void updateAnchorPositioningStatesAfterInterleavedLayout(const Document&);


### PR DESCRIPTION
#### 6c4544363ad49efd41d503ce907f971e17d204b6
<pre>
[css-anchor-position-1] Allow anchor-size() in sizing/margin properties specified in animation keyframes
<a href="https://rdar.apple.com/144569184">rdar://144569184</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287442">https://bugs.webkit.org/show_bug.cgi?id=287442</a>

Reviewed by Tim Nguyen.

Current animation code only takes into account anchor functions (anchor()
and anchor-size()) when they&apos;re used in inset properties. This is correct for
anchor(), but anchor-size() can also be used in sizing/margin properties.
Fix this to allow anchor functions to be used in those properties too.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-animation-expected.txt:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::updatePropertiesMetadata):
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::propertyAllowsAnchorFunction):
(WebCore::Style::AnchorPositionEvaluator::evaluate):
(WebCore::Style::anchorSizeDimensionToPhysicalDimension):
(WebCore::Style::AnchorPositionEvaluator::propertyAllowsAnchorSizeFunction):
(WebCore::Style::AnchorPositionEvaluator::evaluateSize):
* Source/WebCore/style/AnchorPositionEvaluator.h:

Canonical link: <a href="https://commits.webkit.org/290343@main">https://commits.webkit.org/290343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/566d23adc1028fa3262891134bf7aa05b372a083

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44618 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40363 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69013 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7035 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35806 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39469 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77886 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17033 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19081 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21637 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9945 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22107 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16532 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/19983 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->