### PR TITLE
ChromeClient::exitFullScreenForElement should take a CompletionHandler

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -492,7 +492,7 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual void updateImageSource(Element&) { }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
-    virtual void exitFullScreenForElement(Element*) { }
+    virtual void exitFullScreenForElement(Element*, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(false); }
     virtual void setRootFullScreenLayer(GraphicsLayer*) { }
 #endif
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1209,11 +1209,11 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
             m_client.beganEnterFullScreen(toAPI(m_page.get()), toAPI(initialFrame), toAPI(finalFrame), m_client.base.clientInfo);
         }
 
-        void exitFullScreen() override
+        void exitFullScreen(CompletionHandler<void(bool)>&& completionHandler) override
         {
             if (!m_client.exitFullScreen)
-                return;
-            m_client.exitFullScreen(toAPI(m_page.get()), m_client.base.clientInfo);
+                return completionHandler(false);
+            completionHandler(m_client.exitFullScreen(toAPI(m_page.get()), m_client.base.clientInfo));
         }
 
         void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override
@@ -1244,15 +1244,6 @@ void WKPageDidEnterFullScreen(WKPageRef pageRef)
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr manager = toImpl(pageRef)->fullScreenManager())
         manager->didEnterFullScreen();
-#endif
-}
-
-void WKPageWillExitFullScreen(WKPageRef pageRef)
-{
-    CRASH_IF_SUSPENDED;
-#if ENABLE(FULLSCREEN_API)
-    if (RefPtr manager = toImpl(pageRef)->fullScreenManager())
-        manager->willExitFullScreen();
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -231,7 +231,6 @@ WK_EXPORT void WKPageSetPageInjectedBundleClient(WKPageRef page, const WKPageInj
 
 WK_EXPORT void WKPageSetFullScreenClientForTesting(WKPageRef page, const WKPageFullScreenClientBase* client);
 WK_EXPORT void WKPageDidEnterFullScreen(WKPageRef pageRef);
-WK_EXPORT void WKPageWillExitFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageDidExitFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageRequestExitFullScreen(WKPageRef pageRef);
 

--- a/Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h
@@ -35,7 +35,7 @@ typedef struct WKRect WKRect;
 
 typedef bool (*WKPageWillEnterFullScreenCallback)(WKPageRef page, const void* clientInfo);
 typedef void (*WKPageFullScreenCallbackWithRects)(WKPageRef page, WKRect initialFrame, WKRect finalFrame, const void* clientInfo);
-typedef void (*WKPageFullScreenCallback)(WKPageRef page, const void* clientInfo);
+typedef bool (*WKPageExitFullScreenCallback)(WKPageRef page, const void* clientInfo);
 
 typedef struct WKPageFullScreenClientBase {
     int version;
@@ -48,7 +48,7 @@ typedef struct WKPageFullScreenClientV0 {
     // Version 0.
     WKPageWillEnterFullScreenCallback willEnterFullScreen;
     WKPageFullScreenCallbackWithRects beganEnterFullScreen;
-    WKPageFullScreenCallback exitFullScreen;
+    WKPageExitFullScreenCallback exitFullScreen;
     WKPageFullScreenCallbackWithRects beganExitFullScreen;
 
 } WKPageFullScreenClientV0;

--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
@@ -107,12 +107,8 @@ void WKViewSetVisible(WKViewRef view, bool visible)
     setViewActivityStateFlag(view, WebCore::ActivityState::IsVisible, visible);
 }
 
-void WKViewWillEnterFullScreen(WKViewRef view)
+void WKViewWillEnterFullScreen(WKViewRef)
 {
-#if ENABLE(FULLSCREEN_API)
-    // FIXME: Replace this and WKViewSetViewClient's enterFullScreen with a listener object.
-    WebKit::toImpl(view)->willEnterFullScreen([] (bool) { });
-#endif
 }
 
 void WKViewDidEnterFullScreen(WKViewRef view)
@@ -122,11 +118,8 @@ void WKViewDidEnterFullScreen(WKViewRef view)
 #endif
 }
 
-void WKViewWillExitFullScreen(WKViewRef view)
+void WKViewWillExitFullScreen(WKViewRef)
 {
-#if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(view)->willExitFullScreen();
-#endif
 }
 
 void WKViewDidExitFullScreen(WKViewRef view)
@@ -174,16 +167,15 @@ void WKViewSetViewClient(WKViewRef view, const WKViewClientBase* client)
             if (!m_client.enterFullScreen)
                 return completionHandler(false);
             m_client.enterFullScreen(WebKit::toAPI(&view), m_client.base.clientInfo);
-
-            // FIXME: Replace this and WKViewWillEnterFullScreen with a listener object.
-            completionHandler(false);
+            completionHandler(true);
         }
         
-        void exitFullScreen(WebKit::PlayStationWebView& view)
+        void exitFullScreen(WebKit::PlayStationWebView& view, CompletionHandler<void(bool)>&& completionHandler)
         {
             if (!m_client.exitFullScreen)
                 return;
             m_client.exitFullScreen(WebKit::toAPI(&view), m_client.base.clientInfo);
+            completionHandler(true);
         }
         
         void closeFullScreen(WebKit::PlayStationWebView& view)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -427,15 +427,15 @@ void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionH
         webkitWebViewBaseEnterFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));
 }
 
-void PageClientImpl::exitFullScreen()
+void PageClientImpl::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_viewWidget)
-        return;
+        return completionHandler(false);
 
     if (!isFullScreen())
-        return;
+        return completionHandler(false);
 
-    webkitWebViewBaseWillExitFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));
+    webkitWebViewBaseWillExitFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget), WTFMove(completionHandler));
 
     if (!WEBKIT_IS_WEB_VIEW(m_viewWidget) || !webkitWebViewExitFullScreen(WEBKIT_WEB_VIEW(m_viewWidget)))
         webkitWebViewBaseExitFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -133,7 +133,7 @@ private:
     void closeFullScreenManager() override;
     bool isFullScreen() override;
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
-    void exitFullScreen() override;
+    void exitFullScreen(CompletionHandler<void(bool)>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
 #endif

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2658,12 +2658,11 @@ static void webkitWebViewBaseDidEnterFullScreen(WebKitWebViewBase* webkitWebView
     priv->sleepDisabler = PAL::SleepDisabler::create(String::fromUTF8(_("Website running in fullscreen mode")), PAL::SleepDisabler::Type::Display);
 }
 
-void webkitWebViewBaseWillExitFullScreen(WebKitWebViewBase* webkitWebViewBase)
+void webkitWebViewBaseWillExitFullScreen(WebKitWebViewBase* webkitWebViewBase, CompletionHandler<void(bool)>&& completionHandler)
 {
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
     ASSERT(priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen || priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::InFullscreen);
-    if (auto* fullScreenManagerProxy = priv->pageProxy->fullScreenManager())
-        fullScreenManagerProxy->willExitFullScreen();
+    completionHandler(true);
     priv->fullScreenState = WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBasePrivate.h
@@ -59,7 +59,7 @@ void webkitWebViewBaseChildMoveResize(WebKitWebViewBase*, GtkWidget*, const WebC
 #if ENABLE(FULLSCREEN_API)
 void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase*, CompletionHandler<void(bool)>&&);
 void webkitWebViewBaseEnterFullScreen(WebKitWebViewBase*);
-void webkitWebViewBaseWillExitFullScreen(WebKitWebViewBase*);
+void webkitWebViewBaseWillExitFullScreen(WebKitWebViewBase*, CompletionHandler<void(bool)>&&);
 void webkitWebViewBaseExitFullScreen(WebKitWebViewBase*);
 bool webkitWebViewBaseIsFullScreen(WebKitWebViewBase*);
 #endif

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -454,12 +454,12 @@ void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionH
     }
 }
 
-void PageClientImpl::exitFullScreen()
+void PageClientImpl::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!isFullScreen())
-        return;
+        return completionHandler(false);
 
-    m_view.willExitFullScreen();
+    m_view.willExitFullScreen(WTFMove(completionHandler));
 #if ENABLE(WPE_PLATFORM)
     if (m_view.wpeView()) {
         static_cast<WKWPE::ViewPlatform&>(m_view).exitFullScreen();

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -168,7 +168,7 @@ private:
     void closeFullScreenManager() override;
     bool isFullScreen() override;
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
-    void exitFullScreen() override;
+    void exitFullScreen(CompletionHandler<void(bool)>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
 #endif

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -160,12 +160,10 @@ void View::willEnterFullScreen(CompletionHandler<void(bool)>&& completionHandler
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen;
 }
 
-void View::willExitFullScreen()
+void View::willExitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen || m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::InFullscreen);
-
-    if (auto* fullScreenManagerProxy = page().fullScreenManager())
-        fullScreenManagerProxy->willExitFullScreen();
+    completionHandler(true);
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen;
 }
 #endif // ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -77,7 +77,7 @@ public:
 #if ENABLE(FULLSCREEN_API)
     bool isFullScreen() const;
     void willEnterFullScreen(CompletionHandler<void(bool)>&&);
-    void willExitFullScreen();
+    void willExitFullScreen(CompletionHandler<void(bool)>&&);
 #endif
 
     void selectionDidChange();

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -177,29 +177,28 @@ void ViewPlatform::didEnterFullScreen()
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::InFullscreen;
 }
 
-void ViewPlatform::exitFullScreen()
+void ViewPlatform::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen);
 
     if (m_client->exitFullScreen(*this))
-        return;
+        return completionHandler(true);
 
     auto* toplevel = wpe_view_get_toplevel(m_wpeView.get());
     if (!viewToplevelIsFullScreen(toplevel) || m_viewWasAlreadyInFullScreen) {
-        didExitFullScreen();
+        didExitFullScreen(WTFMove(completionHandler));
         return;
     }
 
     if (toplevel)
         wpe_toplevel_unfullscreen(toplevel);
+    completionHandler(true);
 }
 
-void ViewPlatform::didExitFullScreen()
+void ViewPlatform::didExitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen);
-
-    if (auto* fullScreenManagerProxy = page().fullScreenManager())
-        fullScreenManagerProxy->didExitFullScreen();
+    completionHandler();
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::NotInFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.h
@@ -52,8 +52,8 @@ public:
 #if ENABLE(FULLSCREEN_API)
     void enterFullScreen();
     void didEnterFullScreen();
-    void exitFullScreen();
-    void didExitFullScreen();
+    void exitFullScreen(CompletionHandler<void(bool)>&&);
+    void didExitFullScreen(CompletionHandler<void(bool)>&&);
     void requestExitFullScreen();
 #endif
 

--- a/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm
@@ -101,6 +101,7 @@ void FullscreenClient::didEnterFullscreen(WebPageProxy*)
 
 void FullscreenClient::willExitFullscreen(WebPageProxy*)
 {
+    // FIXME: This needs separate calls before and after the value changes.
     [m_webView willChangeValueForKey:@"fullscreenState"];
     [m_webView didChangeValueForKey:@"fullscreenState"];
 #if PLATFORM(MAC)
@@ -114,6 +115,7 @@ void FullscreenClient::willExitFullscreen(WebPageProxy*)
 
 void FullscreenClient::didExitFullscreen(WebPageProxy*)
 {
+    // FIXME: This needs separate calls before and after the value changes.
     [m_webView willChangeValueForKey:@"fullscreenState"];
     [m_webView didChangeValueForKey:@"fullscreenState"];
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -72,7 +72,7 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual void updateImageSource() = 0;
 #endif
-    virtual void exitFullScreen() = 0;
+    virtual void exitFullScreen(CompletionHandler<void(bool)>&&) = 0;
     virtual void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) = 0;
     virtual void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) = 0;
 
@@ -114,7 +114,6 @@ public:
     FullscreenState fullscreenState() const { return m_fullscreenState; }
     void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void didEnterFullScreen();
-    void willExitFullScreen();
     void didExitFullScreen();
     void setAnimatingFullScreen(bool);
     void requestRestoreFullScreen(CompletionHandler<void(bool)>&&);
@@ -134,7 +133,7 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(FullScreenMediaDetails&&);
 #endif
-    void exitFullScreen();
+    void exitFullScreen(CompletionHandler<void(bool)>&&);
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
     void callCloseCompletionHandlers();

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -32,7 +32,7 @@ messages -> WebFullScreenManagerProxy {
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif
-    ExitFullScreen()
+    ExitFullScreen() -> (bool success)
     BeganEnterFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect)
     BeganExitFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect)
     Close()

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -251,7 +251,7 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource() override;
 #endif
-    void exitFullScreen() override;
+    void exitFullScreen(CompletionHandler<void(bool)>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     bool lockFullscreenOrientation(WebCore::ScreenOrientationType) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -822,9 +822,11 @@ void PageClientImpl::updateImageSource()
 }
 #endif
 
-void PageClientImpl::exitFullScreen()
+void PageClientImpl::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
-    [[webView() fullScreenWindowController] exitFullScreen];
+    if (![webView() fullScreenWindowController])
+        return completionHandler(false);
+    [[webView() fullScreenWindowController] exitFullScreen:WTFMove(completionHandler)];
 }
 
 static UIInterfaceOrientationMask toUIInterfaceOrientationMask(WebCore::ScreenOrientationType orientation)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -51,7 +51,7 @@
 - (void)beganEnterFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;
 - (void)requestRestoreFullScreen:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)requestExitFullScreen;
-- (void)exitFullScreen;
+- (void)exitFullScreen:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)beganExitFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)orientations;
 - (void)resetSupportedOrientations;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -224,7 +224,7 @@ private:
     void closeFullScreenManager() override;
     bool isFullScreen() override;
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
-    void exitFullScreen() override;
+    void exitFullScreen(CompletionHandler<void(bool)>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
 #endif

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -835,9 +835,9 @@ void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionH
     [m_impl->fullScreenWindowController() enterFullScreen:nil completionHandler:WTFMove(completionHandler)];
 }
 
-void PageClientImpl::exitFullScreen()
+void PageClientImpl::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
-    [m_impl->fullScreenWindowController() exitFullScreen];
+    [m_impl->fullScreenWindowController() exitFullScreen:WTFMove(completionHandler)];
 }
 
 void PageClientImpl::beganEnterFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -59,7 +59,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
     RetainPtr<NSTimer> _watchdogTimer;
     RetainPtr<NSArray> _savedConstraints;
 
-    bool _requestedExitFullScreen;
+    CompletionHandler<void(bool)> _exitFullScreenCompletionHandler;
     FullScreenState _fullScreenState;
 
     double _savedScale;
@@ -77,7 +77,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 - (BOOL)isFullScreen;
 
 - (void)enterFullScreen:(NSScreen *)screen completionHandler:(CompletionHandler<void(bool)>&&)completionHandler;
-- (void)exitFullScreen;
+- (void)exitFullScreen:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)exitFullScreenImmediately;
 - (void)requestExitFullScreen;
 - (void)close;

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -266,9 +266,9 @@ void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionH
     m_view.enterFullScreen(WTFMove(completionHandler));
 }
 
-void PageClientImpl::exitFullScreen()
+void PageClientImpl::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_view.exitFullScreen();
+    m_view.exitFullScreen(WTFMove(completionHandler));
 }
 
 void PageClientImpl::beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame)

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -138,7 +138,7 @@ private:
     void closeFullScreenManager() override;
     bool isFullScreen() override;
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
-    void exitFullScreen() override;
+    void exitFullScreen(CompletionHandler<void(bool)>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
 #endif

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -126,11 +126,6 @@ void PlayStationWebView::didEnterFullScreen()
     m_page->fullScreenManager()->didEnterFullScreen();
 }
 
-void PlayStationWebView::willExitFullScreen()
-{
-    m_page->fullScreenManager()->willExitFullScreen();
-}
-
 void PlayStationWebView::didExitFullScreen()
 {
     m_page->fullScreenManager()->didExitFullScreen();
@@ -163,10 +158,12 @@ void PlayStationWebView::enterFullScreen(CompletionHandler<void(bool)>&& complet
         completionHandler(false);
 }
 
-void PlayStationWebView::exitFullScreen()
+void PlayStationWebView::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     if (m_client && isFullScreen())
-        m_client->exitFullScreen(*this);
+        m_client->exitFullScreen(*this, WTFMove(completionHandler));
+    else
+        completionHandler(false);
 }
 
 void PlayStationWebView::beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame)

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
@@ -61,7 +61,6 @@ public:
 #if ENABLE(FULLSCREEN_API)
     void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void didEnterFullScreen();
-    void willExitFullScreen();
     void didExitFullScreen();
     void requestExitFullScreen();
 #endif
@@ -72,7 +71,7 @@ public:
     bool isFullScreen();
     void closeFullScreenManager();
     void enterFullScreen(CompletionHandler<void(bool)>&&);
-    void exitFullScreen();
+    void exitFullScreen(CompletionHandler<void(bool)>&&);
     void beganEnterFullScreen(const WebCore::IntRect&, const WebCore::IntRect&);
     void beganExitFullScreen(const WebCore::IntRect&, const WebCore::IntRect&);
 #endif

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -324,9 +324,9 @@ void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionH
     completionHandler(false);
 }
 
-void PageClientImpl::exitFullScreen()
+void PageClientImpl::exitFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
-    notImplemented();
+    completionHandler(false);
 }
 
 void PageClientImpl::beganEnterFullScreen(const IntRect& /* initialFrame */, const IntRect& /* finalFrame */)

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -128,7 +128,7 @@ private:
     void closeFullScreenManager() override;
     bool isFullScreen() override;
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
-    void exitFullScreen() override;
+    void exitFullScreen(CompletionHandler<void(bool)>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
 #endif

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -328,7 +328,7 @@ void WebFullScreenManager::updateImageSource(WebCore::Element& element)
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
-void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element)
+void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (element)
         ALWAYS_LOG(LOGIDENTIFIER, "<", element->tagName(), " id=\"", element->getIdAttribute(), "\">");
@@ -336,7 +336,11 @@ void WebFullScreenManager::exitFullScreenForElement(WebCore::Element* element)
         ALWAYS_LOG(LOGIDENTIFIER, "null");
 
     m_page->prepareToExitElementFullScreen();
-    m_page->send(Messages::WebFullScreenManagerProxy::ExitFullScreen());
+    m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::ExitFullScreen(), [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] (bool success) mutable {
+        if (success)
+            willExitFullScreen();
+        completionHandler(success);
+    });
 
     if (m_inWindowFullScreenMode) {
         willExitFullScreen();

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -70,7 +70,7 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&);
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
-    void exitFullScreenForElement(WebCore::Element*);
+    void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void(bool)>&&);
 
     void willEnterFullScreen(CompletionHandler<void(WebCore::ExceptionOr<void>)>&&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode = WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard);
     void didEnterFullScreen();

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -29,7 +29,6 @@ messages -> WebFullScreenManager {
     RequestRestoreFullScreen() -> (bool succeeded) Async
     RequestExitFullScreen()
     DidEnterFullScreen()
-    WillExitFullScreen()
     DidExitFullScreen()
     SetAnimatingFullScreen(bool animating)
     SetFullscreenInsets(WebCore::FloatBoxExtent insets)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1345,7 +1345,7 @@ void WebChromeClient::updateImageSource(Element& element)
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
-void WebChromeClient::exitFullScreenForElement(Element* element)
+void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandler<void(bool)>&& completionHandler)
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     bool exitingInWindowFullscreen = false;
@@ -1354,7 +1354,7 @@ void WebChromeClient::exitFullScreenForElement(Element* element)
             exitingInWindowFullscreen = videoElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
     }
 #endif
-    protectedPage()->fullScreenManager().exitFullScreenForElement(element);
+    protectedPage()->fullScreenManager().exitFullScreenForElement(element, WTFMove(completionHandler));
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (exitingInWindowFullscreen)
         clearVideoFullscreenMode(*dynamicDowncast<HTMLVideoElement>(*element), HTMLMediaElementEnums::VideoFullscreenModeInWindow);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -338,7 +338,7 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&) final;
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
-    void exitFullScreenForElement(WebCore::Element*) final;
+    void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void(bool)>&&) final;
 #endif // ENABLE(FULLSCREEN_API)
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -560,7 +560,7 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 #if ENABLE(FULLSCREEN_API)
     auto* document = m_localFrame->document();
     if (document && document->fullscreenManager().fullscreenElement())
-        webPage->fullScreenManager().exitFullScreenForElement(webPage->fullScreenManager().element());
+        webPage->fullScreenManager().exitFullScreenForElement(webPage->fullScreenManager().element(), [] (bool) { });
 #endif
 
     webPage->findController().hideFindUI();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -211,7 +211,7 @@ private:
 #if ENABLE(FULLSCREEN_API)
     bool supportsFullScreenForElement(const WebCore::Element&, bool withKeyboard) final;
     void enterFullScreenForElement(WebCore::Element&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, CompletionHandler<void(WebCore::ExceptionOr<void>)>&&) final;
-    void exitFullScreenForElement(WebCore::Element*) final;
+    void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void(bool)>&&) final;
 #endif
 
     bool selectItemWritingDirectionIsNatural() override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -1058,7 +1058,7 @@ void WebChromeClient::enterFullScreenForElement(Element& element, HTMLMediaEleme
     completionHandler({ });
 }
 
-void WebChromeClient::exitFullScreenForElement(Element* element)
+void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandler<void(bool)>&& completionHandler)
 {
     SEL selector = @selector(webView:exitFullScreenForElement:listener:);
     if ([[m_webView UIDelegate] respondsToSelector:selector]) {
@@ -1069,6 +1069,7 @@ void WebChromeClient::exitFullScreenForElement(Element* element)
     else
         [m_webView _exitFullScreenForElement:element];
 #endif
+    completionHandler(true);
 }
 
 #endif // ENABLE(FULLSCREEN_API)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -487,17 +487,16 @@ void TestController::beganEnterFullScreen(WKPageRef page, WKRect initialFrame, W
     WKPageDidEnterFullScreen(page);
 }
 
-void TestController::exitFullScreen(WKPageRef page, const void* clientInfo)
+bool TestController::exitFullScreen(WKPageRef page, const void* clientInfo)
 {
-    static_cast<TestController*>(const_cast<void*>(clientInfo))->exitFullScreen(page);
+    return static_cast<TestController*>(const_cast<void*>(clientInfo))->exitFullScreen(page);
 }
 
-void TestController::exitFullScreen(WKPageRef page)
+bool TestController::exitFullScreen(WKPageRef page)
 {
     if (m_dumpFullScreenCallbacks)
         protectedCurrentInvocation()->outputText("exitFullScreenForElement()\n"_s);
-
-    WKPageWillExitFullScreen(page);
+    return true;
 }
 
 void TestController::beganExitFullScreen(WKPageRef page, WKRect initialFrame, WKRect finalFrame, const void* clientInfo)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -205,8 +205,8 @@ public:
     bool willEnterFullScreen(WKPageRef);
     static void beganEnterFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame, const void*);
     void beganEnterFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame);
-    static void exitFullScreen(WKPageRef, const void*);
-    void exitFullScreen(WKPageRef);
+    static bool exitFullScreen(WKPageRef, const void*);
+    bool exitFullScreen(WKPageRef);
     static void beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame, const void*);
     void beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame);
 


### PR DESCRIPTION
#### a1d3703bb73f96c15e64cd2908909ab4bb222ab0
<pre>
ChromeClient::exitFullScreenForElement should take a CompletionHandler
<a href="https://bugs.webkit.org/show_bug.cgi?id=287583">https://bugs.webkit.org/show_bug.cgi?id=287583</a>
<a href="https://rdar.apple.com/144731005">rdar://144731005</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::cancelFullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::willEnterFullscreen):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::exitFullScreenForElement):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetFullScreenClientForTesting):
(WKPageWillExitFullScreen): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h:
* Source/WebKit/UIProcess/Cocoa/FullscreenClient.mm:
(WebKit::FullscreenClient::willExitFullscreen):
(WebKit::FullscreenClient::didExitFullscreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::exitFullScreen):
(WebKit::WebFullScreenManagerProxy::willExitFullScreen): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController exitFullScreen]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::exitFullScreen):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController dealloc]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController exitFullScreen:]):
(-[WKFullScreenWindowController exitFullScreenImmediately]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
(-[WKFullScreenWindowController _startExitFullScreenAnimationWithDuration:]):
(-[WKFullScreenWindowController _watchdogTimerFired:]):
(-[WKFullScreenWindowController exitFullScreen]): Deleted.
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::exitFullScreenForElement):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::exitFullScreenForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::exitFullScreenForElement):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::exitFullScreen):
* Tools/WebKitTestRunner/TestController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1d3703bb73f96c15e64cd2908909ab4bb222ab0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44480 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94608 "Hash a1d3703b for PR 40506 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17422 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/94608 "Hash a1d3703b for PR 40506 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26668 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81328 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/94608 "Hash a1d3703b for PR 40506 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7044 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35711 "Found 3 new test failures: imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-twice.html imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-display-contents.html (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39489 "Hash a1d3703b for PR 40506 does not build (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77397 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36721 "Found 15 new test failures: fullscreen/full-screen-document-background-color.html imported/w3c/web-platform-tests/css/selectors/modal-pseudo-class.html imported/w3c/web-platform-tests/fullscreen/api/document-fullscreen-element.html imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-display-contents.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering.html imported/w3c/web-platform-tests/fullscreen/api/promises-resolve.html imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html imported/w3c/web-platform-tests/screen-orientation/hidden_document.html imported/w3c/web-platform-tests/screen-orientation/lock-basic.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96436 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16798 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12340 "Found 12 new test failures: fullscreen/full-screen-document-background-color.html imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-display-contents.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering.html imported/w3c/web-platform-tests/fullscreen/api/promises-resolve.html imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html imported/w3c/web-platform-tests/screen-orientation/hidden_document.html imported/w3c/web-platform-tests/screen-orientation/lock-basic.html imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77893 "Found 5 new test failures: fullscreen/full-screen-document-background-color.html imported/w3c/web-platform-tests/screen-orientation/lock-basic.html imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html imported/w3c/web-platform-tests/screen-orientation/orientation-reading.html imported/w3c/web-platform-tests/screen-orientation/unlock.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77213 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21645 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20230 "Found 13 new test failures: fullscreen/full-screen-document-background-color.html imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-namespaces.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-display-contents.html imported/w3c/web-platform-tests/fullscreen/api/fullscreen-reordering.html imported/w3c/web-platform-tests/fullscreen/api/promises-resolve.html imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html imported/w3c/web-platform-tests/screen-orientation/hidden_document.html imported/w3c/web-platform-tests/screen-orientation/lock-basic.html imported/w3c/web-platform-tests/screen-orientation/lock-unlock-check.html imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html ... (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/9965 "Hash a1d3703b for PR 40506 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16811 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22127 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->