### PR TITLE
Follow-up: Enable -Wunsafe-buffer-usage-in-libc-call

### DIFF
--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -263,7 +263,9 @@ int XPCServiceMain(int, const char**)
 #if ASAN_ENABLED
         // EXC_RESOURCE on ASAN builds freezes the process for several minutes: rdar://65027596
         if (char *disableFreezingOnExcResource = getenv("DISABLE_FREEZING_ON_EXC_RESOURCE")) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             if (!strcasecmp(disableFreezingOnExcResource, "yes") || !strcasecmp(disableFreezingOnExcResource, "true") || !strcasecmp(disableFreezingOnExcResource, "1")) {
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                 int val = 1;
                 int rc = sysctlbyname("debug.toggle_address_reuse", nullptr, 0, &val, sizeof(val));
                 if (rc < 0)


### PR DESCRIPTION
#### fc16715ddffa55307251fea00c7d508bc4f6daf3
<pre>
Follow-up: Enable -Wunsafe-buffer-usage-in-libc-call
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=287209">https://bugs.webkit.org/show_bug.cgi?id=287209</a>&gt;
&lt;<a href="https://rdar.apple.com/144351483">rdar://144351483</a>&gt;

Unreviewed build fix.

* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceMain):
- Add WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN and
  WTF_ALLOW_UNSAFE_BUFFER_USAGE_END to ignore the warning for now.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc16715ddffa55307251fea00c7d508bc4f6daf3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89602 "Failed to checkout and rebase branch from PR 40508") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9129 "Failed to checkout and rebase branch from PR 40508") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44465 "Failed to checkout and rebase branch from PR 40508") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94594 "Failed to checkout and rebase branch from PR 40508") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/40369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9518 "Failed to checkout and rebase branch from PR 40508") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17408 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/94594 "Failed to checkout and rebase branch from PR 40508") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/40369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92603 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/9518 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/55/builds/44465 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/94594 "Failed to checkout and rebase branch from PR 40508") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/9518 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/55/builds/44465 "Failed to checkout and rebase branch from PR 40508") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/39475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/9518 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/55/builds/44465 "Failed to checkout and rebase branch from PR 40508") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96422 "Failed to checkout and rebase branch from PR 40508") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/16784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/17408 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/96422 "Failed to checkout and rebase branch from PR 40508") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/17039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/55/builds/44465 "Failed to checkout and rebase branch from PR 40508") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/96422 "Failed to checkout and rebase branch from PR 40508") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/55/builds/44465 "Failed to checkout and rebase branch from PR 40508") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/9951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/16797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/19989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->