### PR TITLE
Add formForBindings() and controlForBindings() methods.

### DIFF
--- a/Source/WebCore/html/FormAssociatedElement.cpp
+++ b/Source/WebCore/html/FormAssociatedElement.cpp
@@ -35,6 +35,11 @@ FormAssociatedElement::FormAssociatedElement(HTMLFormElement* form)
 {
 }
 
+HTMLFormElement* FormAssociatedElement::formForBindings() const
+{
+    return form();
+}
+
 void FormAssociatedElement::setFormInternal(RefPtr<HTMLFormElement>&& newForm)
 {
     ASSERT(m_form.get() != newForm);

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -38,6 +38,7 @@ public:
     virtual void formWillBeDestroyed() { m_form = nullptr; }
 
     HTMLFormElement* form() const { return m_form.get(); }
+    virtual HTMLFormElement* formForBindings() const;
 
     void setForm(RefPtr<HTMLFormElement>&&);
     virtual void elementInsertedIntoAncestor(Element&, Node::InsertionType);

--- a/Source/WebCore/html/HTMLButtonElement.idl
+++ b/Source/WebCore/html/HTMLButtonElement.idl
@@ -22,7 +22,7 @@
     Exposed=Window
 ] interface HTMLButtonElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded] attribute [AtomString] USVString formAction;
 
     [CEReactions=NotNeeded] attribute [AtomString] DOMString formEnctype;

--- a/Source/WebCore/html/HTMLFieldSetElement.idl
+++ b/Source/WebCore/html/HTMLFieldSetElement.idl
@@ -21,7 +21,7 @@
     Exposed=Window
 ] interface HTMLFieldSetElement : HTMLElement {
     [CEReactions=Needed, Reflect] attribute boolean disabled;
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
 
     readonly attribute DOMString type;

--- a/Source/WebCore/html/HTMLInputElement.idl
+++ b/Source/WebCore/html/HTMLInputElement.idl
@@ -48,7 +48,7 @@ enum AutofillButtonType {
     [EnabledBySetting=InputTypeColorEnhancementsEnabled, CEReactions=NotNeeded] attribute [AtomString] DOMString colorSpace;
     [CEReactions=NotNeeded, Reflect] attribute DOMString dirName;
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [ImplementedAs=filesForBindings] attribute FileList? files;
     [CEReactions=NotNeeded] attribute [AtomString] USVString formAction;
 

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -87,6 +87,11 @@ RefPtr<HTMLElement> HTMLLabelElement::control() const
     return isConnected() ? firstElementWithIdIfLabelable(treeScope(), controlId) : nullptr;
 }
 
+RefPtr<HTMLElement> HTMLLabelElement::controlForBindings() const
+{
+    return control();
+}
+
 HTMLFormElement* HTMLLabelElement::form() const
 {
     if (auto element = control()) {
@@ -94,6 +99,11 @@ HTMLFormElement* HTMLLabelElement::form() const
             return listedElement->form();
     }
     return nullptr;
+}
+
+HTMLFormElement* HTMLLabelElement::formForBindings() const
+{
+    return form();
 }
 
 void HTMLLabelElement::setActive(bool down, Style::InvalidationScope invalidationScope)

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -36,7 +36,9 @@ public:
     static Ref<HTMLLabelElement> create(Document&);
 
     WEBCORE_EXPORT RefPtr<HTMLElement> control() const;
+    WEBCORE_EXPORT RefPtr<HTMLElement> controlForBindings() const;
     WEBCORE_EXPORT HTMLFormElement* form() const;
+    WEBCORE_EXPORT HTMLFormElement* formForBindings() const;
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
     void updateLabel(TreeScope&, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue);

--- a/Source/WebCore/html/HTMLLabelElement.idl
+++ b/Source/WebCore/html/HTMLLabelElement.idl
@@ -21,8 +21,8 @@
 [
     Exposed=Window
 ] interface HTMLLabelElement : HTMLElement {
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded, Reflect=for] attribute DOMString htmlFor;
-    readonly attribute HTMLElement control;
+    [ImplementedAs=controlForBindings] readonly attribute HTMLElement control;
 };
 

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -55,5 +55,10 @@ HTMLFormElement* HTMLLegendElement::form() const
     RefPtr fieldset = dynamicDowncast<HTMLFieldSetElement>(parentNode());
     return fieldset ? fieldset->form() : nullptr;
 }
+
+HTMLFormElement* HTMLLegendElement::formForBindings() const
+{
+    return form();
+}
     
 } // namespace

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -35,6 +35,7 @@ public:
     static Ref<HTMLLegendElement> create(const QualifiedName&, Document&);
 
     WEBCORE_EXPORT HTMLFormElement* form() const;
+    WEBCORE_EXPORT HTMLFormElement* formForBindings() const;
 
 private:
     HTMLLegendElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLLegendElement.idl
+++ b/Source/WebCore/html/HTMLLegendElement.idl
@@ -21,7 +21,7 @@
 [
     Exposed=Window
 ] interface HTMLLegendElement : HTMLElement {
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
 };
 

--- a/Source/WebCore/html/HTMLObjectElement.idl
+++ b/Source/WebCore/html/HTMLObjectElement.idl
@@ -22,7 +22,7 @@
     Plugin,
     Exposed=Window
 ] interface HTMLObjectElement : HTMLElement {
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString code;
     [CEReactions=NotNeeded, Reflect] attribute DOMString align;
     [CEReactions=NotNeeded, Reflect] attribute DOMString archive;

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -145,6 +145,11 @@ HTMLFormElement* HTMLOptionElement::form() const
     return nullptr;
 }
 
+HTMLFormElement* HTMLOptionElement::formForBindings() const
+{
+    return form();
+}
+
 int HTMLOptionElement::index() const
 {
     // It would be faster to cache the index, but harder to get it right in all cases.

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -44,6 +44,7 @@ public:
     void setText(String&&);
 
     WEBCORE_EXPORT HTMLFormElement* form() const;
+    WEBCORE_EXPORT HTMLFormElement* formForBindings() const;
 
     WEBCORE_EXPORT int index() const;
 

--- a/Source/WebCore/html/HTMLOptionElement.idl
+++ b/Source/WebCore/html/HTMLOptionElement.idl
@@ -25,7 +25,7 @@
     LegacyFactoryFunction=Option(optional DOMString text = "", optional [AtomString] DOMString value, optional boolean defaultSelected = false, optional boolean selected = false),
 ] interface HTMLOptionElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString label;
     [CEReactions=NotNeeded, Reflect=selected] attribute boolean defaultSelected;
     attribute boolean selected;

--- a/Source/WebCore/html/HTMLOutputElement.idl
+++ b/Source/WebCore/html/HTMLOutputElement.idl
@@ -29,7 +29,7 @@
     [CallWith=CurrentDocument, HTMLConstructor] constructor();
 
     [SameObject, PutForwards=value] readonly attribute DOMTokenList htmlFor;
-    readonly attribute HTMLFormElement? form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
 
     readonly attribute DOMString type;

--- a/Source/WebCore/html/HTMLSelectElement.idl
+++ b/Source/WebCore/html/HTMLSelectElement.idl
@@ -25,7 +25,7 @@
 ] interface HTMLSelectElement : HTMLElement {
     [CEReactions=NotNeeded] attribute [AtomString] DOMString autocomplete;
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    readonly attribute HTMLFormElement? form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement? form;
     [CEReactions=NotNeeded, Reflect] attribute boolean multiple;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;
     [CEReactions=NotNeeded, Reflect] attribute boolean required;

--- a/Source/WebCore/html/HTMLTextAreaElement.idl
+++ b/Source/WebCore/html/HTMLTextAreaElement.idl
@@ -26,7 +26,7 @@
 ] interface HTMLTextAreaElement : HTMLElement {
     [CEReactions=NotNeeded, Reflect] attribute DOMString dirName;
     [CEReactions=NotNeeded, Reflect] attribute boolean disabled;
-    readonly attribute HTMLFormElement form;
+    [ImplementedAs=formForBindings] readonly attribute HTMLFormElement form;
     [CEReactions=NotNeeded] attribute long minLength;
     [CEReactions=NotNeeded] attribute long maxLength;
     [CEReactions=NotNeeded, Reflect] attribute DOMString name;


### PR DESCRIPTION
#### 11632dcce8d13985cf29c0f7cbb5506c3f6db2f6
<pre>
Add formForBindings() and controlForBindings() methods.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287536">https://bugs.webkit.org/show_bug.cgi?id=287536</a>

Reviewed by Ryosuke Niwa.

These methods currently delegate directly to form() and control() respectively,
but will later be modified to ensure that nodes don&apos;t leak out of shadow roots
once referenceTarget is supported.

* Source/WebCore/html/FormAssociatedElement.cpp:
(WebCore::FormAssociatedElement::formForBindings const):
* Source/WebCore/html/FormAssociatedElement.h:
* Source/WebCore/html/HTMLButtonElement.idl:
* Source/WebCore/html/HTMLFieldSetElement.idl:
* Source/WebCore/html/HTMLInputElement.idl:
* Source/WebCore/html/HTMLLabelElement.cpp:
(WebCore::HTMLLabelElement::controlForBindings const):
(WebCore::HTMLLabelElement::formForBindings const):
* Source/WebCore/html/HTMLLabelElement.h:
* Source/WebCore/html/HTMLLabelElement.idl:
* Source/WebCore/html/HTMLLegendElement.cpp:
(WebCore::HTMLLegendElement::formForBindings const):
* Source/WebCore/html/HTMLLegendElement.h:
* Source/WebCore/html/HTMLLegendElement.idl:
* Source/WebCore/html/HTMLObjectElement.idl:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::formForBindings const):
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLOptionElement.idl:
* Source/WebCore/html/HTMLOutputElement.idl:
* Source/WebCore/html/HTMLSelectElement.idl:
* Source/WebCore/html/HTMLTextAreaElement.idl:

Canonical link: <a href="https://commits.webkit.org/290323@main">https://commits.webkit.org/290323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdd73d58ca5b8c3b2ec1d000e66d5138c96296f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/40449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/40449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49430 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7083 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39555 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96502 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77258 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19073 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21692 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10034 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16877 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16618 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20069 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->