### PR TITLE
[Screen Time Refactoring] Add WKWebsiteDataStore property for Screen Time history donations

### DIFF
--- a/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.h
@@ -27,10 +27,12 @@
 
 #if ENABLE(SCREEN_TIME)
 
+#import <ScreenTime/STWebHistory.h>
 #import <ScreenTime/STWebpageController.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, ScreenTime)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, STWebpageController)
+SOFT_LINK_CLASS_FOR_HEADER(PAL, STWebHistory)
 
 #endif // ENABLE(SCREEN_TIME)

--- a/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.mm
@@ -27,11 +27,14 @@
 
 #if ENABLE(SCREEN_TIME)
 
+#import <ScreenTime/STWebHistory.h>
 #import <ScreenTime/STWebpageController.h>
 #import <wtf/SoftLinking.h>
 
 SOFT_LINK_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, PAL_EXPORT)
 
 SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, STWebpageController, PAL_EXPORT)
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, ScreenTime, STWebHistory, PAL_EXPORT)
+
 
 #endif // ENABLE(SCREEN_TIME)

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -74,6 +74,9 @@ const OptionSet<WebsiteDataType>& WebResourceLoadStatisticsStore::monitoredDataT
         WebsiteDataType::SessionStorage,
         WebsiteDataType::ServiceWorkerRegistrations,
         WebsiteDataType::FileSystem,
+#if ENABLE(SCREEN_TIME)
+        WebsiteDataType::ScreenTime
+#endif
     }));
 
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteData.cpp
@@ -79,6 +79,10 @@ WebsiteDataProcessType WebsiteData::ownerProcess(WebsiteDataType dataType)
 #endif
     case WebsiteDataType::FileSystem:
         return WebsiteDataProcessType::Network;
+#if ENABLE(SCREEN_TIME)
+    case WebsiteDataType::ScreenTime:
+        return WebsiteDataProcessType::UI;
+#endif
     }
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.h
@@ -50,6 +50,9 @@ enum class WebsiteDataType : uint32_t {
 #endif
     FileSystem = 1 << 19,
     BackgroundFetchStorage = 1 << 20,
+#if ENABLE(SCREEN_TIME)
+    ScreenTime = 1 << 21,
+#endif
 };
 
 } // namespace WebKit
@@ -81,6 +84,9 @@ template<> struct EnumTraitsForPersistence<WebKit::WebsiteDataType> {
 #endif
         WebKit::WebsiteDataType::FileSystem,
         WebKit::WebsiteDataType::BackgroundFetchStorage
+#if ENABLE(SCREEN_TIME)
+        , WebKit::WebsiteDataType::ScreenTime
+#endif
     >;
 };
 

--- a/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in
@@ -45,4 +45,7 @@ headers: "WebsiteDataType.h"
 #endif
     FileSystem,
     BackgroundFetchStorage,
+#if ENABLE(SCREEN_TIME)
+    ScreenTime,
+#endif
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm
@@ -46,6 +46,7 @@ NSString * const WKWebsiteDataTypeFileSystem = @"WKWebsiteDataTypeFileSystem";
 NSString * const WKWebsiteDataTypeSearchFieldRecentSearches = @"WKWebsiteDataTypeSearchFieldRecentSearches";
 NSString * const WKWebsiteDataTypeMediaKeys = @"WKWebsiteDataTypeMediaKeys";
 NSString * const WKWebsiteDataTypeHashSalt = @"WKWebsiteDataTypeHashSalt";
+NSString * const WKWebsiteDataTypeScreenTime = @"WKWebsiteDataTypeScreenTime";
 
 NSString * const _WKWebsiteDataTypeMediaKeys = WKWebsiteDataTypeMediaKeys;
 NSString * const _WKWebsiteDataTypeHSTSCache = @"_WKWebsiteDataTypeHSTSCache";
@@ -56,6 +57,7 @@ NSString * const _WKWebsiteDataTypeAdClickAttributions = @"_WKWebsiteDataTypeAdC
 NSString * const _WKWebsiteDataTypePrivateClickMeasurements = @"_WKWebsiteDataTypePrivateClickMeasurements";
 NSString * const _WKWebsiteDataTypeAlternativeServices = @"_WKWebsiteDataTypeAlternativeServices";
 NSString * const _WKWebsiteDataTypeFileSystem = WKWebsiteDataTypeFileSystem;
+NSString * const _WKWebsiteDataTypeScreenTime = WKWebsiteDataTypeScreenTime;
 
 @implementation WKWebsiteDataRecord
 
@@ -113,6 +115,10 @@ static NSString *dataTypesToString(NSSet *dataTypes)
         [array addObject:@"Private Click Measurements"];
     if ([dataTypes containsObject:_WKWebsiteDataTypeAlternativeServices])
         [array addObject:@"Alternative Services"];
+#if ENABLE(SCREEN_TIME)
+    if ([dataTypes containsObject:_WKWebsiteDataTypeScreenTime])
+        [array addObject:@"Screen Time"];
+#endif
 
     return [array componentsJoinedByString:@", "];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
@@ -79,6 +79,10 @@ static inline std::optional<WebsiteDataType> toWebsiteDataType(NSString *website
     if ([websiteDataType isEqualToString:_WKWebsiteDataTypeAlternativeServices])
         return WebsiteDataType::AlternativeServices;
 #endif
+#if ENABLE(SCREEN_TIME)
+    if ([websiteDataType isEqualToString:_WKWebsiteDataTypeScreenTime])
+        return WebsiteDataType::ScreenTime;
+#endif
     return std::nullopt;
 }
 
@@ -137,6 +141,10 @@ static inline RetainPtr<NSSet> toWKWebsiteDataTypes(OptionSet<WebKit::WebsiteDat
 #if HAVE(ALTERNATIVE_SERVICE)
     if (websiteDataTypes.contains(WebsiteDataType::AlternativeServices))
         [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeAlternativeServices];
+#endif
+#if ENABLE(SCREEN_TIME)
+    if (websiteDataTypes.contains(WebsiteDataType::ScreenTime))
+        [wkWebsiteDataTypes addObject:_WKWebsiteDataTypeScreenTime];
 #endif
 
     return wkWebsiteDataTypes;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h
@@ -39,6 +39,7 @@ WK_EXTERN NSString * const _WKWebsiteDataTypeAdClickAttributions WK_API_AVAILABL
 WK_EXTERN NSString * const _WKWebsiteDataTypePrivateClickMeasurements WK_API_AVAILABLE(macos(12.0), ios(15.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeAlternativeServices WK_API_AVAILABLE(macos(11.0), ios(14.0));
 WK_EXTERN NSString * const _WKWebsiteDataTypeFileSystem WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebsiteDataTypeFileSystem", macos(13.0, 14.0), ios(16.0, 17.0));
+WK_EXTERN NSString * const _WKWebsiteDataTypeScreenTime WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @interface WKWebsiteDataRecord (WKPrivate)
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.h
@@ -32,6 +32,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 #include <wtf/OptionSet.h>
+#include <wtf/URLHash.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -283,6 +283,10 @@ public:
     void resetCacheMaxAgeCapForPrevalentResources(CompletionHandler<void()>&&);
     const WebsiteDataStoreConfiguration::Directories& resolvedDirectories() const;
     FileSystem::Salt mediaKeysStorageSalt() const;
+#if ENABLE(SCREEN_TIME)
+    void removeScreenTimeData(const HashSet<URL>& websitesToRemove);
+    void removeScreenTimeDataWithInterval(WallTime);
+#endif
 
     static void setCachedProcessSuspensionDelayForTesting(Seconds);
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -119,6 +119,10 @@ public:
     {
     }
 
+    virtual void getScreenTimeURLs(std::optional<WTF::UUID>, CompletionHandler<void(HashSet<URL>&&)>&&) const
+    {
+    }
+
     enum class CanSuspend : bool { No, Yes };
     virtual void didExceedMemoryFootprintThreshold(size_t, const String&, unsigned, Seconds, bool, WebCore::WasPrivateRelayed, CanSuspend)
     {


### PR DESCRIPTION
#### 640cc8483b4c7816045e413c10eca9f2dfe424e2
<pre>
[Screen Time Refactoring] Add WKWebsiteDataStore property for Screen Time history donations
<a href="https://bugs.webkit.org/show_bug.cgi?id=285239">https://bugs.webkit.org/show_bug.cgi?id=285239</a>
<a href="https://rdar.apple.com/140439004">rdar://140439004</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Added WKWebsiteDataStore property for Screen Time history deletions with
identifiers.
Created a new WebsiteDataType::ScreenTime.

Altered WebsiteDataStore::fetchDataAndApply to call Screen Time&apos;s new
API to obtain urls for a certain profile identifier.

Added two new methods:
- removeScreenTimeData corresponds to removeDataOfTypes that takes
in NSArray&lt;WKWebsiteDataRecord *&gt; * dataRecords
- removeScreenTimeDataWithInterval corresponds to removeDataOfTypes that takes
in an NSDate * date

Wrote two new API tests (RemoveDataWithTimeInterval and RemoveData).
RemoveData relies on Screen Time&apos;s API and will need to be changed later on.

* Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/ScreenTimeSoftLink.mm:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
(WebKit::WebResourceLoadStatisticsStore::monitoredDataTypes):
* Source/WebKit/Shared/WebsiteData/WebsiteData.cpp:
(WebKit::WebsiteData::ownerProcess):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.h:
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecord.mm:
(dataTypesToString):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h:
(WebKit::toWebsiteDataType):
(WebKit::toWKWebsiteDataTypes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore allWebsiteDataTypes]):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::removeScreenTimeData):
(WebKit::WebsiteDataStore::removeScreenTimeDataWithInterval):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::getScreenTimeURLs const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, RemoveDataWithTimeInterval)):
(TEST(ScreenTime, RemoveData)):

Canonical link: <a href="https://commits.webkit.org/290431@main">https://commits.webkit.org/290431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a9ff798a5e0fdab36d18a602d52eb581b6ef625

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9471 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44841 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94942 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91994 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69247 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26863 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92943 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7551 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49603 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7277 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35977 "Found 6 new test failures: fast/html/process-end-tag-for-inbody-crash.html fullscreen/empty-anonymous-block-continuation-crash.html fullscreen/full-screen-request-removed.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77620 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17130 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78213 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77447 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10324 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17140 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22465 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16881 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20333 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->