### PR TITLE
[Cocoa] Report network transferred length instead of decoded buffer size.

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/compressed-resource-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/compressed-resource-expected.txt
@@ -1,0 +1,11 @@
+Ensure the monitor watches the encoded size, not the decoded size.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is 20 * 1024
+PASS document.querySelector('iframe[name=frame1]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/compressed-resource.html
+++ b/LayoutTests/http/tests/iframe-monitor/compressed-resource.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="./resources/monitor-setup.js"></script>
+</head>
+<body>
+<script>
+
+description("Ensure the monitor watches the encoded size, not the decoded size.");
+window.jsTestIsAsync = true;
+var result;
+
+onload = async () => {
+    if (!await setup()) {
+        return;
+    }
+
+    // Make sure iframe load is done after rule is set correctly.
+    const stage = document.querySelector('#stage');
+    const base = 'http://localhost:8080/iframe-monitor/resources';
+
+    stage.innerHTML = `
+        <iframe name="frame1" src="${base}/--eligible--/compressed.html"></iframe>
+    `;
+
+    window.addEventListener('message', async (event) => {
+        await pause(100);
+        result = event.data;
+
+        shouldBe('result', '20 * 1024');
+        shouldBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+        finishJSTest();
+    });
+}
+</script>
+
+<div id="stage"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/compressed.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/--eligible--/compressed.html
@@ -1,0 +1,10 @@
+Using significant resources and eligible for resource monitoring.
+Resource is compressed so network usage is very low.
+
+<script>
+    const size = 20 * 1024;
+    fetch(`../generate-byte.py?size=${size}&compress=1`).then(async (response) => {
+        const body = await response.blob();
+        parent.postMessage(body.size, "*");
+    });
+</script>

--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -455,6 +455,7 @@ enum : NSUInteger {
 @interface NSURLSessionTask ()
 @property (nonatomic, copy, nullable) NSArray<NSHTTPCookie*>* (^_cookieTransformCallback)(NSArray<NSHTTPCookie*>* cookies);
 @property (nonatomic, readonly, nullable) NSArray<NSString*>* _resolvedCNAMEChain;
+@property (nonatomic, readonly) int64_t _countOfBytesReceivedEncoded;
 @end
 
 #endif // defined(__OBJC__)


### PR DESCRIPTION
#### 1b949aac3e4f06f538dfbca9b93c2bc7db68742a
<pre>
[Cocoa] Report network transferred length instead of decoded buffer size.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287591">https://bugs.webkit.org/show_bug.cgi?id=287591</a>
<a href="https://rdar.apple.com/144530889">rdar://144530889</a>

Reviewed by Ben Nham.

ResourceMonitor wants to use precise network usage for accuracy purposes. Add implementation
to track the network transferred bytes in NetworkDataTask.

* LayoutTests/http/tests/iframe-monitor/compressed-resource-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/compressed-resource.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/--eligible--/compressed.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/generate-byte.py:
* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didReceiveData):

Canonical link: <a href="https://commits.webkit.org/290353@main">https://commits.webkit.org/290353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5a34477940d08c20ef56a91ef4ceb0726c53097

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89759 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/9288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/44645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91811 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/9675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17565 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/94752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/40527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92760 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/9675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/44645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/9675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/44645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39661 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/9675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/44645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96579 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16941 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/77999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17197 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/44645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19082 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21762 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/44645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10120 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16954 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->