### PR TITLE
Support --gtest_filter and --gtest_list_tests in TestWebKitAPI.app

### DIFF
--- a/Tools/TestWebKitAPI/TestBundle/TestWebKitAPI.xctestplan
+++ b/Tools/TestWebKitAPI/TestBundle/TestWebKitAPI.xctestplan
@@ -14,7 +14,7 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:..\/OpenSource\/Tools\/TestWebKitAPI\/TestWebKitAPI.xcodeproj",
+        "containerPath" : "container:TestWebKitAPI.xcodeproj",
         "identifier" : "A17C582D2C9B3EAD009DD0B5",
         "name" : "TestWebKitAPIBundle"
       }


### PR DESCRIPTION
#### 3ae6ca86367a415e5b56c967bc7368c960ee375c
<pre>
Support --gtest_filter and --gtest_list_tests in TestWebKitAPI.app
<a href="https://bugs.webkit.org/show_bug.cgi?id=287598">https://bugs.webkit.org/show_bug.cgi?id=287598</a>
<a href="https://rdar.apple.com/problem/144744485">rdar://problem/144744485</a>

Reviewed by Alex Christensen and Abrar Rahman Protyasha.

Added support for specifying --gtest_filter and --gtest_list_tests command-line arguments when
running API tests via TestWebKitAPI.app, mimicing the behavior of these arguments when tests are
run in a command-line application via RUN_ALL_TESTS().

gtest does not provide an API for filtering tests independent of actually running them, so this
patch tricks gtest by setting the list_tests flag prior to calling RUN_ALL_TESTS(). With this flag
set, gtest prints the filtered list of tests and updates the values of TestCase::should_run() and
TestInfo::should_run() but does not actually run the tests. Later, +registerTestClasses uses these
values to skip creating XCTestCase subclasses and methods for tests that are filtered out.

While here, made it so that if --gtest_list_tests is specified as a command-line argument,
RUN_ALL_TESTS() is called to print the filtered tests and no XCTestCase subclasses are created.

Finally, as a drive-by fix, corrected the containerPath for TestWebKitAPIBundle in TestWebKitAPI.xctestplan.

* Tools/TestWebKitAPI/TestBundle/GoogleTests.mm:
(+[GoogleTestLoader registerTestClasses]):
* Tools/TestWebKitAPI/TestBundle/TestWebKitAPI.xctestplan:

Canonical link: <a href="https://commits.webkit.org/290362@main">https://commits.webkit.org/290362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10bc64b89a13eb75dbaf00f6c7cd0b8632b098de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40424 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17463 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69041 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26686 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81355 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7066 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35735 "Found 2 new test failures: media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39530 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96477 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12354 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/fullscreen-pseudo-class-in-has.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77912 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17095 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77238 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19092 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10006 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16852 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20044 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->