### PR TITLE
Draft PR to test Playstation build of https://github.com/WebKit/WebKit/pull/40528

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp
@@ -56,7 +56,6 @@ TEST_F(PublicSuffix, IsPublicSuffix)
     EXPECT_TRUE(publicSuffixStore.isPublicSuffix("co.uk"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix("bl.uk"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix("test.co.uk"_s));
-    EXPECT_TRUE(publicSuffixStore.isPublicSuffix("xn--zf0ao64a.tw"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix("r4---asdf.test.com"_s));
     EXPECT_FALSE(publicSuffixStore.isPublicSuffix(utf16String(bidirectionalDomain)));
     EXPECT_TRUE(publicSuffixStore.isPublicSuffix(utf16String(u"\u6803\u6728.jp")));
@@ -167,8 +166,6 @@ TEST_F(PublicSuffix, TopPrivatelyControlledDomain)
     EXPECT_EQ(String("test.co.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("subdomain.test.co.uk"_s));
     EXPECT_EQ(String("bl.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("bl.uk"_s));
     EXPECT_EQ(String("bl.uk"_s), publicSuffixStore.topPrivatelyControlledDomain("subdomain.bl.uk"_s));
-    EXPECT_EQ(String("test.xn--zf0ao64a.tw"_s), publicSuffixStore.topPrivatelyControlledDomain("test.xn--zf0ao64a.tw"_s));
-    EXPECT_EQ(String("test.xn--zf0ao64a.tw"_s), publicSuffixStore.topPrivatelyControlledDomain("www.test.xn--zf0ao64a.tw"_s));
     EXPECT_EQ(String("127.0.0.1"_s), publicSuffixStore.topPrivatelyControlledDomain("127.0.0.1"_s));
     EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("1"_s));
     EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomain("com"_s));
@@ -200,8 +197,6 @@ TEST_F(PublicSuffix, topPrivatelyControlledDomainWithoutPublicSuffix)
     EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("subdomain.test.co.uk"_s));
     EXPECT_EQ(String("bl"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("bl.uk"_s));
     EXPECT_EQ(String("bl"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("subdomain.bl.uk"_s));
-    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("test.xn--zf0ao64a.tw"_s));
-    EXPECT_EQ(String("test"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("www.test.xn--zf0ao64a.tw"_s));
     EXPECT_EQ(String("127.0.0.1"_s), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("127.0.0.1"_s));
     EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("1"_s));
     EXPECT_EQ(String(), publicSuffixStore.topPrivatelyControlledDomainWithoutPublicSuffix("com"_s));


### PR DESCRIPTION
#### e0531a1be46640d27dda370bd64d4a0093140c48
<pre>
Draft PR to test Playstation build of <a href="https://github.com/WebKit/WebKit/pull/40528">https://github.com/WebKit/WebKit/pull/40528</a>

This PR: <a href="https://github.com/WebKit/WebKit/pull/40528">https://github.com/WebKit/WebKit/pull/40528</a>
isn&apos;t building on Playstation because the Playstation bot
can&apos;t deal with the special characters in the branch name.

So I&apos;m uploading this draft PR just to check that it builds on Playstation.

* Tools/TestWebKitAPI/Tests/WebCore/PublicSuffix.cpp:
(TestWebKitAPI::TEST_F(PublicSuffix, IsPublicSuffix)):
(TestWebKitAPI::TEST_F(PublicSuffix, TopPrivatelyControlledDomain)):
(TestWebKitAPI::TEST_F(PublicSuffix, topPrivatelyControlledDomainWithoutPublicSuffix)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0531a1be46640d27dda370bd64d4a0093140c48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44593 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94665 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69058 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26696 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7351 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49424 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39545 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96492 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16854 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77927 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17110 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77252 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21684 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10024 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16867 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16608 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->