### PR TITLE
WebIDL Parser should support dots as delimiters in enumerations

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2474,7 +2474,14 @@ sub GetEnumerationValueName
 
     return "EmptyString" if $name eq "";
     return "WebRTC" if $name eq "webrtc";
-    $name = join("", map { $codeGenerator->WK_ucfirst($_) } split("-", $name));
+
+    my @parts = split("-", $name);
+    @parts = map {
+        my $part = $_;
+        my @dotParts = split(/\./, $part);
+        join("", map { $codeGenerator->WK_ucfirst($_) } @dotParts)
+    } @parts;
+    $name = join("", @parts);
     $name = "_$name" if $name =~ /^\d/;
     return $name;
 }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -36,12 +36,18 @@ using namespace JSC;
 
 String convertEnumerationToString(TestStandaloneEnumeration enumerationValue)
 {
-    static const std::array<NeverDestroyed<String>, 2> values {
+    static const std::array<NeverDestroyed<String>, 5> values {
         MAKE_STATIC_STRING_IMPL("enumValue1"),
         MAKE_STATIC_STRING_IMPL("enumValue2"),
+        MAKE_STATIC_STRING_IMPL("enum-value3"),
+        MAKE_STATIC_STRING_IMPL("enum.value.4"),
+        MAKE_STATIC_STRING_IMPL("enum-value.5"),
     };
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue1) == 0, "TestStandaloneEnumeration::EnumValue1 is not 0 as expected");
     static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue2) == 1, "TestStandaloneEnumeration::EnumValue2 is not 1 as expected");
+    static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue3) == 2, "TestStandaloneEnumeration::EnumValue3 is not 2 as expected");
+    static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue4) == 3, "TestStandaloneEnumeration::EnumValue4 is not 3 as expected");
+    static_assert(static_cast<size_t>(TestStandaloneEnumeration::EnumValue5) == 4, "TestStandaloneEnumeration::EnumValue5 is not 4 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }
@@ -53,7 +59,10 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneEnumeration en
 
 template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String& stringValue)
 {
-    static constexpr std::array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>, 2> mappings {
+    static constexpr std::array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>, 5> mappings {
+        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum-value.5"_s, TestStandaloneEnumeration::EnumValue5 },
+        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum-value3"_s, TestStandaloneEnumeration::EnumValue3 },
+        std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enum.value.4"_s, TestStandaloneEnumeration::EnumValue4 },
         std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enumValue1"_s, TestStandaloneEnumeration::EnumValue1 },
         std::pair<ComparableASCIILiteral, TestStandaloneEnumeration> { "enumValue2"_s, TestStandaloneEnumeration::EnumValue2 },
     };
@@ -70,7 +79,7 @@ template<> std::optional<TestStandaloneEnumeration> parseEnumeration<TestStandal
 
 template<> ASCIILiteral expectedEnumerationValues<TestStandaloneEnumeration>()
 {
-    return "\"enumValue1\", \"enumValue2\""_s;
+    return "\"enumValue1\", \"enumValue2\", \"enum-value3\", \"enum.value.4\", \"enum-value.5\""_s;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/test/TestStandaloneEnumeration.idl
+++ b/Source/WebCore/bindings/scripts/test/TestStandaloneEnumeration.idl
@@ -30,6 +30,9 @@
     Conditional=CONDITION,
 ] enum TestStandaloneEnumeration {
     "enumValue1",
-    "enumValue2"
+    "enumValue2",
+    "enum-value3",
+    "enum.value.4",
+    "enum-value.5",
 };
 


### PR DESCRIPTION
#### 9b41952fe55d5333ff1b6a664cb3ca680bb0bdc8
<pre>
WebIDL Parser should support dots as delimiters in enumerations
<a href="https://bugs.webkit.org/show_bug.cgi?id=287606">https://bugs.webkit.org/show_bug.cgi?id=287606</a>
<a href="https://rdar.apple.com/144753892">rdar://144753892</a>

Reviewed by Chris Dumez.

Adds support for dots as delimiters in enumerations
in the WebIDL code generator. This is needed as some other organizatons are
using dots in their enumerations (e.g, &quot;org.iso.mdoc&quot;).

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GetEnumerationValueName):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp:
(WebCore::convertEnumerationToString):
(WebCore::parseEnumerationFromString&lt;TestStandaloneEnumeration&gt;):
(WebCore::expectedEnumerationValues&lt;TestStandaloneEnumeration&gt;):
* Source/WebCore/bindings/scripts/test/TestStandaloneEnumeration.idl:

Canonical link: <a href="https://commits.webkit.org/290454@main">https://commits.webkit.org/290454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff661a0762166735283523753dd5234f511218c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69189 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26812 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49550 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7206 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35920 "Found 1 new test failure: media/modern-media-controls/invalid-placard/invalid-placard.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39778 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77553 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36965 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96695 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17059 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78068 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77393 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19146 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10236 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22391 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16811 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->