### PR TITLE
[WebGPU] Simplify MTLSamplerState cach

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287580-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287580-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287580.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287580.html
@@ -1,0 +1,6814 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'float32-blendable',
+    'timestamp-query',
+  ],
+  requiredLimits: {maxUniformBufferBindingSize: 66530453, maxStorageBufferBindingSize: 186475044},
+});
+let sampler0 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 55.62,
+});
+let texture0 = device0.createTexture({
+  size: [78, 10, 36],
+  dimension: '3d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let promise0 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\u{1faf8}\u{1fd8d}\ufa22\ude7f\u054f\u0d58';
+} catch {}
+let buffer0 = device0.createBuffer({size: 200, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture1 = device0.createTexture({
+  size: {width: 72, height: 15, depthOrArrayLayers: 27},
+  sampleCount: 1,
+  format: 'r8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView0 = texture1.createView({dimension: '2d'});
+let commandEncoder0 = device0.createCommandEncoder({});
+let textureView1 = texture1.createView({arrayLayerCount: 2});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 3,
+});
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder({});
+let texture2 = device0.createTexture({
+  size: {width: 288, height: 60, depthOrArrayLayers: 80},
+  mipLevelCount: 3,
+  format: 'astc-6x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer1 = device0.createBuffer({size: 36, usage: GPUBufferUsage.INDEX});
+let computePassEncoder1 = commandEncoder1.beginComputePass();
+let sampler2 = device0.createSampler({magFilter: 'linear', mipmapFilter: 'linear', lodMaxClamp: 84.64});
+let querySet0 = device0.createQuerySet({type: 'timestamp', count: 565});
+let sampler3 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.80,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder1.end();
+} catch {}
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder2 = device0.createCommandEncoder({});
+try {
+  await promise0;
+} catch {}
+try {
+adapter0.label = '\u7da6\ua258\u3e83\u0262\u{1f9a5}\uc032';
+} catch {}
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder3 = device0.createCommandEncoder();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 7, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let computePassEncoder2 = commandEncoder1.beginComputePass();
+let computePassEncoder3 = commandEncoder4.beginComputePass();
+let commandEncoder5 = device0.createCommandEncoder({});
+let sampler4 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'equal',
+  maxAnisotropy: 13,
+});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpte240m', transfer: 'smpteSt4281'} });
+let commandEncoder6 = device0.createCommandEncoder();
+let sampler5 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 88.79,
+});
+let pipelineLayout3 = device0.createPipelineLayout({
+  bindGroupLayouts: [veryExplicitBindGroupLayout1, veryExplicitBindGroupLayout0, veryExplicitBindGroupLayout1],
+});
+let commandEncoder7 = device0.createCommandEncoder();
+let computePassEncoder4 = commandEncoder2.beginComputePass({timestampWrites: {querySet: querySet0}});
+let sampler6 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 85.89,
+  compare: 'never',
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.77,
+});
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture3 = device0.createTexture({
+  size: [72, 15, 65],
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder5.beginComputePass();
+let promise1 = device0.queue.onSubmittedWorkDone();
+let buffer2 = device0.createBuffer({size: 40, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let textureView2 = texture3.createView({dimension: '3d', mipLevelCount: 1, baseArrayLayer: 0});
+let texture4 = device0.createTexture({
+  size: {width: 576, height: 120, depthOrArrayLayers: 33},
+  dimension: '2d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView3 = texture2.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 8});
+let computePassEncoder6 = commandEncoder7.beginComputePass();
+try {
+commandEncoder1.insertDebugMarker('\u8816');
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture5 = device0.createTexture({
+  size: {width: 313, height: 40, depthOrArrayLayers: 112},
+  format: 'r16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder8.beginComputePass();
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView4 = texture5.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 6});
+let texture6 = device0.createTexture({
+  size: [4],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView5 = texture4.createView({dimension: '2d', aspect: 'all', baseMipLevel: 0, baseArrayLayer: 11});
+let commandEncoder12 = device0.createCommandEncoder();
+let texture7 = device0.createTexture({
+  label: '\u{1ffd4}\u8de2\u0293\u9013\u0557\uc891\u4c26\u{1fa14}\u281e',
+  size: {width: 576, height: 120, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView6 = texture0.createView({mipLevelCount: 1});
+try {
+buffer1.unmap();
+} catch {}
+let textureView7 = texture6.createView({baseArrayLayer: 0});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less',
+});
+let commandBuffer0 = commandEncoder1.finish();
+let computePassEncoder8 = commandEncoder11.beginComputePass();
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true});
+try {
+renderBundleEncoder0.setIndexBuffer(buffer1, 'uint32', 0, 8);
+} catch {}
+try {
+renderBundleEncoder0.setVertexBuffer(7, undefined, 0);
+} catch {}
+let videoFrame1 = new VideoFrame(videoFrame0, {timestamp: 0});
+let renderBundle0 = renderBundleEncoder0.finish();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({size: [32, 32, 1], dimension: '3d', format: 'rg16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let texture9 = device0.createTexture({size: [313], dimension: '1d', format: 'rg16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'smpte170m', transfer: 'pq'} });
+let buffer3 = device0.createBuffer({
+  size: 36,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder14 = device0.createCommandEncoder({});
+let sampler9 = device0.createSampler({
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 96.59,
+  maxAnisotropy: 10,
+});
+try {
+buffer1.unmap();
+} catch {}
+try {
+commandEncoder14.copyTextureToTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 12, y: 21, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 8, new Uint32Array(214), 47, 4);
+} catch {}
+let textureView8 = texture2.createView({dimension: '2d', format: 'astc-6x6-unorm-srgb', mipLevelCount: 2, baseArrayLayer: 3});
+let computePassEncoder9 = commandEncoder12.beginComputePass();
+let sampler10 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let sampler11 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 84.42,
+});
+let buffer4 = device0.createBuffer({
+  label: '\u935b\u3457\ua91f\ue2fd',
+  size: 56,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let texture10 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 179},
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture11 = device0.createTexture({
+  size: [288],
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+commandEncoder14.clearBuffer(buffer3, 8);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let commandEncoder15 = device0.createCommandEncoder({});
+let querySet1 = device0.createQuerySet({type: 'timestamp', count: 626});
+let texture12 = device0.createTexture({
+  size: [78, 10, 1],
+  mipLevelCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder10 = commandEncoder9.beginComputePass({timestampWrites: {querySet: querySet0}});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 87.11,
+});
+let textureView9 = texture0.createView({label: '\u2ffa\uae26\u027c\u{1fa86}\u{1fa1a}\u5946\ua659\ufb55\u084a\u{1fd4f}', arrayLayerCount: 1});
+let textureView10 = texture5.createView({dimension: '2d'});
+let computePassEncoder11 = commandEncoder10.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 175}});
+let sampler13 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', minFilter: 'nearest', lodMaxClamp: 83.77});
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 12, new BigUint64Array(11524), 72, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 14, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(9).fill(214), /* required buffer size: 9 */
+{offset: 9, bytesPerRow: 230}, {width: 30, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u0380\uc954\u{1f7ec}\ueee9\u0529\u7b25\ub6ed';
+} catch {}
+try {
+device0.label = '\u1814\uf8f5\u{1ffec}\u32c2\ucf83\u0437\u19e5\u0bed\u56e9\u{1f70a}';
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder({});
+let querySet2 = device0.createQuerySet({type: 'timestamp', count: 320});
+let textureView11 = texture6.createView({});
+let computePassEncoder12 = commandEncoder15.beginComputePass();
+try {
+device0.queue.writeBuffer(buffer3, 16, new Uint32Array(38397), 7363, 0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+let texture13 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 179},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder13 = commandEncoder3.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 178}});
+try {
+buffer3.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 1,
+  origin: {x: 42, y: 0, z: 25},
+  aspect: 'all',
+}, new Uint8Array(2_056).fill(178), /* required buffer size: 2_056 */
+{offset: 766, bytesPerRow: 37, rowsPerImage: 32}, {width: 12, height: 18, depthOrArrayLayers: 2});
+} catch {}
+let buffer5 = device0.createBuffer({size: 180, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let computePassEncoder14 = commandEncoder16.beginComputePass({timestampWrites: {querySet: querySet2, endOfPassWriteIndex: 268}});
+let imageData0 = new ImageData(4, 72);
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpte432', transfer: 'gamma22curve'} });
+let commandEncoder17 = device0.createCommandEncoder({});
+let textureView12 = texture3.createView({aspect: 'all'});
+let texture14 = device0.createTexture({size: {width: 78}, dimension: '1d', format: 'rg16float', usage: GPUTextureUsage.COPY_DST});
+let sampler14 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat'});
+try {
+  await promise3;
+} catch {}
+let img0 = await imageWithData(119, 53, '#10101010', '#20202020');
+let commandEncoder18 = device0.createCommandEncoder({});
+let querySet3 = device0.createQuerySet({type: 'timestamp', count: 341});
+try {
+device0.queue.writeBuffer(buffer4, 0, new Int16Array(7067), 2204, 0);
+} catch {}
+let commandEncoder19 = device0.createCommandEncoder();
+let texture15 = device0.createTexture({
+  size: [78, 10, 120],
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView13 = texture8.createView({aspect: 'all'});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 78, height: 10, depthOrArrayLayers: 120}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 1, y: 2, z: 120},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let commandEncoder20 = device0.createCommandEncoder();
+let texture16 = device0.createTexture({
+  size: [156, 20, 12],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder15 = commandEncoder13.beginComputePass({timestampWrites: {querySet: querySet2, beginningOfPassWriteIndex: 88, endOfPassWriteIndex: 103}});
+let sampler15 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 86.10,
+});
+let img1 = await imageWithData(93, 28, '#10101010', '#20202020');
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'bt2020_10bit'} });
+let commandEncoder21 = device0.createCommandEncoder({});
+let textureView14 = texture12.createView({dimension: '2d-array'});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame4, colorSpace: 'srgb'});
+try {
+  await promise1;
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct FragmentOutput0 {
+  @location(0) @interpolate(linear, center) f0: vec4f,
+}
+
+struct VertexOutput0 {
+  @location(14) @interpolate(flat, either) f0: vec4u,
+  @location(13) f1: vec4h,
+  @location(12) @interpolate(linear, either) f2: vec4f,
+  @invariant @builtin(position) f3: vec4f,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @size(664) f0: array<array<atomic<i32>, 1>>,
+}
+
+struct T2 {
+  @align(8) @size(160) f0: array<atomic<u32>>,
+}
+
+struct T1 {
+  @size(256) f0: array<array<atomic<u32>, 2>>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<workgroup> vw0: array<vec4f, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* zero global variables used */
+fn fn0(a0: mat3x4h, a1: ptr<function, VertexOutput0>) {
+  (*a1).f1 -= exp2(vec4h(unconst_f16(6016.2), unconst_f16(-8774.2), unconst_f16(9861.9), unconst_f16(5516.0)));
+  let vf0: u32 = (*a1).f0[unconst_u32(94071248)];
+  (*a1).f0 >>= vec4u(acosh(vec4h(unconst_f16(-19108.5), unconst_f16(9240.2), unconst_f16(-21397.2), unconst_f16(9780.6))));
+  (*a1).f2 = bitcast<vec4f>((*a1).f0);
+  (*a1) = VertexOutput0(bitcast<vec4u>(countLeadingZeros(vec2i(unconst_i32(527400129), unconst_i32(243571266))).xxyy), bitcast<vec4h>(countLeadingZeros(vec2i(unconst_i32(527400129), unconst_i32(243571266)))), bitcast<vec4f>(countLeadingZeros(vec2i(unconst_i32(527400129), unconst_i32(243571266))).xyyy), vec4f(countLeadingZeros(vec2i(unconst_i32(527400129), unconst_i32(243571266))).gggr));
+  {
+  (*a1).f2 *= vec4f((*a1).f1);
+  (*a1).f1 -= vec4h((*a1).f2.rrar.bggg.bbag.zwwx);
+  let vf1: vec3h = cross(vec3h(unconst_f16(15540.2), unconst_f16(13418.3), unconst_f16(4737.1)), vec3h(unconst_f16(18738.6), unconst_f16(954.1), unconst_f16(520.1)));
+  (*a1).f2 *= vec4f(a0[unconst_u32(667352617)].xzyy.xywx);
+  var vf2: bool = all(vec4<bool>(unconst_bool(false), unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+}
+}
+
+/* zero global variables used */
+@vertex
+fn vertex0() -> VertexOutput0 {
+  var out: VertexOutput0;
+  let vf3: bool = any(unconst_bool(false));
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  var vf4: vec2f = unpack2x16float(bitcast<u32>(exp(unconst_f32(-0.04204))));
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(2, 1, 2)
+fn compute0() {
+  vw0[unconst_u32(2061204340)] = vec4f((*&vw0)[unconst_u32(75846864)][unconst_u32(3960737311)]);
+  vw0[unconst_u32(295150599)] = vec4f(f32(atan(unconst_f16(1085.9))));
+  var vf5: vec3h = (vec3h(unconst_f16(43356.7), unconst_f16(22264.5), unconst_f16(1449.2)) / vec3h(unconst_f16(13530.3), unconst_f16(10813.1), unconst_f16(20434.5)));
+  vf5 -= vec3h(unpack4x8snorm(unconst_u32(608540514)).grg);
+  loop {
+  var vf6: vec3u = select(vec3u(unconst_u32(500314782), unconst_u32(20331861), unconst_u32(443260717)), vec3u(unconst_u32(26599263), unconst_u32(182931322), unconst_u32(1583716972)), vec3<bool>(workgroupUniformLoad(&vw0)[0].wxw.yyy));
+  vf6 >>= vec3u(vw0[unconst_u32(60644954)].zxw.gbr.brr.bgr.xxx.rbr.yxy);
+  break;
+}
+  vw0[unconst_u32(940031275)] -= vec4f(bitcast<f32>(dot4I8Packed(unconst_u32(514362022), u32(cosh(vec4f(unconst_f32(-0.05232), unconst_f32(0.09878e14), unconst_f32(0.05991e24), unconst_f32(0.1320)))[3]))));
+  vf5 *= vec3h(degrees(vec2f(vf5.zz.xy.xy.rr.rr.yy.xx)).rrg);
+}`,
+});
+let texture17 = device0.createTexture({size: [4, 2, 179], format: 'rg16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder16 = commandEncoder6.beginComputePass();
+let imageData1 = new ImageData(76, 20);
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 7, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder22 = device0.createCommandEncoder({});
+let querySet4 = device0.createQuerySet({type: 'timestamp', count: 355});
+let sampler16 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 98.97});
+let texture18 = device0.createTexture({
+  size: {width: 16, height: 10, depthOrArrayLayers: 179},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView15 = texture17.createView({dimension: '2d', baseArrayLayer: 6, arrayLayerCount: 1});
+let computePassEncoder17 = commandEncoder14.beginComputePass();
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(204).fill(5), /* required buffer size: 204 */
+{offset: 204}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let buffer6 = device0.createBuffer({size: 193, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let texture19 = device0.createTexture({
+  size: [105, 805, 1],
+  mipLevelCount: 3,
+  format: 'astc-5x5-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+commandEncoder19.resolveQuerySet(querySet1, 16, 2, buffer5, 0);
+} catch {}
+let buffer7 = device0.createBuffer({size: 156, usage: GPUBufferUsage.INDEX});
+let commandEncoder23 = device0.createCommandEncoder();
+let texture20 = device0.createTexture({
+  size: {width: 288},
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView16 = texture4.createView({aspect: 'all', baseArrayLayer: 3, arrayLayerCount: 5});
+document.body.append(img1);
+let buffer8 = device0.createBuffer({size: 138, usage: GPUBufferUsage.STORAGE});
+let sampler17 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 95.30,
+});
+try {
+adapter0.label = '\ud058\u60c9\uba75\u0fdf\uba8e\ua3fc\u{1ff4b}\u95ba';
+} catch {}
+let buffer9 = device0.createBuffer({size: 624, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder24 = device0.createCommandEncoder({});
+try {
+commandEncoder19.clearBuffer(buffer4);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder23.beginComputePass({timestampWrites: {querySet: querySet3, endOfPassWriteIndex: 209}});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let pipeline0 = await device0.createComputePipelineAsync({layout: pipelineLayout2, compute: {module: shaderModule0}});
+document.body.append(img0);
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let buffer10 = device0.createBuffer({size: 44, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+try {
+buffer3.unmap();
+} catch {}
+let texture21 = device0.createTexture({
+  size: {width: 626, height: 80, depthOrArrayLayers: 15},
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView17 = texture5.createView({label: '\u{1fee7}\u{1fe02}', dimension: '2d', baseArrayLayer: 5});
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder17.resolveQuerySet(querySet2, 20, 0, buffer10, 0);
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer11 = device0.createBuffer({size: 135, usage: GPUBufferUsage.VERTEX});
+document.body.prepend(img0);
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpteRp431', transfer: 'unspecified'} });
+let bindGroup0 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 44, resource: textureView4},
+    {binding: 76, resource: externalTexture0},
+    {binding: 14, resource: textureView12},
+  ],
+});
+let texture22 = device0.createTexture({
+  label: '\u9a12\u{1fca9}\u9b4d',
+  size: {width: 78, height: 10, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+let buffer12 = device0.createBuffer({size: 344, usage: GPUBufferUsage.STORAGE});
+let computePassEncoder19 = commandEncoder24.beginComputePass();
+try {
+computePassEncoder17.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+commandEncoder22.copyTextureToTexture({
+  texture: texture18,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 40},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1, veryExplicitBindGroupLayout1]});
+let texture23 = device0.createTexture({size: [32], dimension: '1d', format: 'rg16float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let sampler18 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 77.20});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(3, bindGroup0, new Uint32Array(602), 257, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+let buffer13 = device0.createBuffer({size: 332, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let querySet5 = device0.createQuerySet({type: 'timestamp', count: 1052});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder20.resolveQuerySet(querySet3, 47, 0, buffer10, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 39, height: 5, depthOrArrayLayers: 120}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 1, y: 0, z: 10},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer14 = device0.createBuffer({size: 468, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let textureView18 = texture8.createView({});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 4, new Uint32Array(2491), 627, 0);
+} catch {}
+let bindGroup1 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 7, resource: externalTexture0}, {binding: 0, resource: externalTexture0}],
+});
+let commandEncoder26 = device0.createCommandEncoder();
+let texture24 = device0.createTexture({
+  size: {width: 626, height: 80, depthOrArrayLayers: 3},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['depth24plus'],
+});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(1089), 49, 0);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte432', transfer: 'bt2020_12bit'} });
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 0, resource: externalTexture0}, {binding: 7, resource: externalTexture0}],
+});
+let texture25 = device0.createTexture({
+  size: [2, 1, 179],
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView19 = texture17.createView({dimension: '2d', baseArrayLayer: 15});
+try {
+computePassEncoder0.setPipeline(pipeline0);
+} catch {}
+try {
+adapter0.label = '\u4241\u{1f8c8}\uecaf\u001e\u568f';
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 945});
+let texture26 = device0.createTexture({
+  size: [4, 2, 179],
+  sampleCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView20 = texture0.createView({arrayLayerCount: 1});
+let computePassEncoder20 = commandEncoder16.beginComputePass({timestampWrites: {querySet: querySet2, beginningOfPassWriteIndex: 37, endOfPassWriteIndex: 314}});
+let promise4 = device0.queue.onSubmittedWorkDone();
+let texture27 = device0.createTexture({
+  size: {width: 576, height: 120, depthOrArrayLayers: 51},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView21 = texture18.createView({dimension: '2d', baseArrayLayer: 6, arrayLayerCount: 1});
+let computePassEncoder21 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'jedecP22Phosphors', transfer: 'unspecified'} });
+let buffer15 = device0.createBuffer({
+  size: 256,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture28 = device0.createTexture({
+  size: {width: 626},
+  dimension: '1d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 7, resource: externalTexture0}, {binding: 0, resource: externalTexture0}],
+});
+let buffer16 = device0.createBuffer({size: 352, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder29 = device0.createCommandEncoder({});
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+buffer14.unmap();
+} catch {}
+let pipeline1 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout3,
+  multisample: {mask: 0x330544d0},
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'zero', dstFactor: 'dst-alpha'},
+  },
+}],
+},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let buffer17 = device0.createBuffer({size: 26, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let commandEncoder30 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 179},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup2);
+} catch {}
+let renderPassEncoder0 = commandEncoder20.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -292.6, g: -334.7, b: -67.27, a: -402.3, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet0},
+});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint32', 24, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 4, new Int16Array(12983), 1867, 0);
+} catch {}
+let bindGroup4 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 196, resource: textureView0},
+    {binding: 2, resource: {buffer: buffer12}},
+    {binding: 15, resource: {buffer: buffer14}},
+  ],
+});
+let buffer18 = device0.createBuffer({size: 230, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let textureView22 = texture1.createView({dimension: '2d', baseArrayLayer: 2});
+let computePassEncoder22 = commandEncoder21.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+await gc();
+let computePassEncoder23 = commandEncoder17.beginComputePass({
+  label: '\u{1f828}\u7638\u4ef0\ucac7\u8180',
+  timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 478},
+});
+let sampler19 = device0.createSampler({lodMaxClamp: 94.03, maxAnisotropy: 1});
+let promise5 = shaderModule0.getCompilationInfo();
+try {
+buffer13.unmap();
+} catch {}
+document.body.append(img0);
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+await gc();
+let textureView23 = texture3.createView({mipLevelCount: 1});
+let texture30 = device0.createTexture({
+  size: {width: 626, height: 80, depthOrArrayLayers: 1},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder24 = commandEncoder30.beginComputePass();
+let renderPassEncoder1 = commandEncoder25.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -688.6, g: -357.4, b: 629.0, a: 710.7, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+  maxDrawCount: 309951660,
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 0, 15);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture2,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 26},
+  aspect: 'all',
+}, new Uint8Array(1_296).fill(137), /* required buffer size: 1_296 */
+{offset: 328, bytesPerRow: 88, rowsPerImage: 11}, {width: 0, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 7, y: 7, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let bindGroup5 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 196, resource: textureView22},
+    {binding: 2, resource: {buffer: buffer15}},
+  ],
+});
+let texture31 = device0.createTexture({
+  size: [4, 2, 179],
+  mipLevelCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView24 = texture10.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 85});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+commandEncoder19.copyBufferToTexture({
+  /* bytesInLastRow: 104 widthInBlocks: 26 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 56 */
+  offset: 56,
+  bytesPerRow: 3072,
+  buffer: buffer16,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 93, y: 14, z: 0},
+  aspect: 'all',
+}, {width: 26, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer3);
+} catch {}
+let commandBuffer1 = commandEncoder22.finish();
+let textureView25 = texture16.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder25 = commandEncoder27.beginComputePass();
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 12, new Uint32Array(2893), 451, 0);
+} catch {}
+let bindGroup6 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 196, resource: textureView0},
+    {binding: 2, resource: {buffer: buffer12}},
+  ],
+});
+let buffer19 = device0.createBuffer({size: 46, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder31 = device0.createCommandEncoder({});
+let textureView26 = texture21.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 3});
+let computePassEncoder26 = commandEncoder19.beginComputePass();
+let renderPassEncoder2 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -453.6, g: -224.4, b: -830.9, a: 997.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+await gc();
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 0, resource: externalTexture0}, {binding: 7, resource: externalTexture0}],
+});
+let textureView27 = texture31.createView({dimension: '2d', baseArrayLayer: 45});
+let computePassEncoder27 = commandEncoder29.beginComputePass();
+try {
+computePassEncoder11.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 0, new BigUint64Array(8887), 1010, 0);
+} catch {}
+let buffer20 = device0.createBuffer({size: 252, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder32 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: {width: 8, height: 5, depthOrArrayLayers: 78},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder10.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(3, bindGroup5, new Uint32Array(276), 7, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup7, new Uint32Array(5162), 257, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder32.copyBufferToBuffer(buffer19, 4, buffer13, 12, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 7, y: 0, z: 5},
+  aspect: 'all',
+}, new Uint8Array(480_668).fill(131), /* required buffer size: 480_668 */
+{offset: 482, bytesPerRow: 111, rowsPerImage: 206}, {width: 13, height: 0, depthOrArrayLayers: 22});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T2 {
+  @align(32) @size(160) f0: vec4u,
+  @align(16) @size(32) f1: atomic<u32>,
+  @align(32) @size(1056) f2: array<vec4i>,
+}
+
+@group(0) @binding(0) var et0: texture_external;
+
+struct T3 {
+  @align(128) @size(384) f0: array<u32>,
+}
+
+struct VertexOutput1 {
+  @location(11) @interpolate(linear, first) f4: vec2h,
+  @builtin(position) f5: vec4f,
+  @location(9) @interpolate(flat, centroid) f6: vec2i,
+}
+
+struct S1 {
+  @location(1) @interpolate(flat) f0: f16,
+}
+
+struct FragmentOutput1 {
+  @location(0) @interpolate(flat, centroid) f0: vec4f,
+  @location(5) f1: u32,
+  @builtin(sample_mask) f2: u32,
+}
+
+struct S0 {
+  @location(0) @interpolate(linear) f0: vec4f,
+  @location(10) f1: vec4u,
+  @location(3) f2: vec4f,
+  @location(7) @interpolate(flat) f3: vec4f,
+  @location(9) f4: vec2i,
+  @location(14) f5: vec4h,
+  @location(4) @interpolate(flat) f6: u32,
+  @location(11) @interpolate(flat, sample) f7: u32,
+  @location(15) @interpolate(linear) f8: vec4h,
+  @location(13) f9: u32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp0 = frexp(vec3f(0.05382, 0.03113, 0.00985e17));
+
+alias vec3b = vec3<bool>;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @size(40) f0: array<vec2f, 1>,
+}
+
+struct T1 {
+  f0: vec4f,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex1(@location(5) a0: vec4u, @builtin(instance_index) a1: u32, a2: S0, @location(2) @interpolate(flat) a3: vec4f, @builtin(vertex_index) a4: u32, @location(6) @interpolate(linear, centroid) a5: f32, @location(8) @interpolate(flat, centroid) a6: u32, @location(12) @interpolate(flat) a7: vec2u, a8: S1) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f4 = vec2h(tan(unconst_f16(18133.2)));
+  out.f4 = vec2h(f16((unconst_f16(13.40) <= unconst_f16(19240.5))));
+  let vf7: vec4h = a2.f5;
+  while bool(pack4xU8(a2.f1)) {
+  vp0.fract = vec3f(f32(a6));
+  vp0.exp = bitcast<vec3i>(a2.f2.gag.grb.xxx);
+  var vf8: vec2h = refract(vec2h(unconst_f16(-325.0), unconst_f16(6317.8)), vec2h(unconst_f16(10900.5), unconst_f16(1640.1)), unconst_f16(12868.5));
+  out.f4 = a2.f5.rr;
+}
+  let vf9: vec4h = a2.f8;
+  return out;
+}
+
+/* used global variables: et0 */
+@fragment
+fn fragment1(@location(14) @interpolate(flat, sample) a0: vec4u) -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let vf10: vec3f = saturate(atanh(vec3f(unconst_f32(0.1604e11), unconst_f32(0.1502e-5), unconst_f32(0.1871e19))));
+  var vf11: f32 = vf10[unconst_u32(1413436670)];
+  let vf12: vec3f = saturate(vec3f(unconst_f32(0.09349e-35), unconst_f32(0.3047), unconst_f32(0.02265e28)));
+  out.f2 -= textureDimensions(et0).x;
+  let ptr0: ptr<function, f32> = &vf11;
+  let ptr1: ptr<function, f32> = &(*ptr0);
+  vp0.exp &= vec3i(i32(a0[unconst_u32(114239301)]));
+  return out;
+  _ = et0;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  var vf13: vec2f = smoothstep(vec2f(unconst_f32(0.01811), unconst_f32(0.4247)), vec2f(unconst_f32(0.1867), unconst_f32(0.08815)), vec2f(unconst_f32(0.01293), unconst_f32(0.2265e-45)));
+  vf13 = vec2f((vec3u(step(vec3h(smoothstep(vec2f(unconst_f32(0.1537e12), unconst_f32(0.03165)), vec2f(unconst_f32(0.2595e36), unconst_f32(0.07160)), vec2f(unconst_f32(0.09714e-16), unconst_f32(0.1171))).yxx.brb.bbg), vec3h(unconst_f16(5093.4), unconst_f16(2083.6), unconst_f16(4840.2)))).z / vec4u(unconst_u32(388430274), unconst_u32(27076038), unconst_u32(870692799), unconst_u32(684765711))).wx);
+  while bool(step(vec3h(unconst_f16(18283.9), unconst_f16(6726.4), unconst_f16(4826.6)), vec3h(unconst_f16(7235.3), unconst_f16(18546.2), unconst_f16(22163.4))).r) {
+  vp0 = vp0;
+  var vf14: i32 = dot4I8Packed(pack4x8unorm(atanh(vec4f(bitcast<f32>(dot4U8Packed(bitcast<vec3u>(smoothstep(vec3f(unconst_f32(0.00570), unconst_f32(0.01872), unconst_f32(0.02754e1)), vec3f(unconst_f32(0.01116e29), unconst_f32(0.01467), unconst_f32(0.2096e-38)), vec3f(unconst_f32(0.7249e1), unconst_f32(0.08603e-5), unconst_f32(-0.1321))))[0], unconst_u32(478502215)))))), bitcast<u32>(vp0.fract.r));
+  switch bitcast<vec4i>(unpack4xU8(unconst_u32(396426425))).w { 
+  default {
+  var vf15: vec4i = (vec4i(unconst_i32(434690607), unconst_i32(340313659), unconst_i32(-613519619), unconst_i32(171351941)) << vec4u(unconst_u32(863653506), unconst_u32(765864594), unconst_u32(497725193), unconst_u32(943016762)));
+  vf15 += vec4i(asin(vec3h(unconst_f16(27281.0), unconst_f16(22740.2), unconst_f16(19171.5))).brbb);
+  vf15 = vec4i(smoothstep(vec3f(unconst_f32(0.04394), unconst_f32(0.00761), unconst_f32(0.06392e37)), vec3f(unconst_f32(0.1825), unconst_f32(-0.1613e-16), unconst_f32(-0.1097)), vec3f(unconst_f32(0.07586), unconst_f32(0.2209), unconst_f32(0.3247e-30))).zyyz);
+  vp0.exp &= vec3i(i32(exp(unconst_f32(0.3541e-16))));
+}
+  }
+  let vf16: f16 = min(vec3h(smoothstep(vec3f(f32(dot4I8Packed(unconst_u32(96590556), unconst_u32(216741521)))), vec3f(unconst_f32(0.6705e26), unconst_f32(0.00220e-39), unconst_f32(0.08050e13)), vec3f(unconst_f32(0.2302e-34), unconst_f32(-0.03765e8), unconst_f32(0.02724e33))).bbb.bgg)[0], unconst_f16(27449.5));
+  loop {
+  while bool(dot4I8Packed(unconst_u32(351750729), unconst_u32(469731235))) {
+  vp0 = frexp(vec3f(f32((unconst_bool(false) || unconst_bool(true)))));
+  var vf17: i32 = extractBits(unconst_i32(194130449), unconst_u32(469012210), unconst_u32(661913393));
+}
+  let ptr2: ptr<private, vec3i> = &vp0.exp;
+  vp0.fract += unpack2x16unorm(unconst_u32(635102938)).ggg;
+  vp0 = frexp(bitcast<vec3f>(vp0.exp));
+  break;
+}
+  vp0 = frexp(vec3f(f32(vf16)));
+  return;
+}
+  var vf18: vec4u = (unconst_u32(573518269) / vec4u(unconst_u32(533185082), unconst_u32(162459094), unconst_u32(4294967295), unconst_u32(269246897)));
+  let vf19: f32 = length(vec4f(unconst_f32(0.1461e-36), unconst_f32(0.1912), unconst_f32(-0.2262), unconst_f32(0.3659)));
+  var vf20: u32 = vf18[unconst_u32(262506190)];
+  let ptr3: ptr<function, vec2f> = &vf13;
+}`,
+});
+let recycledExplicitBindGroupLayout1 = pipeline1.getBindGroupLayout(1);
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 7, resource: externalTexture0}, {binding: 0, resource: externalTexture0}],
+});
+let commandEncoder33 = device0.createCommandEncoder({});
+let texture33 = device0.createTexture({
+  size: {width: 156, height: 20, depthOrArrayLayers: 72},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder28 = commandEncoder28.beginComputePass({timestampWrites: {querySet: querySet2, beginningOfPassWriteIndex: 239, endOfPassWriteIndex: 198}});
+let renderPassEncoder3 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -544.9, g: 848.5, b: -739.1, a: 946.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup0, new Uint32Array(1605), 142, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(6.945133508609482, 8.003478877769313, 1.2796929604503269, 1.0519083855048639, 0.7856767527490812, 0.857752578030361);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer4, 0, 11);
+} catch {}
+try {
+commandEncoder32.copyTextureToTexture({
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 10},
+  aspect: 'depth-only',
+},
+{
+  texture: texture26,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder33.resolveQuerySet(querySet6, 8, 2, buffer3, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 78, height: 10, depthOrArrayLayers: 120}
+*/
+{
+  source: videoFrame5,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 8},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture34 = device0.createTexture({
+  size: {width: 72, height: 15, depthOrArrayLayers: 65},
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'film', transfer: 'gamma28curve'} });
+let textureView28 = texture32.createView({});
+let textureView29 = texture32.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 0, 14);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline1);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 53},
+  aspect: 'all',
+}, new Uint8Array(65_559).fill(159), /* required buffer size: 65_559 */
+{offset: 35, bytesPerRow: 65, rowsPerImage: 126}, {width: 1, height: 1, depthOrArrayLayers: 9});
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0, new Uint32Array(2897), 49, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(14.76395941247112, 4.495802250727205, 0.6011564364311455, 4.558199923520561, 0.38378381247127225, 0.7913214537715286);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer20, 4, 44);
+} catch {}
+try {
+commandEncoder33.clearBuffer(buffer3);
+} catch {}
+let buffer21 = device0.createBuffer({size: 172, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder34 = device0.createCommandEncoder({});
+let texture35 = device0.createTexture({
+  size: [8, 5, 1128],
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture36 = device0.createTexture({
+  size: {width: 78, height: 10, depthOrArrayLayers: 36},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder29 = commandEncoder32.beginComputePass();
+let renderPassEncoder4 = commandEncoder33.beginRenderPass({
+  colorAttachments: [{
+  view: textureView25,
+  clearValue: { r: -500.3, g: 145.9, b: -917.2, a: -140.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8 */
+  offset: 8,
+  buffer: buffer16,
+}, {
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder34.clearBuffer(buffer17, 4, 4);
+} catch {}
+try {
+commandEncoder34.resolveQuerySet(querySet5, 195, 0, buffer3, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let texture37 = device0.createTexture({
+  size: {width: 72, height: 15, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder30 = commandEncoder34.beginComputePass({timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 47}});
+let sampler20 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', lodMaxClamp: 89.45});
+try {
+computePassEncoder26.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+commandEncoder35.clearBuffer(buffer4);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 179}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 15},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'bt470bg', transfer: 'bt709'} });
+let bindGroup9 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 2, resource: {buffer: buffer19, offset: 0, size: 16}},
+    {binding: 196, resource: textureView22},
+  ],
+});
+let buffer22 = device0.createBuffer({
+  size: 343,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder36 = device0.createCommandEncoder({});
+let querySet7 = device0.createQuerySet({type: 'timestamp', count: 976});
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle1, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 40, 20);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 342, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(7).fill(76), /* required buffer size: 7 */
+{offset: 7, bytesPerRow: 114}, {width: 23, height: 72, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(img0);
+let commandEncoder37 = device0.createCommandEncoder();
+let sampler21 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.90,
+  maxAnisotropy: 8,
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let buffer23 = device0.createBuffer({size: 220, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder38 = device0.createCommandEncoder({});
+try {
+computePassEncoder3.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer7, 'uint16', 16, 15);
+} catch {}
+try {
+commandEncoder37.clearBuffer(buffer3);
+} catch {}
+let imageData2 = new ImageData(12, 12);
+let texture38 = device0.createTexture({
+  size: [32, 32, 13],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView30 = texture12.createView({format: 'rg16float'});
+let renderPassEncoder5 = commandEncoder38.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -471.7, g: 129.8, b: 813.5, a: 204.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet6,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder10); computePassEncoder10.dispatchWorkgroupsIndirect(buffer0, 24); };
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture33,
+  mipLevel: 0,
+  origin: {x: 1, y: 1, z: 8},
+  aspect: 'all',
+}, new Uint8Array(18_130).fill(246), /* required buffer size: 18_130 */
+{offset: 32, bytesPerRow: 50, rowsPerImage: 44}, {width: 6, height: 10, depthOrArrayLayers: 9});
+} catch {}
+let pipeline2 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  fragment: {
+  module: shaderModule0,
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-constant'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: 0,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex1',
+    buffers: [
+      {
+        arrayStride: 424,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x2', offset: 28, shaderLocation: 5},
+          {format: 'snorm16x4', offset: 16, shaderLocation: 1},
+          {format: 'uint32x3', offset: 12, shaderLocation: 12},
+          {format: 'snorm16x4', offset: 56, shaderLocation: 6},
+          {format: 'snorm8x2', offset: 160, shaderLocation: 3},
+          {format: 'float32x2', offset: 16, shaderLocation: 14},
+          {format: 'sint8x2', offset: 128, shaderLocation: 9},
+          {format: 'uint8x4', offset: 24, shaderLocation: 8},
+          {format: 'float32x2', offset: 40, shaderLocation: 7},
+          {format: 'float32', offset: 100, shaderLocation: 0},
+          {format: 'uint32x2', offset: 4, shaderLocation: 13},
+          {format: 'uint32x4', offset: 24, shaderLocation: 10},
+          {format: 'unorm8x4', offset: 76, shaderLocation: 15},
+          {format: 'uint32x3', offset: 80, shaderLocation: 4},
+          {format: 'snorm8x4', offset: 20, shaderLocation: 2},
+          {format: 'uint32x4', offset: 32, shaderLocation: 11},
+        ],
+      },
+    ],
+  },
+});
+try {
+commandEncoder3.label = '\ufa4c\u792d\u0154\ub9da\u7b07\u4c33\u8740\u{1fc81}\u0d50\u0291\u{1f99a}';
+} catch {}
+let bindGroup10 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14, offset: 0}},
+    {binding: 2, resource: {buffer: buffer15}},
+    {binding: 196, resource: textureView22},
+  ],
+});
+let textureView31 = texture31.createView({dimension: '2d', baseArrayLayer: 63});
+let textureView32 = texture1.createView({format: 'r8sint', baseArrayLayer: 4, arrayLayerCount: 1});
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 156);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 12, new Uint32Array(33026), 2653, 12);
+} catch {}
+let buffer24 = device0.createBuffer({size: 260, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+let computePassEncoder31 = commandEncoder36.beginComputePass();
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 8, visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 150,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 221,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer25 = device0.createBuffer({size: 12, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder39 = device0.createCommandEncoder();
+let texture39 = device0.createTexture({
+  size: [16, 10, 13],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder32 = commandEncoder35.beginComputePass({timestampWrites: {querySet: querySet3}});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], stencilReadOnly: true});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint32', 0, 11);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise2;
+} catch {}
+let canvas0 = document.createElement('canvas');
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'film', transfer: 'bt2020_12bit'} });
+let commandEncoder40 = device0.createCommandEncoder({});
+let computePassEncoder33 = commandEncoder40.beginComputePass({timestampWrites: {querySet: querySet3}});
+let renderPassEncoder6 = commandEncoder37.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -348.4, g: -754.0, b: 749.7, a: 30.88, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet1, endOfPassWriteIndex: 317},
+});
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 7, resource: externalTexture0}, {binding: 0, resource: externalTexture0}],
+});
+let buffer26 = device0.createBuffer({size: 473, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: false});
+let textureView33 = texture21.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder34 = commandEncoder39.beginComputePass();
+try {
+computePassEncoder10.end();
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup4);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let computePassEncoder35 = commandEncoder9.beginComputePass();
+let sampler22 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 77.22,
+});
+try {
+renderPassEncoder2.setIndexBuffer(buffer21, 'uint32', 4, 15);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer11, 0, 21);
+} catch {}
+let texture40 = device0.createTexture({
+  size: {width: 78},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer20);
+} catch {}
+try {
+  await promise6;
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 196, resource: textureView22},
+    {binding: 2, resource: {buffer: buffer14}},
+  ],
+});
+let querySet8 = device0.createQuerySet({type: 'timestamp', count: 450});
+let textureView34 = texture8.createView({dimension: '3d', baseMipLevel: 0});
+try {
+buffer17.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 24, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(31).fill(30), /* required buffer size: 31 */
+{offset: 31}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline3 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule0, targets: [{format: 'rg16float', writeMask: GPUColorWrite.BLUE}]},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 72,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'float32', offset: 0, shaderLocation: 6},
+          {format: 'uint8x2', offset: 6, shaderLocation: 8},
+          {format: 'snorm16x2', offset: 16, shaderLocation: 1},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 7},
+          {format: 'sint32', offset: 20, shaderLocation: 9},
+          {format: 'uint16x4', offset: 8, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 4,
+        attributes: [
+          {format: 'unorm16x2', offset: 0, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 3},
+          {format: 'uint8x2', offset: 0, shaderLocation: 11},
+          {format: 'uint8x2', offset: 0, shaderLocation: 12},
+          {format: 'snorm16x2', offset: 0, shaderLocation: 15},
+          {format: 'uint8x2', offset: 0, shaderLocation: 13},
+          {format: 'uint8x4', offset: 0, shaderLocation: 5},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 14},
+          {format: 'uint8x4', offset: 0, shaderLocation: 4},
+        ],
+      },
+      {arrayStride: 92, attributes: [{format: 'float32x2', offset: 28, shaderLocation: 2}]},
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32'},
+});
+let commandEncoder41 = device0.createCommandEncoder();
+let textureView35 = texture15.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup10, new Uint32Array(2092), 174, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder11); computePassEncoder11.dispatchWorkgroups(1, 1, 1); };
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup3, new Uint32Array(857), 163, 0);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer24, 16, buffer4, 0, 12);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(112).fill(70), /* required buffer size: 112 */
+{offset: 112, bytesPerRow: 258}, {width: 1, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let promise7 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext0 = canvas0.getContext('webgpu');
+try {
+computePassEncoder4.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2]);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 0, new Uint32Array(2347), 69, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 78, height: 10, depthOrArrayLayers: 120}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 7},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'film', transfer: 'pq'} });
+let textureView36 = texture39.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(6, 0, 15, 1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+try {
+  await promise7;
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline2.getBindGroupLayout(0);
+let buffer27 = device0.createBuffer({size: 221, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let computePassEncoder36 = commandEncoder41.beginComputePass();
+try {
+computePassEncoder13.setBindGroup(2, bindGroup7, new Uint32Array(2692), 129, 0);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+let pipeline4 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule0, constants: {}}});
+await gc();
+let commandEncoder42 = device0.createCommandEncoder({});
+try {
+computePassEncoder25.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer4, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(73).fill(116), /* required buffer size: 73 */
+{offset: 73, bytesPerRow: 12, rowsPerImage: 53}, {width: 1, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup13 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 7, resource: externalTexture0}, {binding: 0, resource: externalTexture0}],
+});
+let textureView37 = texture31.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 72});
+let computePassEncoder37 = commandEncoder42.beginComputePass();
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint32', 0, 14);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 150, resource: {buffer: buffer8, size: 92}},
+    {binding: 8, resource: externalTexture0},
+    {binding: 221, resource: {buffer: buffer14}},
+  ],
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder37.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder4.setViewport(111.18624071659936, 11.814588517660443, 20.54359901596008, 7.537089664818747, 0.20140760929201607, 0.681691821055949);
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder({});
+let computePassEncoder38 = commandEncoder43.beginComputePass({timestampWrites: {querySet: querySet5, endOfPassWriteIndex: 37}});
+let sampler23 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 52.89,
+});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup13, new Uint32Array(4292), 145, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(855);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 8, 8);
+} catch {}
+await gc();
+let buffer28 = device0.createBuffer({size: 280, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+computePassEncoder35.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup10, new Uint32Array(4471), 177, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer23, 'uint16', 22, 21);
+} catch {}
+try {
+computePassEncoder25.pushDebugGroup('\uc7a9');
+} catch {}
+try {
+computePassEncoder22.insertDebugMarker('\u{1f640}');
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let commandEncoder44 = device0.createCommandEncoder({});
+let textureView38 = texture20.createView({aspect: 'all'});
+let computePassEncoder39 = commandEncoder44.beginComputePass();
+try {
+renderPassEncoder1.beginOcclusionQuery(81);
+} catch {}
+try {
+renderPassEncoder3.setStencilReference(59);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u{1ff66}');
+} catch {}
+document.body.append(canvas0);
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let buffer29 = device0.createBuffer({size: 48, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder45 = device0.createCommandEncoder();
+let computePassEncoder40 = commandEncoder45.beginComputePass();
+try {
+computePassEncoder34.setBindGroup(1, bindGroup13);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup14, new Uint32Array(512), 82, 1);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 40, new Uint32Array(8351), 884, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 31},
+  aspect: 'all',
+}, new Uint8Array(3_920).fill(244), /* required buffer size: 3_920 */
+{offset: 294, bytesPerRow: 38, rowsPerImage: 95}, {width: 2, height: 1, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 78, height: 10, depthOrArrayLayers: 120}
+*/
+{
+  source: img0,
+  origin: { x: 16, y: 16 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 0,
+  origin: {x: 14, y: 1, z: 18},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 25, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let texture41 = device0.createTexture({
+  size: [626, 80, 1],
+  mipLevelCount: 5,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView39 = texture23.createView({});
+try {
+computePassEncoder16.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup2, new Uint32Array(2684), 532, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise5;
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3, veryExplicitBindGroupLayout0]});
+let sampler24 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup11, new Uint32Array(6640), 3_186, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer11, 0, 65);
+} catch {}
+let textureView40 = texture19.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder25); computePassEncoder25.dispatchWorkgroupsIndirect(buffer25, 0); };
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer4, 0, 9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer3, 0, new Uint32Array(19572), 4443, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 150, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(90).fill(68), /* required buffer size: 90 */
+{offset: 90}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder46 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'timestamp', count: 2094});
+let renderPassEncoder7 = commandEncoder46.beginRenderPass({
+  label: '\u{1fb37}\u{1ff2d}\u09b3\ud789\u630e\u3d0b\u093a',
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -111.1, g: -120.6, b: 229.4, a: -165.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 87.94,
+  compare: 'never',
+});
+try {
+computePassEncoder30.setBindGroup(2, bindGroup13, new Uint32Array(595), 105, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer7, 'uint16', 56, 27);
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: pipelineLayout0,
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'src'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 4,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint16x2', offset: 0, shaderLocation: 12},
+          {format: 'sint32', offset: 0, shaderLocation: 9},
+          {format: 'uint8x4', offset: 0, shaderLocation: 8},
+          {format: 'uint32', offset: 0, shaderLocation: 13},
+          {format: 'uint32', offset: 0, shaderLocation: 10},
+          {format: 'unorm16x2', offset: 0, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 15},
+          {format: 'float16x2', offset: 0, shaderLocation: 3},
+        ],
+      },
+      {
+        arrayStride: 892,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 164, shaderLocation: 4},
+          {format: 'float16x2', offset: 404, shaderLocation: 14},
+          {format: 'uint32x3', offset: 68, shaderLocation: 5},
+          {format: 'unorm8x4', offset: 308, shaderLocation: 0},
+          {format: 'float32x4', offset: 216, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 24, shaderLocation: 7},
+          {format: 'uint8x4', offset: 16, shaderLocation: 11},
+          {format: 'snorm8x2', offset: 88, shaderLocation: 6},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'point-list', cullMode: 'none'},
+});
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 221, resource: {buffer: buffer12, size: 212}},
+    {binding: 8, resource: externalTexture0},
+    {binding: 150, resource: {buffer: buffer15, offset: 0}},
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer3, 'uint32', 28, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer11, 4, 45);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup5, new Uint32Array(247), 11, 0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer3, 'uint16', 0, 2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer20, 20);
+} catch {}
+try {
+commandEncoder15.copyBufferToBuffer(buffer26, 164, buffer3, 0, 8);
+} catch {}
+try {
+computePassEncoder25.popDebugGroup();
+} catch {}
+let commandEncoder47 = device0.createCommandEncoder();
+let commandBuffer2 = commandEncoder15.finish();
+let texture42 = device0.createTexture({
+  size: [626, 80, 289],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView41 = texture9.createView({});
+let computePassEncoder41 = commandEncoder47.beginComputePass();
+try {
+computePassEncoder24.setPipeline(pipeline4);
+} catch {}
+try {
+adapter0.label = '\u071f\u82eb\ufbf9\uc2fb\u0bf7\u2c48';
+} catch {}
+let bindGroup16 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14, offset: 0}},
+    {binding: 196, resource: textureView0},
+    {binding: 2, resource: {buffer: buffer14}},
+  ],
+});
+let commandEncoder48 = device0.createCommandEncoder();
+let textureView42 = texture22.createView({});
+let computePassEncoder42 = commandEncoder48.beginComputePass();
+let sampler26 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 87.27});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup9, new Uint32Array(2794), 149, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u06a2');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 60},
+  aspect: 'all',
+}, new Uint8Array(2_220).fill(192), /* required buffer size: 2_220 */
+{offset: 42, bytesPerRow: 22, rowsPerImage: 11}, {width: 0, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 39, height: 5, depthOrArrayLayers: 120}
+*/
+{
+  source: img0,
+  origin: { x: 3, y: 29 },
+  flipY: true,
+}, {
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 0, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let texture43 = device0.createTexture({
+  size: {width: 626, height: 80, depthOrArrayLayers: 1},
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(6, buffer22, 0, 14);
+} catch {}
+let commandEncoder49 = device0.createCommandEncoder({});
+let computePassEncoder43 = commandEncoder49.beginComputePass();
+try {
+computePassEncoder43.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup11, new Uint32Array(160), 33, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 60, new Uint32Array(1819), 583, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 103, y: 10, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let buffer30 = device0.createBuffer({size: 372, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture44 = device0.createTexture({
+  size: {width: 4, height: 2, depthOrArrayLayers: 83},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  lodMaxClamp: 59.90,
+});
+try {
+renderPassEncoder4.setViewport(22.692011196299312, 14.939912208758175, 8.816108719693556, 4.0148576683267025, 0.5306129998450198, 0.7023542973256526);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer30, 'uint16', 40, 90);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 0, new Uint32Array(39030), 6593, 0);
+} catch {}
+document.body.append(img1);
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 532,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let texture45 = device0.createTexture({
+  size: [32, 32, 65],
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], depthReadOnly: true});
+let sampler28 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 96.53});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer22, 'uint16', 138, 51);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(4, buffer11);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  label: '\u5f30\u01e6\u101b\u0e54\u0367',
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let renderBundle3 = renderBundleEncoder3.finish({});
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup8, new Uint32Array(397), 17, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer1, 'uint32', 8, 1);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+let sampler29 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 92.30, compare: 'never'});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup14, new Uint32Array(5589), 1_248, 1);
+} catch {}
+try {
+computePassEncoder11.end();
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer22, 0, 97);
+} catch {}
+try {
+commandEncoder10.copyBufferToBuffer(buffer24, 64, buffer18, 16, 4);
+} catch {}
+let buffer31 = device0.createBuffer({size: 66, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder51 = device0.createCommandEncoder({});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup9, new Uint32Array(1057), 22, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+device0.label = '\u{1fffd}\ue6b5\u{1f922}\u8be1\u86db\u0ae1\ubbeb\u9b84\u{1f9bc}';
+} catch {}
+let commandEncoder52 = device0.createCommandEncoder({});
+let computePassEncoder44 = commandEncoder51.beginComputePass();
+let sampler30 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 7,
+});
+try {
+computePassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer22, 28, 120);
+} catch {}
+let bindGroup17 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14, offset: 0}},
+    {binding: 196, resource: textureView22},
+    {binding: 2, resource: {buffer: buffer19, size: 20}},
+  ],
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup6);
+} catch {}
+let commandBuffer3 = commandEncoder10.finish();
+try {
+computePassEncoder4.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+computePassEncoder26.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup8, new Uint32Array(2318), 802, 0);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder5.insertDebugMarker('\u8f17');
+} catch {}
+let bindGroup18 = device0.createBindGroup({layout: veryExplicitBindGroupLayout8, entries: [{binding: 532, resource: textureView31}]});
+let buffer32 = device0.createBuffer({size: 172, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let texture46 = device0.createTexture({
+  size: [626, 80, 1],
+  sampleCount: 4,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView43 = texture18.createView({baseArrayLayer: 20, arrayLayerCount: 14});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup7, new Uint32Array(161), 10, 0);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup9);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let texture47 = device0.createTexture({size: [313, 40, 144], dimension: '3d', format: 'rg16float', usage: GPUTextureUsage.COPY_SRC});
+let computePassEncoder45 = commandEncoder52.beginComputePass({timestampWrites: {querySet: querySet9, beginningOfPassWriteIndex: 770}});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(3074), 1_536, 0);
+} catch {}
+try {
+renderPassEncoder4.setViewport(51.20300114226993, 17.04904039057877, 43.7703146424154, 1.9835574059216625, 0.023718395561002747, 0.4467097521990495);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint16', 20, 11);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 7},
+  aspect: 'all',
+}, new Uint8Array(3_480).fill(212), /* required buffer size: 3_480 */
+{offset: 131, bytesPerRow: 153, rowsPerImage: 19}, {width: 17, height: 3, depthOrArrayLayers: 2});
+} catch {}
+let textureView44 = texture20.createView({dimension: '1d', aspect: 'all'});
+let computePassEncoder46 = commandEncoder50.beginComputePass();
+try {
+computePassEncoder44.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder3.setViewport(2.235665377226084, 5.590577349816459, 2.76115777522271, 4.00877584134809, 0.4330227260517783, 0.8391617317270403);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer26, 160, buffer17, 4, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 4, new BigUint64Array(26600), 1948, 0);
+} catch {}
+let commandBuffer4 = commandEncoder27.finish({});
+let texture48 = device0.createTexture({
+  size: [144, 30, 1],
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView45 = texture45.createView({dimension: '3d'});
+let computePassEncoder47 = commandEncoder53.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 342}});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup10, new Uint32Array(93), 4, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup6, new Uint32Array(643), 7, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(15);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle0, renderBundle1, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 48, new Uint32Array(40485), 18913, 16);
+} catch {}
+let bindGroup19 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 196, resource: textureView22},
+    {binding: 2, resource: {buffer: buffer19, offset: 0, size: 20}},
+    {binding: 15, resource: {buffer: buffer14}},
+  ],
+});
+let buffer33 = device0.createBuffer({
+  size: 81,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let textureView46 = texture47.createView({label: '\ucb94\ue5fd\ub13f\ufa1c\u02fd\u0cbc\u0896\u80c3\ucf35'});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup1, new Uint32Array(3771), 92, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer17, 0, new Int16Array(10119), 225, 0);
+} catch {}
+document.body.prepend(img1);
+let buffer34 = device0.createBuffer({size: 268, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder54 = device0.createCommandEncoder();
+let textureView47 = texture30.createView({dimension: '2d-array'});
+let computePassEncoder48 = commandEncoder54.beginComputePass();
+try {
+computePassEncoder36.setBindGroup(0, bindGroup17);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup6, new Uint32Array(1093), 256, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(15.769419365972885, 0.10868286247859515, 0.08708159761626333, 4.9639962682941485, 0.8254143852512961, 0.8323876834531116);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder55 = device0.createCommandEncoder();
+let texture49 = device0.createTexture({
+  size: [313, 40, 25],
+  mipLevelCount: 2,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let sampler31 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder29.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer22, 'uint32', 180, 50);
+} catch {}
+try {
+commandEncoder55.copyBufferToBuffer(buffer19, 12, buffer3, 4, 0);
+} catch {}
+let img2 = await imageWithData(171, 109, '#10101010', '#20202020');
+let renderPassEncoder8 = commandEncoder55.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 432.3, g: -386.9, b: 352.7, a: 215.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet9},
+  maxDrawCount: 323459234,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup15, [0]);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup15, new Uint32Array(1208), 148, 1);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let texture50 = gpuCanvasContext0.getCurrentTexture();
+let sampler32 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  lodMinClamp: 67.17,
+  lodMaxClamp: 80.55,
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup14, new Uint32Array(1659), 130, 1);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer15, 'uint16', 118, 21);
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let buffer35 = device0.createBuffer({size: 606, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder56 = device0.createCommandEncoder();
+let computePassEncoder49 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder35.setBindGroup(2, bindGroup19, []);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(3, bindGroup15, new Uint32Array(845), 70, 1);
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup8, new Uint32Array(3850), 38, 0);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(15.770315625282189, 5.783169038311964, 0.15914267760699993, 1.5230352719859315, 0.34844318570943356, 0.9806663461068608);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer28);
+} catch {}
+try {
+  await promise8;
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'smpte432', transfer: 'smpte240m'} });
+let buffer36 = device0.createBuffer({size: 228, usage: GPUBufferUsage.INDIRECT});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 269});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup1, new Uint32Array(512), 84, 0);
+} catch {}
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup3, new Uint32Array(3217), 781, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline3);
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({});
+let texture51 = device0.createTexture({
+  size: {width: 313, height: 40, depthOrArrayLayers: 144},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder9 = commandEncoder57.beginRenderPass({
+  colorAttachments: [{
+  view: textureView25,
+  clearValue: { r: -616.9, g: 47.91, b: -997.1, a: -565.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 112913554,
+});
+let sampler33 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 98.87,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup8, []);
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let texture52 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture53 = device0.createTexture({
+  size: [4, 2, 179],
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder50 = commandEncoder58.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(1, bindGroup3, new Uint32Array(953), 289, 0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer22);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let textureView48 = texture51.createView({dimension: '3d', baseArrayLayer: 0, arrayLayerCount: 1});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+computePassEncoder13.setBindGroup(2, bindGroup15, new Uint32Array(1396), 292, 1);
+} catch {}
+try {
+computePassEncoder45.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(1431), 34, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(6, buffer30, 0, 147);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8unorm-srgb'],
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 3, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(146).fill(215), /* required buffer size: 146 */
+{offset: 146}, {width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.prepend(canvas0);
+let texture54 = device0.createTexture({
+  size: [32],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView49 = texture26.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 47});
+let sampler34 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 64.88,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder28.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer33, 28, 3);
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 221, resource: {buffer: buffer12}},
+    {binding: 8, resource: externalTexture0},
+    {binding: 150, resource: {buffer: buffer14, offset: 0}},
+  ],
+});
+let buffer37 = device0.createBuffer({
+  size: 247,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture55 = device0.createTexture({
+  size: [2],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture56 = device0.createTexture({
+  size: [576, 120, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+try {
+computePassEncoder38.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer31, 'uint16', 2, 4);
+} catch {}
+let bindGroup21 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 44, resource: textureView4},
+    {binding: 14, resource: textureView2},
+    {binding: 76, resource: externalTexture0},
+  ],
+});
+let textureView50 = texture54.createView({baseMipLevel: 0, arrayLayerCount: 1});
+try {
+renderPassEncoder6.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 80, new DataView(new ArrayBuffer(8034)), 1960, 92);
+} catch {}
+let canvas1 = document.createElement('canvas');
+let bindGroup22 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 76, resource: externalTexture1},
+    {binding: 14, resource: textureView23},
+    {binding: 44, resource: textureView21},
+  ],
+});
+let texture57 = device0.createTexture({size: [576, 120, 35], mipLevelCount: 2, format: 'astc-12x12-unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView51 = texture30.createView({dimension: '2d-array', format: 'rg16float'});
+let renderPassEncoder10 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 210.9, g: 902.8, b: -96.06, a: 258.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba8uint'],
+  depthStencilFormat: 'depth24plus',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle4 = renderBundleEncoder4.finish();
+try {
+renderPassEncoder10.setScissorRect(3, 3, 0, 0);
+} catch {}
+try {
+renderPassEncoder10.setViewport(2.002553668157425, 1.465314765093787, 0.2209214608613345, 2.2140653109401662, 0.7975874945417119, 0.910939132543312);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder60 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup19, new Uint32Array(546), 165, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 12, new Uint32Array(21596), 9000, 8);
+} catch {}
+let textureView52 = texture41.createView({aspect: 'depth-only', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder51 = commandEncoder60.beginComputePass();
+try {
+computePassEncoder48.setPipeline(pipeline0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.append(img2);
+let bindGroup23 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 2, resource: {buffer: buffer37, size: 32}},
+    {binding: 196, resource: textureView22},
+    {binding: 15, resource: {buffer: buffer14, offset: 0}},
+  ],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder7); computePassEncoder7.dispatchWorkgroupsIndirect(buffer15, 40); };
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 8, 8);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'jedecP22Phosphors', transfer: 'bt709'} });
+let recycledExplicitBindGroupLayout3 = pipeline5.getBindGroupLayout(0);
+let buffer38 = device0.createBuffer({size: 152, usage: GPUBufferUsage.COPY_DST});
+try {
+computePassEncoder51.setBindGroup(3, bindGroup14, [0]);
+} catch {}
+try {
+computePassEncoder7.end();
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup23, new Uint32Array(95), 15, 0);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer7, 'uint32', 52, 1);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline3);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let gpuCanvasContext1 = canvas1.getContext('webgpu');
+document.body.prepend(canvas0);
+let buffer39 = device0.createBuffer({size: 8, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE});
+let texture58 = device0.createTexture({
+  size: [288, 60, 1],
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let texture59 = gpuCanvasContext0.getCurrentTexture();
+try {
+computePassEncoder23.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder37); computePassEncoder37.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(112), 9, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(161);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer21, 'uint32', 72, 43);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(0, buffer30, 68, 18);
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 522},
+  aspect: 'all',
+},
+{
+  texture: texture34,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 31},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let bindGroup24 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 221, resource: {buffer: buffer37, size: 172}},
+    {binding: 150, resource: {buffer: buffer15}},
+    {binding: 8, resource: externalTexture0},
+  ],
+});
+try {
+computePassEncoder41.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder49.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer4, 12, 1);
+} catch {}
+let recycledExplicitBindGroupLayout4 = pipeline2.getBindGroupLayout(0);
+let bindGroup25 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 8, resource: externalTexture0},
+    {binding: 221, resource: {buffer: buffer15}},
+    {binding: 150, resource: {buffer: buffer8, size: 92}},
+  ],
+});
+let texture60 = device0.createTexture({
+  label: '\u{1f7f2}\u7844\u300c\u0f7b\u0d42\u3f8c\u7205\u{1fc58}',
+  size: {width: 16, height: 10, depthOrArrayLayers: 69},
+  dimension: '3d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture61 = gpuCanvasContext0.getCurrentTexture();
+let textureView53 = texture33.createView({dimension: '3d'});
+let computePassEncoder52 = commandEncoder8.beginComputePass();
+let sampler35 = device0.createSampler({label: '\uea11\u0719\uf5fc\ue8b9\u{1faa1}\u03b7', addressModeW: 'mirror-repeat', lodMaxClamp: 98.48});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder10.setViewport(14.86892762624253, 3.6811958024351332, 0.38764186647897775, 5.284896281983656, 0.6326713331593401, 0.7877537418955675);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer15, 'uint32', 44, 6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 24, new Uint32Array(9506), 1771, 4);
+} catch {}
+let bindGroup26 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 76, resource: externalTexture0},
+    {binding: 14, resource: textureView23},
+    {binding: 44, resource: textureView5},
+  ],
+});
+let buffer40 = device0.createBuffer({size: 96, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let texture62 = device0.createTexture({
+  size: [4, 2, 179],
+  mipLevelCount: 1,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler36 = device0.createSampler({magFilter: 'linear', lodMinClamp: 84.80, lodMaxClamp: 91.49, maxAnisotropy: 1});
+try {
+computePassEncoder34.setBindGroup(2, bindGroup4, new Uint32Array(4105), 1_984, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 12, new Uint32Array(684), 271, 0);
+} catch {}
+let sampler37 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 96.38, maxAnisotropy: 1});
+try {
+computePassEncoder40.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(0, buffer27);
+} catch {}
+let textureView54 = texture51.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let textureView55 = texture3.createView({});
+try {
+computePassEncoder52.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup5, new Uint32Array(440), 112, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(294).fill(173), /* required buffer size: 294 */
+{offset: 294, rowsPerImage: 3}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline6 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-src-alpha', dstFactor: 'dst'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'dst-alpha', dstFactor: 'dst'},
+  },
+  writeMask: GPUColorWrite.BLUE | GPUColorWrite.RED,
+}],
+},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 52,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x3', offset: 12, shaderLocation: 8},
+          {format: 'unorm16x4', offset: 0, shaderLocation: 2},
+          {format: 'float32x4', offset: 8, shaderLocation: 0},
+          {format: 'unorm8x2', offset: 6, shaderLocation: 3},
+          {format: 'float16x2', offset: 8, shaderLocation: 1},
+          {format: 'uint32', offset: 20, shaderLocation: 10},
+          {format: 'sint16x2', offset: 8, shaderLocation: 9},
+          {format: 'uint32x4', offset: 0, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 7},
+          {format: 'unorm16x2', offset: 12, shaderLocation: 6},
+          {format: 'float32x2', offset: 8, shaderLocation: 15},
+          {format: 'uint16x4', offset: 0, shaderLocation: 11},
+          {format: 'uint32x2', offset: 4, shaderLocation: 12},
+        ],
+      },
+      {
+        arrayStride: 224,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32x4', offset: 0, shaderLocation: 13},
+          {format: 'float32x2', offset: 56, shaderLocation: 14},
+          {format: 'uint8x4', offset: 64, shaderLocation: 4},
+        ],
+      },
+    ],
+  },
+  primitive: {topology: 'triangle-strip', stripIndexFormat: 'uint32', cullMode: 'front', unclippedDepth: true},
+});
+let imageData3 = new ImageData(32, 88);
+let commandEncoder61 = device0.createCommandEncoder({});
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer29, 4); };
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.draw(139, 0, 139_168_723);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer29, 8);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 8, new Uint32Array(3736), 167, 0);
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 150, resource: {buffer: buffer8, size: 96}},
+    {binding: 221, resource: {buffer: buffer14}},
+    {binding: 8, resource: externalTexture1},
+  ],
+});
+let textureView56 = texture52.createView({arrayLayerCount: 1});
+let texture63 = gpuCanvasContext0.getCurrentTexture();
+let textureView57 = texture20.createView({baseArrayLayer: 0});
+try {
+{ clearResourceUsages(device0, computePassEncoder8); computePassEncoder8.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder3.draw(297, 0, 271_516_561);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer32, 12);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer39, 'uint32', 0, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(6, undefined);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout4,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 2, resource: {buffer: buffer12}},
+    {binding: 196, resource: textureView22},
+  ],
+});
+let buffer41 = device0.createBuffer({
+  size: 240,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'srgb'});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder3.draw(41, 0, 1_321_391_902);
+} catch {}
+try {
+renderPassEncoder3.drawIndexed(0, 0, 0, 183_612_178);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer37, 144);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer20, 0);
+} catch {}
+let texture64 = device0.createTexture({
+  label: '\u0a13\u0e29\u{1f9f6}',
+  size: {width: 156, height: 20, depthOrArrayLayers: 3},
+  format: 'etc2-rgb8a1unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView58 = texture20.createView({dimension: '1d', format: 'rg16float'});
+let computePassEncoder53 = commandEncoder61.beginComputePass();
+try {
+computePassEncoder44.end();
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer31, 'uint16', 10, 4);
+} catch {}
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 112});
+let texture65 = device0.createTexture({
+  size: [8, 5, 179],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder54 = commandEncoder51.beginComputePass();
+let externalTexture3 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline6);
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture10,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup29 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 196, resource: textureView0},
+    {binding: 2, resource: {buffer: buffer37, size: 64}},
+    {binding: 15, resource: {buffer: buffer14}},
+  ],
+});
+let commandEncoder62 = device0.createCommandEncoder({});
+let textureView59 = texture65.createView({dimension: '2d', baseArrayLayer: 73});
+let texture66 = device0.createTexture({
+  size: {width: 156, height: 20, depthOrArrayLayers: 1},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder54.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer10, 'uint32', 4, 10);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer5, 0, 15);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 7, y: 5 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 60, y: 15, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 14, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'unspecified', transfer: 'bt2020_10bit'} });
+let commandEncoder63 = device0.createCommandEncoder({});
+let textureView60 = texture45.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder35); computePassEncoder35.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+computePassEncoder35.end();
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer1, 'uint16', 0, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 179}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 44, resource: textureView35},
+    {binding: 76, resource: externalTexture3},
+    {binding: 14, resource: textureView55},
+  ],
+});
+let buffer42 = device0.createBuffer({size: 60, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder64 = device0.createCommandEncoder();
+let commandBuffer5 = commandEncoder9.finish();
+let textureView61 = texture27.createView({dimension: '2d', format: 'rg16float', mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 1});
+let sampler38 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'never',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup8);
+} catch {}
+try {
+computePassEncoder54.setBindGroup(2, bindGroup22, new Uint32Array(1456), 370, 0);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer20, 0, 75);
+} catch {}
+let pipeline7 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {module: shaderModule0, targets: [{format: 'rg16float'}]},
+  vertex: {
+    module: shaderModule1,
+    constants: {},
+    buffers: [
+      {
+        arrayStride: 324,
+        attributes: [
+          {format: 'float16x2', offset: 20, shaderLocation: 14},
+          {format: 'snorm8x4', offset: 128, shaderLocation: 0},
+          {format: 'uint8x2', offset: 38, shaderLocation: 10},
+          {format: 'unorm10-10-10-2', offset: 128, shaderLocation: 7},
+          {format: 'float32x3', offset: 8, shaderLocation: 3},
+          {format: 'uint32x4', offset: 4, shaderLocation: 11},
+          {format: 'unorm10-10-10-2', offset: 0, shaderLocation: 1},
+          {format: 'float16x2', offset: 68, shaderLocation: 6},
+          {format: 'unorm16x4', offset: 12, shaderLocation: 15},
+          {format: 'uint32x2', offset: 36, shaderLocation: 5},
+          {format: 'sint32x3', offset: 96, shaderLocation: 9},
+          {format: 'uint8x4', offset: 20, shaderLocation: 8},
+          {format: 'snorm16x4', offset: 36, shaderLocation: 2},
+          {format: 'uint16x2', offset: 28, shaderLocation: 4},
+          {format: 'uint32x4', offset: 0, shaderLocation: 13},
+        ],
+      },
+      {arrayStride: 300, attributes: [{format: 'uint8x4', offset: 56, shaderLocation: 12}]},
+    ],
+  },
+  primitive: {cullMode: 'back'},
+});
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let computePassEncoder55 = commandEncoder64.beginComputePass();
+let sampler39 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', compare: 'less'});
+try {
+computePassEncoder55.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer1, 'uint16', 2, 1);
+} catch {}
+try {
+commandEncoder62.copyBufferToTexture({
+  /* bytesInLastRow: 552 widthInBlocks: 138 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 448 */
+  offset: 448,
+  buffer: buffer26,
+}, {
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 138, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame15 = new VideoFrame(img1, {timestamp: 0});
+let bindGroup31 = device0.createBindGroup({layout: veryExplicitBindGroupLayout8, entries: [{binding: 532, resource: textureView27}]});
+let buffer43 = device0.createBuffer({size: 112, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let computePassEncoder56 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder40.setBindGroup(0, bindGroup20, [0]);
+} catch {}
+try {
+computePassEncoder37.end();
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(6, buffer22, 0);
+} catch {}
+document.body.append(img1);
+canvas0.height = 406;
+let bindGroup32 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout1,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14, size: 376}},
+    {binding: 196, resource: textureView22},
+    {binding: 2, resource: {buffer: buffer15, offset: 0, size: 44}},
+  ],
+});
+let sampler40 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 87.60,
+});
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup19, new Uint32Array(1425), 135, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(125);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(2, buffer40);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer44 = device0.createBuffer({size: 8000, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let texture67 = device0.createTexture({
+  size: [2, 1, 179],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder57 = commandEncoder63.beginComputePass();
+try {
+computePassEncoder48.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 48, 33);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer40, 0, 11);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer31, 4, buffer17, 0, 4);
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture68 = device0.createTexture({
+  size: {width: 78, height: 10, depthOrArrayLayers: 8},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView62 = texture36.createView({mipLevelCount: 1});
+let computePassEncoder58 = commandEncoder42.beginComputePass();
+try {
+computePassEncoder40.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder62.copyBufferToBuffer(buffer25, 4, buffer38, 64, 0);
+} catch {}
+await gc();
+let bindGroup33 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 8, resource: externalTexture0},
+    {binding: 150, resource: {buffer: buffer37, size: 100}},
+    {binding: 221, resource: {buffer: buffer37, size: 168}},
+  ],
+});
+let renderPassEncoder11 = commandEncoder62.beginRenderPass({
+  colorAttachments: [{view: textureView35, loadOp: 'clear', storeOp: 'discard'}],
+  maxDrawCount: 92942605,
+});
+let sampler41 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 98.92});
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint16', 42, 11);
+} catch {}
+try {
+commandEncoder65.clearBuffer(buffer24);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder66 = device0.createCommandEncoder();
+let texture69 = device0.createTexture({
+  size: [156, 20, 1],
+  mipLevelCount: 3,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder59 = commandEncoder66.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder42); computePassEncoder42.dispatchWorkgroups(2); };
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer29, 8);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer30, 'uint16', 50, 14);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(3, buffer20, 0, 12);
+} catch {}
+let bindGroup34 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout2,
+  entries: [{binding: 7, resource: externalTexture2}, {binding: 0, resource: externalTexture3}],
+});
+try {
+computePassEncoder32.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer23, 'uint32', 84, 22);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 0, new Uint32Array(16352), 1329, 0);
+} catch {}
+let renderPassEncoder12 = commandEncoder65.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: -908.4, g: 457.8, b: 229.0, a: -274.6, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet0},
+});
+try {
+computePassEncoder55.setBindGroup(2, bindGroup3, new Uint32Array(454), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder19); computePassEncoder19.dispatchWorkgroups(3); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup26, []);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder3.draw(74, 173, 531_902_478, 313_034_117);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer9, 36);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline6);
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+    {binding: 7, visibility: GPUShaderStage.FRAGMENT, externalTexture: {}},
+  ],
+});
+let commandEncoder67 = device0.createCommandEncoder({});
+let commandBuffer6 = commandEncoder67.finish({});
+let texture70 = device0.createTexture({size: [156, 20, 11], format: 'rg16float', usage: GPUTextureUsage.COPY_SRC});
+let textureView63 = texture41.createView({dimension: '2d-array', format: 'depth24plus', baseMipLevel: 1, mipLevelCount: 1});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderPassEncoder3.draw(402, 9, 2_284_075_842, 617_235_158);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer7, 'uint32', 40, 10);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer18, 76, new Uint32Array(266), 16, 4);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 8, resource: externalTexture2},
+    {binding: 150, resource: {buffer: buffer15}},
+    {binding: 221, resource: {buffer: buffer12, offset: 0}},
+  ],
+});
+let sampler42 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', compare: 'greater-equal', maxAnisotropy: 1});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup16);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup1, new Uint32Array(813), 561, 0);
+} catch {}
+try {
+renderPassEncoder3.draw(136, 252, 1_481_003_772, 1_722_054_088);
+} catch {}
+try {
+renderPassEncoder3.drawIndexedIndirect(buffer15, 16);
+} catch {}
+try {
+renderPassEncoder3.drawIndirect(buffer0, 12);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 8, new Uint32Array(1614), 6, 0);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(171, 28);
+try {
+offscreenCanvas0.getContext('webgl');
+} catch {}
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthStencilFormat: 'depth24plus', depthReadOnly: true});
+let externalTexture4 = device0.importExternalTexture({source: videoFrame10, colorSpace: 'display-p3'});
+try {
+computePassEncoder42.end();
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder5.setVertexBuffer(4, buffer43);
+} catch {}
+try {
+commandEncoder48.clearBuffer(buffer33, 0, 24);
+} catch {}
+try {
+device0.queue.submit([commandBuffer5]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer33, 8, new Uint32Array(5661), 917, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(21_098).fill(35), /* required buffer size: 21_098 */
+{offset: 82, bytesPerRow: 69, rowsPerImage: 19}, {width: 10, height: 1, depthOrArrayLayers: 17});
+} catch {}
+let buffer45 = device0.createBuffer({
+  size: 17,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+});
+let renderBundle5 = renderBundleEncoder5.finish({});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer44, 'uint32', 1_804, 2_844);
+} catch {}
+document.body.append(canvas1);
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 2,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 196,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture71 = device0.createTexture({
+  size: {width: 32},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView64 = texture49.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 7});
+let computePassEncoder60 = commandEncoder31.beginComputePass();
+try {
+computePassEncoder58.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder60.setBindGroup(2, bindGroup35, new Uint32Array(4234), 275, 1);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let pipeline8 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule0,
+  targets: [{
+  format: 'rg16float',
+  writeMask: GPUColorWrite.ALL | GPUColorWrite.BLUE | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {unclippedDepth: true},
+});
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 14,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 44,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 76,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture72 = device0.createTexture({
+  size: {width: 156, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder61 = commandEncoder68.beginComputePass();
+try {
+computePassEncoder39.setBindGroup(1, bindGroup0);
+} catch {}
+let texture73 = device0.createTexture({
+  size: {width: 288, height: 60, depthOrArrayLayers: 1},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder62 = commandEncoder48.beginComputePass({timestampWrites: {querySet: querySet9, endOfPassWriteIndex: 365}});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup16, new Uint32Array(913), 94, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2, new Uint32Array(703), 30, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(11.31256465506124, 4.797608129442087, 3.849793462046103, 4.378930494397832, 0.1361085520536457, 0.8586581503410956);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer7, 'uint32', 16, 0);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline8);
+} catch {}
+let bindGroup36 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 150, resource: {buffer: buffer37, size: 112}},
+    {binding: 221, resource: {buffer: buffer15}},
+    {binding: 8, resource: externalTexture4},
+  ],
+});
+let commandBuffer7 = commandEncoder25.finish();
+let texture74 = device0.createTexture({size: [144, 30, 53], dimension: '2d', format: 'depth24plus', usage: GPUTextureUsage.COPY_SRC});
+let textureView65 = texture44.createView({});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup13, new Uint32Array(38), 0, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder47); computePassEncoder47.dispatchWorkgroupsIndirect(buffer25, 0); };
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder69.resolveQuerySet(querySet11, 9, 2, buffer32, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 26, y: 5, z: 13},
+  aspect: 'all',
+}, new Uint8Array(95).fill(181), /* required buffer size: 95 */
+{offset: 95, bytesPerRow: 305, rowsPerImage: 9}, {width: 26, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+document.body.prepend(img2);
+let bindGroup37 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 2, resource: {buffer: buffer45, size: 16}},
+    {binding: 196, resource: textureView0},
+  ],
+});
+try {
+computePassEncoder60.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(690);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, buffer40);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+let texture75 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 179},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder63 = commandEncoder69.beginComputePass({timestampWrites: {querySet: querySet2, endOfPassWriteIndex: 176}});
+try {
+computePassEncoder62.setBindGroup(0, bindGroup26, new Uint32Array(973), 309, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup18, new Uint32Array(2105), 1_009, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer3, 'uint32', 0, 7);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer11, 0, 38);
+} catch {}
+let pipeline9 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule0,
+  targets: [{format: 'rg16float', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.BLUE | GPUColorWrite.GREEN}],
+},
+  vertex: {module: shaderModule0, entryPoint: 'vertex0', buffers: []},
+});
+try {
+adapter0.label = '\uadd9\u1fd3\u5a01\uf2f9\u0d55\u0b4d\u192f\u{1faee}\u012c\u0257\u0390';
+} catch {}
+let textureView66 = texture65.createView({dimension: '2d', baseArrayLayer: 2});
+let texture76 = device0.createTexture({
+  size: [156, 20, 1],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'etc2-rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder49.setBindGroup(2, bindGroup31, new Uint32Array(1843), 853, 0);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup9);
+} catch {}
+let commandEncoder70 = device0.createCommandEncoder();
+try {
+computePassEncoder19.end();
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(4, buffer20, 24);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.TEXTURE_BINDING, alphaMode: 'opaque'});
+} catch {}
+let buffer46 = device0.createBuffer({size: 24, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder71 = device0.createCommandEncoder({});
+let texture77 = device0.createTexture({
+  size: {width: 626, height: 80, depthOrArrayLayers: 289},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView67 = texture8.createView({});
+let computePassEncoder64 = commandEncoder24.beginComputePass();
+let renderPassEncoder13 = commandEncoder70.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: 730.3, g: 322.4, b: 315.9, a: -488.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 4294967295},
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder58); computePassEncoder58.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+document.body.append(canvas1);
+let bindGroup38 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 14, resource: textureView55},
+    {binding: 44, resource: textureView21},
+    {binding: 76, resource: externalTexture3},
+  ],
+});
+let textureView68 = texture65.createView({dimension: '2d', baseArrayLayer: 93});
+let texture78 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 13},
+  sampleCount: 1,
+  format: 'etc2-rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(3, bindGroup21, new Uint32Array(1223), 38, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder36); computePassEncoder36.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup1, new Uint32Array(72), 1, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup39 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 150, resource: {buffer: buffer14}},
+    {binding: 8, resource: externalTexture0},
+    {binding: 221, resource: {buffer: buffer14}},
+  ],
+});
+let texture79 = device0.createTexture({
+  size: {width: 288, height: 60, depthOrArrayLayers: 1},
+  sampleCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder58.end();
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup29, new Uint32Array(24), 5, 0);
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+document.body.append(canvas1);
+let textureView69 = texture18.createView({baseArrayLayer: 5, arrayLayerCount: 5});
+let renderPassEncoder14 = commandEncoder71.beginRenderPass({
+  colorAttachments: [{
+  view: textureView65,
+  depthSlice: 15,
+  clearValue: { r: -447.7, g: -698.8, b: 148.9, a: -967.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  depthStencilAttachment: {
+    view: textureView31,
+    depthClearValue: 0.3140809835362788,
+    depthLoadOp: 'load',
+    depthStoreOp: 'discard',
+    stencilClearValue: 46386,
+    stencilReadOnly: false,
+  },
+  timestampWrites: {querySet: querySet7, beginningOfPassWriteIndex: 575},
+});
+try {
+computePassEncoder13.setBindGroup(0, bindGroup5, new Uint32Array(2406), 251, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder30); computePassEncoder30.dispatchWorkgroupsIndirect(buffer32, 8); };
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer3, 'uint32', 0, 8);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, buffer22);
+} catch {}
+try {
+device0.queue.submit([commandBuffer6]);
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let bindGroup40 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 221, resource: {buffer: buffer14, offset: 0, size: 268}},
+    {binding: 8, resource: externalTexture1},
+    {binding: 150, resource: {buffer: buffer40, size: 92}},
+  ],
+});
+let commandEncoder72 = device0.createCommandEncoder();
+let texture80 = device0.createTexture({size: [8, 5, 179], format: 'depth24plus', usage: GPUTextureUsage.COPY_SRC});
+let textureView70 = texture65.createView({dimension: '2d', baseArrayLayer: 36});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup21, new Uint32Array(279), 1, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(2, bindGroup10, new Uint32Array(1375), 218, 0);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer20, 0, 23);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 88, new Uint32Array(41812), 8376, 4);
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout7,
+  entries: [
+    {binding: 44, resource: textureView21},
+    {binding: 14, resource: textureView23},
+    {binding: 76, resource: externalTexture2},
+  ],
+});
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout11]});
+let texture81 = device0.createTexture({size: [156, 20, 44], format: 'rg16float', usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC});
+let computePassEncoder65 = commandEncoder42.beginComputePass();
+try {
+computePassEncoder60.setBindGroup(0, bindGroup9, new Uint32Array(6498), 823, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(2, buffer5, 60);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture15,
+  mipLevel: 1,
+  origin: {x: 3, y: 1, z: 18},
+  aspect: 'all',
+}, new Uint8Array(112_274).fill(146), /* required buffer size: 112_274 */
+{offset: 176, bytesPerRow: 157, rowsPerImage: 42}, {width: 7, height: 0, depthOrArrayLayers: 18});
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline3.getBindGroupLayout(0);
+let bindGroup42 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 2, resource: {buffer: buffer45, size: 16}},
+    {binding: 196, resource: textureView0},
+  ],
+});
+let texture82 = device0.createTexture({
+  size: {width: 156, height: 20, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder15 = commandEncoder72.beginRenderPass({
+  colorAttachments: [{
+  view: textureView35,
+  clearValue: { r: 90.91, g: 461.8, b: -24.18, a: -975.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder52.setBindGroup(2, bindGroup18);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup40, [0]);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder12.setViewport(2.474562870217143, 0.08004870379414886, 1.351396356570868, 9.671171781863169, 0.7641540824582527, 0.9594109717510728);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer22, 'uint16', 28, 48);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 196, resource: textureView66},
+    {binding: 2, resource: {buffer: buffer8, size: 28}},
+  ],
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true});
+let sampler43 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 76.23,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer5, 60, 27);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderBundleEncoder6.setPipeline(pipeline3);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer4, 0, 31);
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+let texture83 = device0.createTexture({
+  size: {width: 144, height: 30, depthOrArrayLayers: 70},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView71 = texture47.createView({});
+let computePassEncoder66 = commandEncoder73.beginComputePass();
+try {
+renderPassEncoder13.setIndexBuffer(buffer31, 'uint16', 4, 11);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder18.pushDebugGroup('\ue369');
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder();
+let sampler44 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+  maxAnisotropy: 1,
+});
+try {
+renderBundleEncoder6.setIndexBuffer(buffer10, 'uint16', 18, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(2, buffer43, 12, 9);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer43, 24, new Uint32Array(5228), 782, 0);
+} catch {}
+try {
+adapter0.label = '\u{1f807}\u01d6\u{1f998}\ub01f\ub32e\u0845\u{1feaf}\u{1f629}\ua0b1\uca56';
+} catch {}
+let buffer47 = device0.createBuffer({size: 76, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup0, new Uint32Array(862), 260, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(5, buffer20, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.COPY_DST, alphaMode: 'premultiplied'});
+} catch {}
+let texture84 = device0.createTexture({
+  size: {width: 156, height: 20, depthOrArrayLayers: 1},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture85 = device0.createTexture({
+  size: {width: 288, height: 60, depthOrArrayLayers: 261},
+  dimension: '3d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder67 = commandEncoder74.beginComputePass();
+try {
+computePassEncoder30.setBindGroup(1, bindGroup21);
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer3, 'uint16', 0, 2);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup18, new Uint32Array(6629), 11, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(6, buffer43, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 144, height: 30, depthOrArrayLayers: 70}
+*/
+{
+  source: videoFrame12,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture83,
+  mipLevel: 0,
+  origin: {x: 20, y: 1, z: 5},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView72 = texture84.createView({aspect: 'all', arrayLayerCount: 1});
+try {
+computePassEncoder67.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(0, buffer30);
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  label: '\u{1ff55}\u{1fe0e}\u{1fe16}\u02b4\ua9f9\u35a7',
+  layout: veryExplicitBindGroupLayout6,
+  entries: [
+    {binding: 221, resource: {buffer: buffer12}},
+    {binding: 8, resource: externalTexture3},
+    {binding: 150, resource: {buffer: buffer15, size: 108}},
+  ],
+});
+let commandEncoder75 = device0.createCommandEncoder({});
+let textureView73 = texture84.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let texture86 = device0.createTexture({
+  size: {width: 626, height: 80, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView74 = texture36.createView({mipLevelCount: 1});
+let computePassEncoder68 = commandEncoder75.beginComputePass();
+let sampler45 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 84.19,
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup14, new Uint32Array(754), 132, 1);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline2);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup20, [0]);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup3, new Uint32Array(1213), 17, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer44, 'uint16', 1_224, 207);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(5, buffer5, 28, 50);
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+let pipeline10 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'dst-alpha', dstFactor: 'one-minus-dst-alpha'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-src-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+let bindGroup45 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 44, resource: textureView21},
+    {binding: 14, resource: textureView12},
+    {binding: 76, resource: externalTexture4},
+  ],
+});
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: [72],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture88 = device0.createTexture({size: [32], dimension: '1d', format: 'rg8unorm', usage: GPUTextureUsage.COPY_DST});
+let renderPassEncoder16 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{view: textureView65, depthSlice: 55, loadOp: 'load', storeOp: 'discard'}],
+  depthStencilAttachment: {
+    view: textureView37,
+    depthClearValue: -3.2708022298584627,
+    depthLoadOp: 'load',
+    depthStoreOp: 'store',
+    stencilClearValue: 2020,
+  },
+  maxDrawCount: 110658989,
+});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthStencilFormat: 'depth24plus', stencilReadOnly: true});
+let renderBundle6 = renderBundleEncoder8.finish({});
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup34, new Uint32Array(504), 20, 0);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer22, 'uint32', 44, 67);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+await gc();
+let textureView75 = texture33.createView({format: 'rgba16uint', baseArrayLayer: 0});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup28);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline10);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 288, height: 60, depthOrArrayLayers: 261}
+*/
+{
+  source: img2,
+  origin: { x: 43, y: 30 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 126, y: 8, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt470m', transfer: 'pq'} });
+let texture89 = device0.createTexture({
+  size: [626],
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rgba16float'], stencilReadOnly: true});
+let renderBundle7 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup24, [0]);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(0, bindGroup43, new Uint32Array(521), 63, 0);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer7, 'uint16', 96, 17);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer27, 0);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup11);
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 532,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let textureView76 = texture87.createView({aspect: 'all'});
+let renderBundle8 = renderBundleEncoder7.finish({});
+try {
+computePassEncoder55.setBindGroup(0, bindGroup9, []);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup21, new Uint32Array(59), 5, 0);
+} catch {}
+try {
+renderPassEncoder10.drawIndexedIndirect(buffer37, 36);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer23, 'uint32', 4, 5);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline5);
+} catch {}
+let buffer48 = device0.createBuffer({size: 184, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let textureView77 = texture87.createView({});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup36, [0]);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(1, bindGroup42, new Uint32Array(76), 8, 0);
+} catch {}
+try {
+renderPassEncoder10.end();
+} catch {}
+try {
+renderPassEncoder13.setViewport(223.22135669808114, 69.04840217518843, 233.26773433681765, 10.440028034834333, 0.4423034498056382, 0.9312135981441823);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline9);
+} catch {}
+try {
+computePassEncoder18.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+globalThis.someLabel = computePassEncoder54.label;
+} catch {}
+let textureView78 = texture21.createView({dimension: '2d', aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 6});
+let renderPassEncoder17 = commandEncoder59.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: 658.0, g: 442.1, b: 725.4, a: 984.8, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 189516948,
+});
+try {
+computePassEncoder46.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle2, renderBundle2, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(7, 0, 2, 2);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(245);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer37, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer32, 16);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline8);
+} catch {}
+try {
+renderBundleEncoder9.setBindGroup(1, bindGroup15, new Uint32Array(612), 191, 1);
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm'], stencilReadOnly: true});
+let sampler46 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 94.93, compare: 'not-equal'});
+try {
+computePassEncoder30.setBindGroup(3, bindGroup21, new Uint32Array(416), 60, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup20, [0]);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup7, new Uint32Array(13), 2, 0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(217).fill(228), /* required buffer size: 217 */
+{offset: 217}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder78 = device0.createCommandEncoder();
+let computePassEncoder69 = commandEncoder77.beginComputePass();
+let renderBundle9 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder12.executeBundles([renderBundle7]);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let buffer49 = device0.createBuffer({size: 124, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let computePassEncoder70 = commandEncoder37.beginComputePass();
+let externalTexture5 = device0.importExternalTexture({label: '\u{1fc61}\ua072\u{1fecb}\u{1fdad}\u515a\u25f9\u7df9\u7a84\uce60', source: videoFrame14});
+try {
+computePassEncoder52.setBindGroup(1, bindGroup22, new Uint32Array(718), 353, 0);
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle2]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer5, 0);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup11, new Uint32Array(3472), 407, 0);
+} catch {}
+try {
+renderBundleEncoder10.setIndexBuffer(buffer22, 'uint32', 108, 9);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(6, buffer27, 0);
+} catch {}
+let promise12 = shaderModule1.getCompilationInfo();
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise9;
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 2, resource: {buffer: buffer37, size: 28}},
+    {binding: 196, resource: textureView59},
+  ],
+});
+let buffer50 = device0.createBuffer({size: 48, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder69.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle7, renderBundle0, renderBundle2, renderBundle2, renderBundle0, renderBundle0, renderBundle7, renderBundle7, renderBundle1, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer15, 'uint32', 40, 102);
+} catch {}
+let canvas2 = document.createElement('canvas');
+let buffer51 = device0.createBuffer({size: 400, usage: GPUBufferUsage.INDEX});
+let textureView79 = texture67.createView({mipLevelCount: 1, baseArrayLayer: 16, arrayLayerCount: 14});
+let renderPassEncoder18 = commandEncoder78.beginRenderPass({
+  colorAttachments: [{view: textureView35, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet11,
+  timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 337, endOfPassWriteIndex: 269},
+});
+let sampler47 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder6.setBindGroup(3, bindGroup22, new Uint32Array(427), 79, 0);
+} catch {}
+try {
+computePassEncoder30.end();
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer33, 'uint32', 12, 36);
+} catch {}
+let buffer52 = device0.createBuffer({size: 46, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroupsIndirect(buffer29, 4); };
+} catch {}
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline2);
+} catch {}
+try {
+  await buffer50.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer30, 0, buffer33, 24, 28);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 8, new Uint32Array(3656), 497, 12);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 45, y: 1, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(canvas0);
+try {
+externalTexture1.label = '\u{1fe75}\u0817\u0c31';
+} catch {}
+let commandEncoder79 = device0.createCommandEncoder({});
+let textureView80 = texture49.createView({dimension: '2d', aspect: 'depth-only', baseMipLevel: 0, mipLevelCount: 1});
+let computePassEncoder71 = commandEncoder34.beginComputePass();
+try {
+computePassEncoder22.setBindGroup(3, bindGroup35, new Uint32Array(1127), 436, 1);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: img0,
+  origin: { x: 18, y: 6 },
+  flipY: true,
+}, {
+  texture: texture86,
+  mipLevel: 0,
+  origin: {x: 105, y: 14, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 6, height: 3, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout12,
+  entries: [
+    {binding: 196, resource: textureView59},
+    {binding: 2, resource: {buffer: buffer15, offset: 0}},
+    {binding: 15, resource: {buffer: buffer14}},
+  ],
+});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 60});
+try {
+computePassEncoder46.setBindGroup(3, bindGroup20, new Uint32Array(2326), 130, 1);
+} catch {}
+try {
+renderPassEncoder16.setViewport(2.9046374188230244, 0.9202963213871325, 0.24434078889672142, 0.3766029368114603, 0.437307835208958, 0.6375758462721706);
+} catch {}
+try {
+commandEncoder77.resolveQuerySet(querySet4, 153, 0, buffer10, 0);
+} catch {}
+let computePassEncoder72 = commandEncoder77.beginComputePass();
+try {
+computePassEncoder72.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer20, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let gpuCanvasContext2 = canvas2.getContext('webgpu');
+document.body.append(img2);
+let imageBitmap0 = await createImageBitmap(videoFrame15);
+try {
+adapter0.label = '\u0bc6\u45e9\u1a9a\u4e9f\u{1f826}\u75b2\u01ab\u66b3\u2e13';
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+struct VertexOutput2 {
+  @location(9) f7: vec2f,
+  @builtin(position) f8: vec4f,
+  @location(3) @interpolate(flat, first) f9: vec2i,
+}
+
+var<workgroup> vw1: array<vec4<bool>, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+struct T0 {
+  @size(96) f0: vec4f,
+  @size(448) f1: array<array<mat4x2f, 1>, 9>,
+  @align(32) @size(384) f2: array<vec4<bool>, 6>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+/* zero global variables used */
+fn fn0(a0: ptr<private, vec2i>) {
+  vp4.f8 = vec4f(vp6[0][unconst_u32(1083668735)].yxyy);
+  let ptr4: ptr<private, VertexOutput2> = &vp3[0][unconst_u32(837319337)][unconst_u32(210369339)];
+  let ptr5: ptr<private, array<array<VertexOutput2, 1>, 1>> = &vp3[0];
+  for (var it0=u32((*a0)[1]); it0<(vec2u(vp3[unconst_u32(348444987)][0][unconst_u32(339201240)].f7)[0] & 0xfff); it0++) {
+  vp1.whole += vp3[unconst_u32(4294967295)][0][0].f7.rrrg;
+  vp3[0][0][unconst_u32(515621700)].f8 += vp3[unconst_u32(330291154)][0][0].f7.xxxy;
+  let ptr6: ptr<private, vec2i> = &vp6[unconst_u32(106767918)][7];
+  while bool(vp3[0][unconst_u32(1167857904)][unconst_u32(399483402)].f7.r) {
+  vp1 = modf(bitcast<vec4f>(vp3[unconst_u32(546410719)][0][0].f9.yxxy));
+  break;
+}
+  let ptr7: ptr<private, VertexOutput2> = &vp3[unconst_u32(1307298897)][unconst_u32(873998355)][unconst_u32(66025045)];
+  break;
+}
+  let vf21: f32 = (*ptr5)[unconst_u32(181978263)][unconst_u32(574253570)].f8[unconst_u32(308636579)];
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp7 = modf(vec3f(0.4539e-17, 0.3241, 0.05009e17));
+
+var<private> vp3: array<array<array<VertexOutput2, 1>, 1>, 1> = array<array<array<VertexOutput2, 1>, 1>, 1>(array<array<VertexOutput2, 1>, 1>());
+
+var<private> vp5: VertexOutput2 = VertexOutput2();
+
+var<private> vp4: VertexOutput2 = VertexOutput2();
+
+var<private> vp6: array<array<vec2i, 8>, 1> = array<array<vec2i, 8>, 1>(array<vec2i, 8>());
+
+var<private> vp2: vec4u = vec4u(259998185, 158223446, 213400286, 223744631);
+
+/* zero global variables used */
+fn fn1() {
+  vp1.whole *= vp5.f7.ggrr;
+  vp6[unconst_u32(1273683657)][unconst_u32(309890955)] = vec2i(vp3[unconst_u32(278933116)][0][unconst_u32(574248291)].f7);
+  for (var jj94=0u; jj94<3; jj94++) { vp3[unconst_u32(69164051)][jj94][unconst_u32(1470683606)].f8 = sqrt(vec2f(f32(vp4.f9[bitcast<u32>(vp3[unconst_u32(178214047)][0][unconst_u32(83479562)].f9[unconst_u32(1974523496)])]))).gggg; }
+  var vf22: vec2h = acos(vec2h(unconst_f16(-5591.5), unconst_f16(-9450.9)));
+  let ptr8: ptr<private, vec4f> = &vp3[0][0][0].f8;
+  let ptr9: ptr<private, array<VertexOutput2, 1>> = &vp3[0][unconst_u32(572523909)];
+  let ptr10: ptr<private, VertexOutput2> = &(*ptr9)[0];
+  vp2 <<= bitcast<vec4u>(vp3[unconst_u32(210506073)][0][unconst_u32(104399090)].f9.xyxy.xzzz);
+  vp5 = vp3[unconst_u32(1199110341)][0][0];
+  let vf23: i32 = vp4.f9[unconst_u32(775012656)];
+}
+
+var<private> vp1 = modf(vec4f(0.1938, 0.02868, 0.3454, 0.01843));
+
+/* zero global variables used */
+@vertex
+fn vertex2(@builtin(instance_index) a0: u32, @builtin(vertex_index) a1: u32) -> VertexOutput2 {
+  var out: VertexOutput2;
+  fn0(&vp6[u32(vp3[unconst_u32(374251040)][0][0].f9.r)][unconst_u32(373020710)]);
+  fn0(&vp5.f9);
+  fn0(&vp3[unconst_u32(214728869)][unconst_u32(805083678)][0].f9);
+  let ptr11: ptr<private, vec2i> = &vp5.f9;
+  let vf24: i32 = vp3[unconst_u32(118412724)][unconst_u32(592345649)][unconst_u32(918227984)].f9[unconst_u32(176771407)];
+  out.f7 = vp1.fract.xx;
+  let ptr12 = &vp7;
+  let ptr13: ptr<private, vec2i> = &vp3[0][0][0].f9;
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment2() -> @location(200) @interpolate(linear, center) vec2f {
+  var out: vec2f;
+  let vf25: vec4f = cosh(vec4f(unconst_f32(0.1540e21), unconst_f32(0.00471e-40), unconst_f32(-0.2252), unconst_f32(0.1377)));
+  fn1();
+  let ptr14: ptr<private, array<VertexOutput2, 1>> = &vp3[0][unconst_u32(54101862)];
+  let ptr15: ptr<private, vec2i> = &vp3[0][unconst_u32(282849573)][0].f9;
+  let ptr16: ptr<private, vec3f> = &vp7.fract;
+  let ptr17: ptr<private, vec4f> = &vp3[0][unconst_u32(66517540)][0].f8;
+  fn1();
+  loop {
+  let ptr18: ptr<private, array<vec2i, 8>> = &vp6[unconst_u32(936230109)];
+  vp5 = VertexOutput2(vp3[0][unconst_u32(715331640)][unconst_u32(1513515323)].f8.ba, vp3[0][unconst_u32(715331640)][unconst_u32(1513515323)].f8, bitcast<vec2i>(vp3[0][unconst_u32(715331640)][unconst_u32(1513515323)].f8.zx.rr));
+  fn1();
+  break;
+}
+  vp3[unconst_u32(470806706)][bitcast<vec4u>(vp3[unconst_u32(663036136)][0][unconst_u32(127173100)].f8.grra).a][unconst_u32(445006523)] = VertexOutput2(vec2f(bitcast<f32>((*ptr14)[unconst_u32(315756961)].f9[unconst_u32(1089969113)])), vec4f(f32((*ptr14)[unconst_u32(315756961)].f9[unconst_u32(1089969113)])), vec2i((*ptr14)[unconst_u32(315756961)].f9[unconst_u32(1089969113)]));
+  let vf26: f16 = cos(unconst_f16(8249.5));
+  vp1.whole = vp5.f8;
+  return out;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute2() {
+  vp1.fract *= vp3[unconst_u32(9847815)][0][unconst_u32(47941517)].f8;
+  workgroupBarrier();
+  while bool(vp3[unconst_u32(383840836)][0][pack2x16unorm(vp3[0][unconst_u32(401106168)][0].f7)].f9[1]) {
+  let vf27: f32 = vp3[0][0][unconst_u32(676813422)].f7[unconst_u32(1687360949)];
+}
+  let vf28: f32 = vp4.f7[unconst_u32(125873612)];
+  var vf29: f32 = vp5.f7[unconst_u32(292217218)];
+  let ptr19: ptr<private, VertexOutput2> = &vp3[0][0][0];
+}`,
+});
+let bindGroup48 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout5,
+  entries: [
+    {binding: 2, resource: {buffer: buffer12}},
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 196, resource: textureView68},
+  ],
+});
+let commandEncoder80 = device0.createCommandEncoder({});
+let commandBuffer8 = commandEncoder19.finish();
+let textureView81 = texture37.createView({dimension: '2d-array'});
+let renderPassEncoder19 = commandEncoder80.beginRenderPass({
+  colorAttachments: [{
+  view: textureView25,
+  clearValue: { r: 823.3, g: 964.4, b: 956.0, a: 714.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder13.setVertexBuffer(6, buffer28, 176, 10);
+} catch {}
+try {
+device0.queue.submit([commandBuffer7]);
+} catch {}
+let recycledExplicitBindGroupLayout6 = pipeline0.getBindGroupLayout(0);
+let bindGroup49 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 2, resource: {buffer: buffer14}},
+    {binding: 15, resource: {buffer: buffer14}},
+    {binding: 196, resource: textureView68},
+  ],
+});
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout11, veryExplicitBindGroupLayout6]});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup49);
+} catch {}
+try {
+computePassEncoder64.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup2, new Uint32Array(2794), 303, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+computePassEncoder46.insertDebugMarker('\u0ede');
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 44, resource: textureView30},
+    {binding: 14, resource: textureView55},
+    {binding: 76, resource: externalTexture4},
+  ],
+});
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup5, new Uint32Array(2573), 605, 0);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(95);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline10);
+} catch {}
+try {
+commandEncoder79.resolveQuerySet(querySet7, 139, 1, buffer10, 0);
+} catch {}
+await gc();
+let commandEncoder81 = device0.createCommandEncoder({});
+let texture90 = device0.createTexture({
+  size: {width: 32, height: 32, depthOrArrayLayers: 13},
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder15.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(1881);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline9);
+} catch {}
+let pipeline11 = device0.createComputePipeline({layout: pipelineLayout8, compute: {module: shaderModule2}});
+let texture91 = device0.createTexture({size: [576, 120, 1], mipLevelCount: 2, format: 'depth24plus', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+let computePassEncoder73 = commandEncoder79.beginComputePass({timestampWrites: {querySet: querySet7, beginningOfPassWriteIndex: 148}});
+let renderPassEncoder20 = commandEncoder81.beginRenderPass({
+  colorAttachments: [{
+  view: textureView21,
+  clearValue: { r: -933.4, g: 698.9, b: -484.8, a: -579.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder73.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline2);
+} catch {}
+let bindGroup51 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 14, resource: textureView23},
+    {binding: 44, resource: textureView17},
+    {binding: 76, resource: externalTexture2},
+  ],
+});
+let buffer53 = device0.createBuffer({size: 40, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder82 = device0.createCommandEncoder({});
+let computePassEncoder74 = commandEncoder82.beginComputePass({timestampWrites: {querySet: querySet9}});
+try {
+computePassEncoder74.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup40, new Uint32Array(3639), 63, 1);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer3, 'uint16', 2, 2);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let externalTexture6 = device0.importExternalTexture({source: videoFrame1, colorSpace: 'srgb'});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer0, 0); };
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer51, 'uint16', 0, 30);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline6);
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout3,
+  fragment: {module: shaderModule2, constants: {}, targets: [{format: 'rg16float', writeMask: GPUColorWrite.ALL}]},
+  vertex: {
+    module: shaderModule1,
+    buffers: [
+      {
+        arrayStride: 24,
+        attributes: [
+          {format: 'float32x4', offset: 0, shaderLocation: 7},
+          {format: 'unorm8x2', offset: 0, shaderLocation: 14},
+          {format: 'unorm16x2', offset: 4, shaderLocation: 1},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 15},
+          {format: 'uint8x4', offset: 4, shaderLocation: 8},
+          {format: 'float32', offset: 0, shaderLocation: 2},
+          {format: 'unorm8x4', offset: 0, shaderLocation: 6},
+          {format: 'uint8x2', offset: 2, shaderLocation: 11},
+          {format: 'snorm8x4', offset: 0, shaderLocation: 3},
+          {format: 'uint32x3', offset: 0, shaderLocation: 4},
+          {format: 'uint32', offset: 0, shaderLocation: 10},
+          {format: 'uint16x2', offset: 0, shaderLocation: 12},
+          {format: 'uint32x2', offset: 0, shaderLocation: 13},
+          {format: 'snorm16x4', offset: 0, shaderLocation: 0},
+          {format: 'uint16x2', offset: 12, shaderLocation: 5},
+          {format: 'sint8x4', offset: 0, shaderLocation: 9},
+        ],
+      },
+    ],
+  },
+  primitive: {
+  topology: 'line-strip',
+  stripIndexFormat: 'uint16',
+  frontFace: 'cw',
+  cullMode: 'none',
+  unclippedDepth: true,
+},
+});
+try {
+computePassEncoder33.label = '\u654b\u5171\u41cf';
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 44, resource: textureView35},
+    {binding: 14, resource: textureView12},
+    {binding: 76, resource: externalTexture5},
+  ],
+});
+let buffer54 = device0.createBuffer({
+  size: 64,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup39, new Uint32Array(213), 94, 1);
+} catch {}
+try {
+device0.queue.submit([commandBuffer8]);
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [
+    {binding: 76, resource: externalTexture1},
+    {binding: 44, resource: textureView10},
+    {binding: 14, resource: textureView55},
+  ],
+});
+let computePassEncoder75 = commandEncoder40.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder28); computePassEncoder28.dispatchWorkgroupsIndirect(buffer9, 212); };
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(5, buffer43, 0, 6);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 0, new DataView(new ArrayBuffer(10518)), 1202, 4);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let pipeline13 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {
+  module: shaderModule1,
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'subtract', srcFactor: 'one-minus-dst-alpha', dstFactor: 'constant'},
+    alpha: {operation: 'add', srcFactor: 'one-minus-dst-alpha', dstFactor: 'one-minus-dst'},
+  },
+  writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED,
+}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', cullMode: 'front'},
+});
+await gc();
+let bindGroup54 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout3,
+  entries: [
+    {binding: 76, resource: externalTexture5},
+    {binding: 14, resource: textureView55},
+    {binding: 44, resource: textureView17},
+  ],
+});
+let commandEncoder83 = device0.createCommandEncoder({});
+let computePassEncoder76 = commandEncoder83.beginComputePass({timestampWrites: {querySet: querySet0, endOfPassWriteIndex: 172}});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup40, new Uint32Array(509), 9, 1);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup21, new Uint32Array(1201), 148, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle8, renderBundle0, renderBundle0, renderBundle8]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture86,
+  mipLevel: 2,
+  origin: {x: 71, y: 3, z: 0},
+  aspect: 'all',
+}, new Uint8Array(262).fill(95), /* required buffer size: 262 */
+{offset: 262, bytesPerRow: 18}, {width: 3, height: 3, depthOrArrayLayers: 0});
+} catch {}
+canvas1.width = 561;
+let commandEncoder84 = device0.createCommandEncoder({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup29, new Uint32Array(5334), 636, 0);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer1, 'uint16', 0, 4);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline7);
+} catch {}
+let imageData4 = new ImageData(12, 36);
+let buffer55 = device0.createBuffer({size: 68, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let renderPassEncoder21 = commandEncoder84.beginRenderPass({
+  colorAttachments: [{view: textureView65, depthSlice: 13, loadOp: 'clear', storeOp: 'discard'}],
+  depthStencilAttachment: {view: textureView31, depthReadOnly: true, stencilClearValue: 47632},
+  timestampWrites: {querySet: querySet0, endOfPassWriteIndex: 95},
+  maxDrawCount: 93708090,
+});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup15, new Uint32Array(6653), 2_924, 1);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder66); computePassEncoder66.dispatchWorkgroupsIndirect(buffer25, 0); };
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder14.setViewport(2.367343196562257, 1.1941653732906448, 1.0437892623138387, 0.5876954090595751, 0.8618956757322128, 0.8840790295109994);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(6, buffer33);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture55,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(150).fill(179), /* required buffer size: 150 */
+{offset: 150}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler49 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'clamp-to-edge', lodMaxClamp: 89.51});
+try {
+computePassEncoder64.setBindGroup(3, bindGroup24, [0]);
+} catch {}
+await gc();
+let buffer56 = device0.createBuffer({size: 13664, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let texture92 = device0.createTexture({
+  size: {width: 288},
+  dimension: '1d',
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8unorm'],
+});
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer51, 'uint16', 52, 41);
+} catch {}
+let textureView82 = texture11.createView({mipLevelCount: 1});
+try {
+computePassEncoder40.setBindGroup(1, bindGroup31);
+} catch {}
+let texture93 = device0.createTexture({
+  size: {width: 576},
+  dimension: '1d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['rgba8uint'], depthStencilFormat: 'depth24plus', depthReadOnly: true});
+try {
+computePassEncoder60.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(7, buffer28, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture88,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(336).fill(82), /* required buffer size: 336 */
+{offset: 336}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let renderBundle11 = renderBundleEncoder11.finish({});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame6});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup48, new Uint32Array(1779), 516, 0);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer51, 'uint32', 8, 46);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 76, new Uint32Array(3193), 91, 0);
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline9.getBindGroupLayout(0);
+let bindGroup55 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout13,
+  entries: [
+    {binding: 44, resource: textureView17},
+    {binding: 14, resource: textureView55},
+    {binding: 76, resource: externalTexture3},
+  ],
+});
+let texture94 = device0.createTexture({
+  size: {width: 313},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let textureView83 = texture33.createView({format: 'rgba16uint'});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup48, new Uint32Array(913), 94, 0);
+} catch {}
+try {
+renderPassEncoder9.setPipeline(pipeline2);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let bindGroup56 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [
+    {binding: 196, resource: textureView68},
+    {binding: 2, resource: {buffer: buffer54}},
+    {binding: 15, resource: {buffer: buffer56, offset: 0}},
+  ],
+});
+let commandEncoder85 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'timestamp', count: 227});
+try {
+computePassEncoder23.setBindGroup(3, bindGroup25, [0]);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer44, 'uint32', 36, 764);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline1);
+} catch {}
+try {
+commandEncoder85.copyBufferToBuffer(buffer25, 0, buffer43, 12, 0);
+} catch {}
+try {
+commandEncoder85.insertDebugMarker('\u{1f7bc}');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 12, new Uint32Array(1135), 550, 0);
+} catch {}
+let recycledExplicitBindGroupLayout8 = pipeline7.getBindGroupLayout(0);
+let textureView84 = texture41.createView({dimension: '2d-array', aspect: 'depth-only', mipLevelCount: 1});
+let computePassEncoder77 = commandEncoder85.beginComputePass();
+let sampler50 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.79});
+let arrayBuffer0 = buffer50.getMappedRange(0, 0);
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer57 = device0.createBuffer({size: 88, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder86 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'timestamp', count: 263});
+let computePassEncoder78 = commandEncoder86.beginComputePass();
+try {
+computePassEncoder78.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline2);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 45},
+  aspect: 'all',
+}, new Uint8Array(14_939).fill(123), /* required buffer size: 14_939 */
+{offset: 251, bytesPerRow: 17, rowsPerImage: 72}, {width: 0, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout7]});
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture95 = device0.createTexture({
+  size: {width: 2, height: 1, depthOrArrayLayers: 179},
+  sampleCount: 1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder23.setPipeline(pipeline11);
+} catch {}
+try {
+computePassEncoder77.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setPipeline(pipeline13);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 4, y: 27 },
+  flipY: false,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 117, y: 30, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 15, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder79 = commandEncoder87.beginComputePass();
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup37, new Uint32Array(2100), 86, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(110); };
+} catch {}
+document.body.prepend(canvas0);
+let shaderModule3 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires pointer_composite_access;
+
+struct FragmentOutput2 {
+  @builtin(sample_mask) f0: u32,
+  @location(0) @interpolate(flat) f1: vec4f,
+}
+
+struct T1 {
+  @size(152) f0: array<array<vec2f, 1>>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T2 {
+  @align(2) @size(8) f0: bool,
+}
+
+struct VertexOutput3 {
+  @location(12) @interpolate(perspective, centroid) f10: vec4f,
+  @builtin(position) f11: vec4f,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(0) var et3: texture_external;
+
+/* used global variables: et3 */
+fn fn1(a0: ptr<function, VertexOutput3>) -> bool {
+  var out: bool;
+  let vf32: bool = (all((vec3f(unconst_f32(0.2352), unconst_f32(0.2879), unconst_f32(-0.08143e-11)) <= vec3f(unconst_f32(0.2544e-16), unconst_f32(0.1547), unconst_f32(0.2251e-30)))) || unconst_bool(true));
+  (*a0).f10 = vec4f(vec4f(unconst_f32(0.2817), unconst_f32(0.1420), unconst_f32(0.2002), unconst_f32(0.05615)));
+  while bool(quantizeToF16((*a0).f11[0])) {
+  out = bool(quantizeToF16(vec4f(unconst_f32(0.02213e8), unconst_f32(0.2634e-44), unconst_f32(0.05606e-41), unconst_f32(0.08227e21))).g);
+}
+  out = bool(max(vec3i(unconst_i32(667213110), unconst_i32(-1120245983), unconst_i32(272076534)), vec3i(unconst_i32(359889590), unconst_i32(667921694), unconst_i32(398503527)))[1]);
+  out = bool(refract(vec4h(unconst_f16(11216.2), unconst_f16(301.0), unconst_f16(-1669.7), unconst_f16(22811.5)), vec4h(max(vec3i(unconst_i32(193794424), unconst_i32(38067265), unconst_i32(655495703)), vec3i(unconst_i32(124560289), unconst_i32(128446480), unconst_i32(251324795))).grbr), unconst_f16(24354.6))[0]);
+  out = bool(pack4xU8(vec4u(unconst_u32(604779893), unconst_u32(16324163), unconst_u32(634056096), unconst_u32(2335474086))));
+  var vf33: f16 = exp2(unconst_f16(14930.9));
+  (*a0).f10 = vec4f( ~(vec4u(unconst_u32(360382021), unconst_u32(340743541), unconst_u32(840146573), unconst_u32(412571341)) / vec4u(unconst_u32(1106589414), unconst_u32(642993739), unconst_u32(323651688), unconst_u32(857460627))).rg.yxxx.wzxx);
+  let vf34: f16 = exp2(unconst_f16(2938.8));
+  return out;
+  _ = et3;
+}
+
+struct T0 {
+  @align(32) @size(320) f0: vec4<bool>,
+}
+
+/* zero global variables used */
+@must_use 
+fn fn0() -> vec2f {
+  var out: vec2f;
+  var vf30: vec2f = smoothstep(vec2f(unconst_f32(-0.1780), unconst_f32(0.8861e-37)), vec2f(unconst_f32(0.5742e-34), unconst_f32(0.00120)), vec2f(unconst_f32(0.06398), unconst_f32(0.02017e27)));
+  let vf31: vec4<bool> =  !vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true), unconst_bool(false));
+  out = vec2f(f32((unconst_f16(13274.2) >= acos(unconst_f16(12907.4)))));
+  let ptr20: ptr<function, vec2f> = &vf30;
+  out = vec2f(exp(unconst_f32(0.1577)));
+  return out;
+}
+
+/* used global variables: et3 */
+@vertex
+fn vertex3() -> VertexOutput3 {
+  var out: VertexOutput3;
+  out.f11 *= vec4f(f32(pack4xI8(vec4i(unconst_i32(262952249), unconst_i32(134399999), unconst_i32(172995941), unconst_i32(876650065)))));
+  out.f10 = vec4f(f32((unconst_i32(6237822) & unconst_i32(7324547))));
+  let vf35: vec2u = textureDimensions(et3);
+  out.f11 = vec4f(textureDimensions(et3).xyyx.gbar);
+  out.f10 *= unpack4x8snorm(vf35[unconst_u32(2043034753)]);
+  var vf36: u32 = pack4xI8(vec4i(unconst_i32(150230938), unconst_i32(192462653), unconst_i32(38803687), unconst_i32(113007446)));
+  out.f11 += vec4f(f32(vf35[unconst_u32(2132046346)]));
+  out.f10 = vec4f(transpose(mat4x2h(unconst_f16(-7739.2), unconst_f16(19757.3), unconst_f16(47.31), unconst_f16(20278.4), unconst_f16(55000.3), unconst_f16(635.2), unconst_f16(4223.3), unconst_f16(-6327.5)))[unconst_i32(1)]);
+  _ = et3;
+  return out;
+  _ = et3;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment3() -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf37: mat3x4h = (mat3x4h(unconst_f16(3098.0), unconst_f16(23953.6), unconst_f16(11585.1), unconst_f16(27015.0), unconst_f16(521.3), unconst_f16(634.6), unconst_f16(7430.6), unconst_f16(33370.4), unconst_f16(25148.1), unconst_f16(-1592.1), unconst_f16(1405.5), unconst_f16(-18763.4)) * mat3x3h(unconst_f16(5323.6), unconst_f16(286.6), unconst_f16(3028.8), unconst_f16(3162.4), unconst_f16(25635.9), unconst_f16(8274.2), unconst_f16(7576.0), unconst_f16(15756.4), unconst_f16(773.1)));
+  return out;
+}
+
+/* used global variables: et3 */
+@compute @workgroup_size(1, 1, 2)
+fn compute3() {
+  var vf38: vec3<bool> = (vec3u(unconst_u32(915419077), unconst_u32(297917142), unconst_u32(47323139)) == vec3u((vec3f(unconst_f32(0.2659e36), unconst_f32(0.3434e37), unconst_f32(0.4772e14)) > vec3f(unconst_f32(0.1378), unconst_f32(0.00287e-42), unconst_f32(0.2083e-44))).zxz));
+  vf38 = vec3<bool>(vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true)));
+  var vf39: vec2h = log2(vec2h(unconst_f16(12291.6), unconst_f16(7842.9)));
+  _ = et3;
+}`,
+});
+let sampler51 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMinClamp: 31.95});
+try {
+computePassEncoder57.setBindGroup(1, bindGroup32);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(0, bindGroup12, new Uint32Array(1531), 89, 0);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder21.executeBundles([renderBundle5]);
+} catch {}
+try {
+computePassEncoder51.insertDebugMarker('\u3830');
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder();
+let computePassEncoder80 = commandEncoder88.beginComputePass();
+try {
+computePassEncoder80.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer31, 'uint32', 0, 6);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+let buffer58 = device0.createBuffer({size: 124, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame13});
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer11);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 8, new Uint32Array(4857), 6, 8);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires readonly_and_readwrite_storage_textures;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<workgroup> vw2: S2;
+
+struct T0 {
+  @align(8) @size(8) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(0) @binding(7) var et6: texture_external;
+
+struct FragmentOutput3 {
+  @location(3) @interpolate(flat) f0: vec4f,
+  @location(0) @interpolate(flat) f1: vec4u,
+  @builtin(sample_mask) f2: u32,
+  @builtin(frag_depth) f3: f32,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S2 {
+  @location(5) @interpolate(flat) f0: u32,
+  @location(4) f1: vec2f,
+  @location(8) f2: f16,
+}
+
+struct T1 {
+  @align(32) @size(384) f0: T0,
+}
+
+alias vec3b = vec3<bool>;
+
+@group(0) @binding(0) var et5: texture_external;
+
+/* used global variables: et5 */
+@vertex
+fn vertex4(a0: S2) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf40: vec3h = radians(vec3h(unconst_f16(9851.1), unconst_f16(27345.7), unconst_f16(-1496.7)));
+  vf40 = vec3h(vf40[unconst_u32(671168929)]);
+  out = asinh(vec4f(unconst_f32(0.02274e-7), unconst_f32(-0.1552e-5), unconst_f32(0.00061e8), unconst_f32(0.1453e-35)));
+  let vf41: vec4f = asinh(vec4f(sqrt(unconst_f32(0.05971e6))));
+  loop {
+  out = (vec2f(unconst_f32(0.3170), unconst_f32(-0.02472e-5)) % unconst_f32(-0.01171e-30)).grrg;
+  let vf42: vec2f = unpack2x16float(unconst_u32(606613129));
+  var vf43: bool = any(unconst_bool(true));
+  var vf44: vec4h = faceForward(bitcast<vec4h>(a0.f1), vec4h(unconst_f16(2515.3), unconst_f16(8437.6), unconst_f16(6500.4), unconst_f16(-12690.2)), vec4h(unconst_f16(404.5), unconst_f16(5676.6), unconst_f16(5197.4), unconst_f16(46310.3)));
+  let vf45: vec2u = textureDimensions(et5);
+  out = vec4f(f32(a0.f2));
+  break;
+  _ = et5;
+}
+  return out;
+  _ = et5;
+}
+
+/* used global variables: et5, et6 */
+@fragment
+fn fragment4() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  var vf46: u32 = pack4x8unorm(unpack4x8unorm(pack4x8unorm(vec4f(unconst_f32(0.2982e6), unconst_f32(0.00206e19), unconst_f32(0.1606), unconst_f32(0.1413e-8)))));
+  var vf47: vec2u = textureDimensions(et5);
+  _ = et5;
+  let vf48: u32 = pack4x8unorm(vec4f(unconst_f32(0.2177), unconst_f32(0.4346e-38), unconst_f32(0.08480), unconst_f32(0.1656e-31)));
+  vf47 ^= textureDimensions(et6);
+  return out;
+  _ = et5;
+  _ = et6;
+}
+
+/* used global variables: et5 */
+@compute @workgroup_size(1, 1, 1)
+fn compute4() {
+  loop {
+  vw2.f1 -= vec2f((*&vw2).f1[unconst_u32(412863820)]);
+  switch bitcast<vec2i>(vw2.f1)[1] { 
+  default {
+  vw2.f2 = normalize(vec2h(unconst_f16(2106.2), unconst_f16(4892.6))).y;
+  workgroupBarrier();
+  vw2.f1 *= vec2f(normalize(vec2h(unconst_f16(27981.2), unconst_f16(9128.9))));
+  vw2.f2 *= f16(textureLoad(et5, vec2u(unconst_u32(132030570), unconst_u32(799663656))).g);
+  _ = et5;
+}
+  }
+  let vf49: vec3f = ldexp(vec3f(unconst_f32(0.5552), unconst_f32(0.06687e-6), unconst_f32(0.1199)), vec3i(unconst_i32(278297016), unconst_i32(319994130), unconst_i32(-622225480)));
+  break;
+  _ = et5;
+}
+  var vf50: vec3i = firstTrailingBit(vec3i(unconst_i32(410345186), unconst_i32(28830173), unconst_i32(-121178934)));
+  if bool(clamp(vec2i(unconst_i32(29486497), unconst_i32(78284316)), vec2i(unconst_i32(158388221), unconst_i32(182920664)), vec2i(unconst_i32(216391998), unconst_i32(-437907835))).y) {
+  var vf51: vec2<bool> =  !vec2<bool>(bool((*&vw2).f0));
+  while bool((*&vw2).f0) {
+  var vf52: vec4f = unpack4x8unorm(u32((vec4i(unconst_i32(117359499), unconst_i32(-1201632220), unconst_i32(-220823220), unconst_i32(59033039)) << vec4u(unconst_u32(982827389), unconst_u32(205721834), unconst_u32(119155652), unconst_u32(108767541))).a));
+  let vf53: vec4u = (vec4u(vw2.f1.xxxx) ^ vec4u(unconst_u32(71743292), unconst_u32(112218444), unconst_u32(1486061234), unconst_u32(806265616)));
+}
+  let ptr21: ptr<workgroup, vec2f> = &vw2.f1;
+}
+  vf50 -= bitcast<vec3i>(textureDimensions(et5).grr.gbr.ggb.rbb.brb.xzz.yxy.zxy);
+  vw2.f1 = vec2f(sin(unconst_f32(0.09721e-24)));
+  vw2.f2 *= vw2.f2;
+  let vf54: bool = any(vec4<bool>(bool(extractBits(bitcast<i32>(mix(unconst_f32(-0.04469e31), unconst_f32(0.3381e-44), bitcast<f32>(dot(vec4u(unconst_u32(2097145710), unconst_u32(1030955467), unconst_u32(281539222), unconst_u32(298483966)), vec4u(vw2.f1.xxyx))))), unconst_u32(1778775268), unconst_u32(836612131)))));
+  for (var it1=textureDimensions(et5)[1]; it1<(bitcast<u32>((*&vw2).f1[unconst_u32(284535241)]) & 0xfff); it1++) {
+  var vf55: vec2h = atan2(vec2h(unconst_f16(6447.6), unconst_f16(1307.1)), vec2h(unconst_f16(27840.4), unconst_f16(147.1)));
+  vf55 -= vec2h(workgroupUniformLoad(&vw2).f2);
+  let vf56: u32 = firstTrailingBit(u32(vw2.f2));
+  let ptr22: ptr<workgroup, vec2f> = &(*&vw2).f1;
+  vw2.f1 += bitcast<vec2f>((vec4u(unconst_u32(149355887), unconst_u32(419084072), unconst_u32(230518015), unconst_u32(191220049)) & vec4u(unconst_u32(1320479088), unconst_u32(671659238), unconst_u32(433353121), unconst_u32(146434705))).ar);
+}
+  vw2.f0 += bitcast<u32>(mix(unconst_f32(0.02995e-45), f32(any((vec3u(unconst_u32(1602982985), unconst_u32(782561207), unconst_u32(140374663)) > vec3u(sin(vec4f(unconst_f32(0.02733), unconst_f32(0.1068), unconst_f32(0.1862), unconst_f32(0.08977))).aaa.bgr.xxx.brg.zxy)))), unconst_f32(-0.00927)));
+  var vf57: vec3i = (vec3i((*&vw2).f1.grr) << vec3u(unconst_u32(2137533465), unconst_u32(1818010584), unconst_u32(340131725)));
+  _ = et5;
+}`,
+});
+let buffer59 = device0.createBuffer({size: 592, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let commandEncoder89 = device0.createCommandEncoder({});
+let textureView85 = texture36.createView({mipLevelCount: 1});
+let computePassEncoder81 = commandEncoder89.beginComputePass();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+try {
+computePassEncoder79.setBindGroup(3, bindGroup46);
+} catch {}
+try {
+computePassEncoder81.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2, renderBundle7, renderBundle0, renderBundle7, renderBundle2]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup24, [0]);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(0, bindGroup9, new Uint32Array(107), 2, 0);
+} catch {}
+try {
+renderBundleEncoder13.setVertexBuffer(7, buffer48, 0, 88);
+} catch {}
+try {
+  await promise13;
+} catch {}
+let textureView86 = texture11.createView({arrayLayerCount: 1});
+try {
+computePassEncoder70.setBindGroup(0, bindGroup48);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder46); computePassEncoder46.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder66.end();
+} catch {}
+try {
+computePassEncoder80.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline6);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 179}
+*/
+{
+  source: imageData1,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 56},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder90 = device0.createCommandEncoder({});
+let computePassEncoder82 = commandEncoder73.beginComputePass();
+try {
+computePassEncoder82.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(2, bindGroup45, new Uint32Array(5236), 1_738, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer22, 'uint32', 24, 182);
+} catch {}
+try {
+renderPassEncoder17.setVertexBuffer(4, buffer54, 0);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(1, bindGroup52, new Uint32Array(2374), 7, 0);
+} catch {}
+let commandEncoder91 = device0.createCommandEncoder();
+let textureView87 = texture3.createView({});
+let computePassEncoder83 = commandEncoder91.beginComputePass();
+let sampler52 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+  maxAnisotropy: 9,
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame10, colorSpace: 'srgb'});
+try {
+computePassEncoder56.setBindGroup(3, bindGroup53, new Uint32Array(416), 1, 0);
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer55, 'uint32', 4, 9);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup38, []);
+} catch {}
+let buffer60 = device0.createBuffer({size: 276, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder2.draw(682, 0, 2_081_427_388);
+} catch {}
+try {
+renderPassEncoder2.drawIndexedIndirect(buffer29, 0);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer9, 128);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer45, 'uint32', 4, 1);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderBundleEncoder13.setBindGroup(3, bindGroup51, new Uint32Array(2337), 129, 0);
+} catch {}
+try {
+renderBundleEncoder13.insertDebugMarker('\u4d54');
+} catch {}
+let pipeline14 = await device0.createComputePipelineAsync({
+  label: '\uffe9\u{1f81e}\u2ed1\ua368\u0103\u1994',
+  layout: pipelineLayout2,
+  compute: {module: shaderModule2, entryPoint: 'compute2', constants: {}},
+});
+let videoFrame17 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt709', transfer: 'bt2020_12bit'} });
+let commandBuffer9 = commandEncoder65.finish();
+let texture96 = device0.createTexture({
+  size: [626, 80, 10],
+  mipLevelCount: 4,
+  dimension: '2d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rg8unorm']});
+let renderBundle13 = renderBundleEncoder13.finish({});
+let sampler53 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', magFilter: 'linear'});
+try {
+renderPassEncoder2.draw(627, 0, 2_277_051_535);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer29, 4);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer39, 'uint32', 0, 1);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(buffer16, 60, buffer37, 68, 4);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(20); };
+} catch {}
+let computePassEncoder84 = commandEncoder90.beginComputePass({timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 288, endOfPassWriteIndex: 361}});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup34, new Uint32Array(2871), 959, 0);
+} catch {}
+try {
+renderPassEncoder18.setBindGroup(3, bindGroup18);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup30, new Uint32Array(2293), 126, 0);
+} catch {}
+try {
+renderPassEncoder2.draw(437, 0, 384_248_583);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer54, 16);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer3, 'uint32', 0, 1);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(0, buffer27, 0);
+} catch {}
+try {
+renderBundleEncoder14.setVertexBuffer(7, buffer20, 0, 45);
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout8,
+  fragment: {module: shaderModule0, targets: [{format: 'rg16float', writeMask: 0}]},
+  vertex: {module: shaderModule3, constants: {}, buffers: []},
+  primitive: {
+  topology: 'triangle-strip',
+  stripIndexFormat: 'uint32',
+  frontFace: 'cw',
+  cullMode: 'front',
+  unclippedDepth: true,
+},
+});
+try {
+  await promise11;
+} catch {}
+let bindGroup57 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [
+    {binding: 196, resource: textureView22},
+    {binding: 2, resource: {buffer: buffer49}},
+    {binding: 15, resource: {buffer: buffer56}},
+  ],
+});
+let sampler54 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMinClamp: 53.24,
+  lodMaxClamp: 60.13,
+  compare: 'greater-equal',
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder49); computePassEncoder49.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 0, 0, 33_680_778);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer52, 'uint16', 4, 5);
+} catch {}
+await gc();
+let videoFrame18 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'bt470m', transfer: 'iec6196624'} });
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder85 = commandEncoder92.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder63); computePassEncoder63.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup47);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup15, new Uint32Array(770), 174, 1);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer33, 'uint32', 12, 2);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer52, 'uint16', 14, 2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 16, new Uint32Array(18879), 3938, 8);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 0, 0, 686_280_800);
+} catch {}
+try {
+renderPassEncoder2.drawIndirect(buffer37, 20);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(3, buffer27, 0);
+} catch {}
+let imageData5 = new ImageData(12, 20);
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder93 = device0.createCommandEncoder({});
+let texture97 = device0.createTexture({size: [626, 80, 1], mipLevelCount: 1, format: 'rg8unorm', usage: GPUTextureUsage.COPY_SRC});
+let textureView88 = texture89.createView({dimension: '1d', mipLevelCount: 1});
+let renderPassEncoder22 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView47,
+  clearValue: { r: -47.93, g: 688.1, b: 149.3, a: -488.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet1, beginningOfPassWriteIndex: 587, endOfPassWriteIndex: 334},
+});
+let sampler55 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 86.90,
+});
+try {
+computePassEncoder29.setBindGroup(1, bindGroup25, [0]);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup10, new Uint32Array(595), 22, 0);
+} catch {}
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+computePassEncoder85.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder21.setStencilReference(90);
+} catch {}
+try {
+renderPassEncoder2.drawIndexed(0, 0, 0, 324_892_162);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer31, 'uint32', 36, 1);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer4, 0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(1, bindGroup13, new Uint32Array(2882), 488, 0);
+} catch {}
+document.body.prepend(img0);
+let buffer61 = device0.createBuffer({size: 325, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let commandEncoder94 = device0.createCommandEncoder({label: '\u{1fb36}\u{1f98b}\u{1fd84}\ude58\u0256\u{1f76f}\u6e24\u14ec\u{1ffea}\u{1fda9}\u5e46'});
+let commandBuffer10 = commandEncoder7.finish();
+let computePassEncoder86 = commandEncoder94.beginComputePass();
+let renderBundle14 = renderBundleEncoder14.finish({label: '\u0dc9\u62d6\u8634\u7a62\u115e\ufd60\u00fc\u69a7\u{1fc61}'});
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(3, 109, 0, 383_994_348, 663_925_790);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer29, 0);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+document.body.prepend(canvas1);
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let texture98 = device0.createTexture({
+  size: [16, 10, 179],
+  sampleCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup19);
+} catch {}
+try {
+computePassEncoder46.setBindGroup(2, bindGroup22, new Uint32Array(869), 61, 0);
+} catch {}
+try {
+computePassEncoder47.end();
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(3, bindGroup52);
+} catch {}
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer37, 16);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer30, 'uint32', 84, 53);
+} catch {}
+try {
+renderPassEncoder7.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(2, undefined);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder({});
+let computePassEncoder87 = commandEncoder18.beginComputePass();
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup37);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer5, 8);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(3, buffer49, 36, 1);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 626, height: 80, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture30,
+  mipLevel: 0,
+  origin: {x: 8, y: 21, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandBuffer11 = commandEncoder53.finish({});
+let textureView89 = texture29.createView({dimension: '2d-array', baseArrayLayer: 19, arrayLayerCount: 3});
+let computePassEncoder88 = commandEncoder95.beginComputePass();
+let sampler56 = device0.createSampler({addressModeU: 'repeat', magFilter: 'nearest', lodMaxClamp: 60.18});
+try {
+computePassEncoder72.setBindGroup(3, bindGroup14, new Uint32Array(214), 34, 1);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(3, 267, 3, 372_022_937, 2_530_538_754);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 0, new DataView(new ArrayBuffer(9070)), 1248, 8);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 288, height: 60, depthOrArrayLayers: 261}
+*/
+{
+  source: imageData2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 12, y: 2, z: 56},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+try {
+  await promise12;
+} catch {}
+let imageData6 = new ImageData(20, 60);
+let commandEncoder96 = device0.createCommandEncoder({});
+try {
+computePassEncoder63.setBindGroup(0, bindGroup55, []);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 4, 0, 523_350_618, 328_525_288);
+} catch {}
+try {
+renderPassEncoder8.drawIndexedIndirect(buffer54, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndirect(buffer37, 40);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer51, 'uint16', 96, 82);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+buffer55.unmap();
+} catch {}
+let computePassEncoder89 = commandEncoder96.beginComputePass();
+let externalTexture10 = device0.importExternalTexture({source: videoFrame14, colorSpace: 'srgb'});
+try {
+computePassEncoder88.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup30, new Uint32Array(4154), 1_169, 0);
+} catch {}
+try {
+renderPassEncoder8.drawIndexed(0, 157, 2, 71_682_672, 292_535_699);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer55, 'uint32', 8, 20);
+} catch {}
+try {
+renderPassEncoder19.setPipeline(pipeline3);
+} catch {}
+try {
+buffer60.unmap();
+} catch {}
+let texture99 = gpuCanvasContext1.getCurrentTexture();
+let sampler57 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', compare: 'greater-equal'});
+try {
+computePassEncoder43.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer45, 'uint16', 8, 0);
+} catch {}
+document.body.prepend(img2);
+let commandEncoder97 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder55.beginComputePass({timestampWrites: {querySet: querySet9}});
+let sampler58 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 65.05,
+  maxAnisotropy: 14,
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup33, [0]);
+} catch {}
+try {
+computePassEncoder21.setBindGroup(0, bindGroup28, new Uint32Array(2420), 31, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder5); computePassEncoder5.dispatchWorkgroupsIndirect(buffer25, 0); };
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0, renderBundle7, renderBundle2, renderBundle2, renderBundle0, renderBundle2, renderBundle7, renderBundle2]);
+} catch {}
+try {
+buffer29.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer6, 40, new BigUint64Array(2693), 1756, 0);
+} catch {}
+let videoFrame19 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpteRp431', transfer: 'iec6196624'} });
+try {
+computePassEncoder87.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(0, bindGroup54, new Uint32Array(541), 158, 0);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(3, buffer44);
+} catch {}
+try {
+commandEncoder97.copyBufferToBuffer(buffer25, 4, buffer24, 56, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 2, height: 1, depthOrArrayLayers: 179}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture25,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 97},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView90 = texture40.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder91 = commandEncoder97.beginComputePass();
+try {
+computePassEncoder46.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture6,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(113).fill(225), /* required buffer size: 113 */
+{offset: 113}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline16 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout7,
+  fragment: {module: shaderModule2, entryPoint: 'fragment2', constants: {}, targets: [{format: 'rg16float'}]},
+  vertex: {module: shaderModule2, entryPoint: 'vertex2', buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'ccw', cullMode: 'back'},
+});
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let textureView91 = texture65.createView({dimension: '2d', format: 'r32sint', mipLevelCount: 1, baseArrayLayer: 10});
+try {
+computePassEncoder89.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer10, commandBuffer9]);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(25); };
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+try {
+  await promise14;
+} catch {}
+document.body.append(canvas1);
+let buffer62 = device0.createBuffer({size: 208, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder98 = device0.createCommandEncoder({});
+let texture100 = gpuCanvasContext1.getCurrentTexture();
+let textureView92 = texture84.createView({dimension: '2d-array'});
+let computePassEncoder92 = commandEncoder98.beginComputePass({timestampWrites: {querySet: querySet13, beginningOfPassWriteIndex: 220, endOfPassWriteIndex: 185}});
+try {
+computePassEncoder32.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroupsIndirect(buffer45, 0); };
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline14);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup3, new Uint32Array(289), 11, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame7.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+videoFrame17.close();
+videoFrame19.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.h
+++ b/Source/WebGPU/WebGPU/BindGroup.h
@@ -100,7 +100,7 @@ public:
 
     const BufferAndType* dynamicBuffer(uint32_t) const;
     uint32_t dynamicOffset(uint32_t bindingIndex, const Vector<uint32_t>*) const;
-    void rebindSamplersIfNeeded() const;
+    bool rebindSamplersIfNeeded() const;
     bool updateExternalTextures(ExternalTexture&);
     bool makeSubmitInvalid(ShaderStage, const BindGroupLayout*) const;
     const SamplersContainer& samplers() const { return m_samplers; }

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1349,10 +1349,10 @@ static bool WARN_UNUSED_RETURN setArgumentBuffer(id<MTLArgumentEncoder> encoder,
     return true;
 }
 
-void BindGroup::rebindSamplersIfNeeded() const
+bool BindGroup::rebindSamplersIfNeeded() const
 {
     if (!m_bindGroupLayout)
-        return;
+        return true;
 
     for (auto& [samplerRefPtr, shaderStageArray] : m_samplers) {
         auto sampler = samplerRefPtr;
@@ -1362,6 +1362,8 @@ void BindGroup::rebindSamplersIfNeeded() const
 
         WTFLogAlways("Rebinding of samplers required, if this occurs frequently the application is using too many unique samplers");
         id<MTLSamplerState> samplerState = sampler->samplerState();
+        if (!samplerState)
+            return false;
         if (shaderStageArray[ShaderStage::Vertex].has_value() && setArgumentBuffer(m_bindGroupLayout->vertexArgumentEncoder(), vertexArgumentBuffer()))
             [m_bindGroupLayout->vertexArgumentEncoder() setSamplerState:samplerState atIndex:*shaderStageArray[ShaderStage::Vertex]];
 
@@ -1371,6 +1373,7 @@ void BindGroup::rebindSamplersIfNeeded() const
         if (shaderStageArray[ShaderStage::Compute].has_value() && setArgumentBuffer(m_bindGroupLayout->computeArgumentEncoder(), computeArgumentBuffer()))
             [m_bindGroupLayout->computeArgumentEncoder() setSamplerState:samplerState atIndex:*shaderStageArray[ShaderStage::Compute]];
     }
+    return true;
 }
 
 bool BindGroup::updateExternalTextures(ExternalTexture& externalTexture)

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -615,7 +615,7 @@ void Buffer::skippedDrawIndexedValidation(CommandEncoder& commandEncoder, uint32
     CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
     commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, weakCommandEncoder = WeakPtr { commandEncoder }, firstIndex, indexCount, vertexCount, instanceCount, indexType, firstInstance, primitiveOffset, baseVertex, minInstanceCount](CommandBuffer& commandBuffer) {
         if (!weakThis.get() || !weakCommandEncoder)
-            return;
+            return true;
 
         RefPtr protectedThis = weakThis.get();
         RefPtr protectedCommandEncoder = weakCommandEncoder.get();
@@ -626,6 +626,7 @@ void Buffer::skippedDrawIndexedValidation(CommandEncoder& commandEncoder, uint32
                 protectedThis->m_mustTakeSlowIndexValidationPath = false;
             });
         }
+        return true;
     });
 }
 
@@ -637,7 +638,7 @@ void Buffer::skippedDrawIndirectIndexedValidation(CommandEncoder& commandEncoder
     CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
     commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, apiIndexBuffer = RefPtr { apiIndexBuffer }, weakCommandEncoder = WeakPtr { commandEncoder }, indexType, indexBufferOffsetInBytes, indirectOffset, minVertexCount, minInstanceCount, primitiveType](CommandBuffer& commandBuffer) {
         if (!weakThis.get() || !weakCommandEncoder)
-            return;
+            return true;
 
         RefPtr protectedThis = weakThis.get();
         RefPtr protectedCommandEncoder = weakCommandEncoder.get();
@@ -648,6 +649,7 @@ void Buffer::skippedDrawIndirectIndexedValidation(CommandEncoder& commandEncoder
                 protectedThis->m_mustTakeSlowIndexValidationPath = false;
             });
         }
+        return true;
     });
 }
 
@@ -656,7 +658,7 @@ void Buffer::skippedDrawIndirectValidation(CommandEncoder& commandEncoder, uint6
     CommandEncoder::trackEncoder(commandEncoder, m_skippedValidationCommandEncoders);
     commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, weakCommandEncoder = WeakPtr { commandEncoder }, indirectOffset, minVertexCount, minInstanceCount](CommandBuffer& commandBuffer) {
         if (!weakThis.get() || !weakCommandEncoder)
-            return;
+            return true;
 
         RefPtr protectedThis = weakThis.get();
         RefPtr protectedCommandEncoder = weakCommandEncoder.get();
@@ -667,6 +669,7 @@ void Buffer::skippedDrawIndirectValidation(CommandEncoder& commandEncoder, uint6
                 protectedThis->m_mustTakeSlowIndexValidationPath = false;
             });
         }
+        return true;
     });
 }
 
@@ -713,11 +716,12 @@ void Buffer::indirectBufferInvalidated(CommandEncoder& commandEncoder)
 
     commandEncoder.addOnCommitHandler([weakThis = ThreadSafeWeakPtr { *this }, weakCommandEncoder = WeakPtr { commandEncoder }](CommandBuffer&) {
         if (!weakThis.get() || !weakCommandEncoder)
-            return;
+            return true;
 
         RefPtr protectedThis = weakThis.get();
         RefPtr commandEncoder = weakCommandEncoder.get();
         protectedThis->indirectBufferInvalidated(commandEncoder.get());
+        return true;
     });
 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -140,7 +140,7 @@ public:
     static void trackEncoder(CommandEncoder&, WeakHashSet<CommandEncoder>&);
     uint64_t uniqueId() const { return m_uniqueId; }
     NSMutableSet<id<MTLCounterSampleBuffer>> *timestampBuffers() const { return m_retainedTimestampBuffers; };
-    void addOnCommitHandler(Function<void(CommandBuffer&)>&&);
+    void addOnCommitHandler(Function<bool(CommandBuffer&)>&&);
 
 private:
     CommandEncoder(id<MTLCommandBuffer>, Device&, uint64_t uniqueId);
@@ -184,7 +184,7 @@ private:
     NSMutableSet<id<MTLBuffer>> *m_retainedBuffers { nil };
     HashSet<RefPtr<const Sampler>> m_retainedSamplers;
     NSMutableSet<id<MTLCounterSampleBuffer>> *m_retainedTimestampBuffers { nil };
-    Vector<Function<void(CommandBuffer&)>> m_onCommitHandlers;
+    Vector<Function<bool(CommandBuffer&)>> m_onCommitHandlers;
 private PUBLIC_IN_WEBGPU_SWIFT:
     int m_bufferMapCount { 0 };
     bool m_makeSubmitInvalid { false };

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -2272,7 +2272,7 @@ void CommandEncoder::trackEncoder(CommandEncoder& commandEncoder, WeakHashSet<Co
     encoderHashSet.add(commandEncoder);
 }
 
-void CommandEncoder::addOnCommitHandler(Function<void(CommandBuffer&)>&& onCommitHandler)
+void CommandEncoder::addOnCommitHandler(Function<bool(CommandBuffer&)>&& onCommitHandler)
 {
     ASSERT(m_commandBuffer);
     m_onCommitHandlers.append(WTFMove(onCommitHandler));

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -190,7 +190,9 @@ void ComputePassEncoder::executePreDispatchCommands(const Buffer* indirectBuffer
             return;
         }
 
-        group->rebindSamplersIfNeeded();
+        protectedParentEncoder()->addOnCommitHandler([group](CommandBuffer&) {
+            return group ? group->rebindSamplersIfNeeded() : true;
+        });
         const Vector<uint32_t>* dynamicOffsets = nullptr;
         if (auto it = m_bindGroupDynamicOffsets.find(bindGroupIndex); it != m_bindGroupDynamicOffsets.end())
             dynamicOffsets = &it->value;

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -184,6 +184,7 @@ private:
     using BindGroupDynamicOffsetsContainer = HashMap<uint32_t, Vector<uint32_t>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
     std::optional<BindGroupDynamicOffsetsContainer> m_bindGroupDynamicOffsets;
     HashMap<uint32_t, RefPtr<const BindGroup>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_bindGroups;
+    HashSet<RefPtr<const BindGroup>> m_allBindGroups;
     RenderBundle::MinVertexCountsContainer m_minVertexCountForDrawCommand;
     NSMutableArray<RenderBundleICBWithResources*> *m_icbArray;
     id<MTLBuffer> m_dynamicOffsetsVertexBuffer { nil };

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -555,7 +555,9 @@ bool RenderPassEncoder::executePreDrawCommands(uint32_t firstInstance, uint32_t 
         UNUSED_PARAM(passWasSplit);
 #endif
 
-        group->rebindSamplersIfNeeded();
+        protectedParentEncoder()->addOnCommitHandler([group](CommandBuffer&) {
+            return group->rebindSamplersIfNeeded();
+        });
         const Vector<uint32_t>* dynamicOffsets = nullptr;
         if (auto it = m_bindGroupDynamicOffsets.find(groupIndex); it != m_bindGroupDynamicOffsets.end())
             dynamicOffsets = &it->value;
@@ -1121,6 +1123,9 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
         }
 
         commandEncoder = renderCommandEncoder();
+        protectedParentEncoder()->addOnCommitHandler([bundle](CommandBuffer&) {
+            return bundle->rebindSamplersIfNeeded();
+        });
         if (!bundle->requiresCommandReplay()) {
             bool splitPass = false;
             for (RenderBundleICBWithResources* icb in bundle->renderBundlesResources()) {

--- a/Source/WebGPU/WebGPU/Sampler.h
+++ b/Source/WebGPU/WebGPU/Sampler.h
@@ -26,21 +26,15 @@
 #pragma once
 
 #import <wtf/FastMalloc.h>
+#import <wtf/ListHashSet.h>
 #import <wtf/Lock.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 #import <wtf/TZoneMalloc.h>
+#import <wtf/WeakObjCPtr.h>
 
 struct WGPUSamplerImpl {
 };
-
-@interface SamplerIdentifier : NSObject<NSCopying>
-- (instancetype)initWithFirst:(uint64_t)first second:(uint64_t)second NS_DESIGNATED_INITIALIZER;
-- (instancetype)init NS_UNAVAILABLE;
-
-@property (nonatomic) uint64_t first;
-@property (nonatomic) uint64_t second;
-@end
 
 namespace WebGPU {
 
@@ -50,9 +44,11 @@ class Device;
 class Sampler : public WGPUSamplerImpl, public RefCounted<Sampler> {
     WTF_MAKE_TZONE_ALLOCATED(Sampler);
 public:
-    static Ref<Sampler> create(SamplerIdentifier* samplerIdentifier, const WGPUSamplerDescriptor& descriptor, Device& device)
+    using UniqueSamplerIdentifier = String;
+
+    static Ref<Sampler> create(UniqueSamplerIdentifier&& samplerIdentifier, const WGPUSamplerDescriptor& descriptor, Device& device)
     {
-        return adoptRef(*new Sampler(samplerIdentifier, descriptor, device));
+        return adoptRef(*new Sampler(WTFMove(samplerIdentifier), descriptor, device));
     }
     static Ref<Sampler> createInvalid(Device& device)
     {
@@ -74,17 +70,25 @@ public:
     Device& device() const { return m_device; }
 
 private:
-    Sampler(SamplerIdentifier*, const WGPUSamplerDescriptor&, Device&);
+    Sampler(UniqueSamplerIdentifier&&, const WGPUSamplerDescriptor&, Device&);
     Sampler(Device&);
 
-    SamplerIdentifier* m_samplerIdentifier { nil };
+    std::optional<UniqueSamplerIdentifier> m_samplerIdentifier;
     WGPUSamplerDescriptor m_descriptor { };
 
     const Ref<Device> m_device;
     // static is intentional here as the limit is per process
     static Lock samplerStateLock;
-    static NSMutableDictionary<SamplerIdentifier*, id<MTLSamplerState>> *cachedSamplerStates;
-    static NSMutableOrderedSet<SamplerIdentifier*> *lastAccessedKeys;
+    using CachedSamplerStateContainer = HashMap<UniqueSamplerIdentifier, WeakObjCPtr<id<MTLSamplerState>>>;
+    struct SamplerStateWithReferences {
+        RetainPtr<id<MTLSamplerState>> samplerState;
+        HashSet<const Sampler*> apiSamplerList;
+    };
+    using RetainedSamplerStateContainer = HashMap<UniqueSamplerIdentifier, SamplerStateWithReferences>;
+    using CachedKeyContainer = ListHashSet<UniqueSamplerIdentifier>;
+    static std::unique_ptr<CachedSamplerStateContainer> cachedSamplerStates WTF_GUARDED_BY_LOCK(samplerStateLock);
+    static std::unique_ptr<RetainedSamplerStateContainer> retainedSamplerStates WTF_GUARDED_BY_LOCK(samplerStateLock);
+    static std::unique_ptr<CachedKeyContainer> lastAccessedKeys;
 
     mutable __weak id<MTLSamplerState> m_cachedSamplerState { nil };
 };


### PR DESCRIPTION
#### 6af2ed441c4ac89933830843181d5f2b332ca597
<pre>
[WebGPU] Simplify MTLSamplerState cach
<a href="https://bugs.webkit.org/show_bug.cgi?id=287580">https://bugs.webkit.org/show_bug.cgi?id=287580</a>
<a href="https://rdar.apple.com/144703694">rdar://144703694</a>

Reviewed by Cameron McCormack.

Simplify process side MTLSampler cache to do the following:

* remove custom type, instead use base64 String which is effectively the same
* limit number of process wide samplers to 2048 to avoid using too much
  memory in the GPU process on newer iPhones which have much larger limits.
  Limit is tracked by maxArgumentBufferSamplerCount so we take the smaller of
  the two: 2048 or maxArgumentBufferSamplerCount
* evict null entries from the cache when we reach half the maximum, to avoid unncessarily
  evicting MTLSamplerState instances which are in use.
* use HashMap with weak references to the id&lt;MTLSamplerState&gt; so we know
  when the ref count on the objects has reached zero

* LayoutTests/fast/webgpu/nocrash/fuzz-287580-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287580.html: Added.
Add regresion test.

* Source/WebGPU/WebGPU/Sampler.h:
(WebGPU::Sampler::create):
* Source/WebGPU/WebGPU/Sampler.mm:
(WebGPU::computeDescriptorHash):
(WebGPU::Device::createSampler):
(WebGPU::Sampler::Sampler):
(WebGPU::Sampler::samplerState const):
(-[SamplerIdentifier initWithFirst:second:]): Deleted.
(-[SamplerIdentifier copyWithZone:]): Deleted.
(WebGPU::Sampler::~Sampler): Deleted.
Also switch from Objective-C containers to C++ containers.

* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::executePreDispatchCommands):
* Source/WebGPU/WebGPU/RenderBundle.h:
(WebGPU::RenderBundle::create):
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
(WebGPU::RenderBundle::rebindSamplersIfNeeded const):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::finish):
(WebGPU::RenderBundleEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executePreDrawCommands):
(WebGPU::RenderPassEncoder::executeBundles):
Ensure samplers are rebound prior to command buffer commit
call as opposed to encoding time.

Also, thank you for catching Darryl, RenderBundles failed to
rebind samplers which they internally used.

Canonical link: <a href="https://commits.webkit.org/290438@main">https://commits.webkit.org/290438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64a23231fb22c62de7335f4c7b0fc3199c38d61c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44921 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40793 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69297 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26904 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7326 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77661 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78299 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77511 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10402 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22543 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->