### PR TITLE
Address static analyzer warnings in RemoteScrollingTreeMac.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -19,7 +19,6 @@ UIProcess/API/Cocoa/WKWebViewConfiguration.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
-UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/WebAuthentication/Virtual/VirtualService.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -37,7 +37,6 @@ UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
 UIProcess/Gamepad/UIGamepadProvider.cpp
 UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
 UIProcess/Notifications/WebNotificationManagerProxy.cpp
-UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp
 UIProcess/WebAuthentication/AuthenticatorManager.cpp
 UIProcess/WebAuthentication/Cocoa/NfcService.mm

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -71,8 +71,8 @@ RemoteScrollingTreeMac::~RemoteScrollingTreeMac() = default;
 
 void RemoteScrollingTreeMac::handleWheelEventPhase(ScrollingNodeID nodeID, PlatformWheelEventPhase phase)
 {
-    auto* targetNode = nodeForID(nodeID);
-    if (auto* node = dynamicDowncast<ScrollingTreeScrollingNode>(targetNode))
+    RefPtr targetNode = nodeForID(nodeID);
+    if (RefPtr node = dynamicDowncast<ScrollingTreeScrollingNode>(targetNode))
         node->handleWheelEventPhase(phase);
 }
 
@@ -423,7 +423,7 @@ void RemoteScrollingTreeMac::unlockLayersForHitTesting()
 
 static std::optional<ScrollingNodeID> scrollingNodeIDForLayer(CALayer *layer)
 {
-    auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
+    RefPtr layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
     if (!layerTreeNode)
         return std::nullopt;
 
@@ -437,14 +437,14 @@ static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNod
         if (nodeID == scrollingNodeID)
             return true;
 
-        auto* scrollingNode = tree.nodeForID(nodeID);
-        if (auto* scollProxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
+        RefPtr scrollingNode = tree.nodeForID(nodeID);
+        if (RefPtr scollProxyNode = dynamicDowncast<ScrollingTreeOverflowScrollProxyNode>(scrollingNode)) {
             auto actingOverflowScrollingNodeID = scollProxyNode->overflowScrollingNodeID();
             if (actingOverflowScrollingNodeID == scrollingNodeID)
                 return true;
         }
 
-        if (auto* positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(scrollingNode)) {
+        if (RefPtr positionedNode = dynamicDowncast<ScrollingTreePositionedNode>(scrollingNode)) {
             if (positionedNode->relatedOverflowScrollingNodes().contains(scrollingNodeID))
                 return false;
         }
@@ -455,7 +455,7 @@ static bool isScrolledBy(const ScrollingTree& tree, ScrollingNodeID scrollingNod
 
 static const EventRegion* eventRegionForLayer(CALayer *layer)
 {
-    auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
+    RefPtr layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);
     if (!layerTreeNode)
         return nullptr;
 
@@ -544,13 +544,13 @@ RefPtr<ScrollingTreeNode> RemoteScrollingTreeMac::scrollingNodeForPoint(FloatPoi
 #if ENABLE(WHEEL_EVENT_REGIONS)
 OptionSet<EventListenerRegionType> RemoteScrollingTreeMac::eventListenerRegionTypesForPoint(FloatPoint point) const
 {
-    auto* rootScrollingNode = rootNode();
+    RefPtr rootScrollingNode = downcast<ScrollingTreeFrameScrollingNodeMac>(rootNode());
     if (!rootScrollingNode)
         return { };
 
     ASSERT(m_layerHitTestMutex.isLocked());
 
-    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeMac*>(rootScrollingNode)->rootContentsLayer();
+    auto rootContentsLayer = rootScrollingNode->rootContentsLayer();
 
     Vector<LayerAndPoint, 16> layersAtPoint;
     collectDescendantLayersAtPoint(layersAtPoint, rootContentsLayer.get(), point, layerEventRegionContainsPoint);


### PR DESCRIPTION
#### 68d6cea0b4d38d2498957cc5bcf70771ba0672c3
<pre>
Address static analyzer warnings in RemoteScrollingTreeMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=287617">https://bugs.webkit.org/show_bug.cgi?id=287617</a>

Reviewed by Chris Dumez.

Addressed the static analyzer warnings.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::handleWheelEventPhase):
(WebKit::scrollingNodeIDForLayer):
(WebKit::isScrolledBy):
(WebKit::eventRegionForLayer):
(WebKit::RemoteScrollingTreeMac::eventListenerRegionTypesForPoint const):

Canonical link: <a href="https://commits.webkit.org/290374@main">https://commits.webkit.org/290374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df48b7b8ea4b98317f813ab4588b1fe244f4f0f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40539 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69142 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81466 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49503 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7160 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39672 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36874 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96586 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12450 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78011 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77280 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77328 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21768 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20358 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10130 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14105 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16961 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->