### PR TITLE
Address static analyzer warnings in EventLoop

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -569,8 +569,6 @@ dom/ElementInternals.cpp
 dom/ElementIteratorInlines.h
 dom/EmptyScriptExecutionContext.h
 dom/EventListenerMap.cpp
-dom/EventLoop.cpp
-dom/EventLoop.h
 dom/EventPath.cpp
 dom/EventTarget.cpp
 dom/ExtensionStyleSheets.cpp
@@ -629,7 +627,6 @@ dom/TreeWalker.cpp
 dom/ViewTransition.cpp
 dom/ViewTransitionTypeSet.cpp
 dom/VisitedLinkState.cpp
-dom/WindowEventLoop.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
 dom/mac/ImageControlsMac.cpp
 editing/AlternativeTextController.cpp
@@ -1508,7 +1505,6 @@ workers/DedicatedWorkerGlobalScope.cpp
 workers/Worker.cpp
 workers/WorkerAnimationController.cpp
 workers/WorkerConsoleClient.cpp
-workers/WorkerEventLoop.cpp
 workers/WorkerFontLoadRequest.cpp
 workers/WorkerGlobalScope.cpp
 workers/WorkerInspectorProxy.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -91,7 +91,6 @@ dom/Node.cpp
 dom/Subscriber.cpp
 dom/ViewTransition.cpp
 dom/ViewportArguments.cpp
-dom/WindowEventLoop.cpp
 editing/Editor.cpp
 fileapi/Blob.cpp
 fileapi/FileReader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -295,8 +295,6 @@ dom/ElementIteratorInlines.h
 dom/ElementTextDirection.cpp
 dom/ElementTraversal.h
 dom/Event.cpp
-dom/EventLoop.cpp
-dom/EventLoop.h
 dom/EventPath.cpp
 dom/EventTarget.cpp
 dom/FragmentDirectiveGenerator.cpp
@@ -812,7 +810,6 @@ testing/js/WebCoreTestSupport.cpp
 workers/AbstractWorker.cpp
 workers/Worker.cpp
 workers/WorkerConsoleClient.cpp
-workers/WorkerEventLoop.cpp
 workers/WorkerGlobalScope.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerOrWorkletGlobalScope.cpp

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -416,8 +416,8 @@ void EventLoopTaskGroup::markAsReadyToStop()
     if (RefPtr eventLoop = m_eventLoop.get())
         eventLoop->stopAssociatedGroupsIfNecessary();
 
-    for (auto& timer : m_timers)
-        timer.stop();
+    for (Ref timer : m_timers)
+        timer->stop();
 
     if (wasSuspended && !isStoppedPermanently()) {
         // We we get marked as ready to stop while suspended (happens when a CachedPage gets destroyed) then the
@@ -434,8 +434,8 @@ void EventLoopTaskGroup::suspend()
     m_state = State::Suspended;
     // We don't remove suspended tasks to preserve the ordering.
     // EventLoop::run checks whether each task's group is suspended or not.
-    for (auto& timer : m_timers)
-        timer.suspend();
+    for (Ref timer : m_timers)
+        timer->suspend();
     if (RefPtr eventLoop = m_eventLoop.get())
         m_eventLoop->invalidateNextTimerFireTimeCache();
 }
@@ -449,8 +449,8 @@ void EventLoopTaskGroup::resume()
         eventLoop->resumeGroup(*this);
         eventLoop->invalidateNextTimerFireTimeCache();
     }
-    for (auto& timer : m_timers)
-        timer.resume();
+    for (Ref timer : m_timers)
+        timer->resume();
 }
 
 RefPtr<EventLoop> EventLoopTaskGroup::protectedEventLoop() const
@@ -575,20 +575,22 @@ void EventLoopTaskGroup::setTimerHasReachedMaxNestingLevel(EventLoopTimerHandle 
 
 void EventLoopTaskGroup::adjustTimerNextFireTime(EventLoopTimerHandle handle, Seconds delta)
 {
-    if (!handle.m_timer)
+    RefPtr timer = handle.m_timer;
+    if (!timer)
         return;
-    ASSERT(m_timers.contains(*handle.m_timer));
-    handle.m_timer->adjustNextFireTime(delta);
+    ASSERT(m_timers.contains(*timer));
+    timer->adjustNextFireTime(delta);
     if (RefPtr eventLoop = m_eventLoop.get())
         eventLoop->invalidateNextTimerFireTimeCache();
 }
 
 void EventLoopTaskGroup::adjustTimerRepeatInterval(EventLoopTimerHandle handle, Seconds delta)
 {
-    if (!handle.m_timer)
+    RefPtr timer = handle.m_timer;
+    if (!timer)
         return;
-    ASSERT(m_timers.contains(*handle.m_timer));
-    handle.m_timer->adjustRepeatInterval(delta);
+    ASSERT(m_timers.contains(*timer));
+    timer->adjustRepeatInterval(delta);
     if (RefPtr eventLoop = m_eventLoop.get())
         eventLoop->invalidateNextTimerFireTimeCache();
 }

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -167,7 +167,7 @@ public:
 
     ~EventLoopTaskGroup()
     {
-        if (auto* eventLoop = m_eventLoop.get())
+        if (RefPtr eventLoop = m_eventLoop.get())
             eventLoop->unregisterGroup(*this);
     }
 
@@ -192,7 +192,7 @@ public:
     {
         ASSERT(isReadyToStop());
         m_state = State::Stopped;
-        if (auto* eventLoop = m_eventLoop.get())
+        if (RefPtr eventLoop = m_eventLoop.get())
             eventLoop->stopGroup(*this);
     }
 
@@ -208,7 +208,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-microtask
     WEBCORE_EXPORT void queueMicrotask(EventLoop::TaskFunction&&);
-    MicrotaskQueue& microtaskQueue() { return m_eventLoop->microtaskQueue(); }
+    MicrotaskQueue& microtaskQueue() { return protectedEventLoop()->microtaskQueue(); }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint
     void performMicrotaskCheckpoint();

--- a/Source/WebCore/workers/WorkerEventLoop.cpp
+++ b/Source/WebCore/workers/WorkerEventLoop.cpp
@@ -49,7 +49,7 @@ WorkerEventLoop::~WorkerEventLoop()
 
 void WorkerEventLoop::scheduleToRun()
 {
-    auto* globalScope = downcast<WorkerOrWorkletGlobalScope>(scriptExecutionContext());
+    RefPtr globalScope = downcast<WorkerOrWorkletGlobalScope>(scriptExecutionContext());
     ASSERT(globalScope);
     // Post this task with a special event mode, so that it can be separated from other
     // kinds of tasks so that queued microtasks can run even if other tasks are ignored.
@@ -65,9 +65,10 @@ bool WorkerEventLoop::isContextThread() const
 
 MicrotaskQueue& WorkerEventLoop::microtaskQueue()
 {
-    ASSERT(scriptExecutionContext());
+    RefPtr context = scriptExecutionContext();
+    ASSERT(context);
     if (!m_microtaskQueue)
-        m_microtaskQueue = makeUnique<MicrotaskQueue>(scriptExecutionContext()->vm(), *this);
+        m_microtaskQueue = makeUnique<MicrotaskQueue>(context->vm(), *this);
     return *m_microtaskQueue;
 }
 


### PR DESCRIPTION
#### 05d7433faf61f319f8f2c0ff3d2a49f248dbeaa2
<pre>
Address static analyzer warnings in EventLoop
<a href="https://bugs.webkit.org/show_bug.cgi?id=287618">https://bugs.webkit.org/show_bug.cgi?id=287618</a>

Reviewed by Brady Eidson.

Addressed static analyzer warnings in EventLoop.cpp/h, WindowEventLoop.cpp,
and WorkerEventLoop.cpp.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/EventLoop.cpp:
(WebCore::EventLoopTaskGroup::markAsReadyToStop):
(WebCore::EventLoopTaskGroup::suspend):
(WebCore::EventLoopTaskGroup::resume):
(WebCore::EventLoopTaskGroup::adjustTimerNextFireTime):
(WebCore::EventLoopTaskGroup::adjustTimerRepeatInterval):
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/WindowEventLoop.cpp:
(WebCore::WindowEventLoop::queueMutationObserverCompoundMicrotask):
(WebCore::WindowEventLoop::backupElementQueue):
(WebCore::WindowEventLoop::breakToAllowRenderingUpdate):
* Source/WebCore/workers/WorkerEventLoop.cpp:
(WebCore::WorkerEventLoop::scheduleToRun):
(WebCore::WorkerEventLoop::microtaskQueue):

Canonical link: <a href="https://commits.webkit.org/290419@main">https://commits.webkit.org/290419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bf512cd3f3f399d80c387ace88a17f1eddf481a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44738 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94844 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69177 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26794 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7465 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49538 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7186 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35880 "Found 1 new test failure: fullscreen/full-screen-request-removed.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39752 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96669 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17033 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12491 "Found 3 new test failures: http/tests/pdf/linearized-pdf-in-display-none-iframe.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78059 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77383 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21823 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10210 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22365 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16785 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18568 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->