### PR TITLE
Resync html/semantics/the-button-element

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2954,6 +2954,9 @@ imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-co
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-input-number.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-video-behavior.tentative.html [ Skip ]
 
+# interesttarget failures - not specced yet
+imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative.html [ ImageOnlyFailure ]
+
 # text-transform: full-width
 # no full width mapping for characters ( and )
 imported/w3c/web-platform-tests/css/css-text/text-transform/text-transform-fullwidth-001.xht [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10071,6 +10071,7 @@
         "web-platform-tests/html/semantics/text-level-semantics/the-br-element/br-bidi-ref.html",
         "web-platform-tests/html/semantics/text-level-semantics/the-ruby-element/ruby-usage-notref.html",
         "web-platform-tests/html/semantics/text-level-semantics/the-wbr-element/wbr-element-ref.html",
+        "web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation-ref.html",
         "web-platform-tests/html/syntax/charset/references/after-1kb-ref.html",
         "web-platform-tests/html/syntax/charset/references/after-bogus-after-1kb-ref.html",
         "web-platform-tests/html/syntax/charset/references/after-bogus-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative-expected.txt
@@ -36,6 +36,6 @@ PASS event does not dispatch if invoker is disabled
 PASS event does NOT dispatch if button is form associated, with implicit type
 PASS event dispatches if button is form associated, with explicit type=button
 PASS event does NOT dispatch if button is form associated, with explicit type=submit
-PASS event does NOT dispatch if button is form associated, with explicit type=reset
+FAIL event does dispatch if button is form associated, with explicit type=reset assert_true: event was called expected true got false
 PASS event dispatches if invokee is non-HTML Element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html
@@ -195,8 +195,8 @@
     invokerbutton.setAttribute("form", "aform");
     invokerbutton.setAttribute("type", "reset");
     await clickOn(invokerbutton);
-    assert_false(called, "event was not called");
-  }, "event does NOT dispatch if button is form associated, with explicit type=reset");
+    assert_true(called, "event was called");
+  }, "event does dispatch if button is form associated, with explicit type=reset");
 
   promise_test(async function (t) {
     svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt
@@ -1,0 +1,23 @@
+
+reset  submit  type=button  invalid  missing  missing with command only  missing with commandfor only
+reset submit type=button invalid missing missing with command only missing with commandfor only  reset submit type=button invalid missing
+
+FAIL Button type=reset in form should trigger form reset and toggle popover assert_true: type=reset should trigger form reset event expected true got false
+FAIL Button type=submit in form should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=button in form should not toggle popover
+FAIL Button type=invalid in form should trigger form submit and not toggle popover assert_true: type=invalid should trigger form submit event expected true got false
+PASS Button missing type in form should not trigger form submit and not toggle popover
+FAIL Button missing type in form with only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type in form with only commandfor should not trigger form submit and not toggle popover
+FAIL Button type=reset with form attr should trigger form reset and toggle popover assert_true: type=reset should trigger form reset event expected true got false
+FAIL Button type=submit with form attr should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=button with form attr should toggle popover
+FAIL Button type=invalid with form attr should trigger form submit and not toggle popover assert_true: type=invalid should trigger form submit event expected true got false
+FAIL Button missing type with form attr and only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type with form attr and only commandfor should not trigger form submit and not toggle popover
+PASS Button type=reset outside form should toggle popover
+PASS Button type=submit outside form should toggle popover
+PASS Button type=button outside form should toggle popover
+PASS Button type=invalid outside form should toggle popover
+PASS Button missing type outside form should toggle popover
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:lwarlow@igalia.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id=mypopover popover=auto>popover</div>
+
+<iframe name=foo></iframe>
+<form id="form" target=foo action="about:blank">
+  <button id=reset-in-form type=reset commandfor=mypopover command=toggle-popover>reset</button>
+  <button id=submit-in-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
+  <button id=button-in-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
+  <button id=invalid-in-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+  <button id=missing-in-form commandfor=mypopover command=toggle-popover>missing</button>
+  <button id=missing-in-form-command-only command=toggle-popover>missing with command only</button>
+  <button id=missing-in-form-commandfor-only commandfor=mypopover >missing with commandfor only</button>
+</form>
+
+<button id=reset-attr-form type=reset commandfor=mypopover command=toggle-popover form=form>reset</button>
+<button id=submit-attr-form type=submit commandfor=mypopover command=toggle-popover form=form>submit</button>
+<button id=button-attr-form type=button commandfor=mypopover command=toggle-popover form=form>type=button</button>
+<button id=invalid-attr-form type=invalid commandfor=mypopover command=toggle-popover form=form>invalid</button>
+<button id=missing-attr-form commandfor=mypopover command=toggle-popover form=form>missing</button>
+<button id=missing-attr-form-command-only command=toggle-popover form=form>missing with command only</button>
+<button id=missing-attr-form-commandfor-only commandfor=mypopover form=form>missing with commandfor only</button>
+
+<button id=reset-outside-form type=reset commandfor=mypopover command=toggle-popover>reset</button>
+<button id=submit-outside-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
+<button id=button-outside-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
+<button id=invalid-outside-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+<button id=missing-outside-form commandfor=mypopover command=toggle-popover>missing</button>
+
+<script>
+test((t) => {
+  let formReset = false;
+  function onReset(e) {
+    e.preventDefault();
+    formReset = true;
+  }
+  form.addEventListener('reset', onReset);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('reset', onReset);
+  });
+  document.getElementById('reset-in-form').click();
+  assert_true(formReset, 'type=reset should trigger form reset event');
+  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
+}, 'Button type=reset in form should trigger form reset and toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('submit-in-form').click();
+  assert_true(formSubmit, 'type=submit should trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=submit should not toggle the popover');
+}, 'Button type=submit in form should trigger form submit and not toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('button-in-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'type=button should toggle the popover');
+}, 'Button type=button in form should not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('invalid-in-form').click();
+  assert_true(formSubmit, 'type=invalid should trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button type=invalid in form should trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('missing-in-form').click();
+  assert_false(formSubmit, 'missing type should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button missing type in form should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('missing-in-form-command-only').click();
+  assert_false(formSubmit, 'missing type should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'missing type should not toggle the popover');
+}, 'Button missing type in form with only command should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('missing-in-form-commandfor-only').click();
+  assert_false(formSubmit, 'missing type should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'missing type should not toggle the popover');
+}, 'Button missing type in form with only commandfor should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formReset = false;
+  function onReset(e) {
+    e.preventDefault();
+    formReset = true;
+  }
+  form.addEventListener('reset', onReset);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('reset', onReset);
+  });
+  document.getElementById('reset-attr-form').click();
+  assert_true(formReset, 'type=reset should trigger form reset event');
+  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
+}, 'Button type=reset with form attr should trigger form reset and toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('submit-attr-form').click();
+  assert_true(formSubmit, 'type=submit should trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=submit should not toggle the popover');
+}, 'Button type=submit with form attr should trigger form submit and not toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('button-attr-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'type=button should toggle the popover');
+}, 'Button type=button with form attr should toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('invalid-attr-form').click();
+  assert_true(formSubmit, 'type=invalid should trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'type=invalid should not toggle the popover');
+}, 'Button type=invalid with form attr should trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('missing-attr-form-command-only').click();
+  assert_false(formSubmit, 'missing type should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'missing type should not toggle the popover');
+}, 'Button missing type with form attr and only command should not trigger form submit and not toggle popover');
+
+test((t) => {
+  let formSubmit = false;
+  function onSubmit(e) {
+    e.preventDefault();
+    formSubmit = true;
+  }
+  form.addEventListener('submit', onSubmit);
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+    form.removeEventListener('submit', onSubmit);
+  });
+  document.getElementById('missing-attr-form-commandfor-only').click();
+  assert_false(formSubmit, 'missing type should not trigger form submit event');
+  assert_false(mypopover.matches(':popover-open'), 'missing type should not toggle the popover');
+}, 'Button missing type with form attr and only commandfor should not trigger form submit and not toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('reset-outside-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'type=reset should toggle the popover');
+}, 'Button type=reset outside form should toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('submit-outside-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'type=submit should toggle the popover');
+}, 'Button type=submit outside form should toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('button-outside-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'type=button should toggle the popover');
+}, 'Button type=button outside form should toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('invalid-outside-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'type=invalid should toggle the popover');
+}, 'Button type=invalid outside form should toggle popover');
+
+test((t) => {
+  t.add_cleanup(() => {
+    mypopover.hidePopover();
+  });
+  document.getElementById('missing-outside-form').click();
+  assert_true(mypopover.matches(':popover-open'), 'missing type should toggle the popover');
+}, 'Button missing type outside form should toggle popover');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt
@@ -1,0 +1,26 @@
+
+reset  submit  type=button  invalid  missing  missing with command only  missing with commandfor only
+reset submit type=button invalid missing missing with command only missing with commandfor only  reset submit type=button invalid missing missing with command only missing with commandfor only
+
+PASS Button with id reset-in-form should reflect type correctly
+PASS Button with id submit-in-form should reflect type correctly
+PASS Button with id button-in-form should reflect type correctly
+PASS Button with id invalid-in-form should reflect type correctly
+FAIL Button with id missing-in-form should reflect type correctly assert_equals: type of missing-in-form should be button expected "button" but got "submit"
+FAIL Button with id missing-in-form-command-only should reflect type correctly assert_equals: type of missing-in-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-in-form-commandfor-only should reflect type correctly assert_equals: type of missing-in-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id reset-attr-form should reflect type correctly
+PASS Button with id submit-attr-form should reflect type correctly
+PASS Button with id button-attr-form should reflect type correctly
+PASS Button with id invalid-attr-form should reflect type correctly
+FAIL Button with id missing-attr-form should reflect type correctly assert_equals: type of missing-attr-form should be button expected "button" but got "submit"
+FAIL Button with id missing-attr-form-command-only should reflect type correctly assert_equals: type of missing-attr-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-attr-form-commandfor-only should reflect type correctly assert_equals: type of missing-attr-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id reset-outside-form should reflect type correctly
+PASS Button with id submit-outside-form should reflect type correctly
+PASS Button with id button-outside-form should reflect type correctly
+PASS Button with id invalid-outside-form should reflect type correctly
+FAIL Button with id missing-outside-form should reflect type correctly assert_equals: type of missing-outside-form should be button expected "button" but got "submit"
+FAIL Button with id missing-outside-form-command-only should reflect type correctly assert_equals: type of missing-outside-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-outside-form-commandfor-only should reflect type correctly assert_equals: type of missing-outside-form-commandfor-only should be button expected "button" but got "submit"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:lwarlow@igalia.com">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe name=foo></iframe>
+<form id="form" target=foo action="about:blank">
+  <button id=reset-in-form type=reset commandfor=mypopover command=toggle-popover>reset</button>
+  <button id=submit-in-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
+  <button id=button-in-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
+  <button id=invalid-in-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+  <button id=missing-in-form commandfor=mypopover command=toggle-popover>missing</button>
+  <button id=missing-in-form-command-only command=toggle-popover>missing with command only</button>
+  <button id=missing-in-form-commandfor-only commandfor=mypopover >missing with commandfor only</button>
+</form>
+
+<button id=reset-attr-form type=reset commandfor=mypopover command=toggle-popover form=form>reset</button>
+<button id=submit-attr-form type=submit commandfor=mypopover command=toggle-popover form=form>submit</button>
+<button id=button-attr-form type=button commandfor=mypopover command=toggle-popover form=form>type=button</button>
+<button id=invalid-attr-form type=invalid commandfor=mypopover command=toggle-popover form=form>invalid</button>
+<button id=missing-attr-form commandfor=mypopover command=toggle-popover form=form>missing</button>
+<button id=missing-attr-form-command-only command=toggle-popover form=form>missing with command only</button>
+<button id=missing-attr-form-commandfor-only commandfor=mypopover form=form>missing with commandfor only</button>
+
+<button id=reset-outside-form type=reset commandfor=mypopover command=toggle-popover>reset</button>
+<button id=submit-outside-form type=submit commandfor=mypopover command=toggle-popover>submit</button>
+<button id=button-outside-form type=button commandfor=mypopover command=toggle-popover>type=button</button>
+<button id=invalid-outside-form type=invalid commandfor=mypopover command=toggle-popover>invalid</button>
+<button id=missing-outside-form commandfor=mypopover command=toggle-popover>missing</button>
+<button id=missing-outside-form-command-only command=toggle-popover>missing with command only</button>
+<button id=missing-outside-form-commandfor-only commandfor=mypopover>missing with commandfor only</button>
+
+<script>
+const data = {
+  'reset-in-form': 'reset',
+  'submit-in-form': 'submit',
+  'button-in-form': 'button',
+  'invalid-in-form': 'submit',
+  'missing-in-form': 'button',
+  'missing-in-form-command-only': 'button',
+  'missing-in-form-commandfor-only': 'button',
+  'reset-attr-form': 'reset',
+  'submit-attr-form': 'submit',
+  'button-attr-form': 'button',
+  'invalid-attr-form': 'submit',
+  'missing-attr-form': 'button',
+  'missing-attr-form-command-only': 'button',
+  'missing-attr-form-commandfor-only': 'button',
+  'reset-outside-form': 'reset',
+  'submit-outside-form': 'submit',
+  'button-outside-form': 'button',
+  'invalid-outside-form': 'submit',
+  'missing-outside-form': 'button',
+  'missing-outside-form-command-only': 'button',
+  'missing-outside-form-commandfor-only': 'button',
+};
+
+Object.entries(data).map(([id, expectedType]) => {
+  test(() => {
+    const button = document.getElementById(id);
+    assert_equals(button.type, expectedType, `type of ${id} should be ${expectedType}`);
+  }, `Button with id ${id} should reflect type correctly`);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative-expected.txt
@@ -1,0 +1,19 @@
+
+
+PASS invoker should reflect  properly
+PASS invoker should reflect show-modal properly
+PASS invoker should reflect toggle-popover properly
+PASS invoker should reflect hide-popover properly
+PASS invoker should reflect show-popover properly
+PASS invoker should reflect close properly
+PASS invoker should reflect --custom properly
+FAIL invoker should reflect odd cased sHoW-MoDaL properly - as show-modal assert_equals: invoker should reflect odd cased sHoW-MoDaL properly - as show-modal expected "show-modal" but got "sHoW-MoDaL"
+FAIL invoker should reflect odd cased tOgGlE-pOpOvEr properly - as toggle-popover assert_equals: invoker should reflect odd cased tOgGlE-pOpOvEr properly - as toggle-popover expected "toggle-popover" but got "tOgGlE-pOpOvEr"
+FAIL invoker should reflect odd cased hIdE-pOpOvEr properly - as hide-popover assert_equals: invoker should reflect odd cased hIdE-pOpOvEr properly - as hide-popover expected "hide-popover" but got "hIdE-pOpOvEr"
+FAIL invoker should reflect odd cased sHoW-pOpOvEr properly - as show-popover assert_equals: invoker should reflect odd cased sHoW-pOpOvEr properly - as show-popover expected "show-popover" but got "sHoW-pOpOvEr"
+FAIL invoker should reflect odd cased ClOsE properly - as close assert_equals: invoker should reflect odd cased ClOsE properly - as close expected "close" but got "ClOsE"
+PASS invoker should reflect odd cased --cUsToM properly - as --cUsToM
+FAIL invoker should reflect the invalid value "invalid" as the empty string assert_equals: invoker should reflect the invalid value "invalid" as the empty string expected "" but got "invalid"
+FAIL invoker should reflect the invalid value "show-invalid" as the empty string assert_equals: invoker should reflect the invalid value "show-invalid" as the empty string expected "" but got "show-invalid"
+FAIL invoker should reflect the invalid value "foo-bar" as the empty string assert_equals: invoker should reflect the invalid value "foo-bar" as the empty string expected "" but got "foo-bar"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Keith Cirkel" href="mailto:wpt@keithcirkel.co.uk" />
+<meta name="timeout" content="long" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="invokee"></div>
+<button id="invokerbutton" commandfor="invokee"></button>
+
+<script>
+  ['', 'show-modal', 'toggle-popover', 'hide-popover', 'show-popover', 'close', '--custom'].forEach(command => {
+    test(function (t) {
+      invokerbutton.command = command
+      assert_equals(invokerbutton.command, command, `invoker should reflect ${command} properly`);
+    }, `invoker should reflect ${command} properly`);
+  });
+  [
+    ['sHoW-MoDaL', 'show-modal'],
+    ['tOgGlE-pOpOvEr', 'toggle-popover'],
+    ['hIdE-pOpOvEr', 'hide-popover'],
+    ['sHoW-pOpOvEr', 'show-popover'],
+    ['ClOsE', 'close'],
+    ['--cUsToM', '--cUsToM'
+  ]].forEach(([cased, command]) => {
+    test(function (t) {
+      invokerbutton.command = cased
+        assert_equals(invokerbutton.command, command, `invoker should reflect odd cased ${cased} properly - as ${command}`);
+    }, `invoker should reflect odd cased ${cased} properly - as ${command}`);
+  });
+  ['invalid', 'show-invalid', 'foo-bar'].forEach(command => {
+    test(function (t) {
+      invokerbutton.command = command
+      assert_equals(invokerbutton.command, '', `invoker should reflect the invalid value "${command}" as the empty string`);
+    }, `invoker should reflect the invalid value "${command}" as the empty string`);
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative-expected.txt
@@ -6,9 +6,9 @@ PASS commandForElement reflects set value across shadow root into light dom
 PASS commandForElement does not reflect set value inside shadowroot
 PASS commandForElement throws error on assignment of non Element
 PASS command reflects '' when attribute empty, setAttribute version
-PASS command reflects same casing
+FAIL command reflects correctly for invalid assert_equals: expected "" but got "fooBarBaz"
 PASS command reflects '' when attribute empty, IDL version
-PASS command reflects tostring value
+FAIL command reflects correctly for invalid when array assert_equals: expected "" but got "1,2,3"
 PASS command reflects '' when attribute set to []
-PASS command reflects tostring value 2
+FAIL command reflects correctly for invalid when object assert_equals: expected "" but got "[object Object]"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative.html
@@ -60,8 +60,8 @@
   test(function () {
     invoker.command = "fooBarBaz";
     assert_equals(invoker.getAttribute("command"), "fooBarBaz");
-    assert_equals(invoker.command, "fooBarBaz");
-  }, "command reflects same casing");
+    assert_equals(invoker.command, "");
+  }, "command reflects correctly for invalid");
 
   test(function () {
     invoker.command = "";
@@ -72,8 +72,8 @@
   test(function () {
     invoker.command = [1, 2, 3];
     assert_equals(invoker.getAttribute("command"), "1,2,3");
-    assert_equals(invoker.command, "1,2,3");
-  }, "command reflects tostring value");
+    assert_equals(invoker.command, "");
+  }, "command reflects correctly for invalid when array");
 
   test(function () {
     invoker.command = [];
@@ -83,6 +83,6 @@
 
   test(function () {
     invoker.command = {};
-    assert_equals(invoker.command, "[object Object]");
-  }, "command reflects tostring value 2");
+    assert_equals(invoker.command, "");
+  }, "command reflects correctly for invalid when object");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
@@ -15,6 +15,9 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-interface.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL idl_test setup promise_test: Unhandled rejection with value: object "Error fetching /interfaces/interest-invokers.tentative.idl."
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org" />
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/WebIDLParser.js"></script>
+<script src="/resources/idlharness.js"></script>
+
+<script>
+  idl_test(["interest-invokers.tentative"],
+  ["html","dom","SVG"], (idl_array) => {
+    idl_array.add_objects({
+      HTMLAnchorElement: ['document.createElement("a")'],
+      HTMLAreaElement: ['document.createElement("area")'],
+      HTMLButtonElement: ['document.createElement("button")'],
+      SVGAElement: ['document.createElementNS("http://www.w3.org/2000/svg", "a")'],
+      InterestEvent: ['new InterestEvent("interest")']
+    });
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative-expected.txt
@@ -1,0 +1,11 @@
+
+
+FAIL interestTargetElement reflects interestee HTML element assert_equals: expected (object) Element node <div id="interestee"></div> but got (undefined) undefined
+FAIL interestTargetElement reflects set value assert_equals: expected "" but got "interestee"
+FAIL interestTargetElement reflects set value across shadow root into light dom assert_equals: expected "" but got "interestee"
+FAIL interestTargetElement does not reflect set value inside shadowroot assert_equals: expected null but got Element node <div></div>
+FAIL interestTargetElement does not reflect invalid value assert_equals: expected null but got Element node <div></div>
+FAIL interestTargetElement throws error on assignment of non Element assert_throws_js: interestTargetElement attribute value must be an instance of Element function "function () {
+        buttonInvoker.interestTargetElement = {};
+      }" did not throw
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<button id="buttonInvoker" interesttarget="interestee"></button>
+<a id="aInvoker" interesttarget="interestee"></a>
+<div id="interestee"></div>
+
+<script>
+  test(function () {
+    assert_equals(buttonInvoker.interestTargetElement, interestee);
+    assert_equals(aInvoker.interestTargetElement, interestee);
+  }, "interestTargetElement reflects interestee HTML element");
+
+  test(function () {
+    const div = document.body.appendChild(document.createElement("div"));
+    buttonInvoker.interestTargetElement = div;
+    aInvoker.interestTargetElement = div;
+    assert_equals(buttonInvoker.interestTargetElement, div);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "");
+    assert_equals(aInvoker.interestTargetElement, div);
+    assert_equals(aInvoker.getAttribute("interesttarget"), "");
+  }, "interestTargetElement reflects set value");
+
+  test(function () {
+    const host = document.body.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = shadow.appendChild(document.createElement("button"));
+    button.interestTargetElement = interestee;
+    assert_equals(button.interestTargetElement, interestee);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "");
+  }, "interestTargetElement reflects set value across shadow root into light dom");
+
+  test(function () {
+    const host = document.body.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const div = shadow.appendChild(document.createElement("div"));
+    buttonInvoker.interestTargetElement = div;
+    assert_equals(buttonInvoker.interestTargetElement, null);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "");
+  }, "interestTargetElement does not reflect set value inside shadowroot");
+
+  test(function () {
+    buttonInvoker.setAttribute('interesttarget', 'invalid');
+    assert_equals(buttonInvoker.interestTargetElement, null);
+    assert_equals(buttonInvoker.getAttribute("interesttarget"), "invalid");
+    aInvoker.setAttribute('interesttarget', 'invalid');
+    assert_equals(aInvoker.interestTargetElement, null);
+    assert_equals(aInvoker.getAttribute("interesttarget"), "invalid");
+  }, "interestTargetElement does not reflect invalid value");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        buttonInvoker.interestTargetElement = {};
+      },
+      "interestTargetElement attribute value must be an instance of Element",
+    );
+    assert_throws_js(
+      TypeError,
+      function () {
+        aInvoker.interestTargetElement = {};
+      },
+      "interestTargetElement attribute value must be an instance of Element",
+    );
+  }, "interestTargetElement throws error on assignment of non Element");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL InterestEvent propagates across shadow boundaries retargeting invoker source Can't find variable: InterestEvent
+FAIL cross shadow InterestEvent retargets interestee to host element assert_true: InterestEvent gets fired expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link
+  rel="help"
+  href="https://open-ui.org/components/interest-invokers.explainer/"
+/>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<body>
+  <script>
+  test((t) => {
+    const host = document.createElement("div");
+    t.add_cleanup(() => host.remove());
+    document.body.append(host);
+    const shadow = host.attachShadow({ mode: "closed" });
+    const slot = shadow.appendChild(document.createElement("slot"));
+    let childEvent = null;
+    let childEventTarget = null;
+    let childEventSource = null;
+    let hostEvent = null;
+    let hostEventTarget = null;
+    let hostEventSource = null;
+    slot.addEventListener("interest", (e) => {
+        childEvent = e;
+        childEventTarget = e.target;
+        childEventSource = e.source;
+      }, { once: true });
+    host.addEventListener("interest", (e) => {
+        hostEvent = e;
+        hostEventTarget = e.target;
+        hostEventSource = e.source;
+      }, { once: true });
+    const event = new InterestEvent("interest", {
+      bubbles: true,
+      source: slot,
+      composed: true,
+    });
+    slot.dispatchEvent(event);
+    assert_true(childEvent instanceof InterestEvent, "slot saw interest event");
+    assert_equals(childEventTarget, slot, "target is child inside shadow boundary");
+    assert_equals(childEventSource, slot, "source is child inside shadow boundary");
+    assert_equals(hostEvent, childEvent, "event dispatch propagates across shadow boundary");
+    assert_equals(hostEventTarget, host, "target is retargeted to shadowroot host");
+    assert_equals(hostEventSource, host, "source is retargeted to shadowroot host");
+  }, "InterestEvent propagates across shadow boundaries retargeting invoker source");
+
+  promise_test(async (t) => {
+    const host = document.createElement("div");
+    t.add_cleanup(() => host.remove());
+    document.body.append(host);
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = shadow.appendChild(document.createElement("button"));
+    const interestee = host.appendChild(document.createElement("div"));
+    button.interestTargetElement = interestee;
+    button.style = "interest-target-delay: 0s";
+    let event = null;
+    let eventTarget = null;
+    let eventSource = null;
+    interestee.addEventListener("interest", (e) => {
+        event = e;
+        eventTarget = e.target;
+        eventSource = e.source;
+      },{ once: true });
+    await hoverOver(button);
+    assert_true(!!event,"InterestEvent gets fired");
+    assert_true(event instanceof InterestEvent);
+    assert_equals(eventTarget, interestee, "target is interestee");
+    assert_equals(eventSource, host, "interestee is host");
+  }, "cross shadow InterestEvent retargets interestee to host element");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative-expected.txt
@@ -1,0 +1,30 @@
+
+
+FAIL source is readonly defaulting to null Can't find variable: InterestEvent
+FAIL InterestEventInit properties set value (manual event) Can't find variable: InterestEvent
+FAIL InterestEventInit properties set value (beforetoggle event) Can't find variable: InterestEvent
+FAIL InterestEventInit properties set value (toggle event) Can't find variable: InterestEvent
+FAIL source set to undefined Can't find variable: InterestEvent
+FAIL source set to null Can't find variable: InterestEvent
+FAIL source set to false assert_throws_js: source is not an object function "function () {
+        new InterestEvent("test", { source: false });
+      }" threw object "ReferenceError: Can't find variable: InterestEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL source set to true assert_throws_js: source is not an object function "function () {
+        const event = new InterestEvent("test", { source: true });
+      }" threw object "ReferenceError: Can't find variable: InterestEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL source set to {} assert_throws_js: source is not an object function "function () {
+        const event = new InterestEvent("test", { source: {} });
+      }" threw object "ReferenceError: Can't find variable: InterestEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+FAIL source set to non-Element EventTarget assert_throws_js: source is not an Element function "function () {
+        const eventInit = { source: new XMLHttpRequest() };
+        const event = new InterestEvent("toggle", eventInit);
+      }" threw object "ReferenceError: Can't find variable: InterestEvent" ("ReferenceError") expected instance of function "function TypeError() {
+    [native code]
+}" ("TypeError")
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="div"></div>
+<button id="button"></button>
+
+<script>
+  test(function () {
+    const event = new InterestEvent("test");
+    assert_equals(event.source, null);
+    assert_readonly(event, "source", "readonly attribute value");
+  }, "source is readonly defaulting to null");
+
+  test(function () {
+    const eventInit = { source: document.body };
+    const event = new InterestEvent("test", eventInit);
+    assert_equals(event.source, document.body);
+  }, "InterestEventInit properties set value (manual event)");
+
+  test(function () {
+    const eventInit = {
+      source: document.getElementById("div"),
+    };
+    const event = new InterestEvent("beforetoggle", eventInit);
+    assert_equals(event.source, document.getElementById("div"));
+  }, "InterestEventInit properties set value (beforetoggle event)");
+
+  test(function () {
+    const eventInit = {
+      source: document.getElementById("button"),
+    };
+    const event = new InterestEvent("toggle", eventInit);
+    assert_equals(event.source, document.getElementById("button"));
+  }, "InterestEventInit properties set value (toggle event)");
+
+  test(function () {
+    const event = new InterestEvent("test", { source: undefined });
+    assert_equals(event.source, null);
+  }, "source set to undefined");
+
+  test(function () {
+    const event = new InterestEvent("test", { source: null });
+    assert_equals(event.source, null);
+  }, "source set to null");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        new InterestEvent("test", { source: false });
+      },
+      "source is not an object",
+    );
+  }, "source set to false");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        const event = new InterestEvent("test", { source: true });
+      },
+      "source is not an object",
+    );
+  }, "source set to true");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        const event = new InterestEvent("test", { source: {} });
+      },
+      "source is not an object",
+    );
+  }, "source set to {}");
+
+  test(function () {
+    assert_throws_js(
+      TypeError,
+      function () {
+        const eventInit = { source: new XMLHttpRequest() };
+        const event = new InterestEvent("toggle", eventInit);
+      },
+      "source is not an Element",
+    );
+  }, "source set to non-Element EventTarget");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative-expected.txt
@@ -1,0 +1,8 @@
+Anchor Anchor Other Button
+Anchor
+Child div
+
+FAIL InterestEvent is not dispatched unless the anchor has an href assert_true: interest should now be fired expected true got false
+FAIL InterestEvent dispatches on anchor hover assert_true: InterestEvent is fired expected true got false
+FAIL Nested invoker and invokee assert_array_equals: Hovering anchor should show interest lengths differ, expected array ["interest"] length 1, got [] length 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel=author href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="interestee"></div>
+<a id="nohref" interesttarget="interestee">Anchor</a>
+<a href="/" id="interestanchor" interesttarget="interestee">Anchor</a>
+<button id="otherbutton">Other Button</button>
+<style>
+  [interesttarget] {
+    interest-target-delay: 0s;
+  }
+</style>
+
+<script>
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      await hoverOver(otherbutton);
+    });
+    let gotEvent = false;
+    interestee.addEventListener("interest", () => (gotEvent = true));
+    await hoverOver(nohref);
+    assert_false(gotEvent, "InterestEvent should not get fired");
+    nohref.setAttribute('href','foo');
+    await hoverOver(nohref);
+    assert_false(gotEvent, "adding href while the element is already hovered should not fire interest");
+    await hoverOver(otherbutton);
+    await hoverOver(nohref);
+    assert_true(gotEvent, "interest should now be fired");
+  }, "InterestEvent is not dispatched unless the anchor has an href");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      await hoverOver(otherbutton);
+    });
+    let event = null;
+    interestee.addEventListener("interest", (e) => (event = e), { once: true });
+    await hoverOver(interestanchor);
+    assert_true(!!event, "InterestEvent is fired");
+    assert_true(event instanceof InterestEvent, "event is InterestEvent");
+    assert_equals(event.type, "interest", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, true, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.target, interestee, "target");
+    assert_equals(event.source, interestanchor, "source");
+  }, "InterestEvent dispatches on anchor hover");
+</script>
+
+<br>
+<a href="/" id="parentanchor" interesttarget="childdiv"><span>Anchor</span>
+  <div id="childdiv">Child div</div>
+</a>
+
+<script>
+  promise_test(async function (t) {
+    let events = [];
+    childdiv.addEventListener("interest", (e) => (events.push('interest')));
+    childdiv.addEventListener("loseinterest", (e) => (events.push('loseinterest')));
+    const justAnchor = parentanchor.firstChild;
+    assert_true(justAnchor instanceof HTMLSpanElement);
+    await hoverOver(justAnchor);
+    assert_array_equals(events,['interest'],'Hovering anchor should show interest');
+    await hoverOver(childdiv);
+    assert_array_equals(events,['interest'],'Hovering the target shouldn\'t fire any new events');
+    await hoverOver(justAnchor);
+    assert_array_equals(events,['interest'],'Hovering back on the anchor shouldn\'t fire new events');
+    await hoverOver(otherbutton);
+    assert_array_equals(events,['interest','loseinterest'],'De-hovering both should fire loseinterest');
+  }, "Nested invoker and invokee");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative-expected.txt
@@ -1,0 +1,5 @@
+    Other Button
+
+FAIL InterestEvent is not dispatched unless the area has an href assert_true: interest should now be fired expected true got false
+FAIL InterestEvent dispatches on area hover assert_true: InterestEvent is fired expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel=author href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="interestee"></div>
+<map id="map1"><area shape="default" id="nohref" interesttarget="interestee"></map>
+<img id=nohref_img src="/images/blue.png" usemap="#map1">
+<map id="map2"><area href="/" shape="default" id="interestarea" interesttarget="interestee"></map>
+<img id=interestarea_img src="/images/blue.png" usemap="#map2">
+<button id="otherbutton">Other Button</button>
+<style>
+  [interesttarget] {
+    interest-target-delay: 0s;
+  }
+</style>
+
+<script>
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      await hoverOver(otherbutton);
+    });
+    let gotEvent = false;
+    interestee.addEventListener("interest", () => (gotEvent = true), { once: true });
+    await hoverOver(nohref_img);
+    assert_false(gotEvent, "InterestEvent should not get fired");
+    nohref.setAttribute('href','foo');
+    await hoverOver(nohref_img);
+    assert_false(gotEvent, "adding href while the element is already hovered should not fire interest");
+    await hoverOver(otherbutton);
+    await hoverOver(nohref_img);
+    assert_true(gotEvent, "interest should now be fired");
+  }, "InterestEvent is not dispatched unless the area has an href");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      await hoverOver(otherbutton);
+    });
+    let event = null;
+    interestee.addEventListener("interest", (e) => (event = e), { once: true });
+    await hoverOver(interestarea_img);
+    assert_true(!!event, "InterestEvent is fired");
+    assert_true(event instanceof InterestEvent, "event is InterestEvent");
+    assert_equals(event.type, "interest", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, true, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.target, interestee, "target");
+    assert_equals(event.source, interestarea, "source");
+  }, "InterestEvent dispatches on area hover");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative-expected.txt
@@ -1,0 +1,4 @@
+UnrelatedInvoker
+
+FAIL Basic hover interest and loseinterest behavior promise_test: Unhandled rejection with value: object "TypeError: undefined is not an object (evaluating 'getComputedStyle(invoker).interestTargetShowDelay.slice')"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<body>
+<script>
+// NOTE. This is just a single, basic test of the delays for `interesttarget`.
+// The `interesttarget-hide-delay` and `interesttarget-show-delay` tests take a
+// much more in-depth look at *how* the features work, but due to some nuances
+// (please read the "NOTE" sections in those tests), they could end up passing
+// on browsers that don't actually support this feature. So this test takes
+// considerably longer, but should only pass on browsers that implement the
+// `interesttarget` attribute.
+
+const invokerDelays = 2000; // The CSS delay setting. Should be long enough to ensure it works, even on slow bots.
+const hoverWaitTime = 4000; // How long to wait to cover the delay for sure.
+
+promise_test(async (t) => {
+  assert_true(hoverWaitTime >= 2*invokerDelays,'invokerDelays is the value from CSS, hoverWaitTime should be longer than that');
+  let {popover:div, invoker, unrelated} = await createPopoverAndInvokerForHoverTests(t, invokerDelays, invokerDelays);
+  div.removeAttribute('popover'); // No longer a popover
+  let events = [];
+  div.addEventListener('interest',() => events.push('interest'));
+  div.addEventListener('loseinterest',() => events.push('loseinterest'));
+  // Quickly do the entire test.
+  await hoverOver(invoker);
+  const checkpoint1 = [...events];
+  await waitForHoverTime(hoverWaitTime);
+  const checkpoint2 = [...events];
+  await hoverOver(unrelated);
+  const checkpoint3 = [...events];
+  await waitForHoverTime(hoverWaitTime);
+  const checkpoint4 = [...events];
+  // Now test for expectations.
+  assert_array_equals(checkpoint1,[],'After initial hover, no events fired yet');
+  assert_array_equals(checkpoint2,['interest'],'After wait time, interest gets fired');
+  assert_array_equals(checkpoint3,['interest'],'After initial de-hover, no events fired yet');
+  assert_array_equals(checkpoint4,['interest','loseinterest'],'After wait time, loseinterest gets fired');
+},'Basic hover interest and loseinterest behavior');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative-expected.txt
@@ -1,0 +1,6 @@
+Button Other Button
+
+FAIL InterestEvent dispatches on button hover assert_true: InterestEvent is fired expected true got false
+PASS event does not dispatch if invoker is disabled
+FAIL event dispatches if interestee is non-HTML Element assert_true: InterestEvent is fired expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel=author href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="interestee"></div>
+<button id="interestbutton" interesttarget="interestee">Button</button>
+<button id="otherbutton">Other Button</button>
+<style>
+  [interesttarget] {
+    interest-target-delay: 0s;
+  }
+</style>
+
+<script>
+  promise_test(async function (t) {
+    let event = null;
+    interestee.addEventListener("interest", (e) => (event = e), { once: true });
+    await hoverOver(interestbutton);
+    assert_true(!!event, "InterestEvent is fired");
+    assert_true(event instanceof InterestEvent, "event is InterestEvent");
+    assert_equals(event.type, "interest", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, true, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.target, interestee, "target");
+    assert_equals(event.source, interestbutton, "source");
+  }, "InterestEvent dispatches on button hover");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      interestbutton.removeAttribute('disabled');
+      await hoverOver(otherbutton);
+    });
+    let called = false;
+    interestee.addEventListener(
+      "interest",
+      () => {
+        called = true;
+      },
+      { once: true },
+    );
+    interestbutton.setAttribute("disabled", "");
+    await hoverOver(interestbutton);
+    assert_false(called, "event was not called");
+  }, "event does not dispatch if invoker is disabled");
+
+  promise_test(async function (t) {
+    svgInterestee = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    t.add_cleanup(async () => {
+      interestbutton.interestTargetElement = interestee;
+      svgInterestee.remove();
+      await hoverOver(otherbutton);
+    });
+    document.body.append(svgInterestee);
+    let called = false;
+    assert_false(svgInterestee instanceof HTMLElement);
+    assert_true(svgInterestee instanceof Element);
+    let event = null;
+    svgInterestee.addEventListener("interest", (e) => (event = e), { once: true });
+    interestbutton.interestTargetElement = svgInterestee;
+    await hoverOver(interestbutton);
+    assert_true(!!event, "InterestEvent is fired");
+    assert_equals(event.source, interestbutton, "event.source is set to right element");
+    assert_equals(event.target, svgInterestee, "event.target is set to right element");
+  }, "event dispatches if interestee is non-HTML Element");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative-expected.txt
@@ -1,0 +1,78 @@
+
+FAIL Property interest-target-show-delay value '0s' assert_true: interest-target-show-delay doesn't seem to be supported in the computed style expected true got false
+FAIL Property interest-target-show-delay value '0ms' assert_true: interest-target-show-delay doesn't seem to be supported in the computed style expected true got false
+FAIL Property interest-target-show-delay value '32s' assert_true: interest-target-show-delay doesn't seem to be supported in the computed style expected true got false
+FAIL Property interest-target-show-delay value '123ms' assert_true: interest-target-show-delay doesn't seem to be supported in the computed style expected true got false
+FAIL e.style['interest-target-show-delay'] = "0s" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-show-delay'] = "0ms" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-show-delay'] = "32s" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-show-delay'] = "123ms" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-show-delay'] = "inherit" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['interest-target-show-delay'] = "0" should not set the property value
+PASS e.style['interest-target-show-delay'] = "foo" should not set the property value
+PASS e.style['interest-target-show-delay'] = "-1s" should not set the property value
+PASS e.style['interest-target-show-delay'] = "none" should not set the property value
+PASS e.style['interest-target-show-delay'] = "auto" should not set the property value
+FAIL CSS Transitions: property <interest-target-show-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-show-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-show-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-show-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-show-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-show-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-show-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-show-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-show-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-show-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-show-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-show-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-show-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL Property interest-target-hide-delay value '0s' assert_true: interest-target-hide-delay doesn't seem to be supported in the computed style expected true got false
+FAIL Property interest-target-hide-delay value '0ms' assert_true: interest-target-hide-delay doesn't seem to be supported in the computed style expected true got false
+FAIL Property interest-target-hide-delay value '32s' assert_true: interest-target-hide-delay doesn't seem to be supported in the computed style expected true got false
+FAIL Property interest-target-hide-delay value '123ms' assert_true: interest-target-hide-delay doesn't seem to be supported in the computed style expected true got false
+FAIL e.style['interest-target-hide-delay'] = "0s" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-hide-delay'] = "0ms" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-hide-delay'] = "32s" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-hide-delay'] = "123ms" should set the property value assert_not_equals: property should be set got disallowed value ""
+FAIL e.style['interest-target-hide-delay'] = "inherit" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['interest-target-hide-delay'] = "0" should not set the property value
+PASS e.style['interest-target-hide-delay'] = "foo" should not set the property value
+PASS e.style['interest-target-hide-delay'] = "-1s" should not set the property value
+PASS e.style['interest-target-hide-delay'] = "none" should not set the property value
+PASS e.style['interest-target-hide-delay'] = "auto" should not set the property value
+FAIL CSS Transitions: property <interest-target-hide-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-hide-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-hide-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-hide-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-hide-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions: property <interest-target-hide-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-hide-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-hide-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-hide-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-hide-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-hide-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Transitions with transition: all: property <interest-target-hide-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL CSS Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (-1.5) should be [0s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (-0.3) should be [0.7s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (0) should be [1s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (0.5) should be [1.5s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (1) should be [2s] assert_true: 'from' value should be supported expected true got false
+FAIL Web Animations: property <interest-target-hide-delay> from [1s] to [2000ms] at (1.5) should be [2.5s] assert_true: 'from' value should be supported expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<div id=target></div>
+<div id=scratch></div>
+
+<script>
+function testprop(prop) {
+  // Computed values:
+  test_computed_value(prop, '0s');
+  test_computed_value(prop, '0ms', '0s');
+  test_computed_value(prop, '32s');
+  test_computed_value(prop, '123ms', '0.123s');
+
+  // Valid values:
+  test_valid_value(prop, '0s');
+  test_valid_value(prop, '0ms');
+  test_valid_value(prop, '32s');
+  test_valid_value(prop, '123ms');
+  test_valid_value(prop, 'inherit');
+
+  // Invalid values:
+  test_invalid_value(prop, '0', '0s');
+  test_invalid_value(prop, 'foo');
+  test_invalid_value(prop, '-1s');
+  test_invalid_value(prop, 'none');
+  test_invalid_value(prop, 'auto');
+
+  // Animations:
+  test_interpolation({
+    property: prop,
+    from: '1s',
+    to: '2000ms',
+  }, [
+    {at: -1.5, expect: '0s'}, // Clamping at 0
+    {at: -0.3, expect: '0.7s'},
+    {at: 0, expect: '1s'},
+    {at: 0.5, expect: '1.5s'},
+    {at: 1, expect: '2s'},
+    {at: 1.5, expect: '2.5s'},
+  ]);
+}
+
+testprop('interest-target-show-delay');
+testprop('interest-target-hide-delay');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative-expected.txt
@@ -1,0 +1,14 @@
+
+FAIL e.style['interest-target-delay'] = "0.23s 450ms" should set interest-target-hide-delay assert_equals: interest-target-hide-delay should be canonical expected (string) "450ms" but got (undefined) undefined
+FAIL e.style['interest-target-delay'] = "0.23s 450ms" should set interest-target-show-delay assert_equals: interest-target-show-delay should be canonical expected (string) "0.23s" but got (undefined) undefined
+FAIL e.style['interest-target-delay'] = "0.23s 450ms" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['interest-target-delay'] = "0.23s" should set interest-target-hide-delay assert_equals: interest-target-hide-delay should be canonical expected (string) "0.23s" but got (undefined) undefined
+FAIL e.style['interest-target-delay'] = "0.23s" should set interest-target-show-delay assert_equals: interest-target-show-delay should be canonical expected (string) "0.23s" but got (undefined) undefined
+FAIL e.style['interest-target-delay'] = "0.23s" should not set unrelated longhands assert_true: expected true got false
+FAIL e.style['interest-target-delay'] = "450ms" should set interest-target-hide-delay assert_equals: interest-target-hide-delay should be canonical expected (string) "450ms" but got (undefined) undefined
+FAIL e.style['interest-target-delay'] = "450ms" should set interest-target-show-delay assert_equals: interest-target-show-delay should be canonical expected (string) "450ms" but got (undefined) undefined
+FAIL e.style['interest-target-delay'] = "450ms" should not set unrelated longhands assert_true: expected true got false
+PASS e.style['interest-target-delay'] = "" should not set the property value
+PASS e.style['interest-target-delay'] = "0" should not set the property value
+PASS e.style['interest-target-delay'] = "0.23s 0.23s 0.23s" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+
+<body>
+<script>
+test_shorthand_value('interest-target-delay', '0.23s 450ms', {
+  'interest-target-show-delay': '0.23s',
+  'interest-target-hide-delay': '450ms'
+});
+test_shorthand_value('interest-target-delay', '0.23s', {
+  'interest-target-show-delay': '0.23s',
+  'interest-target-hide-delay': '0.23s'
+});
+test_shorthand_value('interest-target-delay', '450ms', {
+  'interest-target-show-delay': '450ms',
+  'interest-target-hide-delay': '450ms'
+});
+
+test_invalid_value('interest-target-delay', '');
+test_invalid_value('interest-target-delay', '0');
+test_invalid_value('interest-target-delay', '0.23s 0.23s 0.23s');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative-expected.txt
@@ -1,0 +1,7 @@
+Unrelated
+Button
+Target
+
+FAIL The :has-interest pseudo class matches when an element has interest promise_test: Unhandled rejection with value: object "SyntaxError: ':has-interest' is not a valid selector."
+FAIL The :has-interest pseudo class only matches after delays, once interest is shown promise_test: Unhandled rejection with value: object "SyntaxError: ':has-interest' is not a valid selector."
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id=unrelated>Unrelated</div>
+<button id=button interesttarget=target>Button</button>
+<div id=target>Target</div>
+<style>
+  button {
+    interest-target-delay: 0s;
+  }
+</style>
+<script>
+promise_test(async (t) => {
+  let hasInterest = false;
+  target.addEventListener('interest',() => (hasInterest=true));
+  target.addEventListener('loseinterest',() => (hasInterest=false));
+  assert_false(button.matches(':has-interest'));
+  assert_false(target.matches(':has-interest'));
+  assert_false(hasInterest);
+  await hoverOver(button);
+  assert_true(button.matches(':has-interest'),'hovering button shows interest');
+  assert_false(target.matches(':has-interest'),'target never matches the pseudo class');
+  assert_true(hasInterest,'event was fired');
+  await hoverOver(target);
+  assert_true(button.matches(':has-interest'),'hovering the target maintains interest');
+  assert_false(target.matches(':has-interest'),'target never matches the pseudo class');
+  assert_true(hasInterest,'loseinterest event was not yet fired');
+  await hoverOver(unrelated);
+  assert_false(button.matches(':has-interest'),'hovering unrelated loses interest');
+  assert_false(target.matches(':has-interest'),'target never matches the pseudo class');
+  assert_false(hasInterest,'loseinterest event was fired');
+},'The :has-interest pseudo class matches when an element has interest');
+
+const invokerDelayMs = 100; // The CSS delay setting.
+const hoverWaitTime = 200; // How long to wait to cover the delay for sure.
+promise_test(async (t) => {
+  t.add_cleanup(() => button.removeAttribute('style'));
+  button.setAttribute('style',`interest-target-delay: ${invokerDelayMs}ms`);
+  assert_false(button.matches(':has-interest'));
+  const token1 = await mouseOverAndRecord(t,button);
+  const immediate_result = button.matches(':has-interest');
+  if (msSinceMouseOver(token1) < invokerDelayMs) {
+    assert_false(immediate_result,':has-interest should not match before the show delay elapses');
+  }
+  await waitForHoverTime(hoverWaitTime);
+  assert_true(button.matches(':has-interest'),':has-interest should match after hover delay');
+  const token2 = await mouseOverAndRecord(t,unrelated);
+  const immediate_result2 = button.matches(':has-interest');
+  if (msSinceMouseOver(token2) < invokerDelayMs) {
+    assert_true(immediate_result2,':has-interest should still match before the hide delay elapses');
+  }
+  await waitForHoverTime(hoverWaitTime);
+  assert_false(button.matches(':has-interest'),':has-interest should not match after de-hover delay');
+},'The :has-interest pseudo class only matches after delays, once interest is shown');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+FAIL Test the harness assert_true: interesttarget is not supported expected true got false
+FAIL The interest-target-hide-delay causes interest to be lost after a delay assert_true: interesttarget is not supported expected true got false
+FAIL hovering the interest target element keeps the invoker from losing interest assert_true: interesttarget is not supported expected true got false
+FAIL moving hover between the invoker and the target prevents interest lost assert_true: interesttarget is not supported expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<body>
+<script>
+// NOTE about testing methodology:
+// This test uses popovers as an invoker target, and checks whether they are
+// hidden *after* the appropriate de-hover delay. The delay used for testing is
+// kept low, to avoid this test taking too long, but that means that sometimes
+// on a slow bot/client, the hover delay can elapse before we are able to check
+// the popover status. And that can make this test flaky. To avoid that, the
+// msSinceMouseOver() function is used to check that not-too-much time has
+// passed, and if it has, the test is simply skipped. Because of this
+// methodology, many/most of these tests will pass on browsers that do not
+// implement `interesttarget`. See the `interesttarget-basic-delays` test.
+const invokerHideDelay = 100; // The CSS delay setting.
+const hoverWaitTime = 200; // How long to wait to cover the delay for sure.
+
+async function makeTestParts(t) {
+  // This ensures the tests in this file don't succeed sometimes, due to the above NOTE.
+  assert_true(HTMLAnchorElement.prototype.hasOwnProperty('interestTargetElement'),'interesttarget is not supported');
+  let {popover, invoker, unrelated} = await createPopoverAndInvokerForHoverTests(t, /*showdelayMs*/ 0, invokerHideDelay);
+  let mouseOverInvoker;
+  invoker.innerHTML = '<span><span>Click me</span></span>';
+  mouseOverInvoker = invoker.firstElementChild.firstElementChild;
+  assert_true(!!mouseOverInvoker);
+  assert_false(popover.matches(':popover-open'));
+  await hoverOver(invoker); // Always start with the mouse over the invoker, which will invoke the popover immediately
+  assert_true(popover.matches(':popover-open'));
+  return {popover, invoker, unrelated, mouseOverInvoker};
+}
+
+promise_test(async (t) => {
+  const {popover,invoker} = await makeTestParts(t);
+  const token = await mouseOverAndRecord(t,invoker);
+  await waitForHoverTime(hoverWaitTime);
+  assert_true(msSinceMouseOver(token) >= hoverWaitTime,'waitForHoverTime should wait the specified time');
+  assert_true(hoverWaitTime > invokerHideDelay,'invokerHideDelay is the value from CSS, hoverWaitTime should be longer than that');
+},'Test the harness');
+
+promise_test(async (t) => {
+  const {popover,invoker,unrelated} = await makeTestParts(t);
+  const token = await mouseOverAndRecord(t,unrelated);
+  let showing = popover.matches(':popover-open');
+  if (msSinceMouseOver(token) < invokerHideDelay) {
+    // Only check if the WPT runner wasn't too slow.
+    assert_true(showing,'interest shouldn\'t be immediately lost');
+  }
+  await hoverOver(unrelated);
+  await waitForHoverTime(hoverWaitTime);
+  assert_false(popover.matches(':popover-open'),'interest should be lost after delay');
+},`The interest-target-hide-delay causes interest to be lost after a delay`);
+
+promise_test(async (t) => {
+  const {popover,invoker,unrelated} = await makeTestParts(t);
+  await hoverOver(popover);
+  await waitForHoverTime(hoverWaitTime);
+  assert_true(popover.matches(':popover-open'),'hovering the interest target element should keep it showing');
+  const token = await mouseOverAndRecord(t,unrelated);
+  let showing = popover.matches(':popover-open');
+  if (msSinceMouseOver(token) >= invokerHideDelay)
+    return; // The WPT runner was too slow.
+  assert_true(showing,'subsequently hovering unrelated element shouldn\'t immediately cause interest lost');
+  await hoverOver(unrelated);
+  await waitForHoverTime(hoverWaitTime);
+  assert_false(popover.matches(':popover-open'),'hovering unrelated element should cause interest lost after delay');
+},`hovering the interest target element keeps the invoker from losing interest`);
+
+promise_test(async (t) => {
+  const {popover,invoker,unrelated,mouseOverInvoker} = await makeTestParts(t);
+  await hoverOver(popover);
+  await waitForHoverTime(hoverWaitTime);
+  await hoverOver(mouseOverInvoker);
+  await waitForHoverTime(hoverWaitTime);
+  assert_true(popover.matches(':popover-open'),'Moving hover between invoker and target should not cause interest lost');
+  await hoverOver(unrelated);
+  await waitForHoverTime(hoverWaitTime);
+  assert_false(popover.matches(':popover-open'),'Moving hover to unrelated should cause interest lost');
+},`moving hover between the invoker and the target prevents interest lost`);
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative-expected.txt
@@ -1,0 +1,33 @@
+Button Link
+SVG A
+ Other button Another Button
+
+FAIL Basic keyboard behavior, <button> assert_true: Pressing the hot key should trigger interest expected true got false
+PASS Extra Shift modifier on the gain interest hot key, <button>
+PASS Extra Control modifier on the gain interest hot key, <button>
+PASS Extra Meta modifier on the gain interest hot key, <button>
+PASS canceling the interest event stops behavior, <button>
+FAIL Showing interest in a second element loses interest in the first, <button> assert_array_equals: first hotkey lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Cancelling loseinterest caused by keyboard-gained interest cancels interest, <button> assert_array_equals: setup lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Basic keyboard behavior, <a> assert_true: Pressing the hot key should trigger interest expected true got false
+PASS Extra Shift modifier on the gain interest hot key, <a>
+PASS Extra Control modifier on the gain interest hot key, <a>
+PASS Extra Meta modifier on the gain interest hot key, <a>
+PASS canceling the interest event stops behavior, <a>
+FAIL Showing interest in a second element loses interest in the first, <a> assert_array_equals: first hotkey lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Cancelling loseinterest caused by keyboard-gained interest cancels interest, <a> assert_array_equals: setup lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Basic keyboard behavior, <area> assert_equals: Elements should all be focusable expected Element node <area id="<area>" interesttarget="target" href="/" shape=... but got Element node <button id="another" interesttarget="anothertarget">Anoth...
+PASS Extra Shift modifier on the gain interest hot key, <area>
+PASS Extra Control modifier on the gain interest hot key, <area>
+PASS Extra Meta modifier on the gain interest hot key, <area>
+PASS canceling the interest event stops behavior, <area>
+FAIL Showing interest in a second element loses interest in the first, <area> assert_array_equals: first hotkey lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Cancelling loseinterest caused by keyboard-gained interest cancels interest, <area> assert_array_equals: setup lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Basic keyboard behavior, SVG <a> assert_true: Pressing the hot key should trigger interest expected true got false
+PASS Extra Shift modifier on the gain interest hot key, SVG <a>
+PASS Extra Control modifier on the gain interest hot key, SVG <a>
+PASS Extra Meta modifier on the gain interest hot key, SVG <a>
+PASS canceling the interest event stops behavior, SVG <a>
+FAIL Showing interest in a second element loses interest in the first, SVG <a> assert_array_equals: first hotkey lengths differ, expected array ["target interest"] length 1, got [] length 0
+FAIL Cancelling loseinterest caused by keyboard-gained interest cancels interest, SVG <a> assert_array_equals: setup lengths differ, expected array ["target interest"] length 1, got [] length 0
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<meta name="timeout" content="long">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="examples">
+  <button id="<button>" interesttarget=target>Button</button>
+  <a id="<a>" href=foo interesttarget=target>Link</a>
+  <img src="/images/blue.png" usemap="#map">
+  <map id=map>
+    <area id="<area>" interesttarget=target href="/" shape=default id=interestarea>
+  </map>
+    <svg viewBox="0 0 100 100" style="width: 100px" xmlns="http://www.w3.org/2000/svg">
+    <a id="SVG <a>" href=foo interesttarget=target>
+      <text x=50 y=90>SVG A</text>
+    </a>
+  </svg>
+</div>
+
+<div id=target popover>Popover</div>
+<button id="otherbutton">Other button</button>
+<button id="another" interesttarget=anothertarget>Another Button</button>
+<div id=anothertarget popover>Another Popover</div>
+
+<style>
+  [interesttarget] {
+    interest-target-delay: 0s;
+  }
+</style>
+
+<script>
+const kShift = "\uE008";
+const kMeta = "\uE03d";
+const kControl = "\uE009";
+const kAlt = "\uE00A";
+const kArrowUp = '\uE013';
+const kEscape = '\uE00C';
+function sendLoseInterestHotkey() {
+  return new test_driver.Actions()
+    .keyDown(kEscape)
+    .keyUp(kEscape)
+    .send();
+}
+function sendShowInterestHotkey(extra_modifier) {
+  assert_not_equals(extra_modifier,kAlt);
+  let actions = new test_driver.Actions();
+  if (extra_modifier) {
+    actions.keyDown(extra_modifier);
+  }
+  actions.keyDown(kAlt)
+    .keyDown(kArrowUp)
+    .keyUp(kArrowUp)
+    .keyUp(kAlt);
+  if (extra_modifier) {
+    actions.keyUp(extra_modifier);
+  }
+  return actions.send();
+}
+const allInterestTargetElements = document.querySelectorAll('#examples [interesttarget]');
+function verifyInterest(onlyElement,description) {
+  [...allInterestTargetElements, another].forEach(el => {
+    const expectInterest = el == onlyElement;
+    assert_equals(el.matches(':has-interest'),expectInterest,`${description}, element ${el.id} should ${expectInterest ? "" : "NOT "}have interest`);
+  })
+}
+allInterestTargetElements.forEach(el => {
+  const description = `${el.id}`;
+  promise_test(async function (t) {
+    target.hidePopover(); // Just in case
+    el.focus();
+    assert_equals(document.activeElement,el,'Elements should all be focusable');
+    assert_false(target.matches(':popover-open'),'focusing does not trigger interest');
+    await sendShowInterestHotkey();
+    assert_true(target.matches(':popover-open'),'Pressing the hot key should trigger interest');
+    verifyInterest(el,`After show interest in ${el.id}`);
+    await sendLoseInterestHotkey();
+    assert_false(target.matches(':popover-open'),'Pressing lose interest hot key should trigger lose interest');
+    verifyInterest(undefined,`After lose interest in ${el.id}`);
+  },`Basic keyboard behavior, ${description}`);
+
+  for (const key of ['Shift','Control','Meta']) {
+    extra_key = eval('k' + key);
+    promise_test(async function (t) {
+      target.hidePopover(); // Just in case
+      el.focus();
+      await sendShowInterestHotkey(extra_key);
+      assert_false(target.matches(':popover-open'),'Pressing the hot key with extra modifiers should not trigger interest');
+    },`Extra ${key} modifier on the gain interest hot key, ${description}`);
+  }
+
+  promise_test(async function (t) {
+    target.hidePopover(); // Just in case
+    target.addEventListener('interest', (e) => e.preventDefault(), {once: true});
+    el.focus();
+    await sendShowInterestHotkey();
+    assert_false(target.matches(':popover-open'));
+  }, `canceling the interest event stops behavior, ${description}`);
+
+  let events = [];
+  function addListeners(t,element) {
+    const controller = new AbortController();
+    const signal = controller.signal;
+    t.add_cleanup(() => controller.abort());
+    element.addEventListener('interest',(e) => events.push(`${e.target.id} interest`),{signal});
+    element.addEventListener('loseinterest',(e) => events.push(`${e.target.id} loseinterest`),{signal});
+  }
+  promise_test(async function (t) {
+    target.hidePopover(); // Just in case
+    anothertarget.hidePopover(); // Just in case
+    events = [];
+    addListeners(t,target);
+    addListeners(t,anothertarget);
+    el.focus();
+    await sendShowInterestHotkey();
+    assert_array_equals(events,['target interest'],'first hotkey');
+    verifyInterest(el,`After show interest in ${el.id}`);
+    another.focus();
+    assert_array_equals(events,['target interest'],'focusing another element does not change interest');
+    verifyInterest(el,`After focus on ${another.id}`);
+    await sendShowInterestHotkey();
+    assert_array_equals(events,['target interest','target loseinterest','anothertarget interest'],
+        'showing interest in another trigger should lose interest in the first, then gain interest in second');
+    verifyInterest(another,`After show interest in ${another.id}`);
+    await sendLoseInterestHotkey();
+    assert_array_equals(events,['target interest','target loseinterest','anothertarget interest','anothertarget loseinterest']);
+    verifyInterest(undefined,`After lose interest in ${another.id}`);
+    assert_false(target.matches(':popover-open'));
+    assert_false(anothertarget.matches(':popover-open'));
+  }, `Showing interest in a second element loses interest in the first, ${description}`);
+
+  promise_test(async function (t) {
+    target.hidePopover(); // Just in case
+    anothertarget.hidePopover(); // Just in case
+    events = [];
+    addListeners(t,target);
+    addListeners(t,anothertarget);
+    el.focus();
+    await sendShowInterestHotkey();
+    another.focus();
+    assert_array_equals(events,['target interest'],'setup');
+    verifyInterest(el,`After show interest in ${el.id}`);
+    target.addEventListener('loseinterest',(e) => e.preventDefault(),{once: true});
+    await sendShowInterestHotkey();
+    assert_array_equals(events,['target interest','target loseinterest'],
+        'the loseinterest listener should fire, but anothertarget should not get interest');
+    verifyInterest(el,`After show interest in ${another.id}`);
+    el.focus();
+    await sendLoseInterestHotkey();
+    assert_array_equals(events,['target interest','target loseinterest','target loseinterest'],'Another event fired');
+    assert_false(target.matches(':popover-open'));
+    assert_false(anothertarget.matches(':popover-open'));
+    verifyInterest(undefined,`After lose interest in ${el.id}`);
+  }, `Cancelling loseinterest caused by keyboard-gained interest cancels interest, ${description}`);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+
+<button>Button</button>
+<button>Button</button>
+<button id=hasinterest>Button</button>
+<button class=otherselector>Button</button>
+<button class=otherselector>Button</button>
+<div>Target</div>
+
+<style>
+  #hasinterest {
+    background-color: red;
+  }
+  .otherselector {
+    background-color: green;
+  }
+</style>
+
+<script>
+  hasinterest.focus();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+
+<button>Button</button>
+<button>Button</button>
+<button id=hasinterest>Button</button>
+<button class=otherselector>Button</button>
+<button class=otherselector>Button</button>
+<div>Target</div>
+
+<style>
+  #hasinterest {
+    background-color: red;
+  }
+  .otherselector {
+    background-color: green;
+  }
+</style>
+
+<script>
+  hasinterest.focus();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<link rel=match href="interesttarget-keyboard-invalidation-ref.html">
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<button id=b1 interesttarget=target>Button</button>
+<button id=b2 interesttarget=target>Button</button>
+<button id=b3 interesttarget=target>Button</button>
+<button id=b4>Button</button>
+<button id=b5>Button</button>
+<div id=target>Target</div>
+
+<style>
+  :has-interest {
+    background-color: red;
+  }
+  :has-interest + button {
+    background-color: green;
+  }
+  :root:has(:has-interest) #b5 {
+    background-color: green;
+  }
+</style>
+
+<script>
+const kAlt = "\uE00A";
+const kArrowUp = '\uE013';
+function keyboardActivate() {
+  return new test_driver.Actions()
+    .keyDown(kAlt)
+    .keyDown(kArrowUp)
+    .keyUp(kArrowUp)
+    .keyUp(kAlt)
+    .send();
+}
+buttons = Array.from(document.querySelectorAll('[interesttarget]'));
+async function runTest() {
+  for (const b of buttons) {
+    b.focus();
+    await keyboardActivate();
+  }
+  document.documentElement.classList.remove("reftest-wait");
+}
+runTest();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative-expected.txt
@@ -1,0 +1,5 @@
+Interest Invoker Other button
+
+FAIL hover interest invoking closed popover opens assert_true: expected true got false
+PASS interest invoking closed popover with preventDefault does not open
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="interestee" popover>
+  Popover Content
+</div>
+<button id="interestbutton" interesttarget="interestee">Interest Invoker</button>
+<button id="otherbutton">Other button</button>
+<style>
+  [interesttarget] {
+    interest-target-delay: 0s;
+  }
+</style>
+
+<script>
+  async function reset() {
+      await hoverOver(otherbutton);
+      interestee.hidePopover();
+  }
+  promise_test(async function (t) {
+    t.add_cleanup(reset);
+    assert_false(interestee.matches(":popover-open"));
+    await hoverOver(interestbutton);
+    assert_true(interestee.matches(":popover-open"));
+  }, "hover interest invoking closed popover opens");
+
+  promise_test(async function (t) {
+    t.add_cleanup(reset);
+    assert_false(interestee.matches(":popover-open"));
+    interestee.addEventListener("interest", (e) => e.preventDefault(), {
+      once: true,
+    });
+    await hoverOver(interestbutton);
+    assert_false(interestee.matches(":popover-open"));
+  }, "interest invoking closed popover with preventDefault does not open");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative-expected.txt
@@ -1,0 +1,23 @@
+
+FAIL interesttarget fires after a delay, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget should not trigger via mouse click, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget interest-target-show-delay is respected, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does not close an already-open popover, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does nothing when the target is moved out of the document, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does nothing when the target changes, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL moving hover between two invokers for the same target does the right thing, invokerLayout=plain assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget fires after a delay, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget should not trigger via mouse click, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget interest-target-show-delay is respected, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does not close an already-open popover, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does nothing when the target is moved out of the document, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does nothing when the target changes, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL moving hover between two invokers for the same target does the right thing, invokerLayout=nested assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget fires after a delay, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget should not trigger via mouse click, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget interest-target-show-delay is respected, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does not close an already-open popover, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does nothing when the target is moved out of the document, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+FAIL interesttarget does nothing when the target changes, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+FAIL moving hover between two invokers for the same target does the right thing, invokerLayout=nested-offset assert_true: interesttarget is not supported expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<body>
+<script>
+// NOTE about testing methodology:
+// This test uses popovers as an invoker target, and checks whether they are
+// triggered *after* the appropriate hover delay. The delay used for testing is
+// kept low, to avoid this test taking too long, but that means that sometimes
+// on a slow bot/client, the hover delay can elapse before we are able to check
+// the popover status. And that can make this test flaky. To avoid that, the
+// msSinceMouseOver() function is used to check that not-too-much time has
+// passed, and if it has, the test is simply skipped. Because of this
+// methodology, many/most of these tests will pass on browsers that do not
+// implement `interesttarget`. See the `interesttarget-basic-delays` test.
+
+const invokerShowDelay = 100; // The CSS delay setting.
+const hoverWaitTime = 200; // How long to wait to cover the delay for sure.
+
+async function makePopoverAndInvoker(test, invokerLayout, showdelayMs) {
+  // This ensures the tests in this file don't succeed sometimes, due to the above NOTE.
+  assert_true(HTMLAnchorElement.prototype.hasOwnProperty('interestTargetElement'),'interesttarget is not supported');
+  if (showdelayMs === undefined) {
+    showdelayMs = invokerShowDelay;
+  }
+  let {popover, invoker, unrelated} = await createPopoverAndInvokerForHoverTests(test, showdelayMs, /*hidedelayMs*/10000000);
+  invoker.setAttribute('class','invoker');
+  const originalInvoker = invoker;
+  const reassignInvokerTargetFn = (p) => {originalInvoker.interestTargetElement = p};
+  switch (invokerLayout) {
+    case 'plain':
+      // Invoker is just a button.
+      invoker.textContent = 'Invoker';
+      break;
+    case 'nested':
+      // Invoker is just a button containing a div.
+      const child1 = invoker.appendChild(document.createElement('div'));
+      child1.textContent = 'Invoker';
+      break;
+    case 'nested-offset':
+      // Invoker is a child of the invoking button, and is not contained within
+      // the bounds of the interesttarget element.
+      invoker.textContent = 'Invoker';
+      // Reassign invoker to the child:
+      invoker = invoker.appendChild(document.createElement('div'));
+      invoker.textContent = 'Invoker child';
+      invoker.setAttribute('style','position:relative; top:300px; left:300px;');
+      break;
+    default:
+      assert_unreached(`Invalid invokerLayout ${invokerLayout}`);
+  }
+  test.add_cleanup(async () => {
+    originalInvoker.remove();
+    await waitForRender();
+  });
+  await hoverOver(unrelated); // Start by mousing over the unrelated element
+  await waitForRender();
+  assert_false(popover.matches(':popover-open'),'Popover should start out closed');
+  return {popover,invoker,unrelated,reassignInvokerTargetFn};
+}
+
+["plain","nested","nested-offset"].forEach(invokerLayout => {
+  promise_test(async (t) => {
+    const {popover,invoker} = await makePopoverAndInvoker(t,invokerLayout);
+    const token = await mouseOverAndRecord(t,invoker);
+    let showing = popover.matches(':popover-open');
+    // See NOTE above.
+    if (msSinceMouseOver(token) < invokerShowDelay)
+      assert_false(showing,'interest should not be shown immediately');
+    await waitForHoverTime(hoverWaitTime);
+    assert_true(msSinceMouseOver(token) >= hoverWaitTime,'waitForHoverTime should wait the specified time');
+    assert_true(popover.matches(':popover-open'),'interest should be shown after the delay');
+    assert_true(hoverWaitTime > invokerShowDelay,'invokerShowDelay is the CSS setting, hoverWaitTime should be longer than that');
+  },`interesttarget fires after a delay, invokerLayout=${invokerLayout}`);
+
+  promise_test(async (t) => {
+    const {popover,invoker} = await makePopoverAndInvoker(t,invokerLayout);
+    assert_false(popover.matches(':popover-open'));
+    invoker.click(); // Click the invoker
+    assert_false(popover.matches(':popover-open'),'Clicking the invoker should not "show interest"');
+  },`interesttarget should not trigger via mouse click, invokerLayout=${invokerLayout}`);
+
+  promise_test(async (t) => {
+    const longerHoverDelay = hoverWaitTime*2;
+    const {popover,invoker} = await makePopoverAndInvoker(t,invokerLayout,longerHoverDelay);
+    const token = await mouseOverAndRecord(t,invoker);
+    await waitForHoverTime(hoverWaitTime);
+    showing = popover.matches(':popover-open');
+    if (msSinceMouseOver(token) >= longerHoverDelay)
+      return; // The WPT runner was too slow.
+    assert_false(showing,'interesttarget should respect CSS setting');
+  },`interesttarget interest-target-show-delay is respected, invokerLayout=${invokerLayout}`);
+
+  promise_test(async (t) => {
+    const {popover,invoker} = await makePopoverAndInvoker(t,invokerLayout);
+    popover.showPopover();
+    assert_true(popover.matches(':popover-open'));
+    let gotInterest = false;
+    popover.addEventListener('interest',() => (gotInterest=true),{once:true});
+    await hoverOver(invoker);
+    const stillOpen = popover.matches(':popover-open');
+    await waitForHoverTime(hoverWaitTime);
+    assert_true(popover.matches(':popover-open'),'popover should stay showing after delay');
+    assert_true(stillOpen,'popover should have been open before the delay also');
+    assert_true(gotInterest,'interest event should still be fired');
+  },`interesttarget does not close an already-open popover, invokerLayout=${invokerLayout}`);
+
+  promise_test(async (t) => {
+    const {popover,invoker} = await makePopoverAndInvoker(t,invokerLayout);
+    popover.remove(); // Remove from the document
+    let gotInterest = false;
+    popover.addEventListener('interest',() => (gotInterest=true),{once:true});
+    await hoverOver(invoker);
+    await waitForHoverTime(hoverWaitTime);
+    assert_false(gotInterest,'interest should not be shown if the target is removed');
+    // Now put it back in the document and make sure it doesn't trigger.
+    document.body.appendChild(popover);
+    await waitForHoverTime(hoverWaitTime);
+    assert_false(gotInterest,'interest should not be shown even when returned to the document');
+  },`interesttarget does nothing when the target is moved out of the document, invokerLayout=${invokerLayout}`);
+
+  promise_test(async (t) => {
+    const {popover,invoker,reassignInvokerTargetFn} = await makePopoverAndInvoker(t,invokerLayout);
+    const popover2 = document.createElement('div');
+    popover2.popover = 'auto';
+    document.body.appendChild(popover2);
+    t.add_cleanup(() => popover2.remove());
+    const token = await mouseOverAndRecord(t,invoker);
+    let eitherShowing = popover.matches(':popover-open') || popover2.matches(':popover-open');
+    reassignInvokerTargetFn(popover2);
+    // See NOTE above.
+    if (msSinceMouseOver(token) >= invokerShowDelay)
+      return; // The WPT runner was too slow.
+    assert_false(eitherShowing,'interest should should not be shown immediately');
+    await waitForHoverTime(hoverWaitTime);
+    assert_false(popover.matches(':popover-open'),'old target should not receive interest, since interesttarget was reassigned');
+    assert_false(popover2.matches(':popover-open'),'new target should not receive interest, since interesttarget was reassigned');
+  },`interesttarget does nothing when the target changes, invokerLayout=${invokerLayout}`);
+
+  promise_test(async (t) => {
+    const {popover,invoker,unrelated} = await makePopoverAndInvoker(t,invokerLayout,/*showdelayMs*/0);
+    const invoker2 = document.createElement('button');
+    invoker2.interestTargetElement = popover;
+    document.body.appendChild(invoker2);
+    t.add_cleanup(() => invoker2.remove());
+    invoker2.setAttribute('style',`
+      interest-target-show-delay: 0s;
+      interest-target-hide-delay: 10000s;
+      position:fixed;
+      top:300px;
+    `);
+    invoker2.innerText = 'Invoker 2';
+    let events = [];
+    popover.addEventListener('interest',() => events.push('interest'));
+    popover.addEventListener('loseinterest',() => events.push('lose interest'));
+    popover.addEventListener('beforetoggle',(e) => events.push(e.newState));
+    assert_array_equals(events,[]);
+    await hoverOver(invoker);
+    assert_array_equals(events,['interest','open']);
+    // Different invoker for same target - should first (immediately) lose interest on old invoker.
+    await hoverOver(invoker2);
+    assert_array_equals(events,['interest','open','lose interest','closed','interest','open']);
+    // Lose interest delays are long, so nothing happens here.
+    events = [];
+    await hoverOver(unrelated);
+    assert_array_equals(events,[]);
+    // Back to the same invoker - shouldn't re-fire events.
+    await hoverOver(invoker2);
+    assert_array_equals(events,[]);
+    assert_true(popover.matches(':popover-open'));
+    popover.hidePopover();
+  },`moving hover between two invokers for the same target does the right thing, invokerLayout=${invokerLayout}`);
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative-expected.txt
@@ -1,0 +1,7 @@
+SVG A
+SVG A
+ Other Button
+
+FAIL InterestEvent is not dispatched unless the svg <a> has an href assert_true: interest should now be fired expected true got false
+FAIL InterestEvent dispatches on svg <a> hover assert_true: InterestEvent is fired expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<meta charset="utf-8" />
+<link rel="author" title="Keith Cirkel" href="mailto:keithamus@github.com" >
+<link rel="author" title="Luke Warlow" href="mailto:lwarlow@igalia.com" >
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel="help" href="https://open-ui.org/components/interest-invokers.explainer">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<div id="interestee"></div>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <a id="nohref" interesttarget="interestee"><text x="50" y="90">SVG A</text></a>
+</svg>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <a href="/" id="interestsvga" interesttarget="interestee"><text x="50" y="90">SVG A</text></a>
+</svg>
+<button id="otherbutton">Other Button</button>
+<style>
+  [interesttarget] {
+    interest-target-delay: 0s;
+  }
+</style>
+
+<script>
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      await hoverOver(otherbutton);
+    });
+    let gotEvent = false;
+    interestee.addEventListener("interest", () => (gotEvent = true));
+    await hoverOver(nohref);
+    assert_false(gotEvent, "InterestEvent should not get fired");
+    nohref.setAttribute('href','foo');
+    await hoverOver(nohref);
+    assert_false(gotEvent, "adding href while the element is already hovered should not fire interest");
+    await hoverOver(otherbutton);
+    await hoverOver(nohref);
+    assert_true(gotEvent, "interest should now be fired");
+  }, "InterestEvent is not dispatched unless the svg <a> has an href");
+
+  promise_test(async function (t) {
+    t.add_cleanup(async () => {
+      await hoverOver(otherbutton);
+    });
+    let event = null;
+    interestee.addEventListener("interest", (e) => (event = e), { once: true });
+    await hoverOver(interestsvga);
+    assert_true(!!event, "InterestEvent is fired");
+    assert_true(event instanceof InterestEvent, "event is InterestEvent");
+    assert_equals(event.type, "interest", "type");
+    assert_equals(event.bubbles, false, "bubbles");
+    assert_equals(event.composed, true, "composed");
+    assert_equals(event.isTrusted, true, "isTrusted");
+    assert_equals(event.target, interestee, "target");
+    assert_equals(event.source, interestsvga, "source");
+  }, "InterestEvent dispatches on svg <a> hover");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/invoker-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/invoker-utils.js
@@ -1,0 +1,88 @@
+function waitForRender() {
+  return new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+async function clickOn(element) {
+  await waitForRender();
+  let rect = element.getBoundingClientRect();
+  let actions = new test_driver.Actions();
+  // FIXME: Switch to pointerMove(0, 0, {origin: element}) once
+  // https://github.com/web-platform-tests/wpt/issues/41257 is fixed.
+  await actions
+      .pointerMove(Math.round(rect.x + rect.width / 2), Math.round(rect.y + rect.height / 2), {})
+      .pointerDown({button: actions.ButtonType.LEFT})
+      .pointerUp({button: actions.ButtonType.LEFT})
+      .send();
+  await waitForRender();
+}
+async function hoverOver(element) {
+  await waitForRender();
+  let rect = element.getBoundingClientRect();
+  let actions = new test_driver.Actions();
+  // FIXME: Switch to pointerMove(0, 0, {origin: element}) once
+  // https://github.com/web-platform-tests/wpt/issues/41257 is fixed.
+  await actions
+      .pointerMove(Math.round(rect.x + rect.width / 2), Math.round(rect.y + rect.height / 2), {})
+      .send();
+  await waitForRender();
+}
+function mouseOverAndRecord(t,element) {
+  let mouseMoveInfo;
+  t.add_cleanup(() => mouseMoveInfo?.controller.abort());
+  const controller = new AbortController();
+  mouseMoveInfo = {element, controller, moved: false, started: performance.now()};
+  document.addEventListener("mousemove", (e) => {mouseMoveInfo.moved = true;}, {signal: controller.signal});
+  return (new test_driver.Actions())
+      .pointerMove(0, 0, {origin: element})
+      .send()
+      .then(() => mouseMoveInfo);
+}
+// Note that this may err on the side of being too large (reporting a number
+// that is larger than the actual time since the mouseover happened), due to how
+// `mousemoveInfo.started` is initialized, on first mouse move. However, this
+// function is intended to be used as a detector for the test harness taking too
+// long for some tests, so it's ok to be conservative.
+function msSinceMouseOver(mouseMoveInfo) {
+  return performance.now() - mouseMoveInfo.started;
+}
+async function waitForHoverTime(hoverWaitTimeMs) {
+  await new Promise(resolve => step_timeout(resolve,hoverWaitTimeMs));
+  await waitForRender();
+};
+
+async function createPopoverAndInvokerForHoverTests(test, showdelayMs, hideDelayMs) {
+  const unrelated = document.createElement('div');
+  document.body.appendChild(unrelated);
+  unrelated.textContent = 'Unrelated';
+  unrelated.setAttribute('style','position:fixed; top:0;');
+  // Ensure we never hover over an active interesttarget element.
+  await hoverOver(unrelated);
+  const popover = document.createElement('div');
+  popover.popover = 'auto';
+  popover.setAttribute('style','inset:auto; top: 100px;');
+  popover.textContent = 'Popover';
+  document.body.appendChild(popover);
+  let invoker = document.createElement('button');
+  invoker.interestTargetElement = popover;
+  invoker.setAttribute('style',`
+    interest-target-show-delay: ${showdelayMs}ms;
+    interest-target-hide-delay: ${hideDelayMs}ms;
+    position:fixed;
+    top:200px;
+    width:fit-content;
+    height:fit-content;
+    `);
+  invoker.innerText = 'Invoker';
+  document.body.appendChild(invoker);
+  const actualShowDelay = Number(getComputedStyle(invoker).interestTargetShowDelay.slice(0,-1))*1000;
+  assert_equals(actualShowDelay,showdelayMs,'interest-target-show-delay is incorrect');
+  const actualHideDelay = Number(getComputedStyle(invoker).interestTargetHideDelay.slice(0,-1))*1000;
+  assert_equals(actualHideDelay,hideDelayMs,'interest-target-hide-delay is incorrect');
+  test.add_cleanup(async () => {
+    popover.remove();
+    invoker.remove();
+    unrelated.remove();
+    await waitForRender();
+  });
+  assert_false(popover.matches(':popover-open'),'The popover should start out closed');
+  return {popover, invoker, unrelated};
+}

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/invoker-utils.js

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/w3c-import.log
@@ -1,0 +1,35 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative.html

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt
@@ -1,0 +1,23 @@
+
+reset  submit  type=button  invalid  missing  missing with command only missing with commandfor only
+reset submit type=button invalid missing missing with command only missing with commandfor only  reset submit type=button invalid missing
+
+FAIL Button type=reset in form should trigger form reset and toggle popover assert_true: type=reset should trigger form reset event expected true got false
+FAIL Button type=submit in form should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=button in form should not toggle popover
+FAIL Button type=invalid in form should trigger form submit and not toggle popover assert_true: type=invalid should trigger form submit event expected true got false
+PASS Button missing type in form should not trigger form submit and not toggle popover
+FAIL Button missing type in form with only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type in form with only commandfor should not trigger form submit and not toggle popover
+FAIL Button type=reset with form attr should trigger form reset and toggle popover assert_true: type=reset should trigger form reset event expected true got false
+FAIL Button type=submit with form attr should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=button with form attr should toggle popover
+FAIL Button type=invalid with form attr should trigger form submit and not toggle popover assert_true: type=invalid should trigger form submit event expected true got false
+FAIL Button missing type with form attr and only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type with form attr and only commandfor should not trigger form submit and not toggle popover
+PASS Button type=reset outside form should toggle popover
+PASS Button type=submit outside form should toggle popover
+PASS Button type=button outside form should toggle popover
+PASS Button type=invalid outside form should toggle popover
+PASS Button missing type outside form should toggle popover
+

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt
@@ -1,0 +1,26 @@
+
+reset  submit  type=button  invalid  missing  missing with command only missing with commandfor only
+reset submit type=button invalid missing missing with command only missing with commandfor only  reset submit type=button invalid missing missing with command only missing with commandfor only
+
+PASS Button with id reset-in-form should reflect type correctly
+PASS Button with id submit-in-form should reflect type correctly
+PASS Button with id button-in-form should reflect type correctly
+PASS Button with id invalid-in-form should reflect type correctly
+FAIL Button with id missing-in-form should reflect type correctly assert_equals: type of missing-in-form should be button expected "button" but got "submit"
+FAIL Button with id missing-in-form-command-only should reflect type correctly assert_equals: type of missing-in-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-in-form-commandfor-only should reflect type correctly assert_equals: type of missing-in-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id reset-attr-form should reflect type correctly
+PASS Button with id submit-attr-form should reflect type correctly
+PASS Button with id button-attr-form should reflect type correctly
+PASS Button with id invalid-attr-form should reflect type correctly
+FAIL Button with id missing-attr-form should reflect type correctly assert_equals: type of missing-attr-form should be button expected "button" but got "submit"
+FAIL Button with id missing-attr-form-command-only should reflect type correctly assert_equals: type of missing-attr-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-attr-form-commandfor-only should reflect type correctly assert_equals: type of missing-attr-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id reset-outside-form should reflect type correctly
+PASS Button with id submit-outside-form should reflect type correctly
+PASS Button with id button-outside-form should reflect type correctly
+PASS Button with id invalid-outside-form should reflect type correctly
+FAIL Button with id missing-outside-form should reflect type correctly assert_equals: type of missing-outside-form should be button expected "button" but got "submit"
+FAIL Button with id missing-outside-form-command-only should reflect type correctly assert_equals: type of missing-outside-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-outside-form-commandfor-only should reflect type correctly assert_equals: type of missing-outside-form-commandfor-only should be button expected "button" but got "submit"
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt
@@ -1,0 +1,23 @@
+
+reset  submit  type=button  invalid  missing  missing with command only  missing with commandfor only
+reset submit type=button invalid missing missing with command only missing with commandfor only reset submit type=button invalid missing
+
+FAIL Button type=reset in form should trigger form reset and toggle popover assert_true: type=reset should trigger form reset event expected true got false
+FAIL Button type=submit in form should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=button in form should not toggle popover
+FAIL Button type=invalid in form should trigger form submit and not toggle popover assert_true: type=invalid should trigger form submit event expected true got false
+PASS Button missing type in form should not trigger form submit and not toggle popover
+FAIL Button missing type in form with only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type in form with only commandfor should not trigger form submit and not toggle popover
+FAIL Button type=reset with form attr should trigger form reset and toggle popover assert_true: type=reset should trigger form reset event expected true got false
+FAIL Button type=submit with form attr should trigger form submit and not toggle popover assert_true: type=submit should trigger form submit event expected true got false
+PASS Button type=button with form attr should toggle popover
+FAIL Button type=invalid with form attr should trigger form submit and not toggle popover assert_true: type=invalid should trigger form submit event expected true got false
+FAIL Button missing type with form attr and only command should not trigger form submit and not toggle popover assert_false: missing type should not trigger form submit event expected false got true
+PASS Button missing type with form attr and only commandfor should not trigger form submit and not toggle popover
+PASS Button type=reset outside form should toggle popover
+PASS Button type=submit outside form should toggle popover
+PASS Button type=button outside form should toggle popover
+PASS Button type=invalid outside form should toggle popover
+PASS Button missing type outside form should toggle popover
+

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt
@@ -1,0 +1,26 @@
+
+reset  submit  type=button  invalid  missing  missing with command only  missing with commandfor only
+reset submit type=button invalid missing missing with command only missing with commandfor only reset submit type=button invalid missing missing with command only missing with commandfor only
+
+PASS Button with id reset-in-form should reflect type correctly
+PASS Button with id submit-in-form should reflect type correctly
+PASS Button with id button-in-form should reflect type correctly
+PASS Button with id invalid-in-form should reflect type correctly
+FAIL Button with id missing-in-form should reflect type correctly assert_equals: type of missing-in-form should be button expected "button" but got "submit"
+FAIL Button with id missing-in-form-command-only should reflect type correctly assert_equals: type of missing-in-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-in-form-commandfor-only should reflect type correctly assert_equals: type of missing-in-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id reset-attr-form should reflect type correctly
+PASS Button with id submit-attr-form should reflect type correctly
+PASS Button with id button-attr-form should reflect type correctly
+PASS Button with id invalid-attr-form should reflect type correctly
+FAIL Button with id missing-attr-form should reflect type correctly assert_equals: type of missing-attr-form should be button expected "button" but got "submit"
+FAIL Button with id missing-attr-form-command-only should reflect type correctly assert_equals: type of missing-attr-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-attr-form-commandfor-only should reflect type correctly assert_equals: type of missing-attr-form-commandfor-only should be button expected "button" but got "submit"
+PASS Button with id reset-outside-form should reflect type correctly
+PASS Button with id submit-outside-form should reflect type correctly
+PASS Button with id button-outside-form should reflect type correctly
+PASS Button with id invalid-outside-form should reflect type correctly
+FAIL Button with id missing-outside-form should reflect type correctly assert_equals: type of missing-outside-form should be button expected "button" but got "submit"
+FAIL Button with id missing-outside-form-command-only should reflect type correctly assert_equals: type of missing-outside-form-command-only should be button expected "button" but got "submit"
+FAIL Button with id missing-outside-form-commandfor-only should reflect type correctly assert_equals: type of missing-outside-form-commandfor-only should be button expected "button" but got "submit"
+

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4190,6 +4190,9 @@
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html": [
         "slow"
     ],
@@ -4221,6 +4224,18 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-video-behavior.tentative.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_adoption01.html": [


### PR DESCRIPTION
#### 8e392fcd916d77baee38ddd17562f9993d9b3825
<pre>
Resync html/semantics/the-button-element
<a href="https://bugs.webkit.org/show_bug.cgi?id=287625">https://bugs.webkit.org/show_bug.cgi?id=287625</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/4cb608c82eec9cb3638fa4cd4a895f8014429f9b">https://github.com/web-platform-tests/wpt/commit/4cb608c82eec9cb3638fa4cd4a895f8014429f9b</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/idlharness.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestelement-interface.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-dispatch-shadow.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interestevent-interface.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-anchor-event-dispatch.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-area-event-dispatch.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-basic-delays.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-button-event-dispatch.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-properties.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-css-shorthands.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-has-interest-pseudo.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-hide-delay.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-keyboard-invalidation.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-on-popover-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-show-delay.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/interesttarget-svg-a-event-dispatch.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/invoker-utils.js: Added.
(waitForRender):
(async clickOn):
(async hoverOver):
(mouseOverAndRecord):
(async waitForHoverTime):
(async assert_false):
(async createPopoverAndInvokerForHoverTests):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/interest-target/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt: Added.
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.tentative-expected.txt: Added.
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.tentative-expected.txt: Added.
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/290478@main">https://commits.webkit.org/290478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da198f25ee12e6d75348790fde507a712a8c8bcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95140 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40915 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69397 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26998 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81807 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7427 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40046 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96965 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78394 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77599 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19158 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22051 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10562 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17337 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17078 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18862 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->