### PR TITLE
RemoteLayerBackingStoreProperties::m_displayListBufferHandle is unused

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -6120,18 +6120,6 @@ RemoveBackgroundEnabled:
     WebKit:
       default: defaultRemoveBackgroundEnabled()
 
-ReplayCGDisplayListsIntoBackingStore:
-  type: bool
-  status: internal
-  humanReadableName: "Dynamic Content Scaling: Replay for Testing"
-  humanReadableDescription: "Replay Dynamic Content Scaling Display Lists into layer contents for testing"
-  webcoreBinding: none
-  condition: ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-  exposed: [ WebKit ]
-  defaultValue:
-    WebKit:
-      default: false
-
 RequestIdleCallbackEnabled:
   type: bool
   status: stable

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h
@@ -219,7 +219,7 @@ public:
     RemoteLayerBackingStoreProperties() = default;
     RemoteLayerBackingStoreProperties(RemoteLayerBackingStoreProperties&&) = default;
 
-    void applyBackingStoreToLayer(CALayer *, LayerContentsType, std::optional<WebCore::RenderingResourceIdentifier>, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView * hostingView);
+    void applyBackingStoreToLayer(CALayer *, LayerContentsType, std::optional<WebCore::RenderingResourceIdentifier>, UIView * hostingView);
 
     void updateCachedBuffers(RemoteLayerTreeNode&, LayerContentsType);
 
@@ -247,10 +247,6 @@ private:
     std::optional<WebCore::RenderingResourceIdentifier> m_contentsRenderingResourceIdentifier;
 
     std::optional<WebCore::IntRect> m_paintedRect;
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    std::optional<ImageBufferBackendHandle> m_displayListBufferHandle;
-#endif
 
     bool m_isOpaque;
     RemoteLayerBackingStore::Type m_type;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -519,7 +519,7 @@ RetainPtr<id> RemoteLayerBackingStoreProperties::layerContentsBufferFromBackendH
     return contents;
 }
 
-void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer, LayerContentsType contentsType, std::optional<WebCore::RenderingResourceIdentifier> asyncContentsIdentifier, bool replayDynamicContentScalingDisplayListsIntoBackingStore, UIView *hostingView)
+void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer, LayerContentsType contentsType, std::optional<WebCore::RenderingResourceIdentifier> asyncContentsIdentifier, UIView *hostingView)
 {
     if (asyncContentsIdentifier && m_contentsRenderingResourceIdentifier && *asyncContentsIdentifier >= m_contentsRenderingResourceIdentifier)
         return;
@@ -549,28 +549,6 @@ void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer,
         [layer _web_clearContents];
         return;
     }
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    if (m_displayListBufferHandle) {
-        ASSERT([layer isKindOfClass:[WKCompositingLayer class]]);
-        if (![layer isKindOfClass:[WKCompositingLayer class]])
-            return;
-
-        layer.drawsAsynchronously = (m_type == RemoteLayerBackingStore::Type::IOSurface);
-
-        if (!replayDynamicContentScalingDisplayListsIntoBackingStore) {
-            [layer setValue:@1 forKeyPath:WKDynamicContentScalingEnabledKey];
-            [layer setValue:@1 forKeyPath:WKDynamicContentScalingBifurcationEnabledKey];
-            [layer setValue:@(layer.contentsScale) forKeyPath:WKDynamicContentScalingBifurcationScaleKey];
-        } else
-            layer.opaque = m_isOpaque;
-        [(WKCompositingLayer *)layer _setWKContents:contents.get() withDisplayList:WTFMove(std::get<DynamicContentScalingDisplayList>(*m_displayListBufferHandle)) replayForTesting:replayDynamicContentScalingDisplayListsIntoBackingStore];
-        return;
-    } else
-        [layer _web_clearDynamicContentScalingDisplayListIfNeeded];
-#else
-    UNUSED_PARAM(replayDynamicContentScalingDisplayListsIntoBackingStore);
-#endif
 
     layer.contents = contents.get();
     if ([CALayer instancesRespondToSelector:@selector(contentsDirtyRect)]) {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -109,9 +109,6 @@ header: "RemoteLayerBackingStore.h"
     std::optional<WebKit::BufferAndBackendInfo> m_secondaryBackBufferInfo;
     std::optional<WebCore::RenderingResourceIdentifier> m_contentsRenderingResourceIdentifier;
     std::optional<WebCore::IntRect> m_paintedRect;
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    std::optional<WebKit::ImageBufferBackendHandle> m_displayListBufferHandle;
-#endif
 };
 
 [LegacyPopulateFromEmptyConstructor, DisableMissingMemberCheck] class WebKit::RemoteLayerTreeTransaction {

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -440,7 +440,7 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
 #endif
             }
 
-            backingStore->applyBackingStoreToLayer(layer, layerContentsType, asyncContentsIdentifier, layerTreeHost->replayDynamicContentScalingDisplayListsIntoBackingStore(), hostingView);
+            backingStore->applyBackingStoreToLayer(layer, layerContentsType, asyncContentsIdentifier, hostingView);
         } else
             [layer _web_clearContents];
     }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -95,7 +95,6 @@ public:
 
     CALayer *layerWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 
-    bool replayDynamicContentScalingDisplayListsIntoBackingStore() const;
     bool threadedAnimationResolutionEnabled() const;
 
     bool cssUnprefixedBackdropFilterEnabled() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -112,16 +112,6 @@ LayerContentsType RemoteLayerTreeHost::layerContentsType() const
 #endif
 }
 
-bool RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStore() const
-{
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    RefPtr page = m_drawingArea->page();
-    return page && page->protectedPreferences()->replayCGDisplayListsIntoBackingStore();
-#else
-    return false;
-#endif
-}
-
 bool RemoteLayerTreeHost::threadedAnimationResolutionEnabled() const
 {
     RefPtr page = m_drawingArea->page();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.h
@@ -30,15 +30,7 @@
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>
 
-namespace WebCore {
-class DynamicContentScalingDisplayList;
-}
-
 @interface WKCompositingLayer : CALayer
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-- (void)_setWKContents:(id)contents withDisplayList:(WebCore::DynamicContentScalingDisplayList&&)data replayForTesting:(BOOL)replay;
-#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/cocoa/RemoteLayerTreeLayers.mm
@@ -28,66 +28,15 @@
 
 #if PLATFORM(COCOA)
 
-#import "Logging.h"
 #import "RemoteLayerTreeNode.h"
-#import <WebCore/DynamicContentScalingDisplayList.h>
-#import <WebCore/DynamicContentScalingTypes.h>
-#import <pal/spi/cocoa/QuartzCoreSPI.h>
-#import <wtf/MachSendRight.h>
-#import <wtf/cocoa/TypeCastsCocoa.h>
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-#import <CoreRE/RECGCommandsContext.h>
-#endif
 
 @implementation WKCompositingLayer {
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-    RetainPtr<CFDataRef> _displayListDataForTesting;
-#endif
 }
 
 - (NSString *)description
 {
     return WebKit::RemoteLayerTreeNode::appendLayerDescription(super.description, self);
 }
-
-#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
-
-- (void)_setWKContents:(id)contents withDisplayList:(WebCore::DynamicContentScalingDisplayList&&)displayList replayForTesting:(BOOL)replay
-{
-    auto data = displayList.displayList()->createCFData();
-
-    if (replay) {
-        _displayListDataForTesting = data;
-        [self setNeedsDisplay];
-        return;
-    }
-
-    self.contents = contents;
-
-    auto surfaces = displayList.takeSurfaces();
-    auto ports = adoptNS([[NSMutableArray alloc] initWithCapacity:surfaces.size()]);
-    for (MachSendRight& surface : surfaces) {
-        // We `leakSendRight` because CAMachPortCreate "adopts" the incoming reference.
-        RetainPtr portWrapper = adoptCF(CAMachPortCreate(surface.leakSendRight()));
-        [ports addObject:static_cast<id>(portWrapper.get())];
-    }
-
-    [self setValue:bridge_cast(data.get()) forKeyPath:WKDynamicContentScalingContentsKey];
-    [self setValue:ports.get() forKeyPath:WKDynamicContentScalingPortsKey];
-    [self setNeedsDisplay];
-}
-
-- (void)drawInContext:(CGContextRef)context
-{
-    if (!_displayListDataForTesting)
-        return;
-    CGContextScaleCTM(context, 1, -1);
-    CGContextTranslateCTM(context, 0, -self.bounds.size.height);
-    RECGContextDrawCGCommandsEncodedData(context, _displayListDataForTesting.get(), nullptr);
-}
-
-#endif // ENABLE(RE_DYNAMIC_CONTENT_SCALING)
 
 @end
 


### PR DESCRIPTION
#### 9a2d0ef5241c60f1a1748675a6ab3a5072c25c68
<pre>
RemoteLayerBackingStoreProperties::m_displayListBufferHandle is unused
<a href="https://bugs.webkit.org/show_bug.cgi?id=287627">https://bugs.webkit.org/show_bug.cgi?id=287627</a>
<a href="https://rdar.apple.com/144777651">rdar://144777651</a>

Reviewed by NOBODY (OOPS!).

Remove RemoteLayerBackingStoreProperties::m_displayListBufferHandle,
it was never assigned to.

The feature was refactored in 239735@main but the property was not
removed.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::replayDynamicContentScalingDisplayListsIntoBackingStore const): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a2d0ef5241c60f1a1748675a6ab3a5072c25c68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40663 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69209 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7222 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35917 "Found 4 new test failures: fast/html/process-end-tag-for-inbody-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39797 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82691 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96713 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88666 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78090 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77408 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10257 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22409 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111159 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16829 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26618 "Found 5 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->