### PR TITLE
[WPE] Default to run layout tests with WEBKIT_SKIA_ENABLE_CPU_RENDERING=1

### DIFF
--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -63,6 +63,11 @@ class WPEPort(GLibPort):
     def setup_environ_for_server(self, server_name=None):
         environment = super(WPEPort, self).setup_environ_for_server(server_name)
         environment['LIBGL_ALWAYS_SOFTWARE'] = '1'
+        # Run WPE tests with Skia CPU (usual configuration on embedded)
+        # to help catching issues/crashes <https://webkit.org/b/287632>
+        if 'WEBKIT_SKIA_ENABLE_CPU_RENDERING' in environment:
+            _log.warning('Ignoring "WEBKIT_SKIA_ENABLE_CPU_RENDERING" variable from environment. Defaulting to value "1".')
+        environment['WEBKIT_SKIA_ENABLE_CPU_RENDERING'] = '1'
         self._copy_value_from_environ_if_set(environment, 'XR_RUNTIME_JSON')
         self._copy_value_from_environ_if_set(environment, 'BREAKPAD_MINIDUMP_DIR')
         return environment


### PR DESCRIPTION
#### 69bc9c556085ea0563115e7c11913640c68ed32a
<pre>
[WPE] Default to run layout tests with WEBKIT_SKIA_ENABLE_CPU_RENDERING=1
<a href="https://bugs.webkit.org/show_bug.cgi?id=287632">https://bugs.webkit.org/show_bug.cgi?id=287632</a>

Reviewed by Alejandro G. Castro.

We were observing some crashes in WPE when running with skia-cpu that were
unfortunately not being catched by WebKit CI, as bots were running with
skia-gpu only.

We changed that recently by setting WEBKIT_SKIA_ENABLE_CPU_RENDERING=1
on the bots environment but that lead to a situation where the bots run
with a different configuration than the developers, which is far from
ideal as it makes reproducing results from the bots harder.

So the idea is to set WEBKIT_SKIA_ENABLE_CPU_RENDERING=1 for the layout
tests directly from the python tooling to run those tests, so both
developers and bots have the same environment.

This is only done for WPE and not for GTK and that is consistent with
what we recommend these days (i.e. CPU for embedded and GPU for desktop).

* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.setup_environ_for_server):

Canonical link: <a href="https://commits.webkit.org/290397@main">https://commits.webkit.org/290397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/237828dd7c14dd9d23915cec315ea59a5c7159f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40515 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69120 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26746 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81439 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49482 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/89248 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7144 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35813 "Found 6 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39649 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96567 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12435 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/77989 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77256 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77314 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21752 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10106 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14118 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16942 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->