### PR TITLE
REGRESSION (290178@main): [macOS] imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html fails

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -794,8 +794,10 @@ void AsyncScrollingCoordinator::reconcileScrollingState(LocalFrameView& frameVie
     auto obscuredContentInsets = frameView.obscuredContentInsets();
 
     FloatPoint positionForInsetClipLayer;
-    if (insetClipLayer)
+    if (insetClipLayer) {
         positionForInsetClipLayer = LocalFrameView::positionForInsetClipLayer(scrollPosition, obscuredContentInsets);
+        positionForInsetClipLayer.move(frameView.insetForLeftScrollbarSpace(), 0);
+    }
     FloatPoint positionForContentsLayer = frameView.positionForRootContentLayer();
     
     FloatPoint positionForHeaderLayer = FloatPoint(scrollPositionForFixed.x(), LocalFrameView::yPositionForHeaderLayer(scrollPosition, obscuredContentInsets.top()));


### PR DESCRIPTION
#### 524ce3a2495d64566e65f482740813b785095337
<pre>
REGRESSION (290178@main): [macOS] imported/w3c/web-platform-tests/css/css-view-transitions/dialog-in-rtl-iframe.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=287585">https://bugs.webkit.org/show_bug.cgi?id=287585</a>
<a href="https://rdar.apple.com/144732945">rdar://144732945</a>

Reviewed by Abrar Rahman Protyasha.

Prior to 290178@main, logic in `AsyncScrollingCoordinator::reconcileScrollingState` only accounted
for the top content inset when determining the position for the inset clip layer (i.e. the
`RenderLayerCompositor`&apos;s `clipLayer`). Importantly, this preserved the previous `x` value of the
`insetClipLayer`&apos;s position:

```
positionForInsetClipLayer = FloatPoint(insetClipLayer-&gt;position().x(), LocalFrameView::yPositionForInsetClipLayer(scrollPosition, obscuredContentInsets.top()));
```

...after 290178@main, both axes are now accounted for when computing the inset clip layer position:

```
positionForInsetClipLayer = LocalFrameView::positionForInsetClipLayer(scrollPosition, obscuredContentInsets);
```

...however, this introduces a subtle issue where, if the inset clip layer position&apos;s `x` was
nonzero, it would be overridden by the value of the left content inset (in the case of this test,
0). Before reconciling scrolling state, the position of the inset clip layer is previously computed
by the following method:

```
FloatPoint RenderLayerCompositor::positionForClipLayer() const
{
    auto&amp; frameView = m_renderView.frameView();

    auto clipLayerPosition = LocalFrameView::positionForInsetClipLayer(frameView.scrollPosition(), frameView.obscuredContentInsets());
    return FloatPoint(frameView.insetForLeftScrollbarSpace() + clipLayerPosition.x(), clipLayerPosition.y());
}
```

Note that this importantly accounts for `frameView.insetForLeftScrollbarSpace()`, which is nonzero
in the case where there&apos;s an RTL scrollbar. Fix this failing test case by (re-)teaching
`reconcileScrollingState` to account for the left scrollbar inset when computing the inset clip
layer position, such that it&apos;s consistent with `RenderLayerCompositor`.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::reconcileScrollingState):

Canonical link: <a href="https://commits.webkit.org/290373@main">https://commits.webkit.org/290373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c0b312a57a7bfee9f1aa88939c0d4a19e18db48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94771 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40547 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69139 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26762 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49500 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7154 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35837 "Found 6 new test failures: fast/html/process-end-tag-for-inbody-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39680 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77501 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96594 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16969 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77334 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19099 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10138 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16969 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16710 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->