### PR TITLE
Use WorkQueue::protectedMain() when necessary to address Safer CPP failures

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -277,7 +277,7 @@ void PushDatabase::create(const String& path, CreationHandler&& completionHandle
     auto queue = WorkQueue::create("PushDatabase I/O Thread"_s);
     queue->dispatch([queue, path = crossThreadCopy(path), completionHandler = WTFMove(completionHandler)]() mutable {
         auto database = openAndMigrateDatabase(path);
-        WorkQueue::main().dispatch([queue = WTFMove(queue), database = WTFMove(database), completionHandler = WTFMove(completionHandler)]() mutable {
+        WorkQueue::protectedMain()->dispatch([queue = WTFMove(queue), database = WTFMove(database), completionHandler = WTFMove(completionHandler)]() mutable {
             if (!database) {
                 completionHandler(nullptr);
                 return;
@@ -396,7 +396,7 @@ template <class T, class U>
 static void completeOnMainQueue(CompletionHandler<void(T)>&& completionHandler, U&& result)
 {
     ASSERT(!RunLoop::isMain());
-    WorkQueue::main().dispatch([completionHandler = WTFMove(completionHandler), result = crossThreadCopy(std::forward<U>(result))]() mutable {
+    WorkQueue::protectedMain()->dispatch([completionHandler = WTFMove(completionHandler), result = crossThreadCopy(std::forward<U>(result))]() mutable {
         completionHandler(WTFMove(result));
     });
 }

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -944,7 +944,7 @@ Ref<GuaranteedSerialFunctionDispatcher> VideoMediaSampleRenderer::dispatcher() c
 
 dispatch_queue_t VideoMediaSampleRenderer::dispatchQueue() const
 {
-    return m_workQueue ? m_workQueue->dispatchQueue() : WorkQueue::main().dispatchQueue();
+    return m_workQueue ? m_workQueue->dispatchQueue() : WorkQueue::protectedMain()->dispatchQueue();
 }
 
 void VideoMediaSampleRenderer::ensureOnDispatcher(Function<void()>&& function) const

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -249,7 +249,7 @@ VideoFullscreenControllerContext::~VideoFullscreenControllerContext()
         m_playbackModel = nullptr;
         m_presentationModel = nullptr;
     } else
-        WorkQueue::main().dispatchSync(WTFMove(notifyClientsModelWasDestroyed));
+        WorkQueue::protectedMain()->dispatchSync(WTFMove(notifyClientsModelWasDestroyed));
 }
 
 #pragma mark VideoPresentationModel

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -313,7 +313,7 @@ void WebThreadRunOnMainThread(void(^delegateBlock)())
     JSC::JSLock::DropAllLocks dropAllLocks(WebCore::commonVM());
     _WebThreadUnlock();
 
-    WorkQueue::main().dispatchSync(makeBlockPtr(delegateBlock).get());
+    WorkQueue::protectedMain()->dispatchSync(makeBlockPtr(delegateBlock).get());
 
     _WebThreadLock();
 }

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -67,7 +67,6 @@ Shared/Cocoa/WKNSData.mm
 Shared/Cocoa/WKNSDictionary.mm
 Shared/Cocoa/WKNSString.mm
 Shared/Cocoa/WKNSURL.mm
-Shared/Cocoa/WebKit2InitializeCocoa.mm
 Shared/ContextMenuContextData.cpp
 Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -209,7 +208,6 @@ UIProcess/Inspector/WebPageInspectorController.cpp
 UIProcess/Inspector/mac/WKInspectorViewController.mm
 UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
 UIProcess/Notifications/WebNotificationManagerProxy.cpp
-UIProcess/PDF/WKPDFHUDView.mm
 UIProcess/ProvisionalFrameProxy.cpp
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
 UIProcess/RemotePageProxy.cpp
@@ -243,7 +241,6 @@ UIProcess/WebsiteData/WebsiteDataStore.cpp
 UIProcess/WebsiteData/WebsiteDataStoreClient.h
 UIProcess/mac/CorrectionPanel.mm
 UIProcess/mac/DisplayCaptureSessionManager.mm
-UIProcess/mac/ServicesController.mm
 UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
 UIProcess/mac/WKFullScreenWindowController.mm
 UIProcess/mac/WKImmediateActionController.mm
@@ -450,6 +447,4 @@ WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
 webpushd/ApplePushServiceConnection.mm
 webpushd/PushService.h
-webpushd/PushService.mm
-webpushd/PushServiceConnection.mm
 webpushd/WebPushDaemon.mm

--- a/Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm
@@ -73,7 +73,7 @@ void InitializeWebKit2()
         if ([NSThread isMainThread] || linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::InitializeWebKit2MainThreadAssertion))
             runInitializationCode();
         else
-            WorkQueue::main().dispatchSync([] { runInitializationCode(); });
+            WorkQueue::protectedMain()->dispatchSync([] { runInitializationCode(); });
     });
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -117,7 +117,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         WebKit::WebProcessPool::registerGlobalURLSchemeAsHavingCustomProtocolHandlers(scheme);
     else {
         // This cannot be RunLoop::protectedMain()->dispatch because it is called before the main runloop is initialized. See rdar://problem/73615999
-        WorkQueue::main().dispatch([scheme = retainPtr(scheme)] {
+        WorkQueue::protectedMain()->dispatch([scheme = retainPtr(scheme)] {
             WebKit::WebProcessPool::registerGlobalURLSchemeAsHavingCustomProtocolHandlers(scheme.get());
         });
     }
@@ -129,7 +129,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         WebKit::WebProcessPool::unregisterGlobalURLSchemeAsHavingCustomProtocolHandlers(scheme);
     else {
         // This cannot be RunLoop::protectedMain()->dispatch because it is called before the main runloop is initialized. See rdar://problem/73615999
-        WorkQueue::main().dispatch([scheme = retainPtr(scheme)] {
+        WorkQueue::protectedMain()->dispatch([scheme = retainPtr(scheme)] {
             WebKit::WebProcessPool::unregisterGlobalURLSchemeAsHavingCustomProtocolHandlers(scheme.get());
         });
     }

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -155,7 +155,7 @@ static bool processHasActiveRunTimeLimitation()
         return;
 
     RELEASE_LOG(ProcessSuspension, "%p - WKProcessAssertionBackgroundTaskManager: _scheduleReleaseTask because the expiration handler has been called", self);
-    WorkQueue::main().dispatchAfter(releaseBackgroundTaskAfterExpirationDelay, [self, retainedSelf = retainPtr(self)] {
+    WorkQueue::protectedMain()->dispatchAfter(releaseBackgroundTaskAfterExpirationDelay, [self, retainedSelf = retainPtr(self)] {
         _pendingTaskReleaseTask = nil;
         [self _releaseBackgroundTask];
     });

--- a/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm
@@ -110,7 +110,7 @@ static NSArray<NSString *> *controlArray()
     [self setFrame:frame];
 
     WeakObjCPtr<WKPDFHUDView> weakSelf = self;
-    WorkQueue::main().dispatchAfter(Seconds { initialHideTimeInterval }, [weakSelf] {
+    WorkQueue::protectedMain()->dispatchAfter(Seconds { initialHideTimeInterval }, [weakSelf] {
         [weakSelf _hideTimerFired];
     });
     return self;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5436,7 +5436,7 @@ static void selectionChangedWithTouch(WKTextInteractionWrapper *interaction, con
 
         // Give the page some time to present custom editing UI before attempting to detect and evade it.
         auto delayBeforeShowingEditMenu = std::max(0_s, 0.25_s - (ApproximateTime::now() - startTime));
-        WorkQueue::main().dispatchAfter(delayBeforeShowingEditMenu, [completion = WTFMove(completion), weakSelf]() mutable {
+        WorkQueue::protectedMain()->dispatchAfter(delayBeforeShowingEditMenu, [completion = WTFMove(completion), weakSelf]() mutable {
             auto strongSelf = weakSelf.get();
             if (!strongSelf) {
                 completion(UIEditMenuArrowDirectionAutomatic);

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1605,7 +1605,7 @@ void WebPageProxy::willOpenAppLink()
     // We chose 25 seconds because the system only gives us 30 seconds and we don't want to get too close to that limit
     // to avoid assertion invalidation (or even termination).
     takeOpeningAppLinkActivity();
-    WorkQueue::main().dispatchAfter(25_s, [weakThis = WeakPtr { *this }] {
+    WorkQueue::protectedMain()->dispatchAfter(25_s, [weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->dropOpeningAppLinkActivity();
     });

--- a/Source/WebKit/UIProcess/mac/ServicesController.mm
+++ b/Source/WebKit/UIProcess/mac/ServicesController.mm
@@ -99,7 +99,7 @@ void ServicesController::refreshExistingServices(bool refreshImmediately)
         static NeverDestroyed<RetainPtr<NSAttributedString>> attributedStringWithRichContent;
         static std::once_flag attributedStringWithRichContentOnceFlag;
         std::call_once(attributedStringWithRichContentOnceFlag, [&] {
-            WorkQueue::main().dispatchSync([&] {
+            WorkQueue::protectedMain()->dispatchSync([&] {
                 auto attachment = adoptNS([[NSTextAttachment alloc] init]);
                 auto cell = adoptNS([[NSTextAttachmentCell alloc] initImageCell:image]);
                 [attachment setAttachmentCell:cell.get()];

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -89,7 +89,7 @@ static void performAfterFirstUnlock(Function<void()>&& function)
         RELEASE_LOG(Push, "Device has unlocked. Running initialization.");
 
         for (auto& function : functions.get())
-            WorkQueue::main().dispatch(WTFMove(function));
+            WorkQueue::protectedMain()->dispatch(WTFMove(function));
         functions->clear();
 
         if (notifyToken != NOTIFY_TOKEN_INVALID) {
@@ -461,7 +461,7 @@ void SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError(String&& to
 #if !HAVE(APPLE_PUSH_SERVICE_URL_TOKEN_SUPPORT)
     UNUSED_PARAM(topic);
 #else
-    WorkQueue::main().dispatch([this, weakThis = WeakPtr { *this }, topic = WTFMove(topic)]() mutable {
+    WorkQueue::protectedMain()->dispatch([this, weakThis = WeakPtr { *this }, topic = WTFMove(topic)]() mutable {
         if (!weakThis)
             return;
 
@@ -473,7 +473,7 @@ void SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError(String&& to
         connection->setIgnoredTopics(WTFMove(augmentedTopics));
         connection->setIgnoredTopics(WTFMove(originalTopics));
 
-        WorkQueue::main().dispatch([weakThis = WTFMove(weakThis)]() mutable {
+        WorkQueue::protectedMain()->dispatch([weakThis = WTFMove(weakThis)]() mutable {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->startImpl(IsRetry::Yes);
         });
@@ -586,7 +586,7 @@ void PushService::finishedPushServiceRequest(PushServiceRequestMap& map, PushSer
         nextRequest = requestQueue.first().copyRef();
 
     // Even if there's no next request to start, hold on to currentRequest until the next turn of the run loop since we're in the middle of executing the finish() member function of currentRequest.
-    WorkQueue::main().dispatch([currentRequest = WTFMove(currentRequest), nextRequest = WTFMove(nextRequest)] {
+    WorkQueue::protectedMain()->dispatch([currentRequest = WTFMove(currentRequest), nextRequest = WTFMove(nextRequest)] {
         if (nextRequest)
             nextRequest->start();
     });

--- a/Source/WebKit/webpushd/PushServiceConnection.mm
+++ b/Source/WebKit/webpushd/PushServiceConnection.mm
@@ -70,7 +70,7 @@ void PushServiceConnection::startListeningForPushMessages(IncomingPushMessageHan
     if (!m_pendingPushes.size())
         return;
 
-    WorkQueue::main().dispatch([this]() mutable {
+    WorkQueue::protectedMain()->dispatch([this]() mutable {
         while (m_pendingPushes.size()) {
             @autoreleasepool {
                 auto message = m_pendingPushes.takeFirst();

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -247,7 +247,7 @@ void WebPushDaemon::setPushService(RefPtr<PushService>&& pushService)
     if (!m_pendingPushServiceFunctions.size())
         return;
 
-    WorkQueue::main().dispatch([this]() {
+    WorkQueue::protectedMain()->dispatch([this]() {
         while (m_pendingPushServiceFunctions.size()) {
             auto function = m_pendingPushServiceFunctions.takeFirst();
             function();
@@ -520,7 +520,7 @@ void WebPushDaemon::handleIncomingPush(const PushSubscriptionSetIdentifier& iden
             return;
         }
 
-        WorkQueue::main().dispatch([this, identifier = crossThreadCopy(identifier), message = WTFMove(message)] mutable {
+        WorkQueue::protectedMain()->dispatch([this, identifier = crossThreadCopy(identifier), message = WTFMove(message)] mutable {
             handleIncomingPushImpl(identifier, WTFMove(message));
         });
     });
@@ -1018,7 +1018,7 @@ ALLOW_NONLITERAL_FORMAT_END
     center.get().notificationCategories = [NSSet setWithObject:category];
 
     auto blockPtr = makeBlockPtr([this, identifier = crossThreadCopy(identifier), scope = crossThreadCopy(notificationData.serviceWorkerRegistrationURL.string()), completionHandler = WTFMove(completionHandler)](NSError *error) mutable {
-        WorkQueue::main().dispatch([this, identifier = crossThreadCopy(identifier), scope = crossThreadCopy(scope), error = RetainPtr { error }, completionHandler = WTFMove(completionHandler)] mutable {
+        WorkQueue::protectedMain()->dispatch([this, identifier = crossThreadCopy(identifier), scope = crossThreadCopy(scope), error = RetainPtr { error }, completionHandler = WTFMove(completionHandler)] mutable {
             if (error)
                 RELEASE_LOG_ERROR(Push, "Failed to add notification request: %{public}@", error.get());
             else
@@ -1122,7 +1122,7 @@ void WebPushDaemon::getPushPermissionState(PushClientConnection& connection, con
         }(settings.authorizationStatus);
         RELEASE_LOG(Push, "getPushPermissionState for %{sensitive}s with result: %u", originString.utf8().data(), static_cast<unsigned>(permissionState));
 
-        WorkQueue::main().dispatch([replySender = WTFMove(replySender), permissionState] mutable {
+        WorkQueue::protectedMain()->dispatch([replySender = WTFMove(replySender), permissionState] mutable {
             replySender(permissionState);
         });
     });
@@ -1165,7 +1165,7 @@ void WebPushDaemon::requestPushPermission(PushClientConnection& connection, cons
         else
             RELEASE_LOG(Push, "Requested push permission for %{sensitive}s with result: %d", originString.utf8().data(), granted);
 
-        WorkQueue::main().dispatch([replySender = WTFMove(replySender), granted] mutable {
+        WorkQueue::protectedMain()->dispatch([replySender = WTFMove(replySender), granted] mutable {
             replySender(granted);
         });
     });

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -124,7 +124,6 @@ mac/DOM/WebDOMOperations.mm
 mac/History/WebBackForwardList.mm
 mac/History/WebHistoryItem.mm
 mac/Misc/WebCoreStatistics.mm
-mac/Misc/WebDownload.mm
 mac/Misc/WebElementDictionary.mm
 mac/Misc/WebNSPasteboardExtras.mm
 mac/Misc/WebSharingServicePickerController.mm

--- a/Source/WebKitLegacy/mac/Misc/WebDownload.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebDownload.mm
@@ -66,7 +66,7 @@ static void callOnDelegateThreadAndWait(Callable&& work)
     if (shouldCallOnNetworkThread() || isMainThread())
         work();
     else {
-        WorkQueue::main().dispatchSync([work = std::forward<Callable>(work)]() mutable {
+        WorkQueue::protectedMain()->dispatchSync([work = std::forward<Callable>(work)]() mutable {
             work();
         });
     }

--- a/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
+++ b/Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm
@@ -50,7 +50,7 @@ void UIScriptControllerIOS::doAsyncTask(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -61,7 +61,7 @@ void UIScriptControllerIOS::zoomToScale(double scale, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, scale, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, scale, callbackID] {
         [gWebScrollView zoomToScale:scale animated:YES completionHandler:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
             if (!m_context)
                 return;

--- a/Tools/DumpRenderTree/mac/DumpRenderTree.mm
+++ b/Tools/DumpRenderTree/mac/DumpRenderTree.mm
@@ -1276,7 +1276,7 @@ static const char **_argv;
 - (void)_webThreadInvoked
 {
     ASSERT(WebThreadIsCurrent());
-    WorkQueue::main().dispatch([self, retainedSelf = retainPtr(self)] {
+    WorkQueue::protectedMain()->dispatch([self, retainedSelf = retainPtr(self)] {
         [self _webThreadEventLoopHasRun];
     });
 }

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -54,7 +54,7 @@ void UIScriptControllerMac::doAsyncTask(JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -110,7 +110,7 @@ void UIScriptControllerMac::activateDataListSuggestion(unsigned index, JSValueRe
     UNUSED_PARAM(index);
 
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -133,7 +133,7 @@ void UIScriptControllerMac::removeViewFromWindow(JSValueRef callback)
     WebView *webView = [mainFrame webView];
     [webView removeFromSuperview];
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -147,7 +147,7 @@ void UIScriptControllerMac::addViewToWindow(JSValueRef callback)
     WebView *webView = [mainFrame webView];
     [[mainWindow contentView] addSubview:webView];
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -307,7 +307,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
         currentTime += nanosecondsEventInterval;
     }
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -161,7 +161,7 @@ void UIScriptControllerMac::activateDataListSuggestion(unsigned index, JSValueRe
     [table selectRowIndexes:[NSIndexSet indexSetWithIndex:index] byExtendingSelection:NO];
 
     // Send the action after a short delay to simulate normal user interaction.
-    WorkQueue::main().dispatchAfter(50_ms, [this, protectedThis = Ref { *this }, callbackID, table] {
+    WorkQueue::protectedMain()->dispatchAfter(50_ms, [this, protectedThis = Ref { *this }, callbackID, table] {
         if ([table window])
             [table sendAction:[table action] to:[table target]];
 
@@ -222,7 +222,7 @@ void UIScriptControllerMac::chooseMenuAction(JSStringRef jsAction, JSValueRef ca
         [activeMenu cancelTracking];
     }
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -325,7 +325,7 @@ void UIScriptControllerMac::activateAtPoint(long x, long y, JSValueRef callback)
     eventSender->mouseDown(0, 0);
     eventSender->mouseUp(0, 0);
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);
@@ -450,7 +450,7 @@ void UIScriptControllerMac::sendEventStream(JSStringRef eventsJSON, JSValueRef c
         currentTime += nanosecondsEventInterval;
     }
 
-    WorkQueue::main().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+    WorkQueue::protectedMain()->dispatch([this, protectedThis = Ref { *this }, callbackID] {
         if (!m_context)
             return;
         m_context->asyncTaskComplete(callbackID);


### PR DESCRIPTION
#### 8b8536f0392e76b901702703fb515ed0343f9d27
<pre>
Use WorkQueue::protectedMain() when necessary to address Safer CPP failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=287648">https://bugs.webkit.org/show_bug.cgi?id=287648</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::create):
(WebCore::completeOnMainQueue):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::dispatchQueue const):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::~VideoFullscreenControllerContext):
* Source/WebCore/platform/ios/wak/WebCoreThread.mm:
(WebThreadRunOnMainThread):
* Source/WebKit/Shared/Cocoa/WebKit2InitializeCocoa.mm:
(WebKit::InitializeWebKit2):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
* Source/WebKit/UIProcess/API/Cocoa/WKBrowsingContextController.mm:
(+[WKBrowsingContextController registerSchemeForCustomProtocol:]):
(+[WKBrowsingContextController unregisterSchemeForCustomProtocol:]):
* Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm:
(-[WKProcessAssertionBackgroundTaskManager _scheduleReleaseTask]):
* Source/WebKit/UIProcess/PDF/WKPDFHUDView.mm:
(-[WKPDFHUDView initWithFrame:pluginIdentifier:page:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestPreferredArrowDirectionForEditMenuWithCompletionHandler:]):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willOpenAppLink):
* Source/WebKit/UIProcess/mac/ServicesController.mm:
(WebKit::ServicesController::refreshExistingServices):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::performAfterFirstUnlock):
(WebPushD::SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError):
(WebPushD::PushService::finishedPushServiceRequest):
* Source/WebKit/webpushd/PushServiceConnection.mm:
(WebPushD::PushServiceConnection::startListeningForPushMessages):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::setPushService):
(WebPushD::WebPushDaemon::handleIncomingPush):
(WebPushD::WebPushDaemon::showNotification):
(WebPushD::WebPushDaemon::getPushPermissionState):
(WebPushD::WebPushDaemon::requestPushPermission):
* Source/WebKitLegacy/mac/Misc/WebDownload.mm:
(callOnDelegateThreadAndWait):
* Tools/DumpRenderTree/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::doAsyncTask):
(WTR::UIScriptControllerIOS::zoomToScale):
* Tools/DumpRenderTree/mac/DumpRenderTree.mm:
(-[DumpRenderTree _webThreadInvoked]):
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::doAsyncTask):
(WTR::UIScriptControllerMac::activateDataListSuggestion):
(WTR::UIScriptControllerMac::removeViewFromWindow):
(WTR::UIScriptControllerMac::addViewToWindow):
(WTR::UIScriptControllerMac::sendEventStream):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::activateDataListSuggestion):
(WTR::UIScriptControllerMac::chooseMenuAction):
(WTR::UIScriptControllerMac::activateAtPoint):
(WTR::UIScriptControllerMac::sendEventStream):

Canonical link: <a href="https://commits.webkit.org/290388@main">https://commits.webkit.org/290388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ceadea53b1405be9dc83dc89e15dcfab931321d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89879 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69198 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26814 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92880 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81532 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49559 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39785 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96702 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17066 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78073 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77352 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77398 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19103 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21841 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17077 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16818 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->