### PR TITLE
[JSC] Implement core of sequestered arena allocator

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -12671,7 +12671,7 @@
 		};
 		5D5D8ABF0E0D0B0300F9C692 /* Create /usr/local/bin/jsc symlink */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputPaths = (
@@ -12872,7 +12872,7 @@
 		};
 		F4CDF3C927E9147500191928 /* Copy Profiling Data */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 12;
+			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -53,6 +53,7 @@
 #include "TypeProfilerLog.h"
 #include <wtf/BubbleSort.h>
 #include <wtf/GraphNodeWorklist.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/SimpleStats.h>
 #include <wtf/text/MakeString.h>
 

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -39,6 +39,7 @@
 #include "JSInterfaceJIT.h"
 #include "LLIntData.h"
 #include "PCToCodeOriginMap.h"
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
@@ -900,8 +901,8 @@ namespace JSC {
         MathICHolder m_mathICs;
 
         Vector<JITConstantPool::Value> m_constantPool;
-        SegmentedVector<BaselineUnlinkedCallLinkInfo> m_unlinkedCalls;
-        SegmentedVector<BaselineUnlinkedStructureStubInfo> m_unlinkedStubInfos;
+        SaSegmentedVector<BaselineUnlinkedCallLinkInfo> m_unlinkedCalls;
+        SaSegmentedVector<BaselineUnlinkedStructureStubInfo> m_unlinkedStubInfos;
         FixedVector<SimpleJumpTable> m_switchJumpTables;
         FixedVector<StringJumpTable> m_stringSwitchJumpTables;
 

--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -53,6 +53,10 @@ public:
     }
 
 private:
+#if USE(PROTECTED_JIT)
+    // Must be constructed before we allocate anything using SequesteredArenaMalloc
+    ArenaLifetime m_saLifetime { };
+#endif
     JITWorklistThread& m_thread;
     JITPlan::Tier m_tier;
 };

--- a/Source/JavaScriptCore/wasm/WasmWorklist.cpp
+++ b/Source/JavaScriptCore/wasm/WasmWorklist.cpp
@@ -94,6 +94,12 @@ private:
 
     WorkResult work() final
     {
+#if USE(PROTECTED_JIT)
+        // Must be constructed before we allocate anything using
+        // SequesteredArenaMalloc
+        ArenaLifetime m_saLifetime { };
+#endif
+
         auto complete = [&] (const AbstractLocker&) {
             // We need to hold the lock to release our plan otherwise the main thread, while canceling plans
             // might use after free the plan we are looking at

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -234,6 +234,12 @@
 		C2BCFC401F61D13000C9222C /* Language.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC3E1F61D13000C9222C /* Language.cpp */; };
 		C2BCFC421F61D61600C9222C /* LanguageCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC411F61D61600C9222C /* LanguageCF.cpp */; };
 		C2BCFC551F621F3F00C9222C /* LineEnding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2BCFC531F621F3F00C9222C /* LineEnding.cpp */; };
+		C519C35F2D36CCD20064418F /* SequesteredImmortalHeap.h in Headers */ = {isa = PBXBuildFile; fileRef = C519C35E2D36CCCC0064418F /* SequesteredImmortalHeap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C519C3612D36CCD90064418F /* SequesteredImmortalHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C519C3602D36CCD60064418F /* SequesteredImmortalHeap.cpp */; };
+		C519C3632D36CD4D0064418F /* SequesteredAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = C519C3622D36CD450064418F /* SequesteredAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C519C3652D36CD590064418F /* SequesteredAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C519C3642D36CD510064418F /* SequesteredAllocator.cpp */; };
+		C519C3672D36CE220064418F /* SequesteredMalloc.h in Headers */ = {isa = PBXBuildFile; fileRef = C519C3662D36CE1B0064418F /* SequesteredMalloc.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		C519C3692D36CE2E0064418F /* SequesteredMalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C519C3682D36CE2B0064418F /* SequesteredMalloc.cpp */; };
 		C805EF39E5F14481A96D39FC /* ASCIILiteral.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C6F050790D9C432A99085E75 /* ASCIILiteral.cpp */; };
 		CD5497AC15857D0300B5BC30 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5497AA15857D0300B5BC30 /* MediaTime.cpp */; };
 		CEA072AA236FFBF70018839C /* CrashReporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEA072A9236FFBF70018839C /* CrashReporter.cpp */; };
@@ -1600,6 +1606,12 @@
 		C2BCFC531F621F3F00C9222C /* LineEnding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LineEnding.cpp; sourceTree = "<group>"; };
 		C2BCFC541F621F3F00C9222C /* LineEnding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineEnding.h; sourceTree = "<group>"; };
 		C4F8A93619C65EB400B2B15D /* Stopwatch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Stopwatch.h; sourceTree = "<group>"; };
+		C519C35E2D36CCCC0064418F /* SequesteredImmortalHeap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SequesteredImmortalHeap.h; sourceTree = "<group>"; };
+		C519C3602D36CCD60064418F /* SequesteredImmortalHeap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SequesteredImmortalHeap.cpp; sourceTree = "<group>"; };
+		C519C3622D36CD450064418F /* SequesteredAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SequesteredAllocator.h; sourceTree = "<group>"; };
+		C519C3642D36CD510064418F /* SequesteredAllocator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SequesteredAllocator.cpp; sourceTree = "<group>"; };
+		C519C3662D36CE1B0064418F /* SequesteredMalloc.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SequesteredMalloc.h; sourceTree = "<group>"; };
+		C519C3682D36CE2B0064418F /* SequesteredMalloc.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SequesteredMalloc.cpp; sourceTree = "<group>"; };
 		C6F050790D9C432A99085E75 /* ASCIILiteral.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASCIILiteral.cpp; sourceTree = "<group>"; };
 		C8F597CA2A57417FBAB92FD6 /* RandomDevice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RandomDevice.cpp; sourceTree = "<group>"; };
 		CD00360D21501F7800F4ED4C /* StringToIntegerConversion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StringToIntegerConversion.h; sourceTree = "<group>"; };
@@ -2512,6 +2524,12 @@
 				A8A47306151A825B004123FF /* SegmentedVector.h */,
 				A8A47307151A825B004123FF /* SentinelLinkedList.h */,
 				7B8A1DC72A336B9000A4CE4E /* SequenceLocked.h */,
+				C519C3642D36CD510064418F /* SequesteredAllocator.cpp */,
+				C519C3622D36CD450064418F /* SequesteredAllocator.h */,
+				C519C3602D36CCD60064418F /* SequesteredImmortalHeap.cpp */,
+				C519C35E2D36CCCC0064418F /* SequesteredImmortalHeap.h */,
+				C519C3682D36CE2B0064418F /* SequesteredMalloc.cpp */,
+				C519C3662D36CE1B0064418F /* SequesteredMalloc.h */,
 				A8A4731A151A825B004123FF /* SetForScope.h */,
 				A8A47308151A825B004123FF /* SHA1.cpp */,
 				A8A47309151A825B004123FF /* SHA1.h */,
@@ -3612,6 +3630,9 @@
 				DD3DC99227A4BF8E007E5B61 /* SegmentedVector.h in Headers */,
 				DD3DC8C127A4BF8E007E5B61 /* SentinelLinkedList.h in Headers */,
 				7B8A1DC82A336B9000A4CE4E /* SequenceLocked.h in Headers */,
+				C519C3632D36CD4D0064418F /* SequesteredAllocator.h in Headers */,
+				C519C35F2D36CCD20064418F /* SequesteredImmortalHeap.h in Headers */,
+				C519C3672D36CE220064418F /* SequesteredMalloc.h in Headers */,
 				DD3DC88627A4BF8E007E5B61 /* SetForScope.h in Headers */,
 				DD3DC8BB27A4BF8E007E5B61 /* SHA1.h in Headers */,
 				DD3DC88B27A4BF8E007E5B61 /* SharedTask.h in Headers */,
@@ -4262,6 +4283,9 @@
 				7AC314232C6FCF18002CBAFD /* SchedulePairCocoa.mm in Sources */,
 				0F66B28E1DC97BAB004A1D3F /* Seconds.cpp in Sources */,
 				0FA6F38F20CC580F00A03DCD /* SegmentedVector.cpp in Sources */,
+				C519C3652D36CD590064418F /* SequesteredAllocator.cpp in Sources */,
+				C519C3612D36CCD90064418F /* SequesteredImmortalHeap.cpp in Sources */,
+				C519C3692D36CE2E0064418F /* SequesteredMalloc.cpp in Sources */,
 				A8A47421151A825B004123FF /* SHA1.cpp in Sources */,
 				5311BD531EA71CAD00525281 /* Signals.cpp in Sources */,
 				E39664762C7198AA00F91F3A /* SIMDUTF.cpp in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -277,6 +277,9 @@ set(WTF_PUBLIC_HEADERS
     Seconds.h
     SegmentedVector.h
     SentinelLinkedList.h
+    SequesteredAllocator.h
+    SequesteredImmortalHeap.h
+    SequesteredMalloc.h
     SetForScope.h
     SharedTask.h
     SignedPtr.h
@@ -573,6 +576,9 @@ set(WTF_SOURCES
     SafeStrerror.cpp
     Seconds.cpp
     SegmentedVector.cpp
+    SequesteredAllocator.cpp
+    SequesteredImmortalHeap.cpp
+    SequesteredMalloc.cpp
     SixCharacterHash.cpp
     SmallSet.cpp
     StackBounds.cpp

--- a/Source/WTF/wtf/EmbeddedFixedVector.h
+++ b/Source/WTF/wtf/EmbeddedFixedVector.h
@@ -29,6 +29,7 @@
 #include <wtf/MallocCommon.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TrailingArray.h>
 #include <wtf/UniqueRef.h>
 

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -71,6 +71,12 @@ struct MainThreadAccessTraits;
 template<typename> struct ObjectIdentifierMainThreadAccessTraits;
 template<typename> struct ObjectIdentifierThreadSafeAccessTraits;
 
+#if USE(PROTECTED_JIT)
+struct SequesteredArenaMalloc;
+#else
+using SequesteredArenaMalloc = FastMalloc;
+#endif
+
 namespace JSONImpl {
 class Array;
 class Object;
@@ -84,6 +90,7 @@ struct EmbeddedFixedVectorMalloc;
 using VectorBufferMalloc = FastMalloc;
 using EmbeddedFixedVectorMalloc = FastMalloc;
 #endif
+using SegmentedVectorMalloc = FastMalloc;
 
 template<typename> struct DefaultRefDerefTraits;
 
@@ -91,7 +98,8 @@ template<typename> class CompactPtr;
 template<typename> class CompletionHandler;
 template<typename, size_t = 0> class Deque;
 template<typename Key, typename, Key> class EnumeratedArray;
-template<typename, typename = WTF::EmbeddedFixedVectorMalloc> class FixedVector;
+template<typename, typename = EmbeddedFixedVectorMalloc> class FixedVector;
+template<typename, size_t = 8, typename = SegmentedVectorMalloc> class SegmentedVector;
 template<typename> class Function;
 template<typename> struct FlatteningVariantTraits;
 template<typename> struct IsSmartPtr;
@@ -125,6 +133,13 @@ template<typename> struct VariantListSizer;
 template<typename, size_t = 0, typename = CrashOnOverflow, size_t = 16, typename = VectorBufferMalloc> class Vector;
 template<typename, typename WeakPtrImpl = DefaultWeakPtrImpl, typename = RawPtrTraits<WeakPtrImpl>> class WeakPtr;
 template<typename, typename = DefaultWeakPtrImpl> class WeakRef;
+
+template <typename T>
+using SaSegmentedVector = SegmentedVector<T, 8, SequesteredArenaMalloc>;
+template <typename T>
+using SaFixedVector = FixedVector<T, SequesteredArenaMalloc>;
+template <typename T>
+using SaVector = Vector<T, 0, CrashOnOverflow, 16, SequesteredArenaMalloc>;
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<AtomString>;
@@ -170,6 +185,10 @@ inline namespace fundamentals_v3 {
 template<class, class> class expected;
 template<class> class unexpected;
 }}} // namespace std::experimental::fundamentals_v3
+
+using WTF::SaSegmentedVector;
+using WTF::SaFixedVector;
+using WTF::SaVector;
 
 using WTF::ASCIILiteral;
 using WTF::AbstractLocker;

--- a/Source/WTF/wtf/MallocSpan.h
+++ b/Source/WTF/wtf/MallocSpan.h
@@ -38,6 +38,7 @@ namespace WTF {
 
 template<typename T, typename Malloc = FastMalloc> class MallocSpan {
     WTF_MAKE_NONCOPYABLE(MallocSpan);
+    WTF_MAKE_CONFIGURABLE_ALLOCATED(Malloc);
 public:
     MallocSpan() = default;
 

--- a/Source/WTF/wtf/PlatformUse.h
+++ b/Source/WTF/wtf/PlatformUse.h
@@ -314,6 +314,14 @@
 #define USE_ISO_MALLOC 1
 #endif
 
+#if !defined(USE_PROTECTED_JIT)
+#if CPU(ADDRESS64) && OS(DARWIN) && (__SIZEOF_POINTER__ == 8)
+#define USE_PROTECTED_JIT 0
+#else
+#define USE_PROTECTED_JIT 0
+#endif
+#endif
+
 #if !PLATFORM(WATCHOS)
 #define USE_GLYPH_DISPLAY_LIST_CACHE 1
 #endif

--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -39,7 +39,7 @@ namespace WTF {
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SegmentedVector);
 
     // An iterator for SegmentedVector. It supports only the pre ++ operator
-    template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVector;
+    template <typename T, size_t SegmentSize, typename Malloc> class SegmentedVector;
     template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
         WTF_MAKE_CONFIGURABLE_ALLOCATED(FastMalloc);
     private:

--- a/Source/WTF/wtf/SequesteredAllocator.cpp
+++ b/Source/WTF/wtf/SequesteredAllocator.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/SequesteredAllocator.h>
+
+#if USE(PROTECTED_JIT)
+
+namespace WTF {
+
+void SequesteredArenaAllocator::logLiveAllocationDebugInfos()
+{
+    size_t printCount { 0 };
+    for (auto &[p, info] : m_allocationInfos) {
+        if (!info.live)
+            continue;
+        ++printCount;
+        std::span<const LChar> span = info.proximateFrame.span8();
+        std::string toPrint { span.begin(), span.end() };
+        // No newline since we assume the stack frame will have it
+        dataLogIf(verbose, "Allocator ", id(), ": ", info.size, "B @ ",
+            RawPointer(reinterpret_cast<void*>(p)), ": allocated by ",
+            info.proximateFrame);
+    }
+    dataLogLnIf(verbose, "Allocator ", id(), ": ", printCount, " allocations logged");
+}
+
+}
+
+#endif // USE(PROTECTED_JIT)

--- a/Source/WTF/wtf/SequesteredAllocator.h
+++ b/Source/WTF/wtf/SequesteredAllocator.h
@@ -1,0 +1,569 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if USE(PROTECTED_JIT)
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+#include <wtf/Lock.h>
+#include <wtf/SequesteredImmortalHeap.h>
+#include <wtf/StackTrace.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/StdMap.h>
+#include <wtf/text/WTFString.h>
+
+namespace WTF {
+
+constexpr size_t minArenaGranuleSize { 16 * KB };
+
+struct ArenaGranuleHeader {
+    ArenaGranuleHeader* priorGranule;
+    size_t granuleSize;
+
+    static ArenaGranuleHeader& headerForGranule(void* granule)
+    {
+        ASSERT(!(reinterpret_cast<uintptr_t>(granule) % minArenaGranuleSize));
+        ASSERT(granule);
+        return *reinterpret_cast<ArenaGranuleHeader*>(granule);
+    }
+};
+
+
+class alignas(128) SequesteredArenaAllocator {
+private:
+    using AllocationFailureMode = SequesteredImmortalHeap::AllocationFailureMode;
+
+    constexpr static bool verbose { false };
+    constexpr static bool trackAllocationDebugInfo { false };
+    constexpr static size_t pageSize { 16 * KB };
+
+    template<bool canExpand>
+    class Arena {
+        friend SequesteredArenaAllocator;
+
+    public:
+        Arena(SequesteredArenaAllocator* parent)
+            : m_parentSlot(parent) { }
+
+        Arena(Arena&& other) = delete;
+        Arena& operator=(Arena&& other) = delete;
+        Arena(const Arena&) = delete;
+        Arena& operator=(const Arena&) = delete;
+
+        void* allocate(size_t bytes)
+        {
+            auto retval = allocateImpl<AllocationFailureMode::Assert>(bytes);
+            dataLogLnIf(verbose,
+                "Allocator ", m_parentSlot->id(),
+                ": Arena ", arenaIndex(),
+                ": allocated ", bytes, "B: alloc (", RawPointer(retval),
+                "), allocHead (", RawPointer(reinterpret_cast<void*>(m_allocHead)),
+                ")");
+            return retval;
+        }
+
+        void* tryAllocate(size_t bytes)
+        {
+            auto retval = allocateImpl<AllocationFailureMode::ReturnNull>(bytes);
+            dataLogLnIf(verbose && retval,
+                "Allocator ", m_parentSlot->id(),
+                ": Arena ", arenaIndex(),
+                ": allocated ", bytes, "B: alloc (", RawPointer(retval),
+                "), allocHead (", RawPointer(reinterpret_cast<void*>(m_allocHead)),
+                ")");
+            return retval;
+        }
+
+        void* alignedAllocate(size_t alignment, size_t bytes)
+        {
+            auto retval = alignedAllocateImpl<AllocationFailureMode::Assert>(alignment, bytes);
+            dataLogLnIf(verbose,
+                "Allocator ", m_parentSlot->id(),
+                ": Arena ", arenaIndex(),
+                ": align-allocated ", bytes, "B: alloc (", RawPointer(retval),
+                "), allocHead (",
+                RawPointer(reinterpret_cast<void*>(m_allocHead)),
+                ")");
+            return retval;
+        }
+
+        void* tryAlignedAllocate(size_t alignment, size_t bytes)
+        {
+            auto retval = alignedAllocateImpl<AllocationFailureMode::ReturnNull>(alignment, bytes);
+            dataLogLnIf(verbose && retval,
+                "Allocator ", m_parentSlot->id(),
+                ": Arena ", arenaIndex(),
+                ": align-allocated ", bytes, "B: alloc (", RawPointer(retval),
+                "), allocHead (",
+                RawPointer(reinterpret_cast<void*>(m_allocHead)),
+                ")");
+            return retval;
+        }
+
+        void deallocate(void* /*p*/) { }
+
+    private:
+        static constexpr size_t minHeadAlignment = alignof(std::max_align_t);
+
+        uintptr_t headIncrementedBy(size_t bytes) const
+        {
+            const size_t alignmentMask = minHeadAlignment - 1;
+            return (m_allocHead + bytes + alignmentMask) & ~alignmentMask;
+        }
+        uintptr_t headAlignedUpTo(size_t alignment) const
+        {
+            ASSERT(alignment);
+            const size_t minHeadAlignmentMask = minHeadAlignment - 1;
+            const size_t alignmentMask = (alignment - 1) | minHeadAlignmentMask;
+            return (m_allocHead + alignmentMask) & ~alignmentMask;
+        }
+
+        template<AllocationFailureMode mode>
+        void* allocateImpl(size_t bytes)
+        {
+            uintptr_t allocation = m_allocHead;
+            uintptr_t newHead = headIncrementedBy(bytes);
+            if (LIKELY(newHead < m_allocBound)) {
+                m_allocHead = newHead;
+                return reinterpret_cast<void*>(allocation);
+            }
+            if constexpr (!canExpand) {
+                if constexpr (mode == AllocationFailureMode::ReturnNull)
+                    return nullptr;
+                ASSERT(mode == AllocationFailureMode::Assert);
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+            return allocateImplSlowPath<mode>(bytes);
+        }
+
+        template <AllocationFailureMode mode>
+        void* alignedAllocateImpl(size_t alignment, size_t bytes)
+        {
+            uintptr_t allocation = headAlignedUpTo(alignment);
+            uintptr_t newHead = headIncrementedBy((allocation - m_allocHead) + bytes);
+            if (LIKELY(newHead < m_allocBound)) {
+                m_allocHead = newHead;
+                return reinterpret_cast<void*>(allocation);
+            }
+            if constexpr (!canExpand) {
+                if constexpr (mode == AllocationFailureMode::ReturnNull)
+                    return nullptr;
+                ASSERT(mode == AllocationFailureMode::Assert);
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+            return alignedAllocateImplSlowPath<mode>(alignment, bytes);
+        }
+
+        template<AllocationFailureMode mode>
+        NEVER_INLINE void* allocateImplSlowPath(size_t bytes)
+        {
+            void* memory = mapPages<mode>(minArenaGranuleSize);
+            if constexpr (mode == AllocationFailureMode::ReturnNull) {
+                if (UNLIKELY(!memory))
+                    return nullptr;
+            }
+            addGranule(memory, minArenaGranuleSize);
+
+            uintptr_t allocation = m_allocHead;
+            m_allocHead = headIncrementedBy(bytes);
+            ASSERT(m_allocHead <= m_allocBound);
+
+            return reinterpret_cast<void*>(allocation);
+        }
+
+        template<AllocationFailureMode mode>
+        NEVER_INLINE void* alignedAllocateImplSlowPath(size_t alignment, size_t bytes)
+        {
+            void* memory = mapPages<mode>(minArenaGranuleSize);
+            if constexpr (mode == AllocationFailureMode::ReturnNull) {
+                if (UNLIKELY(memory))
+                    return nullptr;
+            }
+            addGranule(memory, minArenaGranuleSize);
+
+            uintptr_t allocation = headAlignedUpTo(alignment);
+            m_allocHead = headIncrementedBy((allocation - m_allocHead) + bytes);
+            ASSERT(m_allocHead <= m_allocBound);
+
+            return reinterpret_cast<void*>(allocation);
+        }
+
+        void addGranule(void* granule, size_t size)
+        {
+            auto& newHeader = ArenaGranuleHeader::headerForGranule(granule);
+            newHeader.priorGranule = m_currentGranule;
+            newHeader.granuleSize = size;
+            m_currentGranule = reinterpret_cast<ArenaGranuleHeader*>(granule);
+            ASSERT(!(reinterpret_cast<uintptr_t>(m_currentGranule) % minArenaGranuleSize));
+
+            static_assert(sizeof(ArenaGranuleHeader) >= minHeadAlignment);
+            m_allocHead = reinterpret_cast<uintptr_t>(granule) + sizeof(ArenaGranuleHeader);
+            m_allocBound = reinterpret_cast<uintptr_t>(granule) + minArenaGranuleSize;
+            dataLogLnIf(verbose,
+                "Allocator ", m_parentSlot->id(),
+                ": Arena ", arenaIndex(),
+                ": expanded: granule was (", newHeader.priorGranule,
+                "), now (", m_currentGranule,
+                "); allocHead (",
+                RawPointer(reinterpret_cast<void*>(m_allocHead)),
+                "), allocBound (",
+                RawPointer(reinterpret_cast<void*>(m_allocBound)),
+                ")");
+        }
+
+        template<AllocationFailureMode mode>
+        void* mapPages(size_t bytes)
+        {
+            return m_parentSlot->mapPages<mode>(bytes);
+        }
+
+        int arenaIndex()
+        {
+            // FIXME: this is a hack, move this logic to SIH
+            auto myOffsetInAllocator = reinterpret_cast<uintptr_t>(this) % sizeof(SequesteredArenaAllocator);
+            return myOffsetInAllocator / sizeof(*this);
+        }
+
+        uintptr_t m_allocHead { 0 };
+        uintptr_t m_allocBound { 0 };
+        ArenaGranuleHeader* m_currentGranule { nullptr };
+        // FIXME: convey the location of the parent via a template offset argument
+        SequesteredArenaAllocator* m_parentSlot;
+    };
+    friend Arena<true>;
+public:
+    SequesteredArenaAllocator() = default;
+
+    void* malloc(size_t bytes)
+    {
+        ASSERT(m_alive);
+        auto retval = m_genericSmallArena.allocate(bytes);
+        registerSuccessfulAllocation(retval, bytes);
+        return retval;
+    }
+
+    void* alignedMalloc(size_t alignment, size_t bytes)
+    {
+        ASSERT(m_alive);
+        auto retval = m_genericSmallArena.alignedAllocate(alignment, bytes);
+        registerSuccessfulAllocation(retval, bytes);
+        return retval;
+    }
+
+    void* zeroedMalloc(size_t bytes)
+    {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        ASSERT(m_alive);
+        auto retval = m_genericSmallArena.allocate(bytes);
+        std::memset(retval, 0, bytes);
+        registerSuccessfulAllocation(retval, bytes);
+        return retval;
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    }
+
+    void* tryMalloc(size_t bytes)
+    {
+        ASSERT(m_alive);
+        auto retval = m_genericSmallArena.tryAllocate(bytes);
+        if (LIKELY(retval))
+            registerSuccessfulAllocation(retval, bytes);
+        return retval;
+    }
+
+    void* tryAlignedMalloc(size_t alignment, size_t bytes)
+    {
+        ASSERT(m_alive);
+        auto retval = m_genericSmallArena.tryAlignedAllocate(alignment, bytes);
+        if (LIKELY(retval))
+            registerSuccessfulAllocation(retval, bytes);
+        return retval;
+    }
+
+    void* tryZeroedMalloc(size_t bytes)
+    {
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        ASSERT(m_alive);
+        auto retval = m_genericSmallArena.tryAllocate(bytes);
+        if (LIKELY(retval)) {
+            std::memset(retval, 0, bytes);
+            registerSuccessfulAllocation(retval, bytes);
+        }
+        return retval;
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    }
+
+    void free(void* p)
+    {
+        ASSERT(m_alive);
+        ASSERT(m_liveAllocations > 0);
+
+        registerSuccessfulFree(p);
+
+        return m_genericSmallArena.deallocate(p);
+    }
+
+    void alignedFree(void* p)
+    {
+        return free(p);
+    }
+
+    void* realloc(void* p, size_t newSize)
+    {
+        ASSERT(m_alive);
+        ASSERT(m_liveAllocations > 0);
+
+        void* newP = m_genericSmallArena.allocate(newSize);
+        registerSuccessfulAllocation(newP, newSize);
+
+        return reallocateInto(p, newP, newSize);
+    }
+
+    void* tryRealloc(void* p, size_t newSize)
+    {
+        ASSERT(m_alive);
+
+        void* newP = m_genericSmallArena.tryAllocate(newSize);
+        if (!newP)
+            return newP;
+
+        auto oldDebugKey = reinterpret_cast<uintptr_t>(p);
+        auto newDebugKey = reinterpret_cast<uintptr_t>(newP);
+        RELEASE_ASSERT(m_allocationInfos.count(oldDebugKey) > 0);
+        m_allocationInfos[newDebugKey] = m_allocationInfos[oldDebugKey];
+
+        return reallocateInto(p, newP, newSize);
+    }
+
+    // Since this is thread-local, we assume beginArenaLifetime and
+    // endArenaLifetime cannot race
+    void beginArenaLifetime()
+    {
+        ASSERT(!m_alive);
+        m_alive = true;
+        m_liveAllocations = 0;
+        dataLogLnIf(verbose, "Allocator ", id(), " in thread ", Thread::current(),
+            ": starting lifetime: granule is (",
+            RawPointer(reinterpret_cast<void*>(m_genericSmallArena.m_currentGranule)),
+            "), allocHead (",
+            RawPointer(reinterpret_cast<void*>(m_genericSmallArena.m_allocHead)),
+            "), allocBound (",
+            RawPointer(reinterpret_cast<void*>(m_genericSmallArena.m_allocBound)),
+            ")");
+    }
+
+    void endArenaLifetime()
+    {
+        ASSERT(m_alive);
+        if constexpr (trackAllocationDebugInfo) {
+            if (m_liveAllocations > 0) {
+                logLiveAllocationDebugInfos();
+                CRASH();
+            }
+        } else
+            RELEASE_ASSERT(!m_liveAllocations);
+        m_alive = false;
+
+        WTF::Locker lock(m_decommitLock);
+        dataLogLnIf(verbose, "Allocator ", id(), " in thread ",
+            Thread::current(), ": ending lifetime: granule is (",
+            RawPointer(reinterpret_cast<void*>(m_genericSmallArena.m_currentGranule)),
+            "), allocHead (",
+            RawPointer(reinterpret_cast<void*>(m_genericSmallArena.m_allocHead)),
+            "), allocBound (",
+            RawPointer(reinterpret_cast<void*>(m_genericSmallArena.m_allocBound)),
+            ")");
+
+        // Splice each arena's owned granules onto our decommit queue
+        ArenaGranuleHeader* top = m_genericSmallArena.m_currentGranule;
+        ArenaGranuleHeader* next = top;
+        if (top)
+            return;
+
+        // FIXME: see if we can optimize out the loop by keeping track of the
+        // bottom granule for each arena
+        for (;;) {
+            auto& header = ArenaGranuleHeader::headerForGranule(next);
+            if (!header.priorGranule) {
+                header.priorGranule = m_decommitHead;
+                m_decommitHead = top;
+                break;
+            }
+            next = header.priorGranule;
+            ASSERT(next != top); // sanity-check no cycles
+        }
+        m_genericSmallArena.m_allocHead = 0;
+        m_genericSmallArena.m_allocBound = 0;
+        m_genericSmallArena.m_currentGranule = nullptr;
+    }
+
+    bool inArenaLifetime()
+    {
+        return m_alive;
+    }
+
+    int id()
+    {
+        return SequesteredImmortalHeap::instance().computeSlotIndex(this);
+    }
+
+    static SequesteredArenaAllocator* getCurrentAllocator()
+    {
+        using SelfT = SequesteredArenaAllocator;
+        auto ptr = reinterpret_cast<SelfT*>(SequesteredImmortalHeap::instance().getSlot());
+        if (UNLIKELY(!ptr)) {
+            ptr = reinterpret_cast<SelfT*>(
+                SequesteredImmortalHeap::instance().allocateAndInstall<SelfT>());
+        }
+        ASSERT(ptr);
+        return ptr;
+    }
+private:
+    struct AllocationDebugInfo {
+        size_t size;
+        String stackTrace;
+        String proximateFrame;
+        bool live;
+    };
+
+    ALWAYS_INLINE void registerSuccessfulAllocation(void* p, size_t bytes) {
+        m_liveAllocations++;
+
+        if constexpr (trackAllocationDebugInfo) {
+            auto debugKey = reinterpret_cast<uintptr_t>(p);
+            RELEASE_ASSERT(!m_allocationInfos.count(debugKey));
+
+            auto fullTrace = StackTrace::captureStackTrace(1000, 3);
+            auto localTrace = StackTrace::captureStackTrace(1, 1);
+            AllocationDebugInfo info {
+                .size = bytes,
+                .stackTrace = fullTrace->toString(),
+                .proximateFrame = localTrace->toString(),
+                .live = true,
+            };
+            m_allocationInfos.emplace(std::make_pair(debugKey, info));
+        }
+    }
+
+    void registerSuccessfulFree(void* p)
+    {
+        m_liveAllocations--;
+
+        if constexpr (trackAllocationDebugInfo) {
+            auto debugKey = reinterpret_cast<uintptr_t>(p);
+            RELEASE_ASSERT(m_allocationInfos.count(debugKey) > 0);
+            m_allocationInfos[debugKey].live = false;
+            m_allocationInfos.erase(debugKey);
+        }
+    }
+
+    void registerSuccessfulReallocation(void* from, void* to, size_t newSize)
+    {
+        if constexpr (trackAllocationDebugInfo) {
+            auto oldDebugKey = reinterpret_cast<uintptr_t>(from);
+            auto newDebugKey = reinterpret_cast<uintptr_t>(to);
+            RELEASE_ASSERT(m_allocationInfos.count(oldDebugKey) > 0);
+            m_allocationInfos[newDebugKey] = m_allocationInfos[oldDebugKey];
+            m_allocationInfos[oldDebugKey].live = false;
+            m_allocationInfos[newDebugKey].size = newSize;
+        }
+    }
+
+    void logLiveAllocationDebugInfos();
+
+    template<AllocationFailureMode mode>
+    void* mapPages(size_t bytes)
+    {
+        return SequesteredImmortalHeap::instance().mapPages<mode>(bytes);
+    }
+
+    void* reallocateInto(void* from, void* to, size_t toSize)
+    {
+        // FIXME: reimplement realloc properly, if necessary
+        // Hopefully it will not be since it would require us to store the size
+        uintptr_t fromInt = reinterpret_cast<uintptr_t>(from);
+        uintptr_t nextPageAfterFrom = (fromInt + pageSize - 1) & ~(pageSize - 1);
+        size_t maxSafeCopySize = nextPageAfterFrom - fromInt;
+
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        size_t copySize = std::min(toSize, maxSafeCopySize);
+        std::memcpy(to, from, copySize);
+        free(from);
+        return to;
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    }
+
+    Arena<true> m_genericSmallArena { this };
+
+    WTF::Lock m_decommitLock { };
+    ArenaGranuleHeader* m_decommitHead { nullptr };
+    bool m_alive { false };
+    // FIXME: wrap this in a child class so we can ifdef it out
+    // when we don't need it
+    StdMap<uintptr_t, AllocationDebugInfo> m_allocationInfos;
+    size_t m_liveAllocations { 0 };
+};
+static_assert(sizeof(SequesteredArenaAllocator) <= SequesteredImmortalHeap::slotSize);
+
+class ArenaLifetime {
+public:
+    ArenaLifetime()
+        : m_slot(SequesteredArenaAllocator::getCurrentAllocator())
+    {
+        m_slot->beginArenaLifetime();
+    }
+    ~ArenaLifetime()
+    {
+        // Should not be created/destroyed in different threads
+        ASSERT(SequesteredArenaAllocator::getCurrentAllocator() == m_slot);
+        m_slot->endArenaLifetime();
+    }
+    ArenaLifetime(ArenaLifetime&& other) = delete;
+    ArenaLifetime& operator=(ArenaLifetime&&) = delete;
+    ArenaLifetime(const ArenaLifetime&) = delete;
+    ArenaLifetime& operator=(const ArenaLifetime&) = delete;
+
+    static bool isAlive()
+    {
+        return SequesteredArenaAllocator::getCurrentAllocator()->inArenaLifetime();
+    }
+private:
+    SequesteredArenaAllocator* m_slot;
+};
+
+} // namespace WTF
+
+using WTF::ArenaLifetime;
+
+#endif // USE(PROTECTED_JIT)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/SequesteredImmortalHeap.h>
+
+#if USE(PROTECTED_JIT)
+
+namespace WTF {
+
+SequesteredImmortalHeap::Instance SequesteredImmortalHeap::s_instance;
+
+}
+
+#endif // USE(PROTECTED_JIT)

--- a/Source/WTF/wtf/SequesteredImmortalHeap.h
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+
+#if USE(PROTECTED_JIT)
+
+#include <cstddef>
+#include <cstdint>
+#include <mach/mach_vm.h>
+#include <mach/vm_map.h>
+#include <mach/vm_param.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <wtf/Assertions.h>
+#include <wtf/Atomics.h>
+#include <wtf/Compiler.h>
+#include <wtf/DataLog.h>
+#include <wtf/Lock.h>
+#include <wtf/Threading.h>
+
+#if OS(DARWIN)
+#include <System/pthread_machdep.h>
+#endif
+
+namespace WTF {
+
+class SequesteredImmortalHeap {
+    static constexpr bool verbose { false };
+    static constexpr pthread_key_t key = __PTK_FRAMEWORK_JAVASCRIPTCORE_KEY0;
+    static constexpr size_t sequesteredImmortalHeapSlotSize { 16 * KB };
+public:
+    static constexpr size_t slotSize { 128 };
+    static constexpr size_t numSlots { 64 };
+
+    enum class AllocationFailureMode {
+        Assert,
+        ReturnNull
+    };
+
+    static SequesteredImmortalHeap& instance()
+    {
+        // FIXME: this storage is not contained within the sequestered region
+        static std::once_flag onceFlag;
+        auto ptr = reinterpret_cast<SequesteredImmortalHeap*>(&s_instance);
+        std::call_once(onceFlag, [] {
+            storeStoreFence();
+            new (&s_instance) SequesteredImmortalHeap();
+        });
+        return *ptr;
+    }
+
+    template <typename T> requires (sizeof(T) <= slotSize)
+    T* allocateAndInstall()
+    {
+        T* slot = nullptr;
+        {
+            WTF::Locker locker { m_scavengerLock };
+            ASSERT(!getUnchecked());
+            // FIXME: implement resizing to a larger capacity
+            RELEASE_ASSERT(m_nextFreeIndex < numSlots);
+
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+            void* buff = &(m_slots[m_nextFreeIndex++]);
+            slot = new (buff) T();
+            WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        }
+        _pthread_setspecific_direct(key, reinterpret_cast<void*>(slot));
+        pthread_key_init_np(key, nullptr);
+
+        dataLogIf(verbose, "SequesteredImmortalHeap: thread (", Thread::current(), ") allocated slot ", instance().m_nextFreeIndex - 1, " (", slot, ")");
+        return slot;
+    }
+
+    void* getSlot()
+    {
+        return getUnchecked();
+    }
+
+    int computeSlotIndex(void* slotPtr)
+    {
+        auto slot = reinterpret_cast<uintptr_t>(slotPtr);
+        auto arrayBase = reinterpret_cast<uintptr_t>(m_slots.begin());
+        auto arrayBound = reinterpret_cast<uintptr_t>(m_slots.begin()) + sizeof(m_slots);
+        ASSERT_UNUSED(arrayBound, slot >= arrayBase && slot < arrayBound);
+        return static_cast<int>((slot - arrayBase) / slotSize);
+    }
+
+    static void scavenge()
+    {
+        // FIXME: provide hook for libpas scavenger
+    }
+
+    template<AllocationFailureMode mode>
+    void* mapPages(size_t bytes)
+    {
+        void* memory = mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
+            MAP_PRIVATE | MAP_ANON, -1, 0);
+        if (UNLIKELY(memory == MAP_FAILED)) {
+            if constexpr (mode == AllocationFailureMode::ReturnNull)
+                return nullptr;
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        return memory;
+    }
+
+private:
+    SequesteredImmortalHeap()
+    {
+        RELEASE_ASSERT(!(reinterpret_cast<uintptr_t>(this) % sequesteredImmortalHeapSlotSize));
+        static_assert(sizeof(*this) <= sequesteredImmortalHeapSlotSize);
+
+        auto flags = VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE | VM_FLAGS_PERMANENT;
+        auto prots = VM_PROT_READ | VM_PROT_WRITE;
+        auto* self = reinterpret_cast<mach_vm_address_t*>(this);
+        mach_vm_map(mach_task_self(), self, sizeof(*this), sequesteredImmortalHeapSlotSize - 1, flags, MEMORY_OBJECT_NULL, 0, false, prots, prots, VM_INHERIT_DEFAULT);
+
+        // Cannot use dataLog here as it takes a lock
+        if constexpr (verbose)
+            fprintf(stderr, "SequesteredImmortalHeap: initialized by thread (%u)\n", Thread::current().uid());
+    }
+
+    static void* getUnchecked()
+    {
+        return _pthread_getspecific_direct(key);
+    }
+
+    struct alignas(WTF::Lock) LockSlot {
+        std::array<std::byte, sizeof(WTF::Lock)> m_bytes;
+        WTF::Lock& asLock()
+        {
+            return *reinterpret_cast<WTF::Lock*>(this);
+        }
+        void initialize()
+        {
+            new (this) WTF::Lock();
+        }
+    };
+
+    struct alignas(slotSize) Slot {
+        std::array<std::byte, slotSize> data;
+    };
+
+    struct alignas(sequesteredImmortalHeapSlotSize) Instance {
+        std::byte data[sequesteredImmortalHeapSlotSize];
+    };
+
+    WTF::Lock m_scavengerLock { };
+    size_t m_nextFreeIndex { };
+    std::array<Slot, numSlots> m_slots { };
+
+    static Instance s_instance;
+};
+
+}
+
+#endif // USE(PROTECTED_JIT)

--- a/Source/WTF/wtf/SequesteredMalloc.cpp
+++ b/Source/WTF/wtf/SequesteredMalloc.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/SequesteredMalloc.h>
+
+#include "SequesteredAllocator.h"
+
+#if USE(PROTECTED_JIT)
+
+namespace WTF {
+
+#if ASSERT_ENABLED
+namespace {
+// We do not use std::numeric_limits<size_t>::max() here due to the edge case in VC++.
+// https://bugs.webkit.org/show_bug.cgi?id=173720
+static size_t maxSingleSequesteredArenaAllocationSize = SIZE_MAX;
+};
+
+void sequesteredArenaSetMaxSingleAllocationSize(size_t size)
+{
+    maxSingleSequesteredArenaAllocationSize = size;
+}
+
+#if ASSERT_ENABLED
+#define ASSERT_IS_WITHIN_LIMIT(size) do { \
+        size_t size__ = (size); \
+        ASSERT_WITH_MESSAGE((size__) <= maxSingleSequesteredArenaAllocationSize, "Requested size (%zu) exceeds max single allocation size set for testing (%zu)", (size__), maxSingleSequesteredArenaAllocationSize); \
+    } while (false)
+#else
+#define ASSERT_IS_WITHIN_LIMIT(size)
+#endif // ASSERT_ENABLED
+
+#define FAIL_IF_EXCEEDS_LIMIT(size) do { \
+        if (UNLIKELY((size) > maxSingleSequesteredArenaAllocationSize)) \
+            return nullptr; \
+    } while (false)
+#else // !ASSERT_ENABLED
+
+#define ASSERT_IS_WITHIN_LIMIT(size)
+#define FAIL_IF_EXCEEDS_LIMIT(size)
+
+#endif // !ASSERT_ENABLED
+
+bool isSequesteredArenaMallocEnabled()
+{
+#if USE(PROTECTED_JIT)
+    return true;
+#else
+    return false;
+#endif
+}
+
+void* sequesteredArenaMalloc(size_t size)
+{
+    ASSERT_IS_WITHIN_LIMIT(size);
+    return SequesteredArenaAllocator::getCurrentAllocator()->malloc(size);
+}
+
+void* sequesteredArenaZeroedMalloc(size_t size)
+{
+    ASSERT_IS_WITHIN_LIMIT(size);
+    return SequesteredArenaAllocator::getCurrentAllocator()->zeroedMalloc(size);
+}
+void* sequesteredArenaCalloc(size_t numElements, size_t elementSize)
+{
+    ASSERT_IS_WITHIN_LIMIT(numElements * elementSize);
+    Checked<size_t> checkedSize = elementSize;
+    checkedSize *= numElements;
+    void* result = sequesteredArenaZeroedMalloc(checkedSize);
+    if (!result)
+        CRASH();
+    return result;
+}
+void* sequesteredArenaRealloc(void* object, size_t newSize)
+{
+    ASSERT_IS_WITHIN_LIMIT(newSize);
+    return SequesteredArenaAllocator::getCurrentAllocator()->realloc(object, newSize);
+}
+
+void sequesteredArenaFree(void* object)
+{
+    SequesteredArenaAllocator::getCurrentAllocator()->free(object);
+}
+
+TryMallocReturnValue trySequesteredArenaMalloc(size_t size)
+{
+    FAIL_IF_EXCEEDS_LIMIT(size);
+    return SequesteredArenaAllocator::getCurrentAllocator()->tryMalloc(size);
+}
+TryMallocReturnValue trySequesteredArenaZeroedMalloc(size_t size)
+{
+    FAIL_IF_EXCEEDS_LIMIT(size);
+    return SequesteredArenaAllocator::getCurrentAllocator()->tryZeroedMalloc(size);
+}
+TryMallocReturnValue trySequesteredArenaCalloc(size_t numElements, size_t elementSize)
+{
+    FAIL_IF_EXCEEDS_LIMIT(numElements * elementSize);
+    CheckedSize checkedSize = elementSize;
+    checkedSize *= numElements;
+    if (checkedSize.hasOverflowed())
+        return nullptr;
+    return trySequesteredArenaZeroedMalloc(checkedSize);
+}
+TryMallocReturnValue trySequesteredArenaRealloc(void* object, size_t newSize)
+{
+    FAIL_IF_EXCEEDS_LIMIT(newSize);
+    return SequesteredArenaAllocator::getCurrentAllocator()->tryRealloc(object, newSize);
+}
+
+void* sequesteredArenaAlignedMalloc(size_t alignment, size_t size)
+{
+    ASSERT_IS_WITHIN_LIMIT(size);
+    return SequesteredArenaAllocator::getCurrentAllocator()->alignedMalloc(alignment, size);
+}
+void* trySequesteredArenaAlignedMalloc(size_t alignment, size_t size)
+{
+    FAIL_IF_EXCEEDS_LIMIT(size);
+    return SequesteredArenaAllocator::getCurrentAllocator()->tryAlignedMalloc(alignment, size);
+}
+void sequesteredArenaAlignedFree(void* p)
+{
+    return SequesteredArenaAllocator::getCurrentAllocator()->free(p);
+}
+
+SequesteredArenaMallocStatistics sequesteredArenaMallocStatistics()
+{
+    return { };
+}
+
+void sequesteredArenaMallocDumpMallocStats()
+{
+}
+
+}
+
+#endif // USE(PROTECTED_JIT)

--- a/Source/WTF/wtf/SequesteredMalloc.h
+++ b/Source/WTF/wtf/SequesteredMalloc.h
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cstdlib>
+#include <new>
+#include <wtf/DebugHeap.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/ForbidHeapAllocation.h>
+#include <wtf/Platform.h>
+#include <wtf/StdLibExtras.h>
+
+#if USE(PROTECTED_JIT)
+
+namespace WTF {
+
+#if ASSERT_ENABLED
+WTF_EXPORT_PRIVATE void sequesteredArenaSetMaxSingleAllocationSize(size_t);
+#endif
+
+WTF_EXPORT_PRIVATE bool isSequesteredArenaMallocEnabled();
+
+WTF_EXPORT_PRIVATE void* sequesteredArenaMalloc(size_t) RETURNS_NONNULL;
+WTF_EXPORT_PRIVATE void* sequesteredArenaZeroedMalloc(size_t) RETURNS_NONNULL;
+WTF_EXPORT_PRIVATE void* sequesteredArenaCalloc(size_t numElements, size_t elementSize) RETURNS_NONNULL;
+WTF_EXPORT_PRIVATE void* sequesteredArenaRealloc(void*, size_t) RETURNS_NONNULL;
+
+WTF_EXPORT_PRIVATE TryMallocReturnValue trySequesteredArenaMalloc(size_t);
+WTF_EXPORT_PRIVATE TryMallocReturnValue trySequesteredArenaZeroedMalloc(size_t);
+WTF_EXPORT_PRIVATE TryMallocReturnValue trySequesteredArenaCalloc(size_t numElements, size_t elementSize);
+WTF_EXPORT_PRIVATE TryMallocReturnValue trySequesteredArenaRealloc(void*, size_t);
+
+WTF_EXPORT_PRIVATE void sequesteredArenaFree(void*);
+
+// Allocations from sequesteredArenaAlignedMalloc() must be freed using sequesteredArenaAlignedFree().
+WTF_EXPORT_PRIVATE void* sequesteredArenaAlignedMalloc(size_t alignment, size_t) RETURNS_NONNULL;
+WTF_EXPORT_PRIVATE void* trySequesteredArenaAlignedMalloc(size_t alignment, size_t);
+WTF_EXPORT_PRIVATE void sequesteredArenaAlignedFree(void*);
+
+struct SequesteredArenaMallocStatistics { /* FIXME: add statistics */ };
+WTF_EXPORT_PRIVATE SequesteredArenaMallocStatistics sequesteredArenaMallocStatistics();
+
+WTF_EXPORT_PRIVATE void sequesteredArenaMallocDumpMallocStats();
+
+template<typename T>
+class SaAllocator {
+public:
+    using value_type = T;
+
+    SaAllocator() = default;
+
+    template<typename U> SaAllocator(const SaAllocator<U>&) { }
+
+    T* allocate(size_t count)
+    {
+        return static_cast<T*>(sequesteredArenaMalloc(sizeof(T) * count));
+    }
+
+    void deallocate(T* pointer, size_t)
+    {
+        sequesteredArenaFree(pointer);
+    }
+
+    template <typename U>
+    struct rebind {
+        using other = SaAllocator<U>;
+    };
+};
+
+template<typename T, typename U> inline bool operator==(const SaAllocator<T>&, const SaAllocator<U>&) { return true; }
+
+struct SequesteredArenaMalloc {
+    static void* malloc(size_t size) { return sequesteredArenaMalloc(size); }
+
+    static void* tryMalloc(size_t size)
+    {
+        auto result = trySequesteredArenaMalloc(size);
+        void* realResult;
+        if (result.getValue(realResult))
+            return realResult;
+        return nullptr;
+    }
+
+    static void* zeroedMalloc(size_t size) { return sequesteredArenaZeroedMalloc(size); }
+
+    static void* tryZeroedMalloc(size_t size)
+    {
+        auto result = trySequesteredArenaZeroedMalloc(size);
+        void* realResult;
+        if (result.getValue(realResult))
+            return realResult;
+        return nullptr;
+    }
+
+    static void* realloc(void* p, size_t size) { return sequesteredArenaRealloc(p, size); }
+
+    static void* tryRealloc(void* p, size_t size)
+    {
+        auto result = trySequesteredArenaRealloc(p, size);
+        void* realResult;
+        if (result.getValue(realResult))
+            return realResult;
+        return nullptr;
+    }
+
+    static void free(void* p) { sequesteredArenaFree(p); }
+
+    static constexpr ALWAYS_INLINE size_t nextCapacity(size_t capacity)
+    {
+        return capacity + capacity / 4 + 1;
+    }
+};
+
+template<typename T>
+struct SaFree {
+    static_assert(std::is_trivially_destructible<T>::value);
+
+    void operator()(T* pointer) const
+    {
+        sequesteredArenaFree(const_cast<typename std::remove_cv<T>::type*>(pointer));
+    }
+};
+
+}
+
+using WTF::SaAllocator;
+using WTF::SequesteredArenaMalloc;
+using WTF::SaFree;
+using WTF::ForbidMallocUseForCurrentThreadScope;
+using WTF::isSequesteredArenaMallocEnabled;
+using WTF::sequesteredArenaCalloc;
+using WTF::sequesteredArenaFree;
+using WTF::sequesteredArenaMalloc;
+using WTF::sequesteredArenaRealloc;
+using WTF::sequesteredArenaZeroedMalloc;
+using WTF::trySequesteredArenaAlignedMalloc;
+using WTF::trySequesteredArenaCalloc;
+using WTF::trySequesteredArenaMalloc;
+using WTF::trySequesteredArenaZeroedMalloc;
+using WTF::sequesteredArenaAlignedMalloc;
+using WTF::sequesteredArenaAlignedFree;
+
+#include <wtf/SequesteredAllocator.h>
+#include <wtf/SequesteredImmortalHeap.h>
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_COMMON \
+    void* operator new(size_t, void* p) { return p; } \
+    void* operator new[](size_t, void* p) { return p; } \
+    \
+    void* operator new(size_t size) \
+    { \
+        return ::WTF::sequesteredArenaMalloc(size); \
+    } \
+    \
+    void operator delete(void* p) \
+    { \
+        ::WTF::sequesteredArenaFree(p); \
+    } \
+    \
+    void* operator new[](size_t size) \
+    { \
+        return ::WTF::sequesteredArenaMalloc(size); \
+    } \
+    \
+    void operator delete[](void* p) \
+    { \
+        ::WTF::sequesteredArenaFree(p); \
+    } \
+    void* operator new(size_t, NotNullTag, void* location) \
+    { \
+        ASSERT(location); \
+        return location; \
+    } \
+    static void freeAfterDestruction(void* p) \
+    { \
+        ::WTF::sequesteredArenaFree(p); \
+    } \
+    using WTFIsSaAllocated = int; \
+
+#define WTF_MAKE_SEQUESTERED_ARENA_NONALLOCATABLE(name) WTF_FORBID_HEAP_ALLOCATION
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(name) \
+public: \
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_COMMON \
+private: \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_FALLBACK_FAST_ALLOCATED(name) \
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(name)
+
+#define WTF_MAKE_STRUCT_SEQUESTERED_ARENA_ALLOCATED(name) \
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_COMMON \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_STRUCT_SEQUESTERED_ARENA_ALLOCATED_FALLBACK_FAST_ALLOCATED(name) \
+    WTF_MAKE_STRUCT_SEQUESTERED_ARENA_ALLOCATED(name)
+
+#define WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED(name) \
+public: \
+    WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED_COMMON \
+private: \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED_EXPORT(name, exportMacro) \
+    WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED(name)
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_EXPORT(name, exportMacro) \
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(name)
+
+#define WTF_MAKE_STRUCT_COMPACT_SEQUESTERED_ARENA_ALLOCATED(name) \
+    WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED_COMMON \
+using __thisIsHereToForceASemicolonAfterThisMacro UNUSED_TYPE_ALIAS = int
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE(name) WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(name)
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL(_templateParameters, _type)
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS()
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(type)
+
+#else // !USE(PROTECTED_JIT)
+
+namespace WTF {
+using SequesteredArenaMalloc = FastMalloc;
+}
+
+using WTF::SequesteredArenaMalloc;
+
+#define WTF_MAKE_SEQUESTERED_ARENA_NONALLOCATABLE(name) WTF_FORBID_HEAP_ALLOCATION
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(name) WTF_MAKE_TZONE_ALLOCATED(name)
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_FALLBACK_FAST_ALLOCATED(name) WTF_MAKE_FAST_ALLOCATED
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_EXPORT(name, exportMacro) WTF_MAKE_TZONE_ALLOCATED_EXPORT(name, exportMacro)
+
+#define WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED(name) WTF_MAKE_COMPACT_TZONE_ALLOCATED(name)
+#define WTF_MAKE_COMPACT_SEQUESTERED_ARENA_ALLOCATED_EXPORT(name, exportMacro) WTF_MAKE_COMPACT_TZONE_ALLOCATED_EXPORT(name, exportMacro)
+
+#define WTF_MAKE_STRUCT_SEQUESTERED_ARENA_ALLOCATED(name) WTF_MAKE_STRUCT_TZONE_ALLOCATED(name)
+#define WTF_MAKE_STRUCT_SEQUESTERED_ARENA_ALLOCATED_FALLBACK_FAST_ALLOCATED(name) WTF_MAKE_FAST_ALLOCATED
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(type) WTF_MAKE_TZONE_ALLOCATED_IMPL(type)
+
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE(name) WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(name)
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL(_templateParameters, _type) WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(_templateParameters, _type)
+#define WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS() \
+    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS()
+
+#endif // !USE(PROTECTED_JIT)


### PR DESCRIPTION
#### 9dd52f49f7c30106f48751f6776a01e948ee97e0
<pre>
[JSC] Implement core of sequestered arena allocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=287524">https://bugs.webkit.org/show_bug.cgi?id=287524</a>
<a href="https://rdar.apple.com/114840482">rdar://114840482</a>

Reviewed by Yusuke Suzuki.

This implements the core functionality of a new arena allocator built
around a sequestered pool of memory. The intention is for this allocator
to be used by the JIT compiler for allocating datastructures; as of
right now, only a small number of datatypes are set up to use the new
allocator. As this is an arena allocator, users need to specify the
lifetime of their allocations indirectly via the ArenaLifetime object.
Currently, the allocator is disabled, and has been stripped of several
unstable components which are still under development. In particular,
the `free` flow is intended to hook into the libpas scavenger, but right
now eagerly frees to tide us over; moreover, each thread&apos;s allocator
will eventually have at least a small number (2-3) of different
size-classed arenas, but for now we only use one.

This allocator is by design separate from libpas. This is because we
want to isolate not only the backing memory but also all allocator
metadata and internal memory. To do this within libpas would require we
duplicate essentially the entire libpas heap hierarchy, from
pas_large_heap up to the various bootstrap heaps, and color them
according to which pool of pages they&apos;re supposed to pull from.

Performance-wise, turning this on has no effect at the moment, but the
hope is that in time it will prove to be a progression. The arena
semantics allow us to batch all frees from a given compiler pass into
one, reducing the actual cost of `free` to a no-op as well as reducing
the load on the scavenger. It also allows us to significantly simplify
the allocation path, removing some overhead even in the shortest-path
malloc case and making it possible to stick to the bump-allocation
regime without ever having to fall back on free lists or &amp;c.

In time, we will need to add a persistent allocator which allocates from
the same pool as well -- something like SEQUESTERED_PERSISTENT_MALLOC.

With regards to the naming, I considered a couple of alternatives:
  - Protected JIT Arena Malloc
  - JIT Arena Malloc
  - Secure Arena Malloc
For the first two, I want to avoid using the term &quot;JIT&quot; as it&apos;s very
overloaded -- I&apos;ve seen it refer to things relevant to
  A) The JIT compiler
  B) Allocating RWX memory
  C) Threads executing in previously JITted code
and so would like to avoid using it here. It also has the problem that
the short-form (JaMalloc) sounds a lot like jemalloc, which could cause
further confusion.
&quot;Secure&quot; would imply that libpas/FastMalloc are &quot;insecure&quot;, which I also
want to avoid.
&quot;Sequestered&quot; is nice because it describes exactly what characterizes
this allocator: it uses memory sequestered from the rest of the system,
and it allocates it using an arena.
Thus SequesteredArenaMalloc.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::~JIT):
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITAllocator.h:
* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
* Source/JavaScriptCore/jit/SecureAllocator.cpp: Copied from Source/JavaScriptCore/jit/JITAllocator.h.
* Source/JavaScriptCore/jit/SecureAllocator.h: Copied from Source/JavaScriptCore/jit/JITAllocator.h.
* Source/JavaScriptCore/jit/SecureAllocatorInlines.h: Copied from Source/JavaScriptCore/jit/JITAllocator.h.
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Bag.h:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/CheckedRef.h:
(WTF::CanMakeCheckedPtr::~CanMakeCheckedPtr):
(WTF::CanMakeThreadSafeCheckedPtr::~CanMakeThreadSafeCheckedPtr):
* Source/WTF/wtf/EmbeddedFixedVector.h:
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::tryFastMalloc):
(WTF::fastMalloc):
(WTF::tryFastCalloc):
(WTF::fastCalloc):
(WTF::fastRealloc):
(WTF::tryFastRealloc):
(WTF::fastZeroedMalloc):
(WTF::tryFastZeroedMalloc):
(WTF::fastAlignedMalloc):
(WTF::tryFastAlignedMalloc):
(WTF::fastCompactMalloc):
(WTF::fastCompactZeroedMalloc):
(WTF::tryFastCompactZeroedMalloc):
(WTF::fastCompactRealloc):
(WTF::fastCompactAlignedMalloc):
(WTF::tryFastCompactAlignedMalloc):
(WTF::tryFastCompactMalloc):
(WTF::tryFastCompactRealloc):
(WTF::ForbidMallocUseForCurrentThreadScope::ForbidMallocUseForCurrentThreadScope): Deleted.
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope): Deleted.
(WTF::DisableMallocRestrictionsForCurrentThreadScope::DisableMallocRestrictionsForCurrentThreadScope): Deleted.
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope): Deleted.
* Source/WTF/wtf/FastMalloc.h:
(WTF::FastMalloc::fastFree):
(WTF::FastCompactMalloc::fastFree):
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope): Deleted.
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope): Deleted.
(WTF::TryMallocReturnValue::TryMallocReturnValue): Deleted.
(WTF::TryMallocReturnValue::~TryMallocReturnValue): Deleted.
(WTF::TryMallocReturnValue::getValue): Deleted.
* Source/WTF/wtf/FixedVector.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/MallocCommon.cpp: Copied from Source/JavaScriptCore/jit/JITAllocator.h.
(WTF::ForbidMallocUseForCurrentThreadScope::ForbidMallocUseForCurrentThreadScope):
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope):
(WTF::DisableMallocRestrictionsForCurrentThreadScope::DisableMallocRestrictionsForCurrentThreadScope):
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope):
(WTF::assertMallocRestrictionForCurrentThreadScope):
* Source/WTF/wtf/MallocCommon.h: Added.
(WTF::TryMallocReturnValue::TryMallocReturnValue):
(WTF::TryMallocReturnValue::~TryMallocReturnValue):
(WTF::TryMallocReturnValue::getValue):
(WTF::ForbidMallocUseForCurrentThreadScope::~ForbidMallocUseForCurrentThreadScope):
(WTF::DisableMallocRestrictionsForCurrentThreadScope::~DisableMallocRestrictionsForCurrentThreadScope):
(WTF::assertMallocRestrictionForCurrentThreadScope):
* Source/WTF/wtf/MallocSpan.h:
* Source/WTF/wtf/PlatformUse.h:
* Source/WTF/wtf/ProtectedJITMalloc.cpp: Added.
(WTF::sequesteredArenaSetMaxSingleAllocationSize):
(WTF::isSequesteredArenaMallocEnabled):
(WTF::sequesteredArenaMalloc):
(WTF::sequesteredArenaZeroedMalloc):
(WTF::sequesteredArenaCalloc):
(WTF::sequesteredArenaRealloc):
(WTF::sequesteredArenaFree):
(WTF::trySequesteredArenaMalloc):
(WTF::trySequesteredArenaZeroedMalloc):
(WTF::trySequesteredArenaCalloc):
(WTF::trySequesteredArenaRealloc):
(WTF::sequesteredArenaAlignedMalloc):
(WTF::trySequesteredArenaAlignedMalloc):
(WTF::sequesteredArenaAlignedFree):
(WTF::sequesteredArenaMallocStatistics):
(WTF::sequesteredArenaMallocDumpMallocStats):
* Source/WTF/wtf/ProtectedJITMalloc.h: Added.
(WTF::SequesteredArenaAllocator::SequesteredArenaAllocator):
(WTF::SequesteredArenaAllocator::allocate):
(WTF::SequesteredArenaAllocator::deallocate):
(WTF::operator==):
(WTF::SequesteredArenaMalloc::malloc):
(WTF::SequesteredArenaMalloc::tryMalloc):
(WTF::SequesteredArenaMalloc::zeroedMalloc):
(WTF::SequesteredArenaMalloc::tryZeroedMalloc):
(WTF::SequesteredArenaMalloc::realloc):
(WTF::SequesteredArenaMalloc::tryRealloc):
(WTF::SequesteredArenaMalloc::free):
(WTF::SequesteredArenaMalloc::nextCapacity):
(WTF::SequesteredArenaFree::operator() const):
* Source/WTF/wtf/ProtectedJITSpareFile.cpp: Added.
* Source/WTF/wtf/ProtectedJITSpareFile.h: Added.
* Source/WTF/wtf/SegmentedVector.h:
* Source/WTF/wtf/SequesteredAllocator.cpp: Added.
(WTF::SequesteredArenaAllocator::logLiveAllocationDebugInfos):
* Source/WTF/wtf/SequesteredAllocator.h: Added.
(WTF::ArenaLifetime::ArenaLifetime):
(WTF::ArenaLifetime::~ArenaLifetime):
(WTF::ArenaLifetime::isAlive):
* Source/WTF/wtf/SequesteredImmortalHeap.cpp: Added.
* Source/WTF/wtf/SequesteredImmortalHeap.h: Added.
(WTF::SequesteredImmortalHeap::instance):
(WTF::SequesteredImmortalHeap::allocateAndInstall):
(WTF::SequesteredImmortalHeap::getSlot):
(WTF::SequesteredImmortalHeap::computeSlotIndex):
(WTF::SequesteredImmortalHeap::scavenge):
(WTF::SequesteredImmortalHeap::mapPages):
(WTF::SequesteredImmortalHeap::SequesteredImmortalHeap):
(WTF::SequesteredImmortalHeap::getUnchecked):
(WTF::SequesteredImmortalHeap::threadIdForLogging):
* Source/WTF/wtf/StdLibExtras.h:
(WTF::makeUnique):
(WTF::makeUniqueWithoutRefCountedCheck):
* Source/WTF/wtf/ThreadSpecific.h:
(WTF::ThreadSpecific::Data::Data):
(WTF::mustBeCompilerThread&gt;::ThreadSpecific):
(WTF::mustBeCompilerThread&gt;::get):
(WTF::mustBeCompilerThread&gt;::setInTLS):
(WTF::mustBeCompilerThread&gt;::destroy):
(WTF::mustBeCompilerThread&gt;::set):
(WTF::mustBeCompilerThread&gt;::isSet):
(WTF::T):
(WTF::mustBeCompilerThread&gt;::operator):
(WTF::canBeGCThread&gt;::ThreadSpecific): Deleted.
(WTF::canBeGCThread&gt;::get): Deleted.
(WTF::canBeGCThread&gt;::setInTLS): Deleted.
(WTF::canBeGCThread&gt;::destroy): Deleted.
(WTF::canBeGCThread&gt;::set): Deleted.
(WTF::canBeGCThread&gt;::isSet): Deleted.
(WTF::canBeGCThread&gt;::operator): Deleted.
* Source/WTF/wtf/Threading.cpp:
* Source/WTF/wtf/UniqueRef.h:
(WTF::makeUniqueRefWithoutRefCountedCheck):
(WTF::makeUniqueRef):
* Source/WTF/wtf/Vector.h:
* Source/bmalloc/bmalloc/IsoHeap.h:
* Source/bmalloc/bmalloc/IsoHeapInlines.h:
* Source/bmalloc/bmalloc/TZoneHeap.h:
* Source/bmalloc/bmalloc/TZoneHeapInlines.h:

Canonical link: <a href="https://commits.webkit.org/291155@main">https://commits.webkit.org/291155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85311d93866d2e52fe9606dec48cd91c408db18c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92156 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1254 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/20178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95157 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/84917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/12016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/90868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/20178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14640 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113477 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->