### PR TITLE
Address some of the Safer CPP warnings in ScrollableArea.cpp and RenderLayerScrollableArea.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -77,7 +77,6 @@ rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerModelObject.cpp
-rendering/RenderLayerScrollableArea.cpp
 rendering/RenderListBox.cpp
 rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnFlow.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -64,7 +64,6 @@ rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerModelObject.cpp
-rendering/RenderLayerScrollableArea.cpp
 rendering/RenderListBox.cpp
 rendering/RenderMarquee.cpp
 rendering/RenderObject.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1239,7 +1239,6 @@ rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
-rendering/RenderLayerScrollableArea.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
 rendering/RenderListMarker.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -600,7 +600,6 @@ platform/CaretAnimator.cpp
 platform/DictationCaretAnimator.cpp
 platform/KeyboardScrollingAnimator.cpp
 platform/ScrollView.cpp
-platform/ScrollableArea.cpp
 platform/ThreadGlobalData.cpp
 platform/ThreadGlobalData.h
 platform/animation/AcceleratedEffect.cpp
@@ -681,7 +680,6 @@ rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
-rendering/RenderLayerScrollableArea.cpp
 rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
 rendering/RenderMarquee.cpp

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -132,7 +132,7 @@ float ScrollableArea::adjustVerticalPageScrollStepForFixedContent(float step)
 
 bool ScrollableArea::scroll(ScrollDirection direction, ScrollGranularity granularity, unsigned stepCount)
 {
-    auto* scrollbar = scrollbarForDirection(direction);
+    RefPtr scrollbar = scrollbarForDirection(direction);
     if (!scrollbar)
         return false;
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -173,6 +173,7 @@ public:
     String name() const;
 
     Page& page() const { return renderer().page(); }
+    Ref<Page> protectedPage() const { return renderer().page(); }
     RenderLayerModelObject& renderer() const { return m_renderer; }
     RenderBox* renderBox() const { return dynamicDowncast<RenderBox>(renderer()); }
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -102,23 +102,23 @@ void RenderLayerScrollableArea::clear()
 {
     auto& renderer = m_layer.renderer();
     if (m_registeredScrollableArea)
-        renderer.view().frameView().removeScrollableArea(this);
+        renderer.view().protectedFrameView()->removeScrollableArea(this);
     
     if (m_isRegisteredForAnimatedScroll) {
-        renderer.view().frameView().removeScrollableAreaForAnimatedScroll(this);
+        renderer.view().protectedFrameView()->removeScrollableAreaForAnimatedScroll(this);
         m_isRegisteredForAnimatedScroll = false;
     }
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     unregisterAsTouchEventListenerForScrolling();
 #endif
-    if (auto* element = renderer.element())
+    if (RefPtr element = renderer.element())
         element->setSavedLayerScrollPosition(m_scrollPosition);
 
     destroyScrollbar(ScrollbarOrientation::Horizontal);
     destroyScrollbar(ScrollbarOrientation::Vertical);
 
-    if (RefPtr scrollingCoordinator = renderer.page().scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = renderer.protectedPage()->scrollingCoordinator())
         scrollingCoordinator->willDestroyScrollableArea(*this);
 
     clearScrollCorner();
@@ -127,7 +127,7 @@ void RenderLayerScrollableArea::clear()
 
 void RenderLayerScrollableArea::restoreScrollPosition()
 {
-    auto* element = m_layer.renderer().element();
+    RefPtr element = m_layer.renderer().element();
     if (!element)
         return;
 
@@ -187,7 +187,7 @@ bool RenderLayerScrollableArea::isUserScrollInProgress() const
     if (!scrollsOverflow())
         return false;
 
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator()) {
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
         if (scrollingCoordinator->isUserScrollInProgress(scrollingNodeID()))
             return true;
     }
@@ -204,7 +204,7 @@ bool RenderLayerScrollableArea::isRubberBandInProgress() const
     if (!scrollsOverflow())
         return false;
 
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator()) {
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
         if (scrollingCoordinator->isRubberBandInProgress(scrollingNodeID()))
             return true;
     }
@@ -268,7 +268,7 @@ bool RenderLayerScrollableArea::requestScrollToPosition(const ScrollPosition& po
 #if ENABLE(ASYNC_SCROLLING)
     LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea::requestScrollToPosition " << position << " options  " << options);
 
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
         return scrollingCoordinator->requestScrollToPosition(*this, position, options);
 #else
     UNUSED_PARAM(position);
@@ -279,7 +279,7 @@ bool RenderLayerScrollableArea::requestScrollToPosition(const ScrollPosition& po
 
 bool RenderLayerScrollableArea::requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData)
 {
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
         return scrollingCoordinator->requestStartKeyboardScrollAnimation(*this, scrollData);
 
     return false;
@@ -287,7 +287,7 @@ bool RenderLayerScrollableArea::requestStartKeyboardScrollAnimation(const Keyboa
 
 bool RenderLayerScrollableArea::requestStopKeyboardScrollAnimation(bool immediate)
 {
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
         return scrollingCoordinator->requestStopKeyboardScrollAnimation(*this, immediate);
 
     return false;
@@ -298,7 +298,7 @@ void RenderLayerScrollableArea::stopAsyncAnimatedScroll()
 #if ENABLE(ASYNC_SCROLLING)
     LOG_WITH_STREAM(Scrolling, stream << m_layer << " stopAsyncAnimatedScroll");
 
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator())
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator())
         return scrollingCoordinator->stopAnimatedScroll(*this);
 #endif
 }
@@ -357,7 +357,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     m_layer.setSelfAndDescendantsNeedPositionUpdate();
 
     auto& renderer = m_layer.renderer();
-    if (auto* element = renderer.element())
+    if (RefPtr element = renderer.element())
         element->setSavedLayerScrollPosition(m_scrollPosition);
 
     RenderView& view = renderer.view();
@@ -365,10 +365,10 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     // Update the positions of our child layers (if needed as only fixed layers should be impacted by a scroll).
     // We don't update compositing layers, because we need to do a deep update from the compositing ancestor.
     if (!view.frameView().layoutContext().isInRenderTreeLayout()) {
-        Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets(m_layer.renderer().document());
+        Style::AnchorPositionEvaluator::updateSnapshottedScrollOffsets(m_layer.renderer().protectedDocument());
 
         // If we're in the middle of layout, we'll just update layers once layout has finished.
-        view.frameView().updateLayerPositionsAfterOverflowScroll(m_layer);
+        view.protectedFrameView()->updateLayerPositionsAfterOverflowScroll(m_layer);
 
         if (!m_updatingMarqueePosition) {
             // Avoid updating compositing layers if, higher on the stack, we're already updating layer
@@ -388,21 +388,21 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
         }
 
         // Update regions, scrolling may change the clip of a particular region.
-        renderer.document().invalidateRenderingDependentRegions();
-        DebugPageOverlays::didLayout(renderer.frame());
+        renderer.protectedDocument()->invalidateRenderingDependentRegions();
+        DebugPageOverlays::didLayout(renderer.protectedFrame());
     }
 
-    LocalFrame& frame = renderer.frame();
+    Ref frame = renderer.frame();
     CheckedPtr repaintContainer = renderer.containerForRepaint().renderer;
     // The caret rect needs to be invalidated after scrolling
-    frame.selection().setCaretRectNeedsUpdate();
+    frame->selection().setCaretRectNeedsUpdate();
 
     auto rectForRepaint = valueOrCompute(layer().cachedClippedOverflowRect(), [&] { return renderer.clippedOverflowRectForRepaint(repaintContainer.get()); });
 
     FloatQuad quadForFakeMouseMoveEvent = FloatQuad(rectForRepaint);
     if (repaintContainer)
         quadForFakeMouseMoveEvent = repaintContainer->localToAbsoluteQuad(quadForFakeMouseMoveEvent);
-    frame.eventHandler().dispatchFakeMouseMoveEventSoonInQuad(quadForFakeMouseMoveEvent);
+    frame->eventHandler().dispatchFakeMouseMoveEventSoonInQuad(quadForFakeMouseMoveEvent);
 
     bool requiresRepaint = true;
     if (usesCompositedScrolling()) {
@@ -430,14 +430,14 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
     }
 
     // Schedule the scroll and scroll-related DOM events.
-    if (Element* element = renderer.element())
-        element->document().addPendingScrollEventTarget(*element);
+    if (RefPtr element = renderer.element())
+        element->protectedDocument()->addPendingScrollEventTarget(*element);
 
     if (scrollsOverflow())
-        view.frameView().didChangeScrollOffset();
+        view.protectedFrameView()->didChangeScrollOffset();
 
-    view.frameView().viewportContentsChanged();
-    frame.editor().renderLayerDidScroll(m_layer);
+    view.protectedFrameView()->viewportContentsChanged();
+    frame->protectedEditor()->renderLayerDidScroll(m_layer);
 }
 
 void RenderLayerScrollableArea::updateCompositingLayersAfterScroll()
@@ -538,7 +538,7 @@ bool RenderLayerScrollableArea::handleWheelEventForScrolling(const PlatformWheel
 
 #if ENABLE(ASYNC_SCROLLING)
     if (usesAsyncScrolling() && scrollingNodeID()) {
-        if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator()) {
+        if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
             auto result = scrollingCoordinator->handleWheelEventForScrolling(wheelEvent, *scrollingNodeID(), gestureState);
             if (!result.needsMainThreadProcessing())
                 return result.wasHandled;
@@ -603,13 +603,13 @@ IntRect RenderLayerScrollableArea::convertFromScrollbarToContainingView(const Sc
     auto& renderer = m_layer.renderer();
     IntRect rect = scrollbarRect;
     rect.move(scrollbarOffset(scrollbar));
-    return renderer.view().frameView().convertFromRendererToContainingView(&renderer, rect);
+    return renderer.view().protectedFrameView()->convertFromRendererToContainingView(&renderer, rect);
 }
 
 IntRect RenderLayerScrollableArea::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntRect& parentRect) const
 {
     auto& renderer = m_layer.renderer();
-    IntRect rect = renderer.view().frameView().convertFromContainingViewToRenderer(&renderer, parentRect);
+    IntRect rect = renderer.view().protectedFrameView()->convertFromContainingViewToRenderer(&renderer, parentRect);
     rect.move(-scrollbarOffset(scrollbar));
     return rect;
 }
@@ -619,13 +619,13 @@ IntPoint RenderLayerScrollableArea::convertFromScrollbarToContainingView(const S
     auto& renderer = m_layer.renderer();
     IntPoint point = scrollbarPoint;
     point.move(scrollbarOffset(scrollbar));
-    return renderer.view().frameView().convertFromRendererToContainingView(&renderer, point);
+    return renderer.view().protectedFrameView()->convertFromRendererToContainingView(&renderer, point);
 }
 
 IntPoint RenderLayerScrollableArea::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntPoint& parentPoint) const
 {
     auto& renderer = m_layer.renderer();
-    IntPoint point = renderer.view().frameView().convertFromContainingViewToRenderer(&renderer, parentPoint);
+    IntPoint point = renderer.view().protectedFrameView()->convertFromContainingViewToRenderer(&renderer, parentPoint);
     point.move(-scrollbarOffset(scrollbar));
     return point;
 }
@@ -668,7 +668,7 @@ void RenderLayerScrollableArea::availableContentSizeChanged(AvailableSizeChangeR
 bool RenderLayerScrollableArea::shouldSuspendScrollAnimations() const
 {
     auto& renderer = m_layer.renderer();
-    return renderer.view().frameView().shouldSuspendScrollAnimations();
+    return renderer.view().protectedFrameView()->shouldSuspendScrollAnimations();
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -695,15 +695,17 @@ RenderLayer::OverflowControlRects RenderLayerScrollableArea::overflowControlsRec
     // Scrollbars sit inside the border box.
     auto overflowControlsPositioningRect = snappedIntRect(renderBox.paddingBoxRectIncludingScrollbar());
 
-    auto horizontalScrollbarHeight = m_hBar ? m_hBar->height() : 0;
-    auto verticalScrollbarWidth = m_vBar ? m_vBar->width() : 0;
+    RefPtr hBar = m_hBar;
+    RefPtr vBar = m_vBar;
+    auto horizontalScrollbarHeight = hBar ? hBar->height() : 0;
+    auto verticalScrollbarWidth = vBar ? vBar->width() : 0;
 
     auto isNonOverlayScrollbar = [](const Scrollbar* scrollbar) {
         return scrollbar && !scrollbar->isOverlayScrollbar();
     };
 
-    bool haveNonOverlayHorizontalScrollbar = isNonOverlayScrollbar(m_hBar.get());
-    bool haveNonOverlayVerticalScrollbar = isNonOverlayScrollbar(m_vBar.get());
+    bool haveNonOverlayHorizontalScrollbar = isNonOverlayScrollbar(hBar.get());
+    bool haveNonOverlayVerticalScrollbar = isNonOverlayScrollbar(vBar.get());
     bool placeVerticalScrollbarOnTheLeft = shouldPlaceVerticalScrollbarOnLeft();
     bool haveResizer = renderBox.style().resize() != Resize::None && renderBox.style().pseudoElementType() == PseudoId::None;
     bool scrollbarsAvoidCorner = ((haveNonOverlayHorizontalScrollbar && haveNonOverlayVerticalScrollbar) || (haveResizer && (haveNonOverlayHorizontalScrollbar || haveNonOverlayVerticalScrollbar))) && renderBox.style().scrollbarWidth() != ScrollbarWidth::None;
@@ -719,7 +721,7 @@ RenderLayer::OverflowControlRects RenderLayerScrollableArea::overflowControlsRec
 
     RenderLayer::OverflowControlRects result;
 
-    if (m_hBar) {
+    if (hBar) {
         auto barRect = overflowControlsPositioningRect;
         barRect.shiftYEdgeTo(barRect.maxY() - horizontalScrollbarHeight);
         if (scrollbarsAvoidCorner) {
@@ -732,7 +734,7 @@ RenderLayer::OverflowControlRects RenderLayerScrollableArea::overflowControlsRec
         result.horizontalScrollbar = barRect;
     }
 
-    if (m_vBar) {
+    if (vBar) {
         auto barRect = overflowControlsPositioningRect;
         if (placeVerticalScrollbarOnTheLeft)
             barRect.setWidth(verticalScrollbarWidth);
@@ -788,12 +790,12 @@ void RenderLayerScrollableArea::invalidateScrollbarRect(Scrollbar& scrollbar, co
         return;
 
     if (&scrollbar == m_vBar.get()) {
-        if (GraphicsLayer* layer = layerForVerticalScrollbar()) {
+        if (RefPtr layer = layerForVerticalScrollbar()) {
             layer->setNeedsDisplayInRect(rect);
             return;
         }
     } else {
-        if (GraphicsLayer* layer = layerForHorizontalScrollbar()) {
+        if (RefPtr layer = layerForHorizontalScrollbar()) {
             layer->setNeedsDisplayInRect(rect);
             return;
         }
@@ -834,14 +836,14 @@ void RenderLayerScrollableArea::invalidateScrollCornerRect(const IntRect& rect)
 
 NativeScrollbarVisibility RenderLayerScrollableArea::horizontalNativeScrollbarVisibility() const
 {
-    auto scrollbar = horizontalScrollbar();
-    return Scrollbar::nativeScrollbarVisibility(scrollbar);
+    RefPtr scrollbar = horizontalScrollbar();
+    return Scrollbar::nativeScrollbarVisibility(scrollbar.get());
 }
 
 NativeScrollbarVisibility RenderLayerScrollableArea::verticalNativeScrollbarVisibility() const
 {
-    auto scrollbar = verticalScrollbar();
-    return Scrollbar::nativeScrollbarVisibility(scrollbar);
+    RefPtr scrollbar = verticalScrollbar();
+    return Scrollbar::nativeScrollbarVisibility(scrollbar.get());
 }
 
 bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const
@@ -851,15 +853,15 @@ bool RenderLayerScrollableArea::canShowNonOverlayScrollbars() const
 
 void RenderLayerScrollableArea::createScrollbarsController()
 {
-    m_layer.page().chrome().client().ensureScrollbarsController(m_layer.page(), *this);
+    m_layer.page().chrome().client().ensureScrollbarsController(m_layer.protectedPage(), *this);
 }
 
 static inline RenderElement* rendererForScrollbar(RenderLayerModelObject& renderer)
 {
-    if (Element* element = renderer.element()) {
-        if (ShadowRoot* shadowRoot = element->containingShadowRoot()) {
+    if (RefPtr element = renderer.element()) {
+        if (RefPtr shadowRoot = element->containingShadowRoot()) {
             if (shadowRoot->mode() == ShadowRootMode::UserAgent)
-                return shadowRoot->host()->renderer();
+                return shadowRoot->protectedHost()->renderer();
         }
     }
 
@@ -881,10 +883,10 @@ Ref<Scrollbar> RenderLayerScrollableArea::createScrollbar(ScrollbarOrientation o
         widget = Scrollbar::createNativeScrollbar(*this, orientation, scrollbarWidthStyle());
         
         didAddScrollbar(widget.get(), orientation);
-        if (m_layer.page().isMonitoringWheelEvents())
-            scrollAnimator().setWheelEventTestMonitor(m_layer.page().wheelEventTestMonitor());
+        if (Ref page = m_layer.page(); page->isMonitoringWheelEvents())
+            scrollAnimator().setWheelEventTestMonitor(page->wheelEventTestMonitor());
     }
-    renderer.view().frameView().addChild(*widget);
+    renderer.view().protectedFrameView()->addChild(*widget);
     return widget.releaseNonNull();
 }
 
@@ -980,30 +982,32 @@ bool RenderLayerScrollableArea::hasScrollableOrRubberbandableAncestor()
 
 int RenderLayerScrollableArea::verticalScrollbarWidth(OverlayScrollbarSizeRelevancy relevancy, bool isHorizontalWritingMode) const
 {
-    if (m_vBar && m_vBar->isOverlayScrollbar() && (relevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize || !m_vBar->shouldParticipateInHitTesting()))
+    RefPtr vBar = m_vBar;
+    if (vBar && vBar->isOverlayScrollbar() && (relevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize || !vBar->shouldParticipateInHitTesting()))
         return 0;
 
-    if (!m_vBar && isHorizontalWritingMode && !(scrollbarGutterStyle().isAuto || ScrollbarTheme::theme().usesOverlayScrollbars()))
+    if (!vBar && isHorizontalWritingMode && !(scrollbarGutterStyle().isAuto || ScrollbarTheme::theme().usesOverlayScrollbars()))
         return ScrollbarTheme::theme().scrollbarThickness(scrollbarWidthStyle());
 
-    if (!m_vBar || !showsOverflowControls())
+    if (!vBar || !showsOverflowControls())
         return 0;
 
-    return m_vBar->width();
+    return vBar->width();
 }
 
 int RenderLayerScrollableArea::horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy relevancy, bool isHorizontalWritingMode) const
 {
-    if (m_hBar && m_hBar->isOverlayScrollbar() && (relevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize || !m_hBar->shouldParticipateInHitTesting()))
+    RefPtr hBar = m_hBar;
+    if (hBar && hBar->isOverlayScrollbar() && (relevancy == OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize || !hBar->shouldParticipateInHitTesting()))
         return 0;
 
-    if (!m_hBar && !isHorizontalWritingMode && !(scrollbarGutterStyle().isAuto || ScrollbarTheme::theme().usesOverlayScrollbars()))
+    if (!hBar && !isHorizontalWritingMode && !(scrollbarGutterStyle().isAuto || ScrollbarTheme::theme().usesOverlayScrollbars()))
         return ScrollbarTheme::theme().scrollbarThickness(scrollbarWidthStyle());
 
-    if (!m_hBar || !showsOverflowControls())
+    if (!hBar || !showsOverflowControls())
         return 0;
 
-    return m_hBar->height();
+    return hBar->height();
 }
 
 OverscrollBehavior RenderLayerScrollableArea::horizontalOverscrollBehavior() const
@@ -1064,18 +1068,18 @@ bool RenderLayerScrollableArea::positionOverflowControls(const IntSize& offsetFr
     auto rects = overflowControlsRects();
     bool changed = false;
 
-    if (m_vBar) {
+    if (RefPtr vBar = m_vBar) {
         rects.verticalScrollbar.move(offsetFromRoot);
-        if (m_vBar->frameRect() != rects.verticalScrollbar) {
-            m_vBar->setFrameRect(rects.verticalScrollbar);
+        if (vBar->frameRect() != rects.verticalScrollbar) {
+            vBar->setFrameRect(rects.verticalScrollbar);
             changed = true;
         }
     }
 
-    if (m_hBar) {
+    if (RefPtr hBar = m_hBar) {
         rects.horizontalScrollbar.move(offsetFromRoot);
-        if (m_hBar->frameRect() != rects.horizontalScrollbar) {
-            m_hBar->setFrameRect(rects.horizontalScrollbar);
+        if (hBar->frameRect() != rects.horizontalScrollbar) {
+            hBar->setFrameRect(rects.horizontalScrollbar);
             changed = true;
         }
     }
@@ -1153,8 +1157,8 @@ void RenderLayerScrollableArea::computeScrollOrigin()
 
     // Horizontal scrollbar offsets depend on the scroll origin when vertical
     // scrollbars are on the left.
-    if (m_hBar)
-        m_hBar->offsetDidChange();
+    if (RefPtr hBar = m_hBar)
+        hBar->offsetDidChange();
 }
 
 void RenderLayerScrollableArea::computeHasCompositedScrollableOverflow(LayoutUpToDate layoutUpToDate)
@@ -1249,12 +1253,12 @@ void RenderLayerScrollableArea::updateScrollbarPresenceAndState(std::optional<bo
     auto horizontalBarState = stateForScrollbarOnAxis(ScrollbarOrientation::Horizontal, hasHorizontalOverflow);
     setHasHorizontalScrollbar(horizontalBarState != ScrollbarState::NoScrollbar);
     if (horizontalBarState != ScrollbarState::NoScrollbar)
-        m_hBar->setEnabled(horizontalBarState == ScrollbarState::Enabled);
+        Ref { *m_hBar }->setEnabled(horizontalBarState == ScrollbarState::Enabled);
 
     auto verticalBarState = stateForScrollbarOnAxis(ScrollbarOrientation::Vertical, hasVerticalOverflow);
     setHasVerticalScrollbar(verticalBarState != ScrollbarState::NoScrollbar);
     if (verticalBarState != ScrollbarState::NoScrollbar)
-        m_vBar->setEnabled(verticalBarState == ScrollbarState::Enabled);
+        Ref { *m_vBar }->setEnabled(verticalBarState == ScrollbarState::Enabled);
 }
 
 void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderStyle* oldStyle)
@@ -1325,10 +1329,10 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
     }
 
     // Set up the range.
-    if (m_hBar)
-        m_hBar->setProportion(roundToInt(box->clientWidth()), m_scrollWidth);
-    if (m_vBar)
-        m_vBar->setProportion(roundToInt(box->clientHeight()), m_scrollHeight);
+    if (RefPtr hBar = m_hBar)
+        hBar->setProportion(roundToInt(box->clientWidth()), m_scrollWidth);
+    if (RefPtr vBar = m_vBar)
+        vBar->setProportion(roundToInt(box->clientHeight()), m_scrollHeight);
 
     updateScrollbarSteps();
 
@@ -1344,13 +1348,13 @@ void RenderLayerScrollableArea::updateScrollbarSteps()
     paddedLayerBounds.contract(box->scrollPaddingForViewportRect(paddedLayerBounds));
 
     // Set up the  page step/line step.
-    if (m_hBar) {
+    if (RefPtr hBar = m_hBar) {
         int width = roundToInt(paddedLayerBounds.width());
-        m_hBar->setSteps(Scrollbar::pixelsPerLineStep(width), Scrollbar::pageStep(width));
+        hBar->setSteps(Scrollbar::pixelsPerLineStep(width), Scrollbar::pageStep(width));
     }
-    if (m_vBar) {
+    if (RefPtr vBar = m_vBar) {
         int height = roundToInt(paddedLayerBounds.height());
-        m_vBar->setSteps(Scrollbar::pixelsPerLineStep(height), Scrollbar::pageStep(height));
+        vBar->setSteps(Scrollbar::pixelsPerLineStep(height), Scrollbar::pageStep(height));
     }
 }
 
@@ -1460,7 +1464,7 @@ void RenderLayerScrollableArea::paintOverflowControls(GraphicsContext& context, 
         if (!paintingRoot)
             paintingRoot = renderer.view().layer();
 
-        if (auto* scrollableArea = paintingRoot->scrollableArea())
+        if (CheckedPtr scrollableArea = paintingRoot->scrollableArea())
             scrollableArea->setContainsDirtyOverlayScrollbars(true);
         return;
     }
@@ -1479,10 +1483,10 @@ void RenderLayerScrollableArea::paintOverflowControls(GraphicsContext& context, 
     positionOverflowControls(toIntSize(adjustedPaintOffset));
 
     // Now that we're sure the scrollbars are in the right place, paint them.
-    if (m_hBar && !layerForHorizontalScrollbar())
-        m_hBar->paint(context, damageRect);
-    if (m_vBar && !layerForVerticalScrollbar())
-        m_vBar->paint(context, damageRect);
+    if (RefPtr hBar = m_hBar; hBar && !layerForHorizontalScrollbar())
+        hBar->paint(context, damageRect);
+    if (RefPtr vBar = m_vBar; vBar && !layerForVerticalScrollbar())
+        vBar->paint(context, damageRect);
 
     if (layerForScrollCorner())
         return;
@@ -1523,7 +1527,8 @@ void RenderLayerScrollableArea::drawPlatformResizerImage(GraphicsContext& contex
     auto& renderer = m_layer.renderer();
     RefPtr<Image> resizeCornerImage;
     FloatSize cornerResizerSize;
-    if (renderer.document().deviceScaleFactor() >= 2) {
+    Ref document = renderer.document();
+    if (document->deviceScaleFactor() >= 2) {
         static NeverDestroyed<Image*> resizeCornerImageHiRes(&ImageAdapter::loadPlatformResource("textAreaResizeCorner@2x").leakRef());
         resizeCornerImage = resizeCornerImageHiRes;
         cornerResizerSize = resizeCornerImage->size();
@@ -1546,7 +1551,7 @@ void RenderLayerScrollableArea::drawPlatformResizerImage(GraphicsContext& contex
 
     if (!resizeCornerImage)
         return;
-    FloatRect imageRect = snapRectToDevicePixels(LayoutRect(resizerCornerRect.maxXMaxYCorner() - cornerResizerSize, cornerResizerSize), renderer.document().deviceScaleFactor());
+    FloatRect imageRect = snapRectToDevicePixels(LayoutRect(resizerCornerRect.maxXMaxYCorner() - cornerResizerSize, cornerResizerSize), document->deviceScaleFactor());
     context.drawImage(*resizeCornerImage, imageRect);
 }
 
@@ -1603,16 +1608,16 @@ bool RenderLayerScrollableArea::hitTestOverflowControls(HitTestResult& result, c
     }
 
     // FIXME: We should hit test the m_scrollCorner and pass it back through the result.
-    if (m_vBar && m_vBar->shouldParticipateInHitTesting()) {
+    if (RefPtr vBar = m_vBar; vBar && vBar->shouldParticipateInHitTesting()) {
         if (rects.verticalScrollbar.contains(localPoint)) {
-            result.setScrollbar(m_vBar.get());
+            result.setScrollbar(vBar.get());
             return true;
         }
     }
 
-    if (m_hBar && m_hBar->shouldParticipateInHitTesting()) {
+    if (RefPtr hBar = m_hBar; hBar && hBar->shouldParticipateInHitTesting()) {
         if (rects.horizontalScrollbar.contains(localPoint)) {
-            result.setScrollbar(m_hBar.get());
+            result.setScrollbar(hBar.get());
             return true;
         }
     }
@@ -1632,7 +1637,7 @@ bool RenderLayerScrollableArea::isActive() const
 
 IntPoint RenderLayerScrollableArea::lastKnownMousePositionInView() const
 {
-    return m_layer.renderer().view().frameView().lastKnownMousePositionInView();
+    return m_layer.renderer().view().protectedFrameView()->lastKnownMousePositionInView();
 }
 
 bool RenderLayerScrollableArea::isHandlingWheelEvent() const
@@ -1648,11 +1653,12 @@ bool RenderLayerScrollableArea::useDarkAppearance() const
 void RenderLayerScrollableArea::updateSnapOffsets()
 {
     // FIXME: Extend support beyond HTMLElements.
-    if (!is<HTMLElement>(m_layer.enclosingElement()) || !m_layer.enclosingElement()->renderBox())
+    RefPtr enclosingElement = m_layer.enclosingElement();
+    if (!is<HTMLElement>(enclosingElement) || !enclosingElement->renderBox())
         return;
 
-    RenderBox* box = m_layer.enclosingElement()->renderBox();
-    updateSnapOffsetsForScrollableArea(*this, *box, box->style(), box->paddingBoxRect(), box->style().writingMode(), m_layer.renderer().document().focusedElement());
+    RenderBox* box = enclosingElement->renderBox();
+    updateSnapOffsetsForScrollableArea(*this, *box, box->style(), box->paddingBoxRect(), box->style().writingMode(), m_layer.renderer().document().protectedFocusedElement().get());
 }
 
 bool RenderLayerScrollableArea::isScrollSnapInProgress() const
@@ -1660,7 +1666,7 @@ bool RenderLayerScrollableArea::isScrollSnapInProgress() const
     if (!scrollsOverflow())
         return false;
 
-    if (RefPtr scrollingCoordinator = m_layer.page().scrollingCoordinator()) {
+    if (RefPtr scrollingCoordinator = m_layer.protectedPage()->scrollingCoordinator()) {
         if (scrollingCoordinator->isScrollSnapInProgress(scrollingNodeID()))
             return true;
     }
@@ -1742,17 +1748,17 @@ bool RenderLayerScrollableArea::scrollingMayRevealBackground() const
 bool RenderLayerScrollableArea::isVisibleToHitTesting() const
 {
     auto& renderer = m_layer.renderer();
-    LocalFrameView& frameView = renderer.view().frameView();
-    return renderer.visibleToHitTesting() && frameView.isVisibleToHitTesting();
+    Ref frameView = renderer.view().frameView();
+    return renderer.visibleToHitTesting() && frameView->isVisibleToHitTesting();
 }
 
 void RenderLayerScrollableArea::updateScrollableAreaSet(bool hasOverflow)
 {
     auto& renderer = m_layer.renderer();
-    LocalFrameView& frameView = renderer.view().frameView();
+    Ref frameView = renderer.view().frameView();
 
     bool isVisibleToHitTest = renderer.visibleToHitTesting();
-    if (HTMLFrameOwnerElement* owner = frameView.frame().ownerElement())
+    if (RefPtr owner = frameView->frame().ownerElement())
         isVisibleToHitTest &= owner->renderer() && owner->renderer()->visibleToHitTesting();
 
     bool needsToBeRegistered = (hasOverflow && isVisibleToHitTest) || scrollAnimationStatus() == ScrollAnimationStatus::Animating;
@@ -1760,11 +1766,11 @@ void RenderLayerScrollableArea::updateScrollableAreaSet(bool hasOverflow)
 
     if (needsToBeRegistered) {
         if (!m_registeredScrollableArea) {
-            addedOrRemoved = frameView.addScrollableArea(this);
+            addedOrRemoved = frameView->addScrollableArea(this);
             m_registeredScrollableArea = true;
         }
     } else if (m_registeredScrollableArea) {
-        addedOrRemoved = frameView.removeScrollableArea(this);
+        addedOrRemoved = frameView->removeScrollableArea(this);
         m_registeredScrollableArea = false;
     }
 
@@ -1786,9 +1792,9 @@ void RenderLayerScrollableArea::updateScrollableAreaSet(bool hasOverflow)
 void RenderLayerScrollableArea::registerScrollableAreaForAnimatedScroll()
 {
     auto& renderer = m_layer.renderer();
-    LocalFrameView& frameView = renderer.view().frameView();
+    Ref frameView = renderer.view().frameView();
     if (!m_registeredScrollableArea) {
-        frameView.addScrollableAreaForAnimatedScroll(this);
+        frameView->addScrollableAreaForAnimatedScroll(this);
         m_isRegisteredForAnimatedScroll = true;
     }
 }
@@ -1805,7 +1811,7 @@ void RenderLayerScrollableArea::updateScrollCornerStyle()
     }
 
     if (!m_scrollCorner) {
-        m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer.document(), WTFMove(*corner));
+        m_scrollCorner = createRenderer<RenderScrollbarPart>(renderer.protectedDocument(), WTFMove(*corner));
         // FIXME: A renderer should be a child of its parent!
         m_scrollCorner->setParent(&renderer);
         m_scrollCorner->initializeStyle();
@@ -1836,7 +1842,7 @@ void RenderLayerScrollableArea::updateResizerStyle()
     }
 
     if (!m_resizer) {
-        m_resizer = createRenderer<RenderScrollbarPart>(renderer.document(), WTFMove(*resizer));
+        m_resizer = createRenderer<RenderScrollbarPart>(renderer.protectedDocument(), WTFMove(*resizer));
         // FIXME: A renderer should be a child of its parent!
         m_resizer->setParent(&renderer);
         m_resizer->initializeStyle();
@@ -1945,7 +1951,7 @@ LayoutRect RenderLayerScrollableArea::scrollRectToVisible(const LayoutRect& abso
 
     auto revealRect = getRectToExposeForScrollIntoView(layerBounds, localExposeRect, options.alignX, options.alignY, localVisiblityRect);
     auto scrollPositionOptions = ScrollPositionChangeOptions::createProgrammatic();
-    if (!box->frame().eventHandler().autoscrollInProgress() && box->element() && useSmoothScrolling(options.behavior, box->element()))
+    if (!box->frame().eventHandler().autoscrollInProgress() && box->element() && useSmoothScrolling(options.behavior, box->protectedElement().get()))
         scrollPositionOptions.animated = ScrollIsAnimated::Yes;
     if (auto result = updateScrollPositionForScrollIntoView(scrollPositionOptions, revealRect, localExposeRect))
         return result.value();
@@ -1990,7 +1996,7 @@ void RenderLayerScrollableArea::scrollByRecursively(const IntSize& delta, Scroll
         if (!remainingScrollOffset.isZero() && renderer.parent()) {
             // FIXME: This skips scrollable frames.
             if (auto* enclosingScrollableLayer = m_layer.enclosingScrollableLayer(IncludeSelfOrNot::ExcludeSelf, CrossFrameBoundaries::Yes)) {
-                if (auto* scrollableArea = enclosingScrollableLayer->scrollableArea())
+                if (CheckedPtr scrollableArea = enclosingScrollableLayer->scrollableArea())
                     scrollableArea->scrollByRecursively(remainingScrollOffset, scrolledArea);
             }
 
@@ -1999,7 +2005,7 @@ void RenderLayerScrollableArea::scrollByRecursively(const IntSize& delta, Scroll
     } else {
         // If we are here, we were called on a renderer that can be programmatically scrolled, but doesn't
         // have an overflow clip. Which means that it is a document node that can be scrolled.
-        renderer.view().frameView().scrollBy(delta);
+        renderer.view().protectedFrameView()->scrollBy(delta);
         if (scrolledArea)
             *scrolledArea = &renderer.view().frameView();
 
@@ -2015,7 +2021,7 @@ bool RenderLayerScrollableArea::mockScrollbarsControllerEnabled() const
 
 void RenderLayerScrollableArea::logMockScrollbarsControllerMessage(const String& message) const
 {
-    m_layer.renderer().document().addConsoleMessage(MessageSource::Other, MessageLevel::Debug, makeString("RenderLayer: "_s, message));
+    m_layer.renderer().protectedDocument()->addConsoleMessage(MessageSource::Other, MessageLevel::Debug, makeString("RenderLayer: "_s, message));
 }
 
 String RenderLayerScrollableArea::debugDescription() const
@@ -2025,22 +2031,22 @@ String RenderLayerScrollableArea::debugDescription() const
 
 void RenderLayerScrollableArea::didStartScrollAnimation()
 {
-    m_layer.page().scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
+    m_layer.protectedPage()->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
 }
 
 void RenderLayerScrollableArea::animatedScrollDidEnd()
 {
     if (m_isRegisteredForAnimatedScroll) {
         auto& renderer = m_layer.renderer();
-        LocalFrameView& frameView = renderer.view().frameView();
+        Ref frameView = renderer.view().frameView();
         m_isRegisteredForAnimatedScroll = false;
-        frameView.removeScrollableAreaForAnimatedScroll(this);
+        frameView->removeScrollableAreaForAnimatedScroll(this);
     }
 }
 
 float RenderLayerScrollableArea::deviceScaleFactor() const
 {
-    return m_layer.renderer().document().deviceScaleFactor();
+    return m_layer.renderer().protectedDocument()->deviceScaleFactor();
 }
 
 void RenderLayerScrollableArea::updateScrollAnchoringElement()


### PR DESCRIPTION
#### f486f35e48df4804921a47069345ad52194e099a
<pre>
Address some of the Safer CPP warnings in ScrollableArea.cpp and RenderLayerScrollableArea.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287653">https://bugs.webkit.org/show_bug.cgi?id=287653</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scroll):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::clear):
(WebCore::RenderLayerScrollableArea::restoreScrollPosition):
(WebCore::RenderLayerScrollableArea::isUserScrollInProgress const):
(WebCore::RenderLayerScrollableArea::isRubberBandInProgress const):
(WebCore::RenderLayerScrollableArea::requestScrollToPosition):
(WebCore::RenderLayerScrollableArea::requestStartKeyboardScrollAnimation):
(WebCore::RenderLayerScrollableArea::requestStopKeyboardScrollAnimation):
(WebCore::RenderLayerScrollableArea::stopAsyncAnimatedScroll):
(WebCore::RenderLayerScrollableArea::scrollTo):
(WebCore::RenderLayerScrollableArea::handleWheelEventForScrolling):
(WebCore::RenderLayerScrollableArea::convertFromScrollbarToContainingView const):
(WebCore::RenderLayerScrollableArea::convertFromContainingViewToScrollbar const):
(WebCore::RenderLayerScrollableArea::shouldSuspendScrollAnimations const):
(WebCore::RenderLayerScrollableArea::overflowControlsRects const):
(WebCore::RenderLayerScrollableArea::invalidateScrollbarRect):
(WebCore::RenderLayerScrollableArea::horizontalNativeScrollbarVisibility const):
(WebCore::RenderLayerScrollableArea::verticalNativeScrollbarVisibility const):
(WebCore::RenderLayerScrollableArea::createScrollbarsController):
(WebCore::rendererForScrollbar):
(WebCore::RenderLayerScrollableArea::createScrollbar):
(WebCore::RenderLayerScrollableArea::verticalScrollbarWidth const):
(WebCore::RenderLayerScrollableArea::horizontalScrollbarHeight const):
(WebCore::RenderLayerScrollableArea::positionOverflowControls):
(WebCore::RenderLayerScrollableArea::computeScrollOrigin):
(WebCore::RenderLayerScrollableArea::updateScrollbarPresenceAndState):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
(WebCore::RenderLayerScrollableArea::updateScrollbarSteps):
(WebCore::RenderLayerScrollableArea::paintOverflowControls):
(WebCore::RenderLayerScrollableArea::drawPlatformResizerImage):
(WebCore::RenderLayerScrollableArea::hitTestOverflowControls):
(WebCore::RenderLayerScrollableArea::lastKnownMousePositionInView const):
(WebCore::RenderLayerScrollableArea::updateSnapOffsets):
(WebCore::RenderLayerScrollableArea::isScrollSnapInProgress const):
(WebCore::RenderLayerScrollableArea::isVisibleToHitTesting const):
(WebCore::RenderLayerScrollableArea::updateScrollableAreaSet):
(WebCore::RenderLayerScrollableArea::registerScrollableAreaForAnimatedScroll):
(WebCore::RenderLayerScrollableArea::updateScrollCornerStyle):
(WebCore::RenderLayerScrollableArea::updateResizerStyle):
(WebCore::RenderLayerScrollableArea::scrollRectToVisible):
(WebCore::RenderLayerScrollableArea::scrollByRecursively):
(WebCore::RenderLayerScrollableArea::logMockScrollbarsControllerMessage const):
(WebCore::RenderLayerScrollableArea::didStartScrollAnimation):
(WebCore::RenderLayerScrollableArea::animatedScrollDidEnd):
(WebCore::RenderLayerScrollableArea::deviceScaleFactor const):

Canonical link: <a href="https://commits.webkit.org/290384@main">https://commits.webkit.org/290384@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/821a304d1420827d812736615d38efeb838d2e2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94786 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40562 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91841 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69151 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81464 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49511 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7167 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35844 "Found 1 new test failure: media/modern-media-controls/invalid-placard/invalid-placard.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39695 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96612 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78021 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77342 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10153 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14111 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16987 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16728 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->