### PR TITLE
[MSE] Tracks shouldn't be exposed in a DedicatedWorker

### DIFF
--- a/LayoutTests/media/media-source/worker/media-managedmse-tracks-worker-expected.txt
+++ b/LayoutTests/media/media-source/worker/media-managedmse-tracks-worker-expected.txt
@@ -6,6 +6,9 @@ info message from worker: 'sourceopen' event received OK
 info message from worker: loaderPromise resolved OK
 info message from worker: sourceBuffer 'update' event received for initsegment OK
 info message from worker: sourceBuffer 'update' event received OK
+info message from worker: sourceBuffer.audioTracks is undefined OK
+info message from worker: sourceBuffer.videoTracks is undefined OK
+info message from worker: sourceBuffer.textTracks is undefined OK
 EXPECTED (video.readyState >= '2') OK
 EXPECTED (video.buffered.length == '1') OK
 EXPECTED (video.audioTracks.length == '1') OK

--- a/LayoutTests/media/media-source/worker/media-managedmse-tracks-worker.html
+++ b/LayoutTests/media/media-source/worker/media-managedmse-tracks-worker.html
@@ -48,3 +48,4 @@
     <video controls></video>
 </body>
 </html>
+

--- a/LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt
+++ b/LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt
@@ -6,6 +6,9 @@ info message from worker: 'sourceopen' event received OK
 info message from worker: loaderPromise resolved OK
 info message from worker: sourceBuffer 'update' event received for initsegment OK
 info message from worker: sourceBuffer 'update' event received OK
+info message from worker: sourceBuffer.audioTracks is undefined OK
+info message from worker: sourceBuffer.videoTracks is undefined OK
+info message from worker: sourceBuffer.textTracks is undefined OK
 EXPECTED (video.readyState >= '2') OK
 EXPECTED (video.buffered.length == '1') OK
 END OF TEST

--- a/LayoutTests/media/media-source/worker/worker.js
+++ b/LayoutTests/media/media-source/worker/worker.js
@@ -24,6 +24,17 @@ function logErrorToMain(msg) {
     postMessage({topic: 'error', arg: msg});
 }
 
+function logTrackInfo(sourceBuffer, type) {
+    let tracks = sourceBuffer[type];
+    if (tracks) {
+        logErrorToMain(`sourceBuffer.${type} is not null`);
+        return false;
+    }
+    
+    logToMain(`sourceBuffer.${type} is undefined`);
+    return true;
+}
+
 function getPath(fullpath) {
     return fullpath.substring(0, fullpath.lastIndexOf('/'));
 }
@@ -61,6 +72,15 @@ onmessage = async (msg) => {
         sourceBuffer.appendBuffer(loader.mediaSegment(0));
         await waitForEvent(sourceBuffer, 'update');
         logToMain("sourceBuffer 'update' event received");
+
+        if (!logTrackInfo(sourceBuffer, 'audioTracks'))
+            return;
+        
+        if (!logTrackInfo(sourceBuffer, 'videoTracks'))
+            return;
+        
+        if (!logTrackInfo(sourceBuffer, 'textTracks'))
+            return;
 
         postMessage({topic: 'done'});
         break;

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.idl
@@ -57,9 +57,9 @@
     attribute double timestampOffset;
 
     // Track support
-    readonly attribute AudioTrackList audioTracks;
-    readonly attribute VideoTrackList videoTracks;
-    readonly attribute TextTrackList textTracks;
+    [Exposed=Window] readonly attribute AudioTrackList audioTracks;
+    [Exposed=Window] readonly attribute VideoTrackList videoTracks;
+    [Exposed=Window] readonly attribute TextTrackList textTracks;
 
     attribute double appendWindowStart;
     attribute unrestricted double appendWindowEnd;


### PR DESCRIPTION
#### 2825c9811c4046795936ee70cdf642846767dbfd
<pre>
[MSE] Tracks shouldn&apos;t be exposed in a DedicatedWorker
<a href="https://bugs.webkit.org/show_bug.cgi?id=287655">https://bugs.webkit.org/show_bug.cgi?id=287655</a>
<a href="https://rdar.apple.com/144808034">rdar://144808034</a>

Reviewed by Jer Noble.

* LayoutTests/media/media-source/worker/media-managedmse-worker-expected.txt:
* LayoutTests/media/media-source/worker/media-managedmse-tracks-worker-expected.txt:

* LayoutTests/media/media-source/worker/worker.js:
(onmessage.async msg):  Update test to verify that video, audio,
and text tracks are not available in a worker.

* Source/WebCore/Modules/mediasource/SourceBuffer.idl: Mark tracks as `[Exposed=Window]`.

Canonical link: <a href="https://commits.webkit.org/290533@main">https://commits.webkit.org/290533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa3af2648612f5c61e293b996a6f0843a386c973

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90367 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92419 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18215 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27148 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7882 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7609 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97204 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17555 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77777 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19197 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20845 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17565 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17306 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20758 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->