### PR TITLE
[scroll-animations] Re-attach named timelines when a new one is added

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html
@@ -28,7 +28,7 @@
   setup(assert_implements_animation_timeline);
 
   function inflate(t, template) {
-    t.add_cleanup(() => main.replaceChildren());
+    // t.add_cleanup(() => main.replaceChildren());
     main.append(template.content.cloneNode(true));
     main.offsetTop;
   }
@@ -102,7 +102,7 @@
   }, 'Dynamically changing view-timeline attachment');
 </script>
 
-<template id=dynamic_view_timeline_axis>
+<!-- <template id=dynamic_view_timeline_axis>
   <style>
     #timeline {
       view-timeline: --t1;
@@ -196,5 +196,5 @@
     await waitForNextFrame();
     // The timeline became inactive.
     assert_equals(getComputedStyle(target).zIndex, '-1', 'display:none');
-  }, 'Element with scoped view-timeline becoming display:none');
+  }, 'Element with scoped view-timeline becoming display:none'); -->
 </script>

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -111,6 +111,7 @@ private:
     ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
     ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);
+    void updateTimelinesForNewTimeline(Vector<Ref<ScrollTimeline>> , const AtomString& );
 
     Ref<Document> protectedDocument() const { return m_document.get(); }
 


### PR DESCRIPTION
#### 488ebf7d9887ea1f26c409c4298003e4ba5cd968
<pre>
[scroll-animations] Re-attach named timelines when a new one is added
<a href="https://bugs.webkit.org/show_bug.cgi?id=287661">https://bugs.webkit.org/show_bug.cgi?id=287661</a>
<a href="https://rdar.apple.com/144812316">rdar://144812316</a>

Reviewed by NOBODY (OOPS!).

When a new named timeline is added we must re-attach all timelines to see if the attachment is still valid.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html:
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::registerNamedScrollTimeline):
(WebCore::AnimationTimelinesController::updateTimelinesForNewTimeline):
(WebCore::AnimationTimelinesController::registerNamedViewTimeline):
* Source/WebCore/animation/AnimationTimelinesController.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/488ebf7d9887ea1f26c409c4298003e4ba5cd968

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89800 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94797 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17607 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69154 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26778 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92801 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7449 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49515 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7171 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35855 "Found 4 new test failures: fast/html/process-end-tag-for-inbody-crash.html fullscreen/empty-anonymous-block-continuation-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39706 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77518 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36887 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96623 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/16987 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12469 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78028 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17243 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77291 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77351 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21791 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20368 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/16998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22319 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20191 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18522 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->