### PR TITLE
Use sendWithAsyncReply for WebFullScreenManagerProxy::BeganExitFullScreen

### DIFF
--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -201,6 +201,7 @@ public:
         WebsiteDataStoreConfiguration,
         WebsitePolicies,
         WindowFeatures,
+        CompletionListener,
 
 #if ENABLE(WEB_AUTHN)
         WebAuthenticationAssertionResponse,

--- a/Source/WebKit/Shared/API/c/WKBase.h
+++ b/Source/WebKit/Shared/API/c/WKBase.h
@@ -147,6 +147,7 @@ typedef const struct OpaqueWKSpeechRecognitionPermissionCallback* WKSpeechRecogn
 typedef const struct OpaqueWKMediaKeySystemPermissionRequest* WKMediaKeySystemPermissionRequestRef;
 typedef const struct OpaqueWKMediaKeySystemPermissionCallback* WKMediaKeySystemPermissionCallbackRef;
 typedef const struct OpaqueWKQueryPermissionResultCallback* WKQueryPermissionResultCallbackRef;
+typedef const struct OpaqueWKCompletionListener* WKCompletionListenerRef;
 
 /* WebKit2 Bundle types */
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.h
+++ b/Source/WebKit/UIProcess/API/C/WKPage.h
@@ -232,7 +232,6 @@ WK_EXPORT void WKPageSetPageInjectedBundleClient(WKPageRef page, const WKPageInj
 WK_EXPORT void WKPageSetFullScreenClientForTesting(WKPageRef page, const WKPageFullScreenClientBase* client);
 WK_EXPORT void WKPageDidEnterFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageWillExitFullScreen(WKPageRef pageRef);
-WK_EXPORT void WKPageDidExitFullScreen(WKPageRef pageRef);
 WK_EXPORT void WKPageRequestExitFullScreen(WKPageRef pageRef);
 
 // A client can implement either a navigation client or loader and policy clients, but never both.

--- a/Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h
+++ b/Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h
@@ -34,8 +34,9 @@ extern "C" {
 typedef struct WKRect WKRect;
 
 typedef bool (*WKPageWillEnterFullScreenCallback)(WKPageRef page, const void* clientInfo);
-typedef void (*WKPageFullScreenCallbackWithRects)(WKPageRef page, WKRect initialFrame, WKRect finalFrame, const void* clientInfo);
-typedef void (*WKPageFullScreenCallback)(WKPageRef page, const void* clientInfo);
+typedef void (*WKPageBeganEnterFullScreenCallback)(WKPageRef page, WKRect initialFrame, WKRect finalFrame, const void* clientInfo);
+typedef void (*WKPageExitFullScreenCallback)(WKPageRef page, const void* clientInfo);
+typedef void (*WKPageBeganExitFullScreenCallback)(WKPageRef page, WKRect initialFrame, WKRect finalFrame, WKCompletionListenerRef listener, const void* clientInfo);
 
 typedef struct WKPageFullScreenClientBase {
     int version;
@@ -47,11 +48,13 @@ typedef struct WKPageFullScreenClientV0 {
 
     // Version 0.
     WKPageWillEnterFullScreenCallback willEnterFullScreen;
-    WKPageFullScreenCallbackWithRects beganEnterFullScreen;
-    WKPageFullScreenCallback exitFullScreen;
-    WKPageFullScreenCallbackWithRects beganExitFullScreen;
+    WKPageBeganEnterFullScreenCallback beganEnterFullScreen;
+    WKPageExitFullScreenCallback exitFullScreen;
+    WKPageBeganExitFullScreenCallback beganExitFullScreen;
 
 } WKPageFullScreenClientV0;
+
+WK_EXPORT void WKCompletionListenerComplete(WKCompletionListenerRef listener);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.cpp
@@ -107,12 +107,8 @@ void WKViewSetVisible(WKViewRef view, bool visible)
     setViewActivityStateFlag(view, WebCore::ActivityState::IsVisible, visible);
 }
 
-void WKViewWillEnterFullScreen(WKViewRef view)
+void WKViewWillEnterFullScreen(WKViewRef)
 {
-#if ENABLE(FULLSCREEN_API)
-    // FIXME: Replace this and WKViewSetViewClient's enterFullScreen with a listener object.
-    WebKit::toImpl(view)->willEnterFullScreen([] (bool) { });
-#endif
 }
 
 void WKViewDidEnterFullScreen(WKViewRef view)
@@ -129,11 +125,8 @@ void WKViewWillExitFullScreen(WKViewRef view)
 #endif
 }
 
-void WKViewDidExitFullScreen(WKViewRef view)
+void WKViewDidExitFullScreen(WKViewRef)
 {
-#if ENABLE(FULLSCREEN_API)
-    WebKit::toImpl(view)->didExitFullScreen();
-#endif
 }
 
 void WKViewRequestExitFullScreen(WKViewRef view)
@@ -174,9 +167,7 @@ void WKViewSetViewClient(WKViewRef view, const WKViewClientBase* client)
             if (!m_client.enterFullScreen)
                 return completionHandler(false);
             m_client.enterFullScreen(WebKit::toAPI(&view), m_client.base.clientInfo);
-
-            // FIXME: Replace this and WKViewWillEnterFullScreen with a listener object.
-            completionHandler(false);
+            completionHandler(true);
         }
         
         void exitFullScreen(WebKit::PlayStationWebView& view)
@@ -200,11 +191,12 @@ void WKViewSetViewClient(WKViewRef view, const WKViewClientBase* client)
             m_client.beganEnterFullScreen(WebKit::toAPI(&view), WebKit::toAPI(initialFrame), WebKit::toAPI(finalFrame), m_client.base.clientInfo);
         }
         
-        void beganExitFullScreen(WebKit::PlayStationWebView& view, const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame)
+        void beganExitFullScreen(WebKit::PlayStationWebView& view, const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&& completionHandler)
         {
             if (!m_client.beganExitFullScreen)
-                return;
+                return completionHandler();
             m_client.beganExitFullScreen(WebKit::toAPI(&view), WebKit::toAPI(initialFrame), WebKit::toAPI(finalFrame), m_client.base.clientInfo);
+            completionHandler();
         }
 
         void setCursor(WebKit::PlayStationWebView& view, const WebCore::Cursor& cursor) final

--- a/Source/WebKit/UIProcess/API/C/playstation/WKView.h
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKView.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebKit/WKDeprecated.h>
 #include <WebKit/WKViewClient.h>
 
 #ifdef __cplusplus
@@ -46,10 +47,10 @@ WK_EXPORT void WKViewSetFocus(WKViewRef, bool);
 WK_EXPORT void WKViewSetActive(WKViewRef, bool);
 WK_EXPORT void WKViewSetVisible(WKViewRef, bool);
 
-WK_EXPORT void WKViewWillEnterFullScreen(WKViewRef);
+WK_EXPORT void WKViewWillEnterFullScreen(WKViewRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKViewDidEnterFullScreen(WKViewRef);
 WK_EXPORT void WKViewWillExitFullScreen(WKViewRef);
-WK_EXPORT void WKViewDidExitFullScreen(WKViewRef);
+WK_EXPORT void WKViewDidExitFullScreen(WKViewRef) WK_C_API_DEPRECATED;
 WK_EXPORT void WKViewRequestExitFullScreen(WKViewRef);
 WK_EXPORT bool WKViewIsFullScreen(WKViewRef);
 

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -446,9 +446,9 @@ void PageClientImpl::beganEnterFullScreen(const IntRect& /* initialFrame */, con
     notImplemented();
 }
 
-void PageClientImpl::beganExitFullScreen(const IntRect& /* initialFrame */, const IntRect& /* finalFrame */)
+void PageClientImpl::beganExitFullScreen(const IntRect& /* initialFrame */, const IntRect& /* finalFrame */, CompletionHandler<void()>&& completionHandler)
 {
-    notImplemented();
+    completionHandler();
 }
 
 #endif // ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -135,7 +135,7 @@ private:
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
 #endif
 
     void didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, std::span<const uint8_t>) override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2685,8 +2685,6 @@ static void webkitWebViewBaseDidExitFullScreen(WebKitWebViewBase* webkitWebViewB
 {
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
     ASSERT(priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen);
-    if (auto* fullScreenManagerProxy = priv->pageProxy->fullScreenManager())
-        fullScreenManagerProxy->didExitFullScreen();
     priv->fullScreenState = WebFullScreenManagerProxy::FullscreenState::NotInFullscreen;
     priv->sleepDisabler = nullptr;
 }

--- a/Source/WebKit/UIProcess/API/playstation/APIViewClient.h
+++ b/Source/WebKit/UIProcess/API/playstation/APIViewClient.h
@@ -50,7 +50,7 @@ public:
     virtual void exitFullScreen(WebKit::PlayStationWebView&) { }
     virtual void closeFullScreen(WebKit::PlayStationWebView&) { }
     virtual void beganEnterFullScreen(WebKit::PlayStationWebView&, const WebCore::IntRect&, const WebCore::IntRect&) { }
-    virtual void beganExitFullScreen(WebKit::PlayStationWebView&, const WebCore::IntRect&, const WebCore::IntRect&) { }
+    virtual void beganExitFullScreen(WebKit::PlayStationWebView&, const WebCore::IntRect&, const WebCore::IntRect&, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void setCursor(WebKit::PlayStationWebView& view, const WebCore::Cursor& cursor) { }
 };
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -450,7 +450,7 @@ void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionH
     WebFullScreenManagerProxy* fullScreenManagerProxy = m_view.page().fullScreenManager();
     if (fullScreenManagerProxy) {
         if (!static_cast<WKWPE::ViewLegacy&>(m_view).setFullScreen(true))
-            fullScreenManagerProxy->didExitFullScreen();
+            fullScreenManagerProxy->requestExitFullScreen();
     }
 }
 
@@ -479,9 +479,9 @@ void PageClientImpl::beganEnterFullScreen(const WebCore::IntRect& /* initialFram
     notImplemented();
 }
 
-void PageClientImpl::beganExitFullScreen(const WebCore::IntRect& /* initialFrame */, const WebCore::IntRect& /* finalFrame */)
+void PageClientImpl::beganExitFullScreen(const WebCore::IntRect& /* initialFrame */, const WebCore::IntRect& /* finalFrame */, CompletionHandler<void()>&& completionHandler)
 {
-    notImplemented();
+    completionHandler();
 }
 
 #endif // ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -170,7 +170,7 @@ private:
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
 #endif
 
     UnixFileDescriptor hostFileDescriptor() final;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
@@ -259,10 +259,8 @@ ViewLegacy::ViewLegacy(struct wpe_view_backend* backend, const API::PageConfigur
             view.page().fullScreenManager()->didEnterFullScreen();
         },
         // did_exit_fullscreen
-        [](void* data)
+        [](void*)
         {
-            auto& view = *reinterpret_cast<ViewLegacy*>(data);
-            view.page().fullScreenManager()->didExitFullScreen();
         },
         // request_enter_fullscreen
         [](void* data)

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp
@@ -197,9 +197,6 @@ void ViewPlatform::exitFullScreen()
 void ViewPlatform::didExitFullScreen()
 {
     ASSERT(m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::ExitingFullscreen);
-
-    if (auto* fullScreenManagerProxy = page().fullScreenManager())
-        fullScreenManagerProxy->didExitFullScreen();
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::NotInFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -74,7 +74,7 @@ public:
 #endif
     virtual void exitFullScreen() = 0;
     virtual void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) = 0;
-    virtual void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) = 0;
+    virtual void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) = 0;
 
     virtual bool lockFullscreenOrientation(WebCore::ScreenOrientationType) { return false; }
     virtual void unlockFullscreenOrientation() { }
@@ -115,7 +115,6 @@ public:
     void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void didEnterFullScreen();
     void willExitFullScreen();
-    void didExitFullScreen();
     void setAnimatingFullScreen(bool);
     void requestRestoreFullScreen(CompletionHandler<void(bool)>&&);
     void requestExitFullScreen();
@@ -136,7 +135,7 @@ private:
 #endif
     void exitFullScreen();
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame);
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&);
     void callCloseCompletionHandlers();
     template<typename M> void sendToWebProcess(M&&);
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -34,7 +34,7 @@ messages -> WebFullScreenManagerProxy {
 #endif
     ExitFullScreen()
     BeganEnterFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect)
-    BeganExitFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect)
+    BeganExitFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> ()
     Close()
 }
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -253,7 +253,7 @@ private:
 #endif
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
     bool lockFullscreenOrientation(WebCore::ScreenOrientationType) override;
     void unlockFullscreenOrientation() override;
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -864,9 +864,11 @@ void PageClientImpl::beganEnterFullScreen(const IntRect& initialFrame, const Int
     [[webView() fullScreenWindowController] beganEnterFullScreenWithInitialFrame:initialFrame finalFrame:finalFrame];
 }
 
-void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)
+void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntRect& finalFrame, CompletionHandler<void()>&& completionHandler)
 {
-    [[webView() fullScreenWindowController] beganExitFullScreenWithInitialFrame:initialFrame finalFrame:finalFrame];
+    if (![webView() fullScreenWindowController])
+        return completionHandler();
+    [[webView() fullScreenWindowController] beganExitFullScreenWithInitialFrame:initialFrame finalFrame:finalFrame completionHandler:WTFMove(completionHandler)];
 }
 
 #endif // ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -52,7 +52,7 @@
 - (void)requestRestoreFullScreen:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)requestExitFullScreen;
 - (void)exitFullScreen;
-- (void)beganExitFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame;
+- (void)beganExitFullScreenWithInitialFrame:(CGRect)initialFrame finalFrame:(CGRect)finalFrame completionHandler:(CompletionHandler<void()>&&)completionHandler;
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)orientations;
 - (void)resetSupportedOrientations;
 - (void)close;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -225,7 +225,7 @@ private:
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
 #endif
 
     void navigationGestureDidBegin() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -842,9 +842,11 @@ void PageClientImpl::beganEnterFullScreen(const IntRect& initialFrame, const Int
     m_impl->updateSupportsArbitraryLayoutModes();
 }
 
-void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntRect& finalFrame)
+void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntRect& finalFrame, CompletionHandler<void()>&& completionHandler)
 {
-    [m_impl->fullScreenWindowController() beganExitFullScreenWithInitialFrame:initialFrame finalFrame:finalFrame];
+    if (!m_impl->fullScreenWindowController())
+        return completionHandler();
+    [m_impl->fullScreenWindowController() beganExitFullScreenWithInitialFrame:initialFrame finalFrame:finalFrame completionHandler:WTFMove(completionHandler)];
     m_impl->updateSupportsArbitraryLayoutModes();
 }
 

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -61,6 +61,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 
     bool _requestedExitFullScreen;
     FullScreenState _fullScreenState;
+    CompletionHandler<void()> _exitFullScreenCompletionHandler;
 
     double _savedScale;
     WebCore::FloatBoxExtent _savedObscuredContentInsets;
@@ -82,7 +83,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 - (void)requestExitFullScreen;
 - (void)close;
 - (void)beganEnterFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame;
-- (void)beganExitFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame;
+- (void)beganExitFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame completionHandler:(CompletionHandler<void()>&&)completionHandler;
 
 - (void)videoControlsManagerDidChange;
 

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -276,9 +276,9 @@ void PageClientImpl::beganEnterFullScreen(const WebCore::IntRect& initialFrame, 
     m_view.beganEnterFullScreen(initialFrame, finalFrame);
 }
 
-void PageClientImpl::beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame)
+void PageClientImpl::beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&& completionHandler)
 {
-    m_view.beganExitFullScreen(initialFrame, finalFrame);
+    m_view.beganExitFullScreen(initialFrame, finalFrame, WTFMove(completionHandler));
 }
 #endif
 

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -140,7 +140,7 @@ private:
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
 #endif
 
     // Custom representations.

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -131,12 +131,6 @@ void PlayStationWebView::willExitFullScreen()
     m_page->fullScreenManager()->willExitFullScreen();
 }
 
-void PlayStationWebView::didExitFullScreen()
-{
-    m_page->fullScreenManager()->didExitFullScreen();
-    m_isFullScreen = false;
-}
-
 void PlayStationWebView::requestExitFullScreen()
 {
     if (isFullScreen())
@@ -175,10 +169,14 @@ void PlayStationWebView::beganEnterFullScreen(const WebCore::IntRect& initialFra
         m_client->beganEnterFullScreen(*this, initialFrame, finalFrame);
 }
 
-void PlayStationWebView::beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame)
+void PlayStationWebView::beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&& completionHandler)
 {
-    if (m_client)
-        m_client->beganExitFullScreen(*this, initialFrame, finalFrame);
+    if (!m_client)
+        return completionHandler();
+    m_client->beganExitFullScreen(*this, initialFrame, finalFrame, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] mutable {
+        m_isFullScreen = false;
+        completionHandler();
+    });
 }
 #endif
 

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.h
@@ -62,7 +62,6 @@ public:
     void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void didEnterFullScreen();
     void willExitFullScreen();
-    void didExitFullScreen();
     void requestExitFullScreen();
 #endif
 
@@ -74,7 +73,7 @@ public:
     void enterFullScreen(CompletionHandler<void(bool)>&&);
     void exitFullScreen();
     void beganEnterFullScreen(const WebCore::IntRect&, const WebCore::IntRect&);
-    void beganExitFullScreen(const WebCore::IntRect&, const WebCore::IntRect&);
+    void beganExitFullScreen(const WebCore::IntRect&, const WebCore::IntRect&, CompletionHandler<void()>&&);
 #endif
     void setCursor(const WebCore::Cursor&);
 

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -334,9 +334,10 @@ void PageClientImpl::beganEnterFullScreen(const IntRect& /* initialFrame */, con
     notImplemented();
 }
 
-void PageClientImpl::beganExitFullScreen(const IntRect& /* initialFrame */, const IntRect& /* finalFrame */)
+void PageClientImpl::beganExitFullScreen(const IntRect& /* initialFrame */, const IntRect& /* finalFrame */, CompletionHandler<void()>&& completionHandler)
 {
     notImplemented();
+    completionHandler();
 }
 #endif // ENABLE(FULLSCREEN_API)
 

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -130,7 +130,7 @@ private:
     void enterFullScreen(CompletionHandler<void(bool)>&&) override;
     void exitFullScreen() override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame) override;
+    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;
 #endif
 
     void didFinishLoadingDataForCustomContentProvider(const String& suggestedFilename, std::span<const uint8_t>) override;

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -462,7 +462,9 @@ void WebFullScreenManager::willExitFullScreen()
 #endif
     // FIXME: The order of these frames is switched, but that is kept for historical reasons.
     // It should probably be fixed to be consistent at some point.
-    m_page->send(Messages::WebFullScreenManagerProxy::BeganExitFullScreen(m_finalFrame, m_initialFrame));
+    m_page->sendWithAsyncReply(Messages::WebFullScreenManagerProxy::BeganExitFullScreen(m_finalFrame, m_initialFrame), [this, protectedThis = Ref { *this }] {
+        didExitFullScreen();
+    });
 }
 
 static Vector<Ref<Element>> collectFullscreenElementsFromElement(Element* element)

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -30,7 +30,6 @@ messages -> WebFullScreenManager {
     RequestExitFullScreen()
     DidEnterFullScreen()
     WillExitFullScreen()
-    DidExitFullScreen()
     SetAnimatingFullScreen(bool animating)
     SetFullscreenInsets(WebCore::FloatBoxExtent insets)
     SetFullscreenAutoHideDuration(Seconds duration)

--- a/Tools/MiniBrowser/playstation/WebViewWindow.cpp
+++ b/Tools/MiniBrowser/playstation/WebViewWindow.cpp
@@ -109,13 +109,11 @@ WebViewWindow::WebViewWindow(WKPageConfigurationRef configuration, Client&& wind
 
         // enterFullScreen
         [](WKViewRef view, const void*) {
-            WKViewWillEnterFullScreen(view);
             WKViewDidEnterFullScreen(view);
         },
         // exitFullScreen
         [](WKViewRef view, const void*) {
             WKViewWillExitFullScreen(view);
-            WKViewDidExitFullScreen(view);
         },
         nullptr, // closeFullScreen
         nullptr, // beganEnterFullScreen

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
@@ -198,7 +199,7 @@ public:
     void dumpPolicyDelegateCallbacks() { m_dumpPolicyDelegateCallbacks = true; }
     void dumpFullScreenCallbacks() { m_dumpFullScreenCallbacks = true; }
     void waitBeforeFinishingFullscreenExit() { m_waitBeforeFinishingFullscreenExit = true; }
-    void finishFullscreenExit(WKPageRef);
+    void finishFullscreenExit();
     void requestExitFullscreenFromUIProcess(WKPageRef);
 
     static bool willEnterFullScreen(WKPageRef, const void*);
@@ -207,8 +208,8 @@ public:
     void beganEnterFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame);
     static void exitFullScreen(WKPageRef, const void*);
     void exitFullScreen(WKPageRef);
-    static void beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame, const void*);
-    void beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame);
+    static void beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame, WKCompletionListenerRef, const void*);
+    void beganExitFullScreen(WKPageRef, WKRect initialFrame, WKRect finalFrame, WKCompletionListenerRef);
 
     void setShouldLogHistoryClientCallbacks(bool shouldLog) { m_shouldLogHistoryClientCallbacks = shouldLog; }
     void setShouldLogCanAuthenticateAgainstProtectionSpace(bool shouldLog) { m_shouldLogCanAuthenticateAgainstProtectionSpace = shouldLog; }
@@ -787,6 +788,7 @@ private:
         { }
     };
     HashMap<String, AbandonedDocumentInfo> m_abandonedDocumentInfo;
+    CompletionHandler<void()> m_finishExitFullscreenHandler;
 
     uint64_t m_serverTrustEvaluationCallbackCallsCount { 0 };
     bool m_shouldDismissJavaScriptAlertsAsynchronously { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -708,7 +708,7 @@ void TestInvocation::didReceiveMessageFromInjectedBundle(WKStringRef messageName
     }
 
     if (WKStringIsEqualToUTF8CString(messageName, "FinishFullscreenExit")) {
-        TestController::singleton().finishFullscreenExit(TestController::singleton().mainWebView()->page());
+        TestController::singleton().finishFullscreenExit();
         return;
     }
 


### PR DESCRIPTION
#### df5c88e585197caff17c1f372d08a82e5cc46e28
<pre>
Use sendWithAsyncReply for WebFullScreenManagerProxy::BeganExitFullScreen
<a href="https://rdar.apple.com/144813733">rdar://144813733</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287664">https://bugs.webkit.org/show_bug.cgi?id=287664</a>

Reviewed by Eric Carlson.

WebFullScreenManager::DidExitFullScreen should only be called as a reply to BeganExitFullScreen,
so I replaced it with a completion handler.  There are a few cases where we used to proactively
send this reply to a question that had not yet been asked by the web content process to the UI
process, but now we wait for the question to be asked before sending the reply.  The correctness
of such cases is tested by unit tests like WKWebViewCloseAllMediaPresentations.ElementFullscreen.

This is a step towards getting fullscreen working properly with site isolation.

I also may have fixed the PlayStation fullscreen code by changing the default from failing to enter
to succeeding to enter immediately.  If they want an async task to happen during the entering
time, they can add a listener object.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(RunJavaScriptConfirmResultListener::create):
(RunJavaScriptConfirmResultListener::~RunJavaScriptConfirmResultListener):
(RunJavaScriptConfirmResultListener::call):
(RunJavaScriptConfirmResultListener::RunJavaScriptConfirmResultListener):
(WKPageSetFullScreenClientForTesting):
(WKPageDidExitFullScreen): Deleted.
(WebKit::RunJavaScriptConfirmResultListener::create): Deleted.
(WebKit::RunJavaScriptConfirmResultListener::~RunJavaScriptConfirmResultListener): Deleted.
(WebKit::RunJavaScriptConfirmResultListener::call): Deleted.
(WebKit::RunJavaScriptConfirmResultListener::RunJavaScriptConfirmResultListener): Deleted.
* Source/WebKit/UIProcess/API/C/WKPage.h:
* Source/WebKit/UIProcess/API/C/WKPageFullScreenClient.h:
* Source/WebKit/UIProcess/API/C/playstation/WKView.cpp:
(WKViewDidExitFullScreen):
(WKViewSetViewClient):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseDidExitFullScreen):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::enterFullScreen):
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::ViewLegacy):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewPlatform.cpp:
(WKWPE::ViewPlatform::didExitFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
(WebKit::WebFullScreenManagerProxy::didExitFullScreen): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController exitFullScreen]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController _completedExitFullScreen:]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
(-[WKFullScreenWindowController _startToDismissFullscreenChanged:]):
(-[WKFullScreenWindowController _dismissFullscreenViewController:]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:]): Deleted.
(-[WKFullScreenWindowController _completedExitFullScreen]): Deleted.
(-[WKFullScreenWindowController _dismissFullscreenViewController]): Deleted.
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:completionHandler:]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
(-[WKFullScreenWindowController beganExitFullScreenWithInitialFrame:finalFrame:]): Deleted.
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
(WebKit::PlayStationWebView::willEnterFullScreen):
(WebKit::PlayStationWebView::beganExitFullScreen):
(WebKit::PlayStationWebView::didExitFullScreen): Deleted.
* Source/WebKit/UIProcess/playstation/PlayStationWebView.h:
* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
(WebKit::PageClientImpl::beganExitFullScreen):
* Source/WebKit/UIProcess/win/PageClientImpl.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::exitFullScreenForElement):
(WebKit::WebFullScreenManager::willExitFullScreen):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::willEnterFullScreen):
(WTR::TestController::beganExitFullScreen):
(WTR::TestController::finishFullscreenExit):
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/290536@main">https://commits.webkit.org/290536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bfe60be8aad1f704c26d337b76a2e395ae47b76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95379 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18221 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27150 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81989 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49929 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36352 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40281 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17561 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17818 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77812 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77788 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22234 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20850 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10828 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14209 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17571 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17312 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->