### PR TITLE
Supress deprecation of NSURLProtectionSpaceFTPProxy

### DIFF
--- a/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm
@@ -39,8 +39,11 @@ static ProtectionSpace::ServerType type(NSURLProtectionSpace *space)
             return ProtectionSpace::ServerType::ProxyHTTP;
         if ([proxyType isEqualToString:NSURLProtectionSpaceHTTPSProxy])
             return ProtectionSpace::ServerType::ProxyHTTPS;
+// FIXME: rdar://144814079
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if ([proxyType isEqualToString:NSURLProtectionSpaceFTPProxy])
             return ProtectionSpace::ServerType::ProxyFTP;
+ALLOW_DEPRECATED_DECLARATIONS_END
         if ([proxyType isEqualToString:NSURLProtectionSpaceSOCKSProxy])
             return ProtectionSpace::ServerType::ProxySOCKS;
 
@@ -77,6 +80,7 @@ static ProtectionSpace::AuthenticationScheme scheme(NSURLProtectionSpace *space)
         return ProtectionSpace::AuthenticationScheme::NTLM;
     if ([method isEqualToString:NSURLAuthenticationMethodNegotiate])
         return ProtectionSpace::AuthenticationScheme::Negotiate;
+// FIXME: rdar://144814079
 #if USE(PROTECTION_SPACE_AUTH_CALLBACK)
     if ([method isEqualToString:NSURLAuthenticationMethodClientCertificate])
         return ProtectionSpace::AuthenticationScheme::ClientCertificateRequested;
@@ -129,9 +133,12 @@ NSURLProtectionSpace *ProtectionSpace::nsSpace() const
     case ProtectionSpace::ServerType::ProxyHTTPS:
         proxyType = NSURLProtectionSpaceHTTPSProxy;
         break;
+// FIXME: rdar://144814079
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     case ProtectionSpace::ServerType::ProxyFTP:
         proxyType = NSURLProtectionSpaceFTPProxy;
         break;
+ALLOW_DEPRECATED_DECLARATIONS_END
     case ProtectionSpace::ServerType::ProxySOCKS:
         proxyType = NSURLProtectionSpaceSOCKSProxy;
         break;


### PR DESCRIPTION
#### 1a5774614ca976683240bf0e67df7570f2758ddd
<pre>
Supress deprecation of NSURLProtectionSpaceFTPProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=287667">https://bugs.webkit.org/show_bug.cgi?id=287667</a>
<a href="https://rdar.apple.com/144811875">rdar://144811875</a>

Unreviewed build fix.

* Source/WebCore/platform/network/cocoa/ProtectionSpaceCocoa.mm:
(WebCore::type):
(WebCore::ProtectionSpace::nsSpace const):

Canonical link: <a href="https://commits.webkit.org/290368@main">https://commits.webkit.org/290368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e93e8a1db5903a006939865c2e93b2f8df4000c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89819 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9348 "Failed to checkout and rebase branch from PR 40583") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/40592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91871 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/9735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/17626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/94817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/40592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92820 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/9735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/94817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/9735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/39725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/9735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/96642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/17006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/17626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/96642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/17262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/96642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/44710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14099 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->