### PR TITLE
[Cocoa] TestWKWebViews and TestWKWebViewHostWindows are leaked after API tests finish running

### DIFF
--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -29,6 +29,7 @@ WKWebViewConfigurationExtras.mm
 cocoa/CGImagePixelReader.cpp
 cocoa/DaemonTestUtilities.mm
 cocoa/DragAndDropSimulator.mm
+cocoa/HostWindowManager.mm
 cocoa/ImageAnalysisTestingUtilities.mm
 cocoa/NSItemProviderAdditions.mm
 cocoa/PlatformUtilitiesCocoa.mm

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3343,6 +3343,8 @@
 		A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NowPlayingMetadataObserver.mm; sourceTree = "<group>"; };
 		A1A4FE5D18DD3DB700B5EA8A /* Download.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Download.mm; sourceTree = "<group>"; };
 		A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLifecycle.mm; sourceTree = "<group>"; };
+		A1AE4A092D5DBFCC00320629 /* HostWindowManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HostWindowManager.h; path = cocoa/HostWindowManager.h; sourceTree = "<group>"; };
+		A1AE4A0A2D5DBFCC00320629 /* HostWindowManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = HostWindowManager.mm; path = cocoa/HostWindowManager.mm; sourceTree = "<group>"; };
 		A1C142C124AA7B2E00444207 /* ContextMenuMouseEvents.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextMenuMouseEvents.mm; sourceTree = "<group>"; };
 		A1C1F5E72C9C96C00042E924 /* TestWebKitAPI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestWebKitAPI.xctestplan; sourceTree = "<group>"; };
 		A1C4FB6C1BACCE50003742D0 /* QuickLook.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = QuickLook.mm; sourceTree = "<group>"; };
@@ -4163,6 +4165,8 @@
 				3302A64D2A11B4410093FA2A /* DragAndDropSimulator.mm */,
 				F44D06481F3962E3001A0E29 /* EditingTestHarness.h */,
 				F44D06491F3962E3001A0E29 /* EditingTestHarness.mm */,
+				A1AE4A092D5DBFCC00320629 /* HostWindowManager.h */,
+				A1AE4A0A2D5DBFCC00320629 /* HostWindowManager.mm */,
 				5C7C24FB237C972300599C91 /* HTTPServer.h */,
 				5C7C24FA237C972300599C91 /* HTTPServer.mm */,
 				F42F081727449FFD007E0D90 /* ImageAnalysisTestingUtilities.h */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -621,6 +621,9 @@ TEST(WebKit, TransferTrackBetweenSameProcessPages)
 
     EXPECT_EQ(webView2.get().microphoneCaptureState, WKMediaCaptureStateActive);
     EXPECT_EQ(webView2.get().cameraCaptureState, WKMediaCaptureStateActive);
+
+    [webView2 removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView2 removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 
 static constexpr auto KeepPermissionForWebAppSameOriginNavigationsText = R"DOCDOCDOC(
@@ -776,6 +779,9 @@ TEST(WebKit, InterruptionBetweenGetDisplayMediaAndGetUserMedia)
 
     cameraCaptureStateChange = false;
     EXPECT_TRUE(waitUntilCameraState(webView1.get(), WKMediaCaptureStateMuted));
+
+    [webView1 removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView1 removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 #endif // PLATFORM(MAC)
 
@@ -1640,6 +1646,9 @@ TEST(WebKit2, ConnectedToHardwareConsole)
     while (--retryCount)
         TestWebKitAPI::Util::spinRunLoop(10);
     EXPECT_TRUE(cameraCaptureState == WKMediaCaptureStateMuted);
+
+    [webView removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 
 TEST(WebKit2, DoNotUnmuteWhenTakingAThumbnail)
@@ -1670,6 +1679,9 @@ TEST(WebKit2, DoNotUnmuteWhenTakingAThumbnail)
         TestWebKitAPI::Util::spinRunLoop(10);
     }
     EXPECT_TRUE(cameraCaptureState == WKMediaCaptureStateMuted);
+
+    [webView removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 #endif
 
@@ -1752,6 +1764,9 @@ TEST(WebKit2, WebRTCAndRemoteCommands)
 
     EXPECT_TRUE(waitUntilCameraState(webView.get(), WKMediaCaptureStateActive));
     EXPECT_TRUE(waitUntilMicrophoneState(webView.get(), WKMediaCaptureStateActive));
+
+    [webView removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 
 TEST(WebKit2, ToggleCameraCaptureWhenRestarting)
@@ -1815,6 +1830,9 @@ TEST(WebKit2, ToggleCameraCaptureWhenRestarting)
     done = false;
     [webView stringByEvaluatingJavaScript:@"validateActionState('deactivating camera, muting camera, deactivating microphone, muting microphone, setCameraActive successful, unmuting camera, end')"];
     TestWebKitAPI::Util::run(&done);
+
+    [webView removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 
 TEST(WebKit2, ToggleMicrophoneCaptureWhenRestarting)
@@ -1882,6 +1900,9 @@ TEST(WebKit2, ToggleMicrophoneCaptureWhenRestarting)
     done = false;
     [webView stringByEvaluatingJavaScript:@"validateActionState('deactivating camera, muting camera, deactivating microphone, muting microphone, setMicrophoneActive successful, unmuting microphone, end')"];
     TestWebKitAPI::Util::run(&done);
+
+    [webView removeObserver:observer.get() forKeyPath:@"microphoneCaptureState"];
+    [webView removeObserver:observer.get() forKeyPath:@"cameraCaptureState"];
 }
 #endif // WK_HAVE_C_SPI
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm
@@ -111,7 +111,7 @@ TEST(WebKit, NavigateDuringDeviceEnumeration)
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto processPoolConfig = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     initializeMediaCaptureConfiguration(configuration.get());
-    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]);
+    WKWebView *webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get() processPoolConfiguration:processPoolConfig.get()]).leakRef();
     auto delegate = adoptNS([[NavigationWhileGetUserMediaPromptDisplayedUIDelegate alloc] init]);
     [webView setUIDelegate:delegate.get()];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm
@@ -75,6 +75,9 @@ TEST(Fullscreen, AudioLifecycle)
     [webView waitForMessage:@"playing"];
 
     ASSERT_FALSE([webView _canEnterFullscreen]);
+
+    [webView removeObserver:observer.get() forKeyPath:canEnterFullscreenKeyPath];
+    [webView removeObserver:observer.get() forKeyPath:fullscreenStateKeyPath];
 }
 
 static void runTest(WKWebViewConfiguration *configuration)
@@ -121,6 +124,9 @@ static void runTest(WKWebViewConfiguration *configuration)
     });
     ASSERT_FALSE([webView _canEnterFullscreen]);
     ASSERT_TRUE(canEnterFullscreenChanged);
+
+    [webView removeObserver:observer.get() forKeyPath:canEnterFullscreenKeyPath];
+    [webView removeObserver:observer.get() forKeyPath:fullscreenStateKeyPath];
 }
 
 TEST(Fullscreen, VideoLifecycle)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm
@@ -368,6 +368,8 @@ TEST(WebKit2, ToggleScreenshare)
     messageReceived = false;
     [webView stringByEvaluatingJavaScript:@"validateActionState('setScreenshareActive successful, muting screenshare, setScreenshareActive successful, unmuting screenshare, end')"];
     TestWebKitAPI::Util::run(&messageReceived);
+
+    [webView removeObserver:observer.get() forKeyPath:@"_displayCaptureState"];
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaMutedState.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaMutedState.mm
@@ -55,6 +55,12 @@ static bool stateDidChange;
     return self;
 }
 
+- (void)dealloc
+{
+    [_webView removeObserver:self forKeyPath:@"_isPlayingAudio"];
+    [super dealloc];
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if (context == audioStateObserverChangeKVOContext) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm
@@ -69,6 +69,8 @@ TEST(NowPlayingSession, HasSession)
         TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
 
     ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
 TEST(NowPlayingSession, NavigateAfterHasSession)
@@ -96,6 +98,8 @@ TEST(NowPlayingSession, NavigateAfterHasSession)
         TestWebKitAPI::Util::run(&hasActiveNowPlayingSessionChanged);
 
     ASSERT_FALSE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
 TEST(NowPlayingSession, NavigateToFragmentAfterHasSession)
@@ -120,6 +124,8 @@ TEST(NowPlayingSession, NavigateToFragmentAfterHasSession)
     [webView _test_waitForDidSameDocumentNavigation];
 
     ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
 TEST(NowPlayingSession, LoadSubframeAfterHasSession)
@@ -144,6 +150,8 @@ TEST(NowPlayingSession, LoadSubframeAfterHasSession)
     [webView waitForMessage:@"subframeLoaded"];
 
     ASSERT_TRUE([webView _hasActiveNowPlayingSession]);
+
+    [webView removeObserver:observer.get() forKeyPath:nowPlayingSessionKeyPath];
 }
 
 @end

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3398,6 +3398,9 @@ TEST(SiteIsolation, ThemeColor)
     Util::run(&observedThemeColor);
     Util::run(&observedUnderPageBackgroundColor);
     Util::runFor(0.1_s);
+
+    [webView.get() removeObserver:observer.get() forKeyPath:@"themeColor"];
+    [webView.get() removeObserver:observer.get() forKeyPath:@"underPageBackgroundColor"];
 }
 
 static WebViewAndDelegates makeWebViewAndDelegates(HTTPServer& server)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm
@@ -85,6 +85,7 @@ TEST(WebKit, WKWebViewIsPlayingAudio)
     [webView synchronouslyLoadTestPageNamed:@"file-with-video"];
     [webView evaluateJavaScript:@"playVideo()" completionHandler:nil];
     TestWebKitAPI::Util::run(&done);
+    [webView removeObserver:observer.get() forKeyPath:@"_isPlayingAudio"];
 }
 
 @interface NoUIDelegate : NSObject <WKNavigationDelegate>
@@ -1256,6 +1257,7 @@ TEST(WebKit, PinnedState)
     [webView addObserver:observer.get() forKeyPath:@"_pinnedState" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld context:nil];
     [webView loadHTMLString:@"<body onload='scroll(100, 100)' style='height:10000vh;'/>" baseURL:[NSURL URLWithString:@"http://example.com/"]];
     TestWebKitAPI::Util::run(&done);
+    [webView removeObserver:observer.get() forKeyPath:@"_pinnedState"];
 }
 
 @interface DidScrollDelegate : NSObject <WKUIDelegatePrivate>

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewThemeColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewThemeColor.mm
@@ -145,6 +145,12 @@ TEST(WKWebViewThemeColor, MetaElementValidSubframe)
     return self;
 }
 
+- (void)dealloc
+{
+    [_webView removeObserver:self forKeyPath:@"themeColor"];
+    [super dealloc];
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if ([_state isEqualToString:@"before-init"]) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm
@@ -136,6 +136,12 @@ TEST(WKWebViewUnderPageBackgroundColor, MultipleBlendedColors)
     return self;
 }
 
+- (void)dealloc
+{
+    [_webView removeObserver:self forKeyPath:@"underPageBackgroundColor"];
+    [super dealloc];
+}
+
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if ([_state isEqualToString:@"before-init"]) {

--- a/Tools/TestWebKitAPI/cocoa/HostWindowManager.h
+++ b/Tools/TestWebKitAPI/cocoa/HostWindowManager.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "PlatformUtilities.h"
+#import <gtest/gtest.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/Vector.h>
+
+namespace TestWebKitAPI {
+
+class HostWindowManager : private testing::EmptyTestEventListener {
+public:
+    static HostWindowManager& singleton();
+
+    void closeHostWindowOnTestEnd(Util::PlatformWindow *);
+
+private:
+    HostWindowManager();
+
+    // testing::EmptyTestEventListener
+    void OnTestEnd(const testing::TestInfo&) final;
+
+    Vector<RetainPtr<Util::PlatformWindow>> m_hostWindows;
+};
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/HostWindowManager.mm
+++ b/Tools/TestWebKitAPI/cocoa/HostWindowManager.mm
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "HostWindowManager.h"
+
+#if PLATFORM(MAC)
+#import <AppKit/AppKit.h>
+#else
+#import <UIKit/UIKit.h>
+#endif
+
+namespace TestWebKitAPI {
+
+HostWindowManager& HostWindowManager::singleton()
+{
+    static HostWindowManager* singleton = new HostWindowManager();
+    return *singleton;
+}
+
+HostWindowManager::HostWindowManager()
+{
+    testing::UnitTest::GetInstance()->listeners().Append(this);
+}
+
+void HostWindowManager::closeHostWindowOnTestEnd(Util::PlatformWindow *hostWindow)
+{
+    m_hostWindows.append(hostWindow);
+}
+
+void HostWindowManager::OnTestEnd(const testing::TestInfo&)
+{
+    for (RetainPtr hostWindow : std::exchange(m_hostWindows, { })) {
+#if PLATFORM(MAC)
+        [hostWindow close];
+#else
+        [hostWindow setHidden:YES];
+#endif
+    }
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
+++ b/Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm
@@ -224,7 +224,8 @@
 
 - (CGImageRef)createCGImage
 {
-    return _image.get();
+    // VKCRemoveBackgroundResult expects callers to release this CGImage, so we need to leak a +1 retain count.
+    return RetainPtr { _image }.leakRef();
 }
 
 - (CGRect)cropRect

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -28,6 +28,7 @@
 
 #import "CGImagePixelReader.h"
 #import "ClassMethodSwizzler.h"
+#import "HostWindowManager.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
@@ -50,6 +51,7 @@
 #import <wtf/Deque.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/Vector.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
 #if PLATFORM(MAC)
@@ -883,7 +885,7 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 #endif
 
 @implementation TestWKWebView {
-    RetainPtr<TestWKWebViewHostWindow> _hostWindow;
+    WeakObjCPtr<TestWKWebViewHostWindow> _hostWindow;
     RetainPtr<TestMessageHandler> _testHandler;
     RetainPtr<WKUserScript> _onloadScript;
 #if PLATFORM(IOS_FAMILY)
@@ -936,19 +938,24 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 
 - (void)_setUpTestWindow:(NSRect)frame
 {
+    RetainPtr<TestWKWebViewHostWindow> hostWindow;
 #if PLATFORM(MAC)
-    _hostWindow = adoptNS([[TestWKWebViewHostWindow alloc] initWithWebView:self contentRect:frame styleMask:(NSWindowStyleMaskBorderless | NSWindowStyleMaskMiniaturizable) backing:NSBackingStoreBuffered defer:NO]);
-    [_hostWindow setHasShadow:NO];
-    [_hostWindow setFrameOrigin:frame.origin];
-    [_hostWindow setIsVisible:YES];
-    [_hostWindow contentView].wantsLayer = YES;
-    [[_hostWindow contentView] addSubview:self];
-    [_hostWindow makeKeyAndOrderFront:self];
+    hostWindow = adoptNS([[TestWKWebViewHostWindow alloc] initWithWebView:self contentRect:frame styleMask:(NSWindowStyleMaskBorderless | NSWindowStyleMaskMiniaturizable) backing:NSBackingStoreBuffered defer:NO]);
+    [hostWindow setHasShadow:NO];
+    [hostWindow setFrameOrigin:frame.origin];
+    [hostWindow setIsVisible:YES];
+    [hostWindow setReleasedWhenClosed:NO];
+    [hostWindow contentView].wantsLayer = YES;
+    [[hostWindow contentView] addSubview:self];
+    [hostWindow makeKeyAndOrderFront:self];
 #else
-    _hostWindow = adoptNS([[TestWKWebViewHostWindow alloc] initWithWebView:self frame:frame]);
-    [_hostWindow setHidden:NO];
-    [_hostWindow addSubview:self];
+    hostWindow = adoptNS([[TestWKWebViewHostWindow alloc] initWithWebView:self frame:frame]);
+    [hostWindow setHidden:NO];
+    [hostWindow addSubview:self];
 #endif
+    _hostWindow = hostWindow.get();
+
+    TestWebKitAPI::HostWindowManager::singleton().closeHostWindowOnTestEnd(hostWindow.get());
 }
 
 - (void)addToTestWindow
@@ -1449,7 +1456,7 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
 
 - (NSWindow *)hostWindow
 {
-    return _hostWindow.get();
+    return _hostWindow.getAutoreleased();
 }
 
 - (void)typeCharacter:(char)character


### PR DESCRIPTION
#### f30f26af2e784246487208b781c11a9b2f551ddc
<pre>
[Cocoa] TestWKWebViews and TestWKWebViewHostWindows are leaked after API tests finish running
<a href="https://bugs.webkit.org/show_bug.cgi?id=287651">https://bugs.webkit.org/show_bug.cgi?id=287651</a>
<a href="https://rdar.apple.com/144805719">rdar://144805719</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

Two issues resulted in TestWKWebViews and TestWKWebViewHostWindows being leaked at the end of an
API test:
1. TestWKWebView retained its host window (via _hostWindow), and TestWKWebViewHostWindow retained
   its web view (via -addSubview:), leading to a retain cycle.
2. The host window remained open at the end of the test, keeping the web view alive.

This leak is harmful in a configuration where multiple tests are run in the same instance of
TestWebKitAPI, which is how XCTest runs tests by default.

Resolved (1) by storing a weak reference to the host window in TestWKWebView. Resolved (2) by
collecting host windows created during a test and explicitly closing them after the test ends.

Deallocating TestWKWebViewHostWindows at the end of an API test uncovered two issues in existing
API tests:
1. an over-release in ImageAnalysisTests.MenuControllerItems, which was resolved by modifying our
   swizzled VKCRemoveBackgroundResult to return a CGImageRef with a +1 retain count from
   -createCGImage.
2. Failures to remove key-value observers in numerous tests, manifesting in crashes when
   deallocating WKWebViews; resolved by adding calls to -removeObserver:forKeyPath:.

* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm:
(TestWebKitAPI::TransferTrackBetweenSameProcessPages)):
(TestWebKitAPI::(WebKit, InterruptionBetweenGetDisplayMediaAndGetUserMedia)):
(TestWebKitAPI::(WebKit2, ConnectedToHardwareConsole)):
(TestWebKitAPI::(WebKit2, DoNotUnmuteWhenTakingAThumbnail)):
(TestWebKitAPI::(WebKit2, WebRTCAndRemoteCommands)):
(TestWebKitAPI::(WebKit2, ToggleCameraCaptureWhenRestarting)):
(TestWebKitAPI::(WebKit2, ToggleMicrophoneCaptureWhenRestarting)):
* Tools/TestWebKitAPI/Tests/WebKit/GetUserMediaNavigation.mm:
(TestWebKitAPI::TEST(WebKit, NavigateDuringDeviceEnumeration)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenLifecycle.mm:
(TEST(Fullscreen, AudioLifecycle)):
(runTest):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/GetDisplayMediaWindowAndScreen.mm:
(TestWebKitAPI::TEST(WebKit2, ToggleScreenshare)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaMutedState.mm:
(-[AudioStateObserver dealloc]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/NowPlayingSession.mm:
(TEST(NowPlayingSession, HasSession)):
(TEST(NowPlayingSession, NavigateAfterHasSession)):
(TEST(NowPlayingSession, NavigateToFragmentAfterHasSession)):
(TEST(NowPlayingSession, LoadSubframeAfterHasSession)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, ThemeColor)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(TEST(WebKit, WKWebViewIsPlayingAudio)):
((WebKit, PinnedState)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewThemeColor.mm:
(-[WKWebViewThemeColorObserver dealloc]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewUnderPageBackgroundColor.mm:
(-[WKWebViewUnderPageBackgroundColorObserver dealloc]):
* Tools/TestWebKitAPI/cocoa/HostWindowManager.h: Added.
* Tools/TestWebKitAPI/cocoa/HostWindowManager.mm: Added.
(TestWebKitAPI::HostWindowManager::singleton):
(TestWebKitAPI::HostWindowManager::HostWindowManager):
(TestWebKitAPI::HostWindowManager::closeHostWindowOnTestEnd):
(TestWebKitAPI::HostWindowManager::OnTestEnd):
* Tools/TestWebKitAPI/cocoa/ImageAnalysisTestingUtilities.mm:
(-[FakeRemoveBackgroundResult createCGImage]):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView _setUpTestWindow:]):
(-[TestWKWebView hostWindow]):

Canonical link: <a href="https://commits.webkit.org/290502@main">https://commits.webkit.org/290502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4091fec7a8ffe978f9588298581bf97c367e3b56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41019 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69471 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27067 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93244 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49831 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7512 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40150 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97070 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17431 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78467 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77673 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19184 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22137 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20743 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10690 "Failed to checkout and rebase branch from PR 40586") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17441 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->