### PR TITLE
Rebaseline JSC stress tests for ICU version 76

### DIFF
--- a/JSTests/stress/bigint-toLocaleString.js
+++ b/JSTests/stress/bigint-toLocaleString.js
@@ -42,7 +42,7 @@ shouldBe(BigInt(1).toLocaleString(), '1');
 shouldThrow(() => 0n.toLocaleString('i'), RangeError);
 
 // Test that locale parameter is passed through properly.
-if ($vm.icuVersion() >= 74 && $vm.icuMinorVersion() >= 2)
+if (($vm.icuVersion() === 74 && $vm.icuMinorVersion() >= 2) || $vm.icuVersion() >= 75)
     shouldBe(123456789n.toLocaleString('ar'), '123,456,789');
 else
     shouldBe(123456789n.toLocaleString('ar'), '١٢٣٬٤٥٦٬٧٨٩');

--- a/JSTests/stress/intl-datetimeformat.js
+++ b/JSTests/stress/intl-datetimeformat.js
@@ -326,7 +326,7 @@ shouldBe(Intl.DateTimeFormat('en-u-ca-hebrew', { timeZone: 'America/Los_Angeles'
 shouldBe(Intl.DateTimeFormat('en-u-ca-indian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '10/4/1937 Saka');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamic', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/14/1437 AH');
 shouldBe(Intl.DateTimeFormat('en-u-ca-islamicc', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '3/13/1437 AH');
-shouldBe(Intl.DateTimeFormat('en-u-ca-ISO8601', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/2015');
+shouldBe(Intl.DateTimeFormat('en-u-ca-ISO8601', { timeZone: 'America/Los_Angeles' }).format(1451099872641), $vm.icuVersion() >= 76 ? '2015-12-25' : '12/25/2015');
 shouldBeOneOf(Intl.DateTimeFormat('en-u-ca-japanese', { timeZone: 'America/Los_Angeles' }).format(1451099872641), [ '12/25/27 H', '12/25/H27' ]);
 shouldBe(Intl.DateTimeFormat('en-u-ca-persian', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '10/4/1394 AP');
 shouldBe(Intl.DateTimeFormat('en-u-ca-roc', { timeZone: 'America/Los_Angeles' }).format(1451099872641), '12/25/104 Minguo');

--- a/JSTests/stress/intl-displaynames-v2.js
+++ b/JSTests/stress/intl-displaynames-v2.js
@@ -62,7 +62,7 @@ function shouldThrow(func, errorMessage) {
     shouldBe(dn.of("month"), "月");
     shouldBe(dn.of("quarter"), "季度");
     shouldBe(dn.of("weekOfYear"), "周");
-    shouldBe(dn.of("weekday"), "工作日");
+    shouldBe(dn.of("weekday"), $vm.icuVersion() >= 76 ? "星期" : "工作日");
     shouldBe(dn.of("dayPeriod"), "上午/下午");
     shouldBe(dn.of("day"), "日");
     shouldBe(dn.of("hour"), "小时");

--- a/JSTests/stress/intl-displaynames.js
+++ b/JSTests/stress/intl-displaynames.js
@@ -96,7 +96,7 @@ shouldBe(scriptNames.of('Kana'), "Katakana");
 
 // Get display names of script in Traditional Chinese
 scriptNames = new Intl.DisplayNames(['zh-Hant'], {type: 'script'});
-shouldBe(scriptNames.of('Latn'), "拉丁文");
+shouldBe(scriptNames.of('Latn'), $vm.icuVersion() >= 76 ? "拉丁字母" : "拉丁字");
 shouldBe(scriptNames.of('Arab'), $vm.icuVersion() >= 72 ? "阿拉伯字母" : "阿拉伯文");
 shouldBe(scriptNames.of('Kana'), "片假名");
 

--- a/JSTests/stress/intl-locale-exceptions.js
+++ b/JSTests/stress/intl-locale-exceptions.js
@@ -1,16 +1,20 @@
-function shouldThrow(func, errorType) {
+function runTest(func, errorType) {
     let error;
     try {
         func();
     } catch (e) {
         error = e;
     }
-
-    if (!(error instanceof errorType))
-        throw new Error(`Expected ${errorType.name}!`);
+    if ($vm.icuVersion() >= 76) {
+        if (error)
+            throw new Error(`Expected no exception but got: ${error}`);
+    } else {
+        if (!(error instanceof errorType))
+            throw new Error(`Expected ${errorType.name}!`);
+    }
 }
 
-shouldThrow(() => {
+runTest(() => {
     let calendarValue = 'buddhist';
     calendarValue = calendarValue.toLocaleString().padEnd(calendarValue.length + 510 * 4, -169);
     var loc = new Intl.Locale('ko', {
@@ -18,7 +22,7 @@ shouldThrow(() => {
     });
 }, RangeError);
 
-shouldThrow(() => {
+runTest(() => {
     let collationValue = 'zhuyin';
     collationValue = collationValue.toLocaleString().padEnd(collationValue.length + 510 * 4, -169);
     var loc = new Intl.Locale('ko', {
@@ -26,7 +30,7 @@ shouldThrow(() => {
     });
 }, RangeError);
 
-shouldThrow(() => {
+runTest(() => {
     let numberingSystemValue = 'latn';
     numberingSystemValue = numberingSystemValue.toLocaleString().padEnd(numberingSystemValue.length + 510 * 4, -169);
     var loc = new Intl.Locale('ko', {

--- a/JSTests/stress/intl-long-locale-id-maximize-minimize.js
+++ b/JSTests/stress/intl-long-locale-id-maximize-minimize.js
@@ -14,11 +14,17 @@ function shouldBe(actual, expected) {
     const locale = new Intl.Locale(`de-variant0-rozaj-biske-nedis-variant1-variant2-variant3-variant4-variant5-variant6-variant7-variant8-variant9-varianta-variantb-variantc-variantd-variante-variantf-variantg-varianth-varianti-variantj-variantk`);
     const result = locale.maximize().toString();
     // "de-Latn-DE" is the right answer. But ICU has a bug and produce "de". The latest AppleICU has a fix and generate "de-Latn-DE".
-    shouldBe(result === `de-Latn-DE` || result === `de`, true);
+    if ($vm.icuVersion() >= 76)
+        shouldBe(result, `en-Latn-US`);
+    else
+        shouldBe(result === `de-Latn-DE` || result === `de`, true);
 }
 {
     const locale = new Intl.Locale(`de-Latn-DE-rozaj-biske-nedis-variant0-variant1-variant2-variant3-variant4-variant5-variant6-variant7-variant8-variant9-varianta-variantb-variantc-variantd-variante-variantf-variantg-varianth-varianti-variantj-variantk`);
     const result = locale.maximize().toString();
     // "de" is the right answer. But ICU has a bug and produce "de-Latn-DE". The latest AppleICU has a fix and generate "de".
-    shouldBe(result === `de` || result === `de-Latn-DE`, true);
+    if ($vm.icuVersion() >= 76)
+        shouldBe(result, `en-Latn-US`);
+    else
+        shouldBe(result === `de` || result === `de-Latn-DE`, true);
 }

--- a/JSTests/stress/intl-numberformat-unified.js
+++ b/JSTests/stress/intl-numberformat-unified.js
@@ -49,4 +49,5 @@ shouldBe((100).toLocaleString("en-CA", {
     style: "currency",
     currency: "USD",
     currencyDisplay: "narrowSymbol"
-}), $vm.icuVersion() >= 72 ? `US$100.00` : `$100.00`);
+}), 72 <= $vm.icuVersion() && $vm.icuVersion() < 76 ? `US$100.00` : `$100.00`);
+

--- a/JSTests/stress/number-toLocaleString.js
+++ b/JSTests/stress/number-toLocaleString.js
@@ -44,7 +44,7 @@ shouldThrow(() => (0).toLocaleString('i'), RangeError);
 shouldBe(Infinity.toLocaleString(), '∞');
 
 // Test that locale parameter is passed through properly.
-if ($vm.icuVersion() >= 74 && $vm.icuMinorVersion() >= 2)
+if (($vm.icuVersion() === 74 && $vm.icuMinorVersion() >= 2) || $vm.icuVersion() >= 75)
     shouldBe((123456.789).toLocaleString('ar'), '123,456.789');
 else
     shouldBe((123456.789).toLocaleString('ar'), '١٢٣٬٤٥٦٫٧٨٩');


### PR DESCRIPTION
#### 1c62045d6f42d1e11ae2e0845385df698d146b04
<pre>
Rebaseline JSC stress tests for ICU version 76
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* JSTests/stress/bigint-toLocaleString.js:
* JSTests/stress/intl-datetimeformat.js:
* JSTests/stress/intl-displaynames-v2.js:
(shouldBe):
* JSTests/stress/intl-displaynames.js:
* JSTests/stress/intl-locale-exceptions.js:
(runTest):
(shouldThrow): Deleted.
* JSTests/stress/intl-long-locale-id-maximize-minimize.js:
(shouldBe):
(else.shouldBe):
* JSTests/stress/intl-numberformat-unified.js:
* JSTests/stress/number-toLocaleString.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c62045d6f42d1e11ae2e0845385df698d146b04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40606 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17640 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26789 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7181 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39739 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82634 "Found 19 new JSC stress test failures: stress/intl-displaynames.js.bytecode-cache, stress/intl-displaynames.js.default, stress/intl-displaynames.js.dfg-eager, stress/intl-displaynames.js.dfg-eager-no-cjit-validate, stress/intl-displaynames.js.eager-jettison-no-cjit, stress/intl-displaynames.js.ftl-eager, stress/intl-displaynames.js.ftl-eager-no-cjit, stress/intl-displaynames.js.ftl-eager-no-cjit-b3o1, stress/intl-displaynames.js.ftl-no-cjit-b3o0, stress/intl-displaynames.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96656 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88609 "Found 19 new JSC stress test failures: stress/intl-displaynames.js.bytecode-cache, stress/intl-displaynames.js.default, stress/intl-displaynames.js.dfg-eager, stress/intl-displaynames.js.dfg-eager-no-cjit-validate, stress/intl-displaynames.js.eager-jettison-no-cjit, stress/intl-displaynames.js.ftl-eager, stress/intl-displaynames.js.ftl-eager-no-cjit, stress/intl-displaynames.js.ftl-eager-no-cjit-b3o1, stress/intl-displaynames.js.ftl-no-cjit-b3o0, stress/intl-displaynames.js.ftl-no-cjit-no-inline-validate ... (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78042 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77365 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21813 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10197 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17031 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111102 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16772 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26608 "Found 23 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-small.js.no-llint, microbenchmarks/set-delete-add.js.bytecode-cache, microbenchmarks/set-delete-add.js.dfg-eager, stress/intl-displaynames.js.bytecode-cache, stress/intl-displaynames.js.default, stress/intl-displaynames.js.dfg-eager, stress/intl-displaynames.js.dfg-eager-no-cjit-validate, stress/intl-displaynames.js.eager-jettison-no-cjit, stress/intl-displaynames.js.lockdown ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18555 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->