### PR TITLE
Experiment: realizeNextFallback look at cache before selector

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -169,13 +169,13 @@ static FontRanges realizeNextFallback(const FontCascadeDescription& description,
         auto visitor = WTF::makeVisitor([&, fontSelector = RefPtr { fontSelector }](const AtomString& family) -> FontRanges {
             if (family.isNull())
                 return FontRanges();
+            if (auto font = fontCache.fontForFamily(description, family))
+                return FontRanges(WTFMove(font));
             if (fontSelector) {
                 auto ranges = fontSelector->fontRangesForFamily(description, family);
                 if (!ranges.isNull())
                     return ranges;
             }
-            if (auto font = fontCache.fontForFamily(description, family))
-                return FontRanges(WTFMove(font));
             return FontRanges();
         }, [&](const FontFamilyPlatformSpecification& fontFamilySpecification) -> FontRanges {
             return { fontFamilySpecification.fontRanges(description), IsGenericFontFamily::Yes };


### PR DESCRIPTION
#### ebfb74a0888ad12b2c6967d5c14acad05786ff9d
<pre>
Experiment: realizeNextFallback look at cache before selector
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::realizeNextFallback):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebfb74a0888ad12b2c6967d5c14acad05786ff9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89848 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17655 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69173 "Found 35 new test failures: fast/borders/rtl-border-04.html fast/borders/rtl-border-05.html fast/css/beforeSelectorOnCodeElement.html fast/css/font-face-default-font.html fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/css/rtl-ordering.html fast/encoding/invalid-UTF-8.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26793 "Found 7 new test failures: fast/canvas/2d.text.draw.fill.maxWidth.gradient.html fast/css/font-face-set-ready-after-document-load.html fast/text/font-fallback.html fast/text/font-promises-gc.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/font-redirect-blocked.html http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92849 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7464 "Found 9 new test failures: fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/forms/ios/focus-input-in-fixed.html fast/text/font-promises-gc.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/font-redirect-blocked.html http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81508 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49534 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7185 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35883 "Found 13 new test failures: fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/html/process-end-tag-for-inbody-crash.html fast/text/font-promises-gc.html fullscreen/fullscreen-cancel-after-request-crash.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/font-redirect-blocked.html http/tests/security/cross-origin-clean-css-resource-timing.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77532 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36925 "Found 8 new test failures: fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/text/font-promises-gc.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/font-redirect-blocked.html http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96671 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17035 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12493 "Found 9 new test failures: fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/text/font-promises-gc.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/font-redirect-blocked.html http/tests/security/cross-origin-clean-css-resource-timing.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78049 "Found 44 new test failures: editing/deleting/5144139-2.html fast/borders/rtl-border-04.html fast/borders/rtl-border-05.html fast/css/beforeSelectorOnCodeElement.html fast/css/font-face-default-font.html fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/css/rtl-ordering.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77373 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21825 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20397 "Found 8 new test failures: fast/css/font-face-implicit-local-font.html fast/css/font-face-in-media-rule.html fast/css/font-face-locally-installed.html fast/css/font-face-set-ready-after-document-load.html fast/text/font-promises-gc.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/font-redirect-blocked.html http/tests/security/cross-origin-clean-css-resource-timing.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22367 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16787 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->