### PR TITLE
Enable ResourceMonitor feature only for web browsers.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3508,10 +3508,8 @@ IFrameResourceMonitoringEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      "PLATFORM(COCOA)": true
       default: false
     WebCore:
-      "PLATFORM(COCOA)": true
       default: false
 
 IPAddressAndLocalhostMixedContentUpgradeTestingEnabled:

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -29,6 +29,7 @@
 #include <wtf/text/WTFString.h>
 
 #if PLATFORM(COCOA)
+#include "DefaultWebBrowserChecks.h"
 #include <wtf/NumberOfCores.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #if PLATFORM(IOS_FAMILY)
@@ -343,5 +344,16 @@ bool defaultCookieStoreAPIEnabled()
     return false;
 #endif
 }
+
+#if ENABLE(CONTENT_EXTENSIONS)
+bool defaultIFrameResourceMonitoringEnabled()
+{
+#if PLATFORM(COCOA)
+    return isFullWebBrowserOrRunningTest();
+#else
+    return false;
+#endif
+}
+#endif
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -167,4 +167,8 @@ bool defaultCookieStoreAPIEnabled();
 bool defaultContentInsetBackgroundFillEnabled();
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+bool defaultIFrameResourceMonitoringEnabled();
+#endif
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm
@@ -154,6 +154,10 @@ void WebPreferences::platformInitializeStore()
         m_store.setBoolValueForKey(WebPreferencesKey::interruptAudioOnPageVisibilityChangeEnabledKey(),  WebCore::RealtimeMediaSourceCenter::shouldInterruptAudioOnPageVisibilityChange());
 #endif
 
+#if ENABLE(CONTENT_EXTENSIONS)
+        m_store.setBoolValueForKey(WebPreferencesKey::iFrameResourceMonitoringEnabledKey(), defaultIFrameResourceMonitoringEnabled());
+#endif
+
 #define INITIALIZE_DEFAULT_OVERRIDABLE_PREFERENCE_FROM_NSUSERDEFAULTS(KeyUpper, KeyLower, TypeName, Type, DefaultValue, HumanReadableName, HumanReadableDescription) \
         setDebug##TypeName##ValueIfInUserDefaults(m_identifier, m_keyPrefix, m_globalDebugKeyPrefix, WebPreferencesKey::KeyLower##Key(), m_store);
 

--- a/Tools/MiniBrowser/mac/Info.plist
+++ b/Tools/MiniBrowser/mac/Info.plist
@@ -75,6 +75,15 @@
 			<key>LSHandlerRank</key>
 			<string>none</string>
 		</dict>
+		<dict>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>http</string>
+				<string>https</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
#### d2db56e2e44af82118dbb2597eca8244c09a3bbc
<pre>
Enable ResourceMonitor feature only for web browsers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287656">https://bugs.webkit.org/show_bug.cgi?id=287656</a>
<a href="https://rdar.apple.com/144808302">rdar://144808302</a>

Reviewed by Per Arne Vollan.

We don’t want to enable this feature on non-browser WebView. Set the feature off by default
for all platform and enable the flag in Cocoa&apos;s `WebPreferences::platformInitializeStore()`.

Also we modify MiniBrowser&apos;s Info.plist to accept `http` and `https` so that it should be
treated as full browser app.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultIFrameResourceMonitoringEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/Cocoa/WebPreferencesCocoa.mm:
(WebKit::WebPreferences::platformInitializeStore):
* Tools/MiniBrowser/mac/Info.plist:

Canonical link: <a href="https://commits.webkit.org/290378@main">https://commits.webkit.org/290378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cabb2138c8108a52ad65b9325d61338f108cbbfa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92851 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49535 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39756 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82651 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96673 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88626 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17037 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21822 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17048 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111119 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/16789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26611 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.no-llint, microbenchmarks/memcpy-wasm.js.no-llint, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->