### PR TITLE
Re-enable RegExp Modifiers

### DIFF
--- a/JSTests/stress/regexp-modifiers-interpreter.js
+++ b/JSTests/stress/regexp-modifiers-interpreter.js
@@ -1,0 +1,4 @@
+//@ runDefault("--useRegExpJIT=0")
+
+load("./regexp-modifiers.js", "caller relative");
+

--- a/JSTests/stress/regexp-modifiers.js
+++ b/JSTests/stress/regexp-modifiers.js
@@ -1,0 +1,240 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError);
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+// Test various valid combinations of flags set and unset
+testRegExp(/(?i:[a-z])/, "A", ["A"]);
+testRegExp(/(?i:[a-z])/i, "A", ["A"]);
+testRegExp(/(?m:[a-z])/, "a", ["a"]);
+testRegExp(/(?s:[a-z])/, "a", ["a"]);
+testRegExp(/(?ims:[a-z])/, "A", ["A"]);
+testRegExp(/(?is:[a-z])/, "A", ["A"]);
+testRegExp(/(?si:[a-z])/, "A", ["A"]);
+testRegExp(/(?i-m:[a-z])/, "A", ["A"]);
+testRegExp(/(?i-ms:[a-z])/, "A", ["A"]);
+testRegExp(/(?-ims:[a-z])/, "a", ["a"]);
+
+// Test removing flags
+testRegExp(/(?-i:[a-z])/i, "A", null);
+testRegExp(/(?sm-i:[a-z])/i, "A", null);
+testRegExp(/(?-s:[a-z])/is, "A", ["A"]);
+testRegExp(/(?-ims:[a-z])/i, "A", null);
+
+// Test adding and removing flags
+testRegExp(/(?i:a(?-i:b)c)/, "AbC", ["AbC"]);
+testRegExp(/(?i:a(?-i:b)c)/, "ABC", null);
+testRegExp(/(?-i:a(?i:b)c)/i, "aBc", ["aBc"]);
+testRegExp(/(?-i:a(?i:b)c)/i, "ABc", null);
+
+testRegExp(/(?i:a(?m:b(?s:c(?-i:d)e)f)g)/i, "ABCdEFG", ["ABCdEFG"]);
+testRegExp(/(?i:a(?m:b(?s:c(?-i:d)e)f)g)/i, "ABCDEFG", null);
+testRegExp(/(?i:a(?m:b(?s:c(?-i:d.)e)f)g)/i, "ABCd\nEFG", ["ABCd\nEFG"]);
+
+// Test any disjunction
+testRegExp(/(?i:reallylong(regular)[expr])/, "ReallyLongRegularE", ["ReallyLongRegularE", "Regular"]);
+testRegExp(/(?i-ms:reallylong(regular)[expr])/, "ReallyLongRegularE", ["ReallyLongRegularE", "Regular"]);
+
+// Test nesting
+testRegExp(/(?i:(?i:nest)ed)/, "nested", ["nested"]);
+testRegExp(/(?i:(?i:nest)ed)/, "nestED", ["nestED"]);
+testRegExp(/(?i:(?i-m:nest)ed)/, "nested", ["nested"]);
+testRegExp(/(?i-m:(?i:nest)ed)/, "nested", ["nested"]);
+testRegExp(/(?i-m:(?i-m:nest)ed)/, "nested", ["nested"]);
+
+// Test incomplete parentheses group
+testRegExpSyntaxError("(?i:[a-z]", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?i:", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?i", "", "SyntaxError: Invalid regular expression: missing )");
+
+testRegExpSyntaxError("(?-i:[a-z]", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?-i:", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?-i", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?-", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+
+testRegExpSyntaxError("(?m-i:[a-z]", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?m-i:", "", "SyntaxError: Invalid regular expression: missing )");
+testRegExpSyntaxError("(?m-", "", "SyntaxError: Invalid regular expression: missing )");
+
+// Test invalid flags
+testRegExpSyntaxError("(?iu:[a-z])", "", "SyntaxError: Invalid regular expression: unrecognized character after (?");
+testRegExpSyntaxError("(?u:[a-z])", "", "SyntaxError: Invalid regular expression: unrecognized character after (?");
+testRegExpSyntaxError("(?u-i:[a-z])", "", "SyntaxError: Invalid regular expression: unrecognized character after (?");
+testRegExpSyntaxError("(?i-u:[a-z])", "", "SyntaxError: Invalid regular expression: unrecognized character after (?");
+testRegExpSyntaxError("(?-u:[a-z])", "", "SyntaxError: Invalid regular expression: unrecognized character after (?");
+
+// It is a Syntax Error if the source text matched by RegularExpressionModifiers contains the same code point more than once.
+testRegExpSyntaxError("(?ii:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+
+// It is a Syntax Error if the source text matched by the first RegularExpressionModifiers and the source text matched by the second RegularExpressionModifiers are both empty.
+testRegExpSyntaxError("(?-:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+
+// It is a Syntax Error if the source text matched by the first RegularExpressionModifiers contains the same code point more than once.
+testRegExpSyntaxError("(?ii-:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+testRegExpSyntaxError("(?ii-m:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+testRegExpSyntaxError("(?sis-m:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+
+// It is a Syntax Error if the source text matched by the second RegularExpressionModifiers contains the same code point more than once.
+testRegExpSyntaxError("(?i-mm:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+testRegExpSyntaxError("(?-mim:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+testRegExpSyntaxError("(?s-mimimimi:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+
+// It is a Syntax Error if any code point in the source text matched by the first RegularExpressionModifiers is also contained in the source text matched by the second RegularExpressionModifiers.
+testRegExpSyntaxError("(?i-i:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+testRegExpSyntaxError("(?ism-i:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");
+testRegExpSyntaxError("(?mis-sim:[a-z])", "", "SyntaxError: Invalid regular expression: invalid regular expression modifier");

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -20,7 +20,6 @@ skip:
     - FinalizationRegistry.prototype.cleanupSome
     - decorators
     - explicit-resource-management
-    - regexp-modifiers
     - source-phase-imports
     - import-defer
   paths:
@@ -77,6 +76,10 @@ skip:
     - test/intl402/Locale/constructor-options-region-valid.js
     - test/intl402/Locale/getters-grandfathered.js
     - test/intl402/Locale/likely-subtags-grandfathered.js
+
+    # Skipping temporarily due to a bug with handling case-insensitive \p escapes
+    - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
+    - test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js
 
     # Depends on Temporal.Duration relativeTo option
     - test/built-ins/Temporal/Duration/compare/basic.js

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -71,6 +71,7 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "invalid operation in class set"_s,                       // InvalidClassSetOperation
         REGEXP_ERROR_PREFIX "negated class set may contain strings"_s,                // NegatedClassSetMayContainStrings
         REGEXP_ERROR_PREFIX "invalid class set character"_s,                          // InvalidClassSetCharacter
+        REGEXP_ERROR_PREFIX "invalid regular expression modifier"_s,                  // InvalidRegularExpressionModifier
 
         // The following are NOT hard errors.
         REGEXP_ERROR_PREFIX "too many nested disjunctions"_s,                         // TooManyDisjunctions
@@ -115,6 +116,7 @@ JSObject* errorToThrow(JSGlobalObject* globalObject, ErrorCode error)
     case ErrorCode::InvalidClassSetOperation:
     case ErrorCode::NegatedClassSetMayContainStrings:
     case ErrorCode::InvalidClassSetCharacter:
+    case ErrorCode::InvalidRegularExpressionModifier:
         return createSyntaxError(globalObject, errorMessage(error));
     case ErrorCode::TooManyDisjunctions:
         return createOutOfMemoryError(globalObject, errorMessage(error));

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -75,6 +75,7 @@ enum class ErrorCode : uint8_t {
     InvalidClassSetOperation,
     NegatedClassSetMayContainStrings,
     InvalidClassSetCharacter,
+    InvalidRegularExpressionModifier,
 
     // The following are NOT hard errors.
     TooManyDisjunctions, // we ran out stack compiling.

--- a/Source/JavaScriptCore/yarr/YarrFlags.h
+++ b/Source/JavaScriptCore/yarr/YarrFlags.h
@@ -42,6 +42,11 @@ namespace JSC { namespace Yarr {
     macro('v', UnicodeSets, unicodeSets, 6) \
     macro('y', Sticky, sticky, 7) \
 
+#define JSC_REGEXP_MOD_FLAGS(macro) \
+    macro('i', IgnoreCase, ignoreCase) \
+    macro('m', Multiline, multiline) \
+    macro('s', DotAll, dotAll) \
+
 #define JSC_COUNT_REGEXP_FLAG(key, name, lowerCaseName, index) + 1
 static constexpr unsigned numberOfFlags = 0 JSC_REGEXP_FLAGS(JSC_COUNT_REGEXP_FLAG);
 #undef JSC_COUNT_REGEXP_FLAG

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.h
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.h
@@ -116,13 +116,15 @@ struct ByteTerm {
         DotStarEnclosure,
     };
     Type type;
+    OptionSet<Flags> m_flags;
     bool m_capture : 1;
     bool m_invert : 1;
     MatchDirection m_matchDirection : 1;
     unsigned inputPosition { 0 };
 
-    ByteTerm(char32_t ch, unsigned inputPos, unsigned frameLocation, Checked<unsigned> quantityCount, QuantifierType quantityType)
+    ByteTerm(char32_t ch, unsigned inputPos, unsigned frameLocation, Checked<unsigned> quantityCount, QuantifierType quantityType, OptionSet<Flags> flags)
         : frameLocation(frameLocation)
+        , m_flags(flags)
         , m_capture(false)
         , m_invert(false)
         , m_matchDirection(Forward)
@@ -148,8 +150,9 @@ struct ByteTerm {
         }
     }
 
-    ByteTerm(char32_t lo, char32_t hi, unsigned inputPos, unsigned frameLocation, Checked<unsigned> quantityCount, QuantifierType quantityType)
+    ByteTerm(char32_t lo, char32_t hi, unsigned inputPos, unsigned frameLocation, Checked<unsigned> quantityCount, QuantifierType quantityType, OptionSet<Flags> flags)
         : frameLocation(frameLocation)
+        , m_flags(flags)
         , m_capture(false)
         , m_invert(false)
         , m_matchDirection(Forward)
@@ -176,8 +179,9 @@ struct ByteTerm {
         atom.quantityMaxCount = quantityCount;
     }
 
-    ByteTerm(CharacterClass* characterClass, bool invert, unsigned inputPos)
+    ByteTerm(CharacterClass* characterClass, bool invert, unsigned inputPos, OptionSet<Flags> flags)
         : type(ByteTerm::Type::CharacterClass)
+        , m_flags(flags)
         , m_capture(false)
         , m_invert(invert)
         , m_matchDirection(Forward)
@@ -189,8 +193,9 @@ struct ByteTerm {
         atom.quantityMaxCount = 1;
     }
 
-    ByteTerm(Type type, unsigned subpatternId, ByteDisjunction* parenthesesInfo, bool capture, unsigned inputPos)
+    ByteTerm(Type type, unsigned subpatternId, ByteDisjunction* parenthesesInfo, bool capture, unsigned inputPos, OptionSet<Flags> flags)
         : type(type)
+        , m_flags(flags)
         , m_capture(capture)
         , m_invert(false)
         , m_matchDirection(Forward)
@@ -204,8 +209,9 @@ struct ByteTerm {
         atom.quantityMaxCount = 1;
     }
     
-    ByteTerm(Type type, bool invert = false)
+    ByteTerm(Type type, OptionSet<Flags> flags, bool invert = false)
         : type(type)
+        , m_flags(flags)
         , m_capture(false)
         , m_invert(invert)
         , m_matchDirection(Forward)
@@ -215,8 +221,9 @@ struct ByteTerm {
         atom.quantityMaxCount = 1;
     }
 
-    ByteTerm(Type type, unsigned subpatternId, bool capture, bool invert, unsigned inputPos)
+    ByteTerm(Type type, unsigned subpatternId, bool capture, bool invert, unsigned inputPos, OptionSet<Flags> flags)
         : type(type)
+        , m_flags(flags)
         , m_capture(capture)
         , m_invert(invert)
         , m_matchDirection(Forward)
@@ -229,8 +236,9 @@ struct ByteTerm {
         atom.quantityMaxCount = 1;
     }
 
-    ByteTerm(Type type, unsigned subpatternId, bool capture, bool invert, MatchDirection matchDirection, unsigned inputPos)
+    ByteTerm(Type type, unsigned subpatternId, bool capture, bool invert, MatchDirection matchDirection, unsigned inputPos, OptionSet<Flags> flags)
         : type(type)
+        , m_flags(flags)
         , m_capture(capture)
         , m_invert(invert)
         , m_matchDirection(matchDirection)
@@ -243,130 +251,130 @@ struct ByteTerm {
         atom.quantityMaxCount = 1;
     }
 
-    static ByteTerm BOL(unsigned inputPos)
+    static ByteTerm BOL(unsigned inputPos, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::AssertionBOL);
+        ByteTerm term(Type::AssertionBOL, flags);
         term.inputPosition = inputPos;
         return term;
     }
 
-    static ByteTerm CheckInput(Checked<unsigned> count)
+    static ByteTerm CheckInput(Checked<unsigned> count, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::CheckInput);
+        ByteTerm term(Type::CheckInput, flags);
         term.checkInputCount = count;
         return term;
     }
 
-    static ByteTerm UncheckInput(Checked<unsigned> count)
+    static ByteTerm UncheckInput(Checked<unsigned> count, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::UncheckInput);
+        ByteTerm term(Type::UncheckInput, flags);
         term.checkInputCount = count;
         return term;
     }
     
-    static ByteTerm HaveCheckedInput(Checked<unsigned> count)
+    static ByteTerm HaveCheckedInput(Checked<unsigned> count, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::HaveCheckedInput);
+        ByteTerm term(Type::HaveCheckedInput, flags);
         term.checkInputCount = count;
         return term;
     }
 
-    static ByteTerm EOL(unsigned inputPos)
+    static ByteTerm EOL(unsigned inputPos, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::AssertionEOL);
+        ByteTerm term(Type::AssertionEOL, flags);
         term.inputPosition = inputPos;
         return term;
     }
 
-    static ByteTerm WordBoundary(bool invert, MatchDirection matchDirection, unsigned inputPos)
+    static ByteTerm WordBoundary(bool invert, MatchDirection matchDirection, unsigned inputPos, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::AssertionWordBoundary, invert);
+        ByteTerm term(Type::AssertionWordBoundary, flags, invert);
         term.m_matchDirection = matchDirection;
         term.inputPosition = inputPos;
         return term;
     }
     
-    static ByteTerm BackReference(unsigned subpatternId, MatchDirection matchDirection, unsigned inputPos)
+    static ByteTerm BackReference(unsigned subpatternId, MatchDirection matchDirection, unsigned inputPos, OptionSet<Flags> flags)
     {
-        return ByteTerm(Type::BackReference, subpatternId, false, false, matchDirection, inputPos);
+        return ByteTerm(Type::BackReference, subpatternId, false, false, matchDirection, inputPos, flags);
     }
 
-    static ByteTerm BodyAlternativeBegin(bool onceThrough)
+    static ByteTerm BodyAlternativeBegin(bool onceThrough, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::BodyAlternativeBegin);
+        ByteTerm term(Type::BodyAlternativeBegin, flags);
         term.alternative.next = 0;
         term.alternative.end = 0;
         term.alternative.onceThrough = onceThrough;
         return term;
     }
 
-    static ByteTerm BodyAlternativeDisjunction(bool onceThrough)
+    static ByteTerm BodyAlternativeDisjunction(bool onceThrough, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::BodyAlternativeDisjunction);
+        ByteTerm term(Type::BodyAlternativeDisjunction, flags);
         term.alternative.next = 0;
         term.alternative.end = 0;
         term.alternative.onceThrough = onceThrough;
         return term;
     }
 
-    static ByteTerm BodyAlternativeEnd()
+    static ByteTerm BodyAlternativeEnd(OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::BodyAlternativeEnd);
+        ByteTerm term(Type::BodyAlternativeEnd, flags);
         term.alternative.next = 0;
         term.alternative.end = 0;
         term.alternative.onceThrough = false;
         return term;
     }
 
-    static ByteTerm AlternativeBegin()
+    static ByteTerm AlternativeBegin(OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::AlternativeBegin);
+        ByteTerm term(Type::AlternativeBegin, flags);
         term.alternative.next = 0;
         term.alternative.end = 0;
         term.alternative.onceThrough = false;
         return term;
     }
 
-    static ByteTerm AlternativeDisjunction()
+    static ByteTerm AlternativeDisjunction(OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::AlternativeDisjunction);
+        ByteTerm term(Type::AlternativeDisjunction, flags);
         term.alternative.next = 0;
         term.alternative.end = 0;
         term.alternative.onceThrough = false;
         return term;
     }
 
-    static ByteTerm AlternativeEnd()
+    static ByteTerm AlternativeEnd(OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::AlternativeEnd);
+        ByteTerm term(Type::AlternativeEnd, flags);
         term.alternative.next = 0;
         term.alternative.end = 0;
         term.alternative.onceThrough = false;
         return term;
     }
 
-    static ByteTerm SubpatternBegin()
+    static ByteTerm SubpatternBegin(OptionSet<Flags> flags)
     {
-        return ByteTerm(Type::SubpatternBegin);
+        return ByteTerm(Type::SubpatternBegin, flags);
     }
 
-    static ByteTerm SubpatternEnd()
+    static ByteTerm SubpatternEnd(OptionSet<Flags> flags)
     {
-        return ByteTerm(Type::SubpatternEnd);
+        return ByteTerm(Type::SubpatternEnd, flags);
     }
 
-    static ByteTerm ParentheticalAssertionBegin(unsigned firstSubpatternId, bool invert, MatchDirection matchDirection)
+    static ByteTerm ParentheticalAssertionBegin(unsigned firstSubpatternId, bool invert, MatchDirection matchDirection, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::ParentheticalAssertionBegin);
+        ByteTerm term(Type::ParentheticalAssertionBegin, flags);
         term.atom.assertionIds.firstSubpatternId = firstSubpatternId;
         term.m_invert = invert;
         term.m_matchDirection = matchDirection;
         return term;
     }
 
-    static ByteTerm ParentheticalAssertionEnd(unsigned firstSubpatternId, unsigned lastSubpatternId, bool invert, MatchDirection matchDirection)
+    static ByteTerm ParentheticalAssertionEnd(unsigned firstSubpatternId, unsigned lastSubpatternId, bool invert, MatchDirection matchDirection, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::ParentheticalAssertionEnd);
+        ByteTerm term(Type::ParentheticalAssertionEnd, flags);
         term.atom.assertionIds.firstSubpatternId = firstSubpatternId;
         term.atom.assertionIds.lastSubpatternId = lastSubpatternId;
         term.m_invert = invert;
@@ -374,9 +382,9 @@ struct ByteTerm {
         return term;
     }
 
-    static ByteTerm DotStarEnclosure(bool bolAnchor, bool eolAnchor)
+    static ByteTerm DotStarEnclosure(bool bolAnchor, bool eolAnchor, OptionSet<Flags> flags)
     {
-        ByteTerm term(Type::DotStarEnclosure);
+        ByteTerm term(Type::DotStarEnclosure, flags);
         term.anchors.m_bol = bolAnchor;
         term.anchors.m_eol = eolAnchor;
         return term;
@@ -437,6 +445,21 @@ struct ByteTerm {
     {
         return m_capture;
     }
+
+    bool ignoreCase()
+    {
+        return m_flags.contains(Flags::IgnoreCase);
+    }
+
+    bool multiline()
+    {
+        return m_flags.contains(Flags::Multiline);
+    }
+
+    bool dotAll()
+    {
+        return m_flags.contains(Flags::DotAll);
+    }
 };
 
 class ByteDisjunction {
@@ -470,10 +493,11 @@ public:
         m_body->terms.shrinkToFit();
 
         newlineCharacterClass = pattern.newlineCharacterClass();
-        if (eitherUnicode() && ignoreCase())
-            wordcharCharacterClass = pattern.wordUnicodeIgnoreCaseCharCharacterClass();
+        if (eitherUnicode())
+            ignoreCaseWordcharCharacterClass = pattern.wordUnicodeIgnoreCaseCharCharacterClass();
         else
-            wordcharCharacterClass = pattern.wordcharCharacterClass();
+            ignoreCaseWordcharCharacterClass = pattern.wordcharCharacterClass();
+        wordcharCharacterClass = pattern.wordcharCharacterClass();
 
         m_allParenthesesInfo.swap(parenthesesInfoToAdopt);
         m_allParenthesesInfo.shrinkToFit();
@@ -528,6 +552,7 @@ public:
 
     CharacterClass* newlineCharacterClass;
     CharacterClass* wordcharCharacterClass;
+    CharacterClass* ignoreCaseWordcharCharacterClass;
 
 private:
     Vector<std::unique_ptr<ByteDisjunction>> m_allParenthesesInfo;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1077,14 +1077,14 @@ class YarrGenerator final : public YarrJITInfo {
             m_jit.load16Unaligned(address, resultReg);
     }
 
-    MacroAssembler::Jump jumpIfCharNotEquals(char32_t ch, Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID character)
+    MacroAssembler::Jump jumpIfCharNotEquals(char32_t ch, Checked<unsigned> negativeCharacterOffset, MacroAssembler::RegisterID character, bool ignoreCase)
     {
         readCharacter(negativeCharacterOffset, character);
 
         // For case-insesitive compares, non-ascii characters that have different
         // upper & lower case representations are converted to a character class.
-        ASSERT(!m_pattern.ignoreCase() || isASCIIAlpha(ch) || isCanonicallyUnique(ch, m_canonicalMode));
-        if (m_pattern.ignoreCase() && isASCIIAlpha(ch)) {
+        ASSERT(!ignoreCase || isASCIIAlpha(ch) || isCanonicallyUnique(ch, m_canonicalMode));
+        if (ignoreCase && isASCIIAlpha(ch)) {
             m_jit.or32(MacroAssembler::TrustedImm32(0x20), character);
             ch |= 0x20;
         }
@@ -1488,7 +1488,7 @@ class YarrGenerator final : public YarrJITInfo {
         YarrOp& op = m_ops[opIndex];
         PatternTerm* term = op.m_term;
 
-        if (m_pattern.multiline()) {
+        if (term->multiline()) {
             const MacroAssembler::RegisterID character = m_regs.regT0;
             const MacroAssembler::RegisterID scratch = m_regs.regT1;
 
@@ -1519,7 +1519,7 @@ class YarrGenerator final : public YarrJITInfo {
         YarrOp& op = m_ops[opIndex];
         PatternTerm* term = op.m_term;
 
-        if (m_pattern.multiline()) {
+        if (term->multiline()) {
             const MacroAssembler::RegisterID character = m_regs.regT0;
             const MacroAssembler::RegisterID scratch = m_regs.regT1;
 
@@ -1561,7 +1561,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         CharacterClass* wordcharCharacterClass;
 
-        if (m_unicodeIgnoreCase)
+        if (m_pattern.eitherUnicode() && term->ignoreCase())
             wordcharCharacterClass = m_pattern.wordUnicodeIgnoreCaseCharCharacterClass();
         else
             wordcharCharacterClass = m_pattern.wordcharCharacterClass();
@@ -1585,7 +1585,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         CharacterClass* wordcharCharacterClass;
 
-        if (m_unicodeIgnoreCase)
+        if (m_pattern.eitherUnicode() && term->ignoreCase())
             wordcharCharacterClass = m_pattern.wordUnicodeIgnoreCaseCharCharacterClass();
         else
             wordcharCharacterClass = m_pattern.wordcharCharacterClass();
@@ -1653,7 +1653,7 @@ class YarrGenerator final : public YarrJITInfo {
 #endif
         readCharacter(op.m_checkedOffset - term->inputPosition, character);
     
-        if (!m_pattern.ignoreCase()) {
+        if (!term->ignoreCase()) {
             characterMatchFails.append(m_jit.branch32(MacroAssembler::Equal, character, MacroAssembler::TrustedImm32(errorCodePoint)));
             characterMatchFails.append(m_jit.branch32(MacroAssembler::NotEqual, character, patternCharacter));
         } else if (m_charSize == CharSize::Char8) {
@@ -1732,7 +1732,7 @@ class YarrGenerator final : public YarrJITInfo {
         PatternTerm* term = op.m_term;
 
 #if !ENABLE(YARR_JIT_BACKREFERENCES_FOR_16BIT_EXPRS)
-        if (m_pattern.ignoreCase() && m_charSize != CharSize::Char8) {
+        if (term->ignoreCase() && m_charSize != CharSize::Char8) {
             m_failureReason = JITFailureReason::BackReference;
             return;
         }
@@ -1994,9 +1994,9 @@ class YarrGenerator final : public YarrJITInfo {
 
         // For case-insesitive compares, non-ascii characters that have different
         // upper & lower case representations are converted to a character class.
-        ASSERT(!m_pattern.ignoreCase() || isASCIIAlpha(ch) || isCanonicallyUnique(ch, m_canonicalMode));
+        ASSERT(!op.m_term->ignoreCase() || isASCIIAlpha(ch) || isCanonicallyUnique(ch, m_canonicalMode));
 
-        if (m_pattern.ignoreCase() && isASCIIAlpha(ch)) {
+        if (op.m_term->ignoreCase() && isASCIIAlpha(ch)) {
 #if CPU(BIG_ENDIAN)
             ignoreCaseMask |= 32 << (m_charSize == CharSize::Char8 ? 24 : 16);
 #else
@@ -2034,11 +2034,11 @@ class YarrGenerator final : public YarrJITInfo {
 
             // For case-insesitive compares, non-ascii characters that have different
             // upper & lower case representations are converted to a character class.
-            ASSERT(!m_pattern.ignoreCase() || isASCIIAlpha(currentCharacter) || isCanonicallyUnique(currentCharacter, m_canonicalMode));
+            ASSERT(!op.m_term->ignoreCase() || isASCIIAlpha(currentCharacter) || isCanonicallyUnique(currentCharacter, m_canonicalMode));
 
             allCharacters |= (static_cast<uint64_t>(currentCharacter) << shiftAmount);
 
-            if (m_pattern.ignoreCase() && isASCIIAlpha(currentCharacter))
+            if (op.m_term->ignoreCase() && isASCIIAlpha(currentCharacter))
                 ignoreCaseMask |= 32ULL << shiftAmount;
         }
 
@@ -2055,7 +2055,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         if (m_charSize == CharSize::Char8) {
             auto check1 = [&] (Checked<unsigned> offset, char32_t characters) {
-                op.m_jumps.append(jumpIfCharNotEquals(characters, offset, character));
+                op.m_jumps.append(jumpIfCharNotEquals(characters, offset, character, term->ignoreCase()));
             };
 
             auto check2 = [&] (Checked<unsigned> offset, uint16_t characters, uint16_t mask) {
@@ -2128,7 +2128,7 @@ class YarrGenerator final : public YarrJITInfo {
             }
         } else {
             auto check1 = [&] (Checked<unsigned> offset, char32_t characters) {
-                op.m_jumps.append(jumpIfCharNotEquals(characters, offset, character));
+                op.m_jumps.append(jumpIfCharNotEquals(characters, offset, character, term->ignoreCase()));
             };
 
             auto check2 = [&] (Checked<unsigned> offset, unsigned characters, unsigned mask) {
@@ -2196,8 +2196,8 @@ class YarrGenerator final : public YarrJITInfo {
         readCharacter(op.m_checkedOffset - term->inputPosition - scaledMaxCount, character, countRegister);
         // For case-insesitive compares, non-ascii characters that have different
         // upper & lower case representations are converted to a character class.
-        ASSERT(!m_pattern.ignoreCase() || isASCIIAlpha(ch) || isCanonicallyUnique(ch, m_canonicalMode));
-        if (m_pattern.ignoreCase() && isASCIIAlpha(ch)) {
+        ASSERT(!term->ignoreCase() || isASCIIAlpha(ch) || isCanonicallyUnique(ch, m_canonicalMode));
+        if (term->ignoreCase() && isASCIIAlpha(ch)) {
             m_jit.or32(MacroAssembler::TrustedImm32(0x20), character);
             ch |= 0x20;
         }
@@ -2232,7 +2232,7 @@ class YarrGenerator final : public YarrJITInfo {
             MacroAssembler::JumpList failures;
             MacroAssembler::Label loop(&m_jit);
             failures.append(atEndOfInput());
-            failures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character));
+            failures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character, term->ignoreCase()));
 
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
@@ -2306,7 +2306,7 @@ class YarrGenerator final : public YarrJITInfo {
             nonGreedyFailures.append(atEndOfInput());
             if (term->quantityMaxCount != quantifyInfinite)
                 nonGreedyFailures.append(m_jit.branch32(MacroAssembler::Equal, countRegister, MacroAssembler::Imm32(term->quantityMaxCount)));
-            nonGreedyFailures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character));
+            nonGreedyFailures.append(jumpIfCharNotEquals(ch, op.m_checkedOffset - term->inputPosition, character, term->ignoreCase()));
 
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
@@ -2606,7 +2606,7 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::JumpList saveStartIndex;
         MacroAssembler::JumpList foundEndingNewLine;
 
-        if (m_pattern.dotAll()) {
+        if (term->dotAll()) {
             m_jit.move(MacroAssembler::TrustedImm32(0), matchPos);
             setMatchStart(matchPos);
             m_jit.move(m_regs.length, m_regs.index);
@@ -2632,7 +2632,7 @@ class YarrGenerator final : public YarrJITInfo {
         m_jit.add32(MacroAssembler::TrustedImm32(1), matchPos); // Advance past newline
         saveStartIndex.link(&m_jit);
 
-        if (!m_pattern.multiline() && term->anchors.bolAnchor)
+        if (!term->multiline() && term->anchors.bolAnchor)
             op.m_jumps.append(m_jit.branchTest32(MacroAssembler::NonZero, matchPos));
 
         ASSERT(!m_pattern.m_body->m_hasFixedSize);
@@ -2652,7 +2652,7 @@ class YarrGenerator final : public YarrJITInfo {
 
         foundEndingNewLine.link(&m_jit);
 
-        if (!m_pattern.multiline() && term->anchors.eolAnchor)
+        if (!term->multiline() && term->anchors.eolAnchor)
             op.m_jumps.append(m_jit.branch32(MacroAssembler::NotEqual, matchPos, m_regs.length));
 
         m_jit.move(matchPos, m_regs.index);
@@ -4572,8 +4572,8 @@ class YarrGenerator final : public YarrJITInfo {
                 return std::nullopt;
             // For case-insesitive compares, non-ascii characters that have different
             // upper & lower case representations are already converted to a character class.
-            ASSERT(!m_pattern.ignoreCase() || isASCIIAlpha(term.patternCharacter) || isCanonicallyUnique(term.patternCharacter, m_canonicalMode));
-            if (m_pattern.ignoreCase() && isASCIIAlpha(term.patternCharacter)) {
+            ASSERT(!term.ignoreCase() || isASCIIAlpha(term.patternCharacter) || isCanonicallyUnique(term.patternCharacter, m_canonicalMode));
+            if (term.ignoreCase() && isASCIIAlpha(term.patternCharacter)) {
                 bmInfo.set(cursor, toASCIIUpper(term.patternCharacter));
                 bmInfo.set(cursor, toASCIILower(term.patternCharacter));
             } else
@@ -4887,7 +4887,7 @@ public:
         }
 
 #if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS) && ENABLE(YARR_JIT_UNICODE_CAN_INCREMENT_INDEX_FOR_NON_BMP)
-        if (m_decodeSurrogatePairs && m_compileMode != JITCompileMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds) {
+        if (m_decodeSurrogatePairs && m_compileMode != JITCompileMode::InlineTest && !m_pattern.multiline() && !m_pattern.m_containsBOL && !m_pattern.m_containsLookbehinds && !m_pattern.m_containsModifiers) {
             ASSERT(m_regs.firstCharacterAdditionalReadSize != InvalidGPRReg);
             m_useFirstNonBMPCharacterOptimization = true;
         }
@@ -5230,7 +5230,7 @@ public:
             case PatternTerm::Type::PatternCharacter:
                 out.printf("PatternCharacter checked-offset:(%u) ", op.m_checkedOffset.value());
                 dumpUChar32(out, term->patternCharacter);
-                if (m_pattern.ignoreCase())
+                if (op.m_term->ignoreCase())
                     out.print("ignore case ");
 
                 term->dumpQuantifier(out);

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -1468,22 +1468,26 @@ private:
                 return;
             }
 
-            switch (consume()) {
+            switch (peek()) {
             case ':':
+                consume();
                 m_delegate.atomParenthesesSubpatternBegin(false);
                 break;
             
             case '=':
+                consume();
                 m_delegate.atomParentheticalAssertionBegin(false, Forward);
                 type = ParenthesesType::Assertion;
                 break;
 
             case '!':
+                consume();
                 m_delegate.atomParentheticalAssertionBegin(true, Forward);
                 type = ParenthesesType::Assertion;
                 break;
 
             case '<': {
+                consume();
                 auto groupName = tryConsumeGroupName();
                 if (hasError(m_errorCode))
                     break;
@@ -1513,6 +1517,67 @@ private:
                     }
                     m_errorCode = ErrorCode::InvalidGroupName;
                 }
+
+                break;
+            }
+
+#define REGEXP_MOD_CASE(key, name, lowerCaseName) \
+            case key:
+
+            // Valid RegularExpressionFlags for regexp modifiers
+            case '-':
+            JSC_REGEXP_MOD_FLAGS(REGEXP_MOD_CASE)
+
+#undef REGEXP_MOD_CASE
+            {
+                // consume characters until :
+                OptionSet<Flags> set;
+                OptionSet<Flags> unset;
+                bool hasHitNegation = false;
+                char32_t c;
+                while (!atEndOfPattern() && (c = consume()) != ':') {
+                    switch (c) {
+                    case '-':
+                        if (hasHitNegation)
+                            m_errorCode = ErrorCode::InvalidRegularExpressionModifier;
+                        hasHitNegation = true;
+                        break;
+
+                    // It is a Syntax Error if the source text matched by RegularExpressionModifiers contains the same code point more than once
+#define HANDLE_REGEXP_MOD_FLAG(key, name, lowerCaseName) \
+                    case key: \
+                        if (hasHitNegation) { \
+                            if (unset.contains(Flags::name)) \
+                                m_errorCode = ErrorCode::InvalidRegularExpressionModifier; \
+                            unset.add(Flags::name); \
+                        } else { \
+                            if (set.contains(Flags::name)) \
+                                m_errorCode = ErrorCode::InvalidRegularExpressionModifier; \
+                            set.add(Flags::name); \
+                        } \
+                        break;
+
+                        JSC_REGEXP_MOD_FLAGS(HANDLE_REGEXP_MOD_FLAG)
+#undef HANDLE_REGEXP_MOD_FLAG
+
+                    default:
+                        m_errorCode = ErrorCode::ParenthesesTypeInvalid;
+                        break;
+                    }
+                }
+
+                if (hasError(m_errorCode))
+                    break;
+
+                // we've consumed (?<flags>:
+
+                // It is a Syntax Error if any code point in the source text matched by the first RegularExpressionModifiers is also contained in the source text matched by the second RegularExpressionModifiers.
+                if (set.containsAny(unset))
+                    m_errorCode = ErrorCode::InvalidRegularExpressionModifier;
+                // It is a Syntax Error if the source text matched by the first RegularExpressionModifiers and the source text matched by the second RegularExpressionModifiers are both empty.
+                if (set.isEmpty() && unset.isEmpty())
+                    m_errorCode = ErrorCode::InvalidRegularExpressionModifier;
+                m_delegate.atomParentheticalModifierBegin(set, unset);
 
                 break;
             }
@@ -2133,6 +2198,7 @@ private:
  *    void atomCharacterClassEnd()
  *    void atomParenthesesSubpatternBegin(bool capture = true, std::optional<String> groupName);
  *    void atomParentheticalAssertionBegin(bool invert, MatchDirection matchDirection);
+ *    void atomParentheticalModifierBegin(OptionSet<Flags> set, OptionSet<Flags> unset);
  *    void atomParenthesesEnd();
  *    void atomBackReference(unsigned subpatternId);
  *    void atomNamedBackReference(const String& subpatternName);

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -217,6 +217,7 @@ struct PatternTerm {
         DotStarEnclosure,
     };
     Type type;
+    OptionSet<Flags> m_currentFlags;
     bool m_capture : 1;
     bool m_invert : 1;
     MatchDirection m_matchDirection : 1;
@@ -242,8 +243,9 @@ struct PatternTerm {
     unsigned inputPosition;
     unsigned frameLocation;
 
-    PatternTerm(char32_t ch, MatchDirection matchDirection = Forward)
+    PatternTerm(char32_t ch, OptionSet<Flags> currFlags, MatchDirection matchDirection = Forward)
         : type(PatternTerm::Type::PatternCharacter)
+        , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
         , m_matchDirection(matchDirection)
@@ -253,8 +255,9 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    PatternTerm(CharacterClass* charClass, bool invert, MatchDirection matchDirection = Forward)
+    PatternTerm(CharacterClass* charClass, bool invert, OptionSet<Flags> currFlags, MatchDirection matchDirection = Forward)
         : type(PatternTerm::Type::CharacterClass)
+        , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(invert)
         , m_matchDirection(matchDirection)
@@ -264,8 +267,9 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    PatternTerm(Type type, unsigned subpatternId, PatternDisjunction* disjunction, bool capture = false, bool invert = false, MatchDirection matchDirection = Forward)
+    PatternTerm(Type type, unsigned subpatternId, PatternDisjunction* disjunction, OptionSet<Flags> currFlags, bool capture = false, bool invert = false, MatchDirection matchDirection = Forward)
         : type(type)
+        , m_currentFlags(currFlags)
         , m_capture(capture)
         , m_invert(invert)
         , m_matchDirection(matchDirection)
@@ -278,8 +282,9 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
     
-    PatternTerm(Type type, bool invert = false)
+    PatternTerm(Type type, OptionSet<Flags> currFlags, bool invert = false)
         : type(type)
+        , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(invert)
         , m_matchDirection(Forward)
@@ -288,8 +293,9 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    PatternTerm(unsigned spatternId)
+    PatternTerm(unsigned spatternId, OptionSet<Flags> currFlags)
         : type(Type::BackReference)
+        , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
         , m_matchDirection(Forward)
@@ -299,8 +305,9 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    PatternTerm(bool bolAnchor, bool eolAnchor)
+    PatternTerm(bool bolAnchor, bool eolAnchor, OptionSet<Flags> currFlags)
         : type(Type::DotStarEnclosure)
+        , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
         , m_matchDirection(Forward)
@@ -311,26 +318,26 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    static PatternTerm ForwardReference()
+    static PatternTerm ForwardReference(OptionSet<Flags> currFlags)
     {
-        auto term = PatternTerm(Type::ForwardReference);
+        auto term = PatternTerm(Type::ForwardReference, currFlags);
         term.backReferenceSubpatternId = 0;
         return term;
     }
 
-    static PatternTerm BOL()
+    static PatternTerm BOL(OptionSet<Flags> currFlags)
     {
-        return PatternTerm(Type::AssertionBOL);
+        return PatternTerm(Type::AssertionBOL, currFlags);
     }
 
-    static PatternTerm EOL()
+    static PatternTerm EOL(OptionSet<Flags> currFlags)
     {
-        return PatternTerm(Type::AssertionEOL);
+        return PatternTerm(Type::AssertionEOL, currFlags);
     }
 
-    static PatternTerm WordBoundary(bool invert)
+    static PatternTerm WordBoundary(bool invert, OptionSet<Flags> currFlags)
     {
-        return PatternTerm(Type::AssertionWordBoundary, invert);
+        return PatternTerm(Type::AssertionWordBoundary, currFlags, invert);
     }
 
     void convertToBackreference()
@@ -357,6 +364,21 @@ struct PatternTerm {
     bool capture()
     {
         return m_capture;
+    }
+
+    bool ignoreCase()
+    {
+        return m_currentFlags.contains(Flags::IgnoreCase);
+    }
+
+    bool multiline()
+    {
+        return m_currentFlags.contains(Flags::Multiline);
+    }
+
+    bool dotAll()
+    {
+        return m_currentFlags.contains(Flags::DotAll);
     }
 
     bool isFixedWidthCharacterClass() const
@@ -705,6 +727,7 @@ struct YarrPattern {
     bool m_containsBOL : 1;
     bool m_containsLookbehinds : 1;
     bool m_containsUnsignedLengthPattern : 1;
+    bool m_containsModifiers : 1;
     bool m_hasCopiedParenSubexpressions : 1;
     bool m_hasNamedCaptureGroups : 1;
     bool m_saveInitialStartValue : 1;

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -49,6 +49,7 @@ public:
     void atomCharacterClassEnd() { }
     void atomParenthesesSubpatternBegin(bool = true, std::optional<String> = std::nullopt) { }
     void atomParentheticalAssertionBegin(bool, MatchDirection) { }
+    void atomParentheticalModifierBegin(OptionSet<Flags>, OptionSet<Flags>) { }
     void atomParenthesesEnd() { }
     void atomBackReference(unsigned) { }
     void atomNamedBackReference(const String&) { }

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -248,6 +248,11 @@ public:
         fail(URLFilterParser::Group);
     }
 
+    void atomParentheticalModifierBegin(OptionSet<JSC::Yarr::Flags>, OptionSet<JSC::Yarr::Flags>)
+    {
+        fail(URLFilterParser::Group);
+    }
+
     void atomParenthesesEnd()
     {
         if (hasError())


### PR DESCRIPTION
#### 87e70c49cbfa0fb0a2268683959770b514a37d6b
<pre>
Re-enable RegExp Modifiers
<a href="https://bugs.webkit.org/show_bug.cgi?id=287678">https://bugs.webkit.org/show_bug.cgi?id=287678</a>
<a href="https://rdar.apple.com/144826381">rdar://144826381</a>

Reviewed by NOBODY.

This re-enables RegExp Modifiers, after it was reverted in 289955@main. The
key fixes are:

- Ensure the YarrParser does not go off the end of the pattern when parsing
  an invalid RegExp Modifier.
- Initialize m_containsModifiers explicitly to false.

Original description:

        This patch implements RegExp Modifiers. The spec can be found at
        <a href="https://github.com/tc39/proposal-regexp-modifiers">https://github.com/tc39/proposal-regexp-modifiers</a>

        This patch adds support to both the interpreter and JIT tiers for
        RegExp modifiers. A lot of the changes are just routing the modified
        flags through the RegExp engine.

* JSTests/stress/regexp-modifiers-interpreter.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* JSTests/stress/regexp-modifiers.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
(JSC::Yarr::errorToThrow):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrFlags.h:
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::tryConsumeBackReference):
(JSC::Yarr::Interpreter::matchAssertionBOL):
(JSC::Yarr::Interpreter::matchAssertionEOL):
(JSC::Yarr::Interpreter::matchAssertionWordBoundary):
(JSC::Yarr::Interpreter::matchDotStarEnclosure):
(JSC::Yarr::ByteCompiler::ByteCompiler):
(JSC::Yarr::ByteCompiler::checkInput):
(JSC::Yarr::ByteCompiler::uncheckInput):
(JSC::Yarr::ByteCompiler::haveCheckedInput):
(JSC::Yarr::ByteCompiler::assertionBOL):
(JSC::Yarr::ByteCompiler::assertionEOL):
(JSC::Yarr::ByteCompiler::assertionWordBoundary):
(JSC::Yarr::ByteCompiler::atomPatternCharacter):
(JSC::Yarr::ByteCompiler::atomCharacterClass):
(JSC::Yarr::ByteCompiler::atomBackReference):
(JSC::Yarr::ByteCompiler::atomParenthesesOnceBegin):
(JSC::Yarr::ByteCompiler::atomParenthesesTerminalBegin):
(JSC::Yarr::ByteCompiler::atomParenthesesSubpatternBegin):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionBegin):
(JSC::Yarr::ByteCompiler::atomParentheticalAssertionEnd):
(JSC::Yarr::ByteCompiler::assertionDotStarEnclosure):
(JSC::Yarr::ByteCompiler::closeAlternative):
(JSC::Yarr::ByteCompiler::closeBodyAlternative):
(JSC::Yarr::ByteCompiler::atomParenthesesSubpatternEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesOnceEnd):
(JSC::Yarr::ByteCompiler::atomParenthesesTerminalEnd):
(JSC::Yarr::ByteCompiler::regexBegin):
(JSC::Yarr::ByteCompiler::alternativeBodyDisjunction):
(JSC::Yarr::ByteCompiler::alternativeDisjunction):
(JSC::Yarr::ByteCompiler::emitDisjunction):
* Source/JavaScriptCore/yarr/YarrInterpreter.h:
(JSC::Yarr::ByteTerm::ByteTerm):
(JSC::Yarr::ByteTerm::BOL):
(JSC::Yarr::ByteTerm::CheckInput):
(JSC::Yarr::ByteTerm::UncheckInput):
(JSC::Yarr::ByteTerm::HaveCheckedInput):
(JSC::Yarr::ByteTerm::EOL):
(JSC::Yarr::ByteTerm::WordBoundary):
(JSC::Yarr::ByteTerm::BackReference):
(JSC::Yarr::ByteTerm::BodyAlternativeBegin):
(JSC::Yarr::ByteTerm::BodyAlternativeDisjunction):
(JSC::Yarr::ByteTerm::BodyAlternativeEnd):
(JSC::Yarr::ByteTerm::AlternativeBegin):
(JSC::Yarr::ByteTerm::AlternativeDisjunction):
(JSC::Yarr::ByteTerm::AlternativeEnd):
(JSC::Yarr::ByteTerm::SubpatternBegin):
(JSC::Yarr::ByteTerm::SubpatternEnd):
(JSC::Yarr::ByteTerm::ParentheticalAssertionBegin):
(JSC::Yarr::ByteTerm::ParentheticalAssertionEnd):
(JSC::Yarr::ByteTerm::DotStarEnclosure):
(JSC::Yarr::ByteTerm::ignoreCase):
(JSC::Yarr::ByteTerm::multiline):
(JSC::Yarr::ByteTerm::dotAll):
(JSC::Yarr::BytecodePattern::BytecodePattern):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseParenthesesBegin):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::putUnicodeIgnoreCase):
(JSC::Yarr::CharacterClassConstructor::setIsCaseInsensitive):
(JSC::Yarr::YarrPatternConstructor::YarrPatternConstructor):
(JSC::Yarr::YarrPatternConstructor::resetForReparsing):
(JSC::Yarr::YarrPatternConstructor::assertionBOL):
(JSC::Yarr::YarrPatternConstructor::assertionEOL):
(JSC::Yarr::YarrPatternConstructor::assertionWordBoundary):
(JSC::Yarr::YarrPatternConstructor::atomPatternCharacter):
(JSC::Yarr::YarrPatternConstructor::atomBuiltInCharacterClass):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassBegin):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassBuiltIn):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassPushNested):
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassEnd):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesSubpatternBegin):
(JSC::Yarr::YarrPatternConstructor::atomParentheticalAssertionBegin):
(JSC::Yarr::YarrPatternConstructor::atomParentheticalModifierBegin):
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::atomBackReference):
(JSC::Yarr::YarrPatternConstructor::atomNamedBackReference):
(JSC::Yarr::YarrPatternConstructor::atomNamedForwardReference):
(JSC::Yarr::YarrPatternConstructor::optimizeBOL):
(JSC::Yarr::YarrPatternConstructor::optimizeDotStarWrappedExpressions):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::SavedContext::SavedContext):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::SavedContext::restore):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::push):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::pop):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::setModifier):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::isModifier const):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::setFlags):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::flags const):
(JSC::Yarr::YarrPatternConstructor::ParenthesisContext::reset):
(JSC::Yarr::YarrPatternConstructor::ignoreCase const):
(JSC::Yarr::YarrPatternConstructor::multiline const):
(JSC::Yarr::YarrPatternConstructor::dotAll const):
(JSC::Yarr::YarrPattern::compile):
(JSC::Yarr::PatternTerm::dump):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::PatternTerm):
(JSC::Yarr::PatternTerm::ForwardReference):
(JSC::Yarr::PatternTerm::BOL):
(JSC::Yarr::PatternTerm::EOL):
(JSC::Yarr::PatternTerm::WordBoundary):
(JSC::Yarr::PatternTerm::ignoreCase):
(JSC::Yarr::PatternTerm::multiline):
(JSC::Yarr::PatternTerm::dotAll):
* Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp:
(JSC::Yarr::SyntaxChecker::atomParentheticalModifierBegin):

Originally-landed-as: 289955@main (868302168e9b). <a href="https://rdar.apple.com/131580854">rdar://131580854</a>
Canonical link: <a href="https://commits.webkit.org/290485@main">https://commits.webkit.org/290485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82a407f4fceb3294222690a0548ae3f898956fbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89862 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44754 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40635 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69186 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26807 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7479 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49547 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7201 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35893 "Found 2 new test failures: fullscreen/full-screen-request-removed.html media/modern-media-controls/fullscreen-button/fullscreen-button.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39768 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82663 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96685 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88638 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12501 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78061 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17305 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19167 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21831 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10226 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22381 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111131 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16801 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26615 "Found 12 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.default-wasm ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->