### PR TITLE
Implement browser.test.addTest to support web platform testing of extensions

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h
@@ -58,10 +58,23 @@ WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 - (void)_webExtensionController:(WKWebExtensionController *)controller receivedTestMessage:(NSString *)message withArgument:(id)argument andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
+ @abstract Delegate for the `browser.test.addTest()` JavaScript testing API.
+ @discussion Default implementation logs a message to the system console that a test was added with `testName`. Test harnesses should use this to perform actions when a new test has been added to the queue.
+ */
+- (void)_webExtensionController:(WKWebExtensionController *)controller recordTestAddedWithName:(NSString *)testName andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
+
+/*!
+ @abstract Delegate for the `browser.test.addTest()` JavaScript testing API.
+ @discussion Default implementation logs a message to the system console that a test was started with `testName`. Test harnesses should use this to perform actions at the start of a test.
+ */
+- (void)_webExtensionController:(WKWebExtensionController *)controller recordTestStartedWithName:(NSString *)testName andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
+
+/*!
  @abstract Delegate for the `browser.test.notifyPass()` and `browser.test.notifyFail()` JavaScript testing APIs.
  @discussion Default implementation logs a message to the system console when `result` is `NO`. Test harnesses should use this to exit the run loop and record a test pass or failure.
+ @note This is also called with the test results of a test that was added with `browser.test.addTest()`.
  */
-- (void)_webExtensionController:(WKWebExtensionController *)controller recordTestFinishedWithResult:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
+- (void)_webExtensionController:(WKWebExtensionController *)controller recordTestFinishedWithName:(NSString *)testName result:(BOOL)result message:(NSString *)message andSourceURL:(NSString *)sourceURL lineNumber:(unsigned)lineNumber;
 
 /*!
  @abstract Delegate notification about the creation of the background web view in the web extension context.

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm
@@ -102,23 +102,48 @@ void WebExtensionController::testSentMessage(String message, String argument, St
     RELEASE_LOG_INFO(Extensions, "Test sent message: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)argument, (NSString *)sourceURL, lineNumber);
 }
 
-void WebExtensionController::testFinished(bool result, String message, String sourceURL, unsigned lineNumber)
+void WebExtensionController::testAdded(String testName, String sourceURL, unsigned lineNumber)
 {
     auto delegate = this->delegate();
-    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:)]) {
-        [delegate _webExtensionController:wrapper() recordTestFinishedWithResult:result message:message andSourceURL:sourceURL lineNumber:lineNumber];
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestAddedWithName:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestAddedWithName:testName andSourceURL:sourceURL lineNumber:lineNumber];
         return;
     }
+
+    RELEASE_LOG_INFO(Extensions, "Test added: %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionController::testStarted(String testName, String sourceURL, unsigned lineNumber)
+{
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestStartedWithName:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestStartedWithName:testName andSourceURL:sourceURL lineNumber:lineNumber];
+        return;
+    }
+
+    RELEASE_LOG_INFO(Extensions, "Test started: %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)sourceURL, lineNumber);
+}
+
+void WebExtensionController::testFinished(String testName, bool result, String message, String sourceURL, unsigned lineNumber)
+{
+    auto delegate = this->delegate();
+    if ([delegate respondsToSelector:@selector(_webExtensionController:recordTestFinishedWithName:result:message:andSourceURL:lineNumber:)]) {
+        [delegate _webExtensionController:wrapper() recordTestFinishedWithName:testName result:result message:message andSourceURL:sourceURL lineNumber:lineNumber];
+        return;
+    }
+
+    if (testName.isEmpty())
+        testName = "(no test name)"_s;
 
     if (message.isEmpty())
         message = "(no message)"_s;
 
     if (result) {
-        RELEASE_LOG_INFO(Extensions, "Test passed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+        RELEASE_LOG_INFO(Extensions, "Test passed: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)message, (NSString *)sourceURL, lineNumber);
         return;
     }
 
-    RELEASE_LOG_ERROR(Extensions, "Test failed: %{public}@ (%{public}@:%{public}u)", (NSString *)message, (NSString *)sourceURL, lineNumber);
+    RELEASE_LOG_ERROR(Extensions, "Test failed: %{public}@ %{public}@ (%{public}@:%{public}u)", (NSString *)testName, (NSString *)message, (NSString *)sourceURL, lineNumber);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -223,7 +223,9 @@ private:
     void testEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber);
     void testLogMessage(String message, String sourceURL, unsigned lineNumber);
     void testSentMessage(String message, String argument, String sourceURL, unsigned lineNumber);
-    void testFinished(bool result, String message, String sourceURL, unsigned lineNumber);
+    void testAdded(String testName, String sourceURL, unsigned lineNumber);
+    void testStarted(String testName, String sourceURL, unsigned lineNumber);
+    void testFinished(String testName, bool result, String message, String sourceURL, unsigned lineNumber);
 
     class HTTPCookieStoreObserver : public API::HTTPCookieStoreObserver {
         WTF_MAKE_TZONE_ALLOCATED_INLINE(HTTPCookieStoreObserver);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in
@@ -41,7 +41,9 @@ messages -> WebExtensionController {
     [Validator=inTestingMode] TestEqual(bool result, String expected, String actual, String message, String sourceURL, unsigned lineNumber)
     [Validator=inTestingMode] TestLogMessage(String message, String sourceURL, unsigned lineNumber)
     [Validator=inTestingMode] TestSentMessage(String message, String argument, String sourceURL, unsigned lineNumber)
-    [Validator=inTestingMode] TestFinished(bool result, String message, String sourceURL, unsigned lineNumber)
+    [Validator=inTestingMode] TestAdded(String testName, String sourceURL, unsigned lineNumber)
+    [Validator=inTestingMode] TestStarted(String testName, String sourceURL, unsigned lineNumber)
+    [Validator=inTestingMode] TestFinished(String testName, bool result, String message, String sourceURL, unsigned lineNumber)
 }
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
+++ b/Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl
@@ -82,4 +82,7 @@
     // Asserts the function does not throw an exception and the result promise is resolved.
     [NeedsScriptContext] any assertSafeResolve(any function, [Optional] DOMString message);
 
+    // Adds a test represented by a promise. If the promise is resolved, the test passes; if the promise is rejected, the test fails.
+    [NeedsScriptContext] any addTest(any function);
+
 };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm
@@ -218,6 +218,264 @@ TEST(WKWebExtensionAPITest, SendMessageOutOfOrder)
     EXPECT_NS_EQUAL(firstMessage, @{ @"key": @"One" });
 }
 
+TEST(WKWebExtensionAPITest, AddAnonymousAsyncTest)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(async () => {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('Passing an anonymous function into addTest resolved the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ });
+}
+
+TEST(WKWebExtensionAPITest, AddAsyncTestThatPasses)
+{
+    auto *testName = @"passingTest";
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertResolves(browser.test.addTest(async function passingTest() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ testName: @YES });
+}
+
+TEST(WKWebExtensionAPITest, AddAsyncTestThatFails)
+{
+    auto *testName = @"failingTest";
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(async function failingTest() {",
+        @"  browser.test.assertTrue(false)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A failing assertion in the addTest method resolved the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ testName: @NO });
+}
+
+TEST(WKWebExtensionAPITest, AddAsyncTestThatThrows)
+{
+    auto *testName = @"failingTest";
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(async function failingTest() {",
+        @"  throw new Error('fail the test')",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('Throwing an error in the addTest method resolved the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ testName: @0 });
+}
+
+TEST(WKWebExtensionAPITest, AddMultipleAsyncTestsThatPass)
+{
+    auto *testNames = @[ @"testA", @"testB" ];
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertResolves(browser.test.addTest(async function testA() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))",
+
+        @"browser.test.assertResolves(browser.test.addTest(async function testB() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, testNames);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, testNames);
+    EXPECT_NS_EQUAL(manager.get().testResults, (@{ testNames.firstObject: @YES, testNames.lastObject: @YES }));
+}
+
+TEST(WKWebExtensionAPITest, AddMultipleAsyncTestsWithFailure)
+{
+    auto *testNames = @[ @"testA", @"testB" ];
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(async function testA() {",
+        @"  browser.test.assertTrue(false)",
+        @"}))",
+        @"  .catch(() => browser.test.notifyFail('A failing assertion in the addTest method resolved the promise.'))",
+
+        @"browser.test.assertResolves(browser.test.addTest(async function testB() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, testNames);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, testNames);
+    EXPECT_NS_EQUAL(manager.get().testResults, (@{ testNames.firstObject: @NO, testNames.lastObject: @YES }));
+}
+
+TEST(WKWebExtensionAPITest, AddAnonymousTest)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(() => {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('Passing an anonymous function into addTest resolved the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ });
+}
+
+TEST(WKWebExtensionAPITest, AddTestThatPasses)
+{
+    auto *testName = @"passingTest";
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertResolves(browser.test.addTest(function passingTest() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ testName: @YES });
+}
+
+TEST(WKWebExtensionAPITest, AddTestThatFails)
+{
+    auto *testName = @"failingTest";
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(function failingTest() {",
+        @"  browser.test.assertTrue(false)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A failing assertion in the addTest method resolved the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ testName: @NO });
+}
+
+TEST(WKWebExtensionAPITest, AddTestThatThrows)
+{
+    auto *testName = @"failingTest";
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(function failingTest() {",
+        @"  throw new Error('fail the test')",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('Throwing an error in the addTest method resolved the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, @[ testName ]);
+    EXPECT_NS_EQUAL(manager.get().testResults, @{ testName: @0 });
+}
+
+TEST(WKWebExtensionAPITest, AddMultipleTestsThatPass)
+{
+    auto *testNames = @[ @"testA", @"testB" ];
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertResolves(browser.test.addTest(function testA() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))",
+
+        @"browser.test.assertResolves(browser.test.addTest(function testB() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, testNames);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, testNames);
+    EXPECT_NS_EQUAL(manager.get().testResults, (@{ testNames.firstObject: @YES, testNames.lastObject: @YES }));
+}
+
+TEST(WKWebExtensionAPITest, AddMultipleTestsWithFailure)
+{
+    auto *testNames = @[ @"testA", @"testB" ];
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.assertRejects(browser.test.addTest(function testA() {",
+        @"  browser.test.assertTrue(false)",
+        @"}))",
+        @"  .catch(() => browser.test.notifyFail('A failing assertion in the addTest method resolved the promise.'))",
+
+        @"browser.test.assertResolves(browser.test.addTest(function testB() {",
+        @"  browser.test.assertTrue(true)",
+        @"}))",
+        @"  .then(() => browser.test.notifyPass())",
+        @"  .catch(() => browser.test.notifyFail('A passing assertion in the addTest method rejected the promise.'))"
+    ]);
+
+    auto manager = Util::loadExtension(manifest, @{ @"background.js": backgroundScript });
+
+    [manager run];
+
+    EXPECT_NS_EQUAL(manager.get().testsAdded, testNames);
+    EXPECT_NS_EQUAL(manager.get().testsStarted, testNames);
+    EXPECT_NS_EQUAL(manager.get().testResults, (@{ testNames.firstObject: @NO, testNames.lastObject: @YES }));
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)

--- a/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
+++ b/Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h
@@ -62,6 +62,9 @@ using CocoaColor = UIColor;
 @property (nonatomic, readonly, strong) TestWebExtensionWindow *defaultWindow;
 @property (nonatomic, readonly, strong) TestWebExtensionTab *defaultTab;
 @property (nonatomic, readonly, copy) NSArray<TestWebExtensionWindow *> *windows;
+@property (nonatomic, readonly, copy) NSArray<NSString *> *testsAdded;
+@property (nonatomic, readonly, copy) NSArray<NSString *> *testsStarted;
+@property (nonatomic, readonly, copy) NSDictionary<NSString *, id> *testResults;
 
 - (TestWebExtensionWindow *)openNewWindow;
 - (TestWebExtensionWindow *)openNewWindowUsingPrivateBrowsing:(BOOL)usesPrivateBrowsing;


### PR DESCRIPTION
#### 5ca13e0fb7c00fa541cfcfe33fbe3024bdb45212
<pre>
Implement browser.test.addTest to support web platform testing of extensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=287566">https://bugs.webkit.org/show_bug.cgi?id=287566</a>
<a href="https://rdar.apple.com/144706714">rdar://144706714</a>

Reviewed by Timothy Hatcher.

This patch adds a new API for running tests that are represented by promises.
If any browser.test assertion within the test method fails, we reject the
promise and notify fail; otherwise, we resolve the promise and notify pass.
It&apos;s worth noting that tests are ran in the order in which they&apos;re added with
the addTest method.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerDelegatePrivate.h:
Define the delegate methods that are called when the following messages are received...

* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.messages.in:
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionControllerAPITestCocoa.mm:
(WebKit::WebExtensionController::testAdded):
(WebKit::WebExtensionController::testStarted):
...the two new messages are:

the testAdded message, which is sent when browser.test.addTest is called,
and the testStarted message, which is called when the next test is removed
from the queue and has started executing.

* Source/WebKit/WebProcess/Extensions/Interfaces/WebExtensionAPITest.idl:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITestCocoa.mm:
(WebKit::WebExtensionAPITest::assertTrue):
(WebKit::WebExtensionAPITest::assertDeepEq):
(WebKit::WebExtensionAPITest::assertEquals):
(WebKit::WebExtensionAPITest::assertEq):
(WebKit::WebExtensionAPITest::addTest):
(WebKit::WebExtensionAPITest::startNextTest):
(WebKit::assertEquals): Deleted.
Implement the logic for browser.test.addTest, which just maintains a queue of
test methods to run and resolves/rejects the promise based on whether or not
any assertions are hit during the execution.

* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPITest.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITest, AddTestThatPasses)):
(TestWebKitAPI::TEST(WKWebExtensionAPITest, AddTestThatFails)):
Add new tests to ensure that passing and failing tests resolve and reject,
respectively. Additionally, check that the new delegate methods are called
as expected.

* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.h:
* Tools/TestWebKitAPI/cocoa/WebExtensionUtilities.mm:
(-[TestWebExtensionManager initForExtension:extensionControllerConfiguration:]):
(-[TestWebExtensionManager _webExtensionController:recordTestAssertionResult:withMessage:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:recordTestEqualityResult:expectedValue:actualValue:withMessage:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:recordTestAddedWithTestName:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:recordTestStartedWithTestName:andSourceURL:lineNumber:]):
(-[TestWebExtensionManager _webExtensionController:recordTestFinishedWithResult:message:andSourceURL:lineNumber:]):
Throw away test events if we&apos;re currently executing a test that was added
with the new browser.test.addTest API. We don&apos;t care what the result of
those assertions are, just that the promise resolves/rejects as expected.

Canonical link: <a href="https://commits.webkit.org/290558@main">https://commits.webkit.org/290558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51a06eace7398386eccbcb468d075b63d2b7b3c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69598 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27164 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7899 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49944 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7633 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36364 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37437 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17586 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78588 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77827 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77800 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22250 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20859 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10857 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14226 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17596 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19121 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->