### PR TITLE
[Cocoa] Add a heuristic to detect and sample colors in fixed-position elements at the edges of the viewport

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1842,6 +1842,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/FileHandle.h
     platform/FileMonitor.h
     platform/FileStreamClient.h
+    platform/FixedContainerEdges.h
     platform/FloatConversion.h
     platform/GraphicsClient.h
     platform/HostWindow.h

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -76,6 +76,7 @@ class ScrollingCoordinator;
 class ScrollAnchoringController;
 class TiledBacking;
 
+struct FixedContainerEdges;
 struct ScrollRectToVisibleOptions;
 struct SimpleRange;
 struct VelocityData;
@@ -357,6 +358,8 @@ public:
     // Functions for querying the current scrolled position, negating the effects of overhang
     // and adjusting for page scale.
     LayoutPoint scrollPositionForFixedPosition() const;
+
+    WEBCORE_EXPORT FixedContainerEdges fixedContainerEdges() const;
     
     // Static function can be called from another thread.
     WEBCORE_EXPORT static LayoutPoint scrollPositionForFixedPosition(const LayoutRect& visibleContentRect, const LayoutSize& totalContentsSize, const LayoutPoint& scrollPosition, const LayoutPoint& scrollOrigin, float frameScaleFactor, bool fixedElementsLayoutRelativeToFrame, ScrollBehaviorForFixedElements, int headerHeight, int footerHeight);

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "PageColorSampler.h"
 
+#include "ColorHash.h"
+#include "ColorSerialization.h"
 #include "ContentfulPaintChecker.h"
 #include "Document.h"
 #include "Element.h"
@@ -51,6 +53,7 @@
 #include "Settings.h"
 #include "Styleable.h"
 #include "WebAnimation.h"
+#include <wtf/HashCountedSet.h>
 #include <wtf/ListHashSet.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Ref.h>
@@ -272,6 +275,96 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
         return averageColor(std::span(samples).subspan<0, numSamples - 1>());
     else
         return averageColor(std::span(samples));
+}
+
+Color PageColorSampler::predominantColor(Page& page, const LayoutRect& absoluteRect)
+{
+    RefPtr frame = page.localMainFrame();
+    if (!frame)
+        return { };
+
+    RefPtr view = frame->view();
+    if (!view)
+        return { };
+
+    RefPtr document = frame->document();
+    if (!document)
+        return { };
+
+    auto colorSpace = DestinationColorSpace::SRGB();
+    auto snapshot = snapshotFrameRect(*frame, snappedIntRect(absoluteRect), {
+        { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection },
+        ImageBufferPixelFormat::BGRA8,
+        colorSpace
+    });
+
+    if (!snapshot)
+        return { };
+
+    auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace }, { { }, snapshot->truncatedLogicalSize() });
+    if (!pixelBuffer)
+        return { };
+
+    static constexpr auto sampleCount = 17;
+    static constexpr auto minimumSampleCountForPredominantColor = 0.5 * sampleCount;
+    static constexpr auto bytesPerPixel = 4;
+
+    auto numberOfBytes = pixelBuffer->bytes().size();
+    auto numberOfPixels = numberOfBytes / bytesPerPixel;
+    if (numberOfPixels <= sampleCount)
+        return { };
+
+    auto byteSamplingInterval = bytesPerPixel * (numberOfPixels / (sampleCount - 1));
+    auto pixels = pixelBuffer->bytes();
+    HashCountedSet<Color> colorDistribution;
+    for (uint64_t i = 0; i < numberOfBytes; i += byteSamplingInterval) {
+        if (auto color = Color { SRGBA<uint8_t> { pixels[i + 2], pixels[i + 1], pixels[i], pixels[i + 3] } }; color.isValid())
+            colorDistribution.add(WTFMove(color));
+    }
+
+    for (auto& [color, count] : colorDistribution) {
+        if (count > minimumSampleCountForPredominantColor)
+            return color;
+    }
+
+    auto colorsAreSimilar = [](const Color& a, const Color& b) {
+        static constexpr auto maxDistanceSquaredForSimilarColors = 36;
+        auto [redA, greenA, blueA, alphaA] = a.toResolvedColorComponentsInColorSpace(DestinationColorSpace::SRGB());
+        auto [redB, greenB, blueB, alphaB] = b.toResolvedColorComponentsInColorSpace(DestinationColorSpace::SRGB());
+        auto distance = pow(redA - redB, 2) + pow(greenA - greenB, 2) + pow(blueA - blueB, 2);
+        return distance <= maxDistanceSquaredForSimilarColors;
+    };
+
+    Vector<std::pair<Color, unsigned>> colorsByDescendingFrequency;
+    colorsByDescendingFrequency.reserveInitialCapacity(colorDistribution.size());
+    for (auto& [color, count] : colorDistribution)
+        colorsByDescendingFrequency.append({ color, count });
+
+    std::stable_sort(colorsByDescendingFrequency.begin(), colorsByDescendingFrequency.end(), [](auto& a, auto& b) {
+        return a.second > b.second;
+    });
+
+    std::optional<Color> mostFrequentColor;
+    unsigned mostFrequentColorCount = 0;
+
+    // FIXME: This doesn't account for the case where a predominant color is not similar to the color with the highest frequency.
+    for (auto& [color, count] : colorsByDescendingFrequency) {
+        if (!mostFrequentColor) {
+            mostFrequentColor = color;
+            mostFrequentColorCount = count;
+            continue;
+        }
+
+        if (!colorsAreSimilar(*mostFrequentColor, color))
+            continue;
+
+        mostFrequentColorCount += count;
+
+        if (mostFrequentColorCount > minimumSampleCountForPredominantColor)
+            return WTFMove(*mostFrequentColor);
+    }
+
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/PageColorSampler.h
+++ b/Source/WebCore/page/PageColorSampler.h
@@ -30,11 +30,13 @@
 
 namespace WebCore {
 
+class LayoutRect;
 class Page;
 
 class PageColorSampler {
 public:
     static std::optional<Color> sampleTop(Page&);
+    static Color predominantColor(Page&, const LayoutRect&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/FixedContainerEdges.h
+++ b/Source/WebCore/platform/FixedContainerEdges.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Color.h"
+#include "RectEdges.h"
+
+namespace WebCore {
+
+struct FixedContainerEdges {
+    RectEdges<Color> predominantColors;
+    RectEdges<bool> fixedEdges;
+
+    bool operator==(const FixedContainerEdges&) const = default;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### f5aa57b6b88aa2ffca5cd1457a45c56723031bcd
<pre>
[Cocoa] Add a heuristic to detect and sample colors in fixed-position elements at the edges of the viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=287690">https://bugs.webkit.org/show_bug.cgi?id=287690</a>
<a href="https://rdar.apple.com/144839983">rdar://144839983</a>

Reviewed by Abrar Rahman Protyasha.

Work towards <a href="https://rdar.apple.com/144839983">rdar://144839983</a>; see below for more details.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Add a helper method that returns the set of `FixedContainerEdges` (see the new header below), by
first hit-testing around all 4 edges of the layout viewport in search of elements with fixed-
position ancestors in the render tree; for each edge with a fixed ancestor, we then use the new
page color sampling helper below to extract the predominant color.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):

Add a helper method that samples the predominant color in the given rect (in absolute coordinates)
by taking a snapshot, building a histogram of color frequencies, and checking whether the number of
similar colors represents a majority of all sampled colors.

* Source/WebCore/page/PageColorSampler.h:
* Source/WebCore/platform/FixedContainerEdges.h: Added.

Add a helper class, `FixedContainerEdges`, that represents two pieces of information about each of
the 4 edges of the layout viewport (top, left, bottom, right):

-   Whether there&apos;s a fixed-position container near that edge.
-   A sampled predominant color, or the invalid color if none is detected (e.g. due to too many
    different colors).

Canonical link: <a href="https://commits.webkit.org/290411@main">https://commits.webkit.org/290411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39503e57c6c7757e4c38e8e89751474d59911e0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40682 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26846 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49590 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7246 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39816 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96732 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17096 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78169 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77428 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19127 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21869 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10285 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22432 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20300 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->