### PR TITLE
Non-unified source build fix of February 2025 (part 7)

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -29,6 +29,7 @@
 #include "IDBIndexIdentifier.h"
 #include "IDBObjectStoreIdentifier.h"
 #include "IDBTransactionInfo.h"
+#include "IndexKey.h"
 #include <wtf/Deque.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -32,6 +32,7 @@
 #include "Document.h"
 #include "Element.h"
 #include "LegacyRenderSVGModelObject.h"
+#include "RenderBlock.h"
 #include "RenderBox.h"
 #include "RenderBoxInlines.h"
 #include "RenderInline.h"

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "InlineIteratorBox.h"
 #include "InlineIteratorLineBox.h"
 #include "RenderBoxModelObjectInlines.h"
 

--- a/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h
@@ -29,6 +29,7 @@
 
 #include "Color.h"
 #include "FELighting.h"
+#include "Filter.h"
 #include "FilterEffect.h"
 #include "FilterEffectApplier.h"
 #include "FilterImageVector.h"

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -50,6 +50,7 @@
 #include "AnchorPositionEvaluator.h"
 #include "Chrome.h"
 #include "DebugPageOverlays.h"
+#include "DocumentInlines.h"
 #include "Editor.h"
 #include "ElementRuleCollector.h"
 #include "EventHandler.h"

--- a/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h
@@ -34,6 +34,7 @@
 namespace WebKit {
 
 class WebPageProxy;
+struct FrameInfoData;
 
 class SpeechRecognitionPermissionManager : public RefCountedAndCanMakeWeakPtr<SpeechRecognitionPermissionManager> {
     WTF_MAKE_TZONE_ALLOCATED(SpeechRecognitionPermissionManager);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
@@ -33,6 +33,7 @@
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
 #include "WebSpeechRecognitionConnectionMessages.h"
+#include <WebCore/Frame.h>
 #include <WebCore/SpeechRecognitionConnectionClient.h>
 #include <WebCore/SpeechRecognitionRequestInfo.h>
 #include <WebCore/SpeechRecognitionUpdate.h>


### PR DESCRIPTION
#### 2cc84f33e955afd04f96e441e2422d28d6e25ae4
<pre>
Non-unified source build fix of February 2025 (part 7)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286904">https://bugs.webkit.org/show_bug.cgi?id=286904</a>

Unreviewed non-unified build fix.

* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebCore/animation/ViewTimeline.cpp:
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxInlines.h:
* Source/WebCore/platform/graphics/filters/software/FELightingSoftwareApplier.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
* Source/WebKit/UIProcess/SpeechRecognitionPermissionManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp:

Canonical link: <a href="https://commits.webkit.org/290391@main">https://commits.webkit.org/290391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd126bae2b84c966af19973ffcf89e22bd980feb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40657 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9800 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17691 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49566 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/35912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39790 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/36959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96707 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17071 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78086 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17327 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77404 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/21849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14115 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17082 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16823 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->