### PR TITLE
Experiment: FontCascadeCache

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -94,11 +94,14 @@ void FontCascadeCache::pruneSystemFallbackFonts()
 
 static FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
+//    if (description.familyCount() && fontSelector && fontSelector)
+//        WTF_ALWAYS_LOG("fontSelector : " << description.familyAt(0) << " " <<  fontSelector->uniqueId() << " " << fontSelector->version()) ;
+
     unsigned familyCount = description.familyCount();
     return FontCascadeCacheKey {
         FontDescriptionKey(description),
         Vector<FontFamilyName, 3>(familyCount, [&](size_t i) { return description.familyAt(i); }),
-        fontSelector ? fontSelector->uniqueId() : 0,
+        0,
         fontSelector ? fontSelector->version() : 0
     };
 }
@@ -114,15 +117,15 @@ Ref<FontCascadeFonts> FontCascadeCache::retrieveOrAddCachedFonts(const FontCasca
     newEntry = makeUnique<FontCascadeCacheEntry>(FontCascadeCacheEntry { WTFMove(key), FontCascadeFonts::create(WTFMove(fontSelector)) });
     Ref<FontCascadeFonts> fonts = newEntry->fonts.get();
 
-    static constexpr unsigned unreferencedPruneInterval = 50;
-    static constexpr int maximumEntries = 400;
-    static unsigned pruneCounter;
+    // static constexpr unsigned unreferencedPruneInterval = 50;
+    // static constexpr int maximumEntries = 400;
+    // static unsigned pruneCounter;
     // Referenced FontCascadeFonts would exist anyway so pruning them saves little memory.
-    if (!(++pruneCounter % unreferencedPruneInterval))
-        pruneUnreferencedEntries();
+    // if (!(++pruneCounter % unreferencedPruneInterval))
+    //     pruneUnreferencedEntries();
     // Prevent pathological growth.
-    if (m_entries.size() > maximumEntries)
-        m_entries.remove(m_entries.random());
+    // if (m_entries.size() > maximumEntries)
+    //     m_entries.remove(m_entries.random());
     return fonts;
 }
 

--- a/Source/WebCore/platform/graphics/WidthCache.h
+++ b/Source/WebCore/platform/graphics/WidthCache.h
@@ -114,6 +114,12 @@ public:
         : m_interval(s_maxInterval)
         , m_countdown(m_interval)
     {
+//        WTF_ALWAYS_LOG("WidthCache built: " << this);
+    }
+
+    ~WidthCache()
+    {
+//        WTF_ALWAYS_LOG("WidthCache destroyed: " << this);
     }
 
     float* add(StringView text, float entry)
@@ -226,8 +232,8 @@ private:
     using SingleCharMap = UncheckedKeyHashMap<uint32_t, float, DefaultHash<uint32_t>, HashTraits<uint32_t>, WTF::FloatWithZeroEmptyKeyHashTraits<float>>;
 
     static constexpr int s_minInterval = -3; // A cache hit pays for about 3 cache misses.
-    static constexpr int s_maxInterval = 20; // Sampling at this interval has almost no overhead.
-    static constexpr unsigned s_maxSize = 500000; // Just enough to guard against pathological growth.
+    static constexpr int s_maxInterval = 10; // Sampling at this interval has almost no overhead.
+    static constexpr unsigned s_maxSize = 500'000'000; // Just enough to guard against pathological growth.
 
     int m_interval;
     int m_countdown;


### PR DESCRIPTION
#### 787d156323b1944781a616126d374ed5ab25ffb1
<pre>
Experiment: FontCascadeCache
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::makeFontCascadeCacheKey):
(WebCore::FontCascadeCache::retrieveOrAddCachedFonts):
* Source/WebCore/platform/graphics/WidthCache.h:
(WebCore::WidthCache::WidthCache):
(WebCore::WidthCache::~WidthCache):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50bf6046cbbe58338813337e4b9ee2e45beae191

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40662 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17696 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69210 "Failure limit exceed. At least found 330 new test failures: css1/pseudo/firstletter-surrogate.html css2.1/t0805-c5518-brdr-t-01-e.html css2.1/t0805-c5519-brdr-r-00-a.html css2.1/t0805-c5520-brdr-b-01-e.html css2.1/t0805-c5521-brdr-l-00-a.html css2.1/t0805-c5521-ibrdr-l-00-a.html css2.1/t0905-c414-flt-02-c.html css2.1/t0905-c414-flt-03-c.html css2.1/t0905-c414-flt-04-c.html css2.1/t0905-c414-flt-fit-01-d-g.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26825 "Found 60 new test failures: editing/caret/emoji.html editing/deleting/delete-emoji-1.html editing/deleting/delete-emoji-2.html editing/deleting/delete-emoji-3.html editing/deleting/delete-emoji-4.html editing/deleting/delete-emoji-5.html editing/deleting/delete-emoji-6.html editing/deleting/delete-emoji-7.html editing/deleting/delete-emoji-8.html editing/deleting/delete-emoji-9.html ... (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92890 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7499 "Found 60 new test failures: compositing/contents-format/deep-color-backing-store.html compositing/tiling/tiled-reflection-inwindow.html css1/pseudo/firstletter-surrogate.html css2.1/t0805-c5518-brdr-t-01-e.html css2.1/t0805-c5519-brdr-r-00-a.html css2.1/t0805-c5520-brdr-b-01-e.html css2.1/t0805-c5521-brdr-l-00-a.html css2.1/t0805-c5521-ibrdr-l-00-a.html css2.1/t0905-c414-flt-02-c.html css2.1/t0905-c414-flt-04-c.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81555 "Found 3 new API test failures: TestWebKitAPI.CopyHTML.SanitizationPreservesCharacterSetInSelectedText, TestWebKitAPI.CopyHTML.SanitizationPreservesCharacterSet, TestWebKitAPI.TextManipulation.StartTextManipulationExtractsPrivateUseCharactersAsExcludedTokens (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49570 "Found 1 new API test failure: /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7221 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/file/send-file-form-iso-2022-jp.html imported/w3c/web-platform-tests/FileAPI/file/send-file-formdata-controls.any.html imported/w3c/web-platform-tests/accname/name/comp_tooltip.html imported/w3c/web-platform-tests/clipboard-apis/text-write-read/async-write-read.https.html imported/w3c/web-platform-tests/cookie-store/change_eventhandler_for_document_cookie.https.window.html imported/w3c/web-platform-tests/cookie-store/cookieStore_event_delete.https.window.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-CSSStyleDeclaration.html imported/w3c/web-platform-tests/css/css-contain/contain-layout-baseline-005.html imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-auto-relevancy-updates.html ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35927 "Found 60 new test failures: accessibility/details-summary-content-hidden.html accessibility/full-size-kana-untransformed.html accessibility/mac/aria-image-emits-object-replacement.html accessibility/mac/character-offset-visible-position-conversion-with-emoji.html accessibility/mac/text-marker-paragraph-nav.html compositing/animation/repaint-after-clearing-shared-backing.html css1/pseudo/firstletter-surrogate.html css2.1/20110323/c543-txt-decor-000.html css2.1/t0805-c5518-brdr-t-01-e.html css2.1/t090501-c414-flt-ln-01-d-g.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39796 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77580 "2 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36981 "Found 60 new test failures: accessibility/full-size-kana-untransformed.html accessibility/mac/aria-image-emits-object-replacement.html accessibility/mac/aria-menuitem-checked-value.html accessibility/mac/text-marker-paragraph-nav.html css1/pseudo/firstletter-surrogate.html css2.1/20110323/word-spacing-remove-space-003.htm css2.1/t0805-c5518-brdr-t-01-e.html css2.1/t090501-c414-flt-ln-01-d-g.html css3/bdi-element.html css3/flexbox/inline-flex-crash.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96712 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17076 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12523 "Exiting early after 60 failures. 16029 tests run. 60 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78091 "Failure limit exceed. At least found 288 new test failures: css1/pseudo/firstletter-surrogate.html css2.1/t0805-c5518-brdr-t-01-e.html css2.1/t0805-c5519-brdr-r-00-a.html css2.1/t0805-c5520-brdr-b-01-e.html css2.1/t0805-c5521-brdr-l-00-a.html css2.1/t0805-c5521-ibrdr-l-00-a.html css2.1/t0905-c414-flt-02-c.html css2.1/t0905-c414-flt-03-c.html css2.1/t0905-c414-flt-04-c.html css2.1/t0905-c414-flt-fit-01-d-g.html ... (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17332 "Failed to checkout and rebase branch from PR 40611") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77375 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77409 "Found 1 new API test failure: /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20443 "Found 60 new test failures: accessibility/full-size-kana-untransformed.html accessibility/mac/alt-for-css-content.html accessibility/mac/aria-image-emits-object-replacement.html accessibility/mac/aria-menuitem-checked-value.html css1/pseudo/firstletter-surrogate.html css2.1/20110323/c543-txt-decor-000.html css2.1/t0805-c5518-brdr-t-01-e.html css2.1/t090501-c414-flt-ln-01-d-g.html css3/bdi-element.html css3/flexbox/inline-flex-crash.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10256 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22408 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20280 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->