### PR TITLE
[Screen Time Refactoring] Do not show shield and perform donations for offscreen web views

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -452,6 +452,7 @@ struct PerWebProcessState {
 #if ENABLE(SCREEN_TIME)
 - (void)_installScreenTimeWebpageController;
 - (void)_uninstallScreenTimeWebpageController;
+- (void)_updateScreenTimeShieldVisibilityForWindow;
 #endif
 
 #if ENABLE(WRITING_TOOLS)
@@ -518,6 +519,11 @@ struct PerWebProcessState {
 - (RefPtr<WebKit::WebPageProxy>)_protectedPage;
 #if ENABLE(SCREEN_TIME)
 - (STWebpageController *)_screenTimeWebpageController;
+#if PLATFORM(MAC)
+- (NSVisualEffectView *)_screenTimeBlurredSnapshot;
+#else
+- (UIVisualEffectView *)_screenTimeBlurredSnapshot;
+#endif
 #endif
 
 @property (nonatomic, setter=_setHasActiveNowPlayingSession:) BOOL _hasActiveNowPlayingSession;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -141,6 +141,9 @@ public:
     void updateScreenTimeWebpageControllerURL(WKWebView *);
 #endif
 
+    void viewIsBecomingVisible() override;
+    void viewIsBecomingInvisible() override;
+
 #if ENABLE(GAMEPAD)
     void setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed) final;
 #if PLATFORM(VISION)
@@ -160,6 +163,7 @@ private:
 #if ENABLE(FULLSCREEN_API)
     void setFullScreenClientForTesting(std::unique_ptr<WebFullScreenManagerProxyClient>&&) final;
 #endif
+
 protected:
     RetainPtr<WKWebView> webView() const { return m_webView.get(); }
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -372,6 +372,20 @@ void PageClientImplCocoa::setURLIsPlayingVideoForScreenTime(bool value)
 
 #endif
 
+void PageClientImplCocoa::viewIsBecomingVisible()
+{
+#if ENABLE(SCREEN_TIME)
+    [m_webView _updateScreenTimeShieldVisibilityForWindow];
+#endif
+}
+
+void PageClientImplCocoa::viewIsBecomingInvisible()
+{
+#if ENABLE(SCREEN_TIME)
+    [m_webView _updateScreenTimeShieldVisibilityForWindow];
+#endif
+}
+
 #if ENABLE(GAMEPAD)
 void PageClientImplCocoa::setGamepadsRecentlyAccessed(GamepadsRecentlyAccessed gamepadsRecentlyAccessed)
 {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -263,6 +263,9 @@ public:
     // Called when the activity state of the page transitions from non-visible to visible.
     virtual void viewIsBecomingVisible() { }
 
+    // Called when the activity state of the page transitions from visible to non-visible.
+    virtual void viewIsBecomingInvisible() { }
+
 #if PLATFORM(COCOA)
     virtual bool canTakeForegroundAssertions() = 0;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7468,6 +7468,9 @@ void WebPageProxy::viewIsBecomingInvisible()
     protectedLegacyMainFrameProcess()->pageIsBecomingInvisible(m_webPageID);
     if (auto* drawingAreaProxy = drawingArea())
         drawingAreaProxy->viewIsBecomingInvisible();
+
+    RefPtr protectedPageClient { pageClient() };
+    protectedPageClient->viewIsBecomingInvisible();
 }
 
 void WebPageProxy::processIsNoLongerAssociatedWithPage(WebProcessProxy& process)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -167,6 +167,8 @@ bool PageClientImpl::isViewVisible()
 
 void PageClientImpl::viewIsBecomingVisible()
 {
+    PageClientImplCocoa::viewIsBecomingVisible();
+
 #if ENABLE(PAGE_LOAD_OBSERVER)
     if (RetainPtr webView = this->webView())
         [webView _updatePageLoadObserverState];


### PR DESCRIPTION
#### 861cf0f5c389289bcc249a923b2d0a476f8f42b3
<pre>
[Screen Time Refactoring] Do not show shield and perform donations for offscreen web views
<a href="https://bugs.webkit.org/show_bug.cgi?id=287445">https://bugs.webkit.org/show_bug.cgi?id=287445</a>
<a href="https://rdar.apple.com/144572971">rdar://144572971</a>

Reviewed by Aditya Keerthi.

Added function and logic _showScreenTimeShieldForWindow which
checks for two cases:
- if we are showing the system Screen Time blocking view,
    hide or show the view depending on if the webview is on/offscreen
- if we are showing a blurred blocking view instead of the system
    blocking view _and_ the view is currently not nil,
    hide or show the view depending on if the webview is on/offscreen

Note that in _showScreenTimeShieldForWindow, we check if we
_showsSystemScreenTimeBlockingView in both cases instead of assuming
a standard if-else case because the blurred blocking view is added and
removed _on demand_ while the system Screen Time blocking view is only
added once and removed once.

This is because the system Screen Time blocking view will
be painted/showed or not depending on if the URLIsBLocked.

Created three new API tests:
- offscreenSystemScreenTimeBlockingView
- offscreenBlurredScreenTimeBlockingView
- doNotDonateURLsInOffscreen, which tests if we suppress usage recording
    when the webview is on/offscreen

To not track URLs while offscreen, we need to set suppress usage recording
if either in private browsing or not in window
(which includes being occluded on macOS but not on iOS).

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _uninstallScreenTimeWebpageController]):
(-[WKWebView _updateScreenTimeShieldVisibilityForWindow]):
(-[WKWebView _screenTimeBlurredSnapshot]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::viewIsBecomingVisible):
(WebKit::PageClientImplCocoa::viewIsBecomingInvisible):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::viewIsBecomingInvisible):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::viewIsBecomingInvisible):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::viewIsBecomingVisible):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(TEST(ScreenTime, OffscreenSystemScreenTimeBlockingView)):
(TEST(ScreenTime, OffscreenBlurredScreenTimeBlockingView)):
(TEST(ScreenTime, DoNotDonateURLsInOffscreenWebView)):

Canonical link: <a href="https://commits.webkit.org/290486@main">https://commits.webkit.org/290486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc0cf454e1daacc6e95540035ba141af502ebe05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69313 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26917 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93045 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7619 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7347 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36037 "Found 8 new test failures: fast/html/process-end-tag-for-inbody-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39951 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96870 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78314 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77520 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20557 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10426 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14180 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22567 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16983 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->