### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/view-timeline-animation.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Default view-timeline assert_equals: expected "-1" but got "100"
-FAIL Horizontal view-timeline assert_equals: expected "-1" but got "100"
-FAIL Multiple view-timelines on the same element assert_equals: expected "-1" but got "100"
+PASS Default view-timeline
+PASS Horizontal view-timeline
+PASS Multiple view-timelines on the same element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation.html
@@ -79,8 +79,12 @@
     assert_equals(getComputedStyle(target).zIndex, '50');
     await scrollTop(scroller, 200); // 100% (exit 100%)
     assert_equals(getComputedStyle(target).zIndex, '100');
+    await scrollTop(scroller, 201); // now over the 100% scroll offset, but "fill: forwards" lets the animation apply.
+    assert_equals(getComputedStyle(target).zIndex, '100');
     document.getAnimations()[0].effect.updateTiming( { fill: 'none' });
     assert_equals(getComputedStyle(target).zIndex, '-1');
+    await scrollTop(scroller, 200); // now back to the 100% scroll offset.
+    assert_equals(getComputedStyle(target).zIndex, '100');
   }, 'Default view-timeline');
 </script>
 
@@ -114,8 +118,12 @@
     assert_equals(getComputedStyle(target).zIndex, '50');
     await scrollLeft(scroller, 200); // 100% (exit 100%)
     assert_equals(getComputedStyle(target).zIndex, '100');
+    await scrollLeft(scroller, 201); // now over the 100% scroll offset, but "fill: forwards" lets the animation apply.
+    assert_equals(getComputedStyle(target).zIndex, '100');
     document.getAnimations()[0].effect.updateTiming( { fill: 'none' });
     assert_equals(getComputedStyle(target).zIndex, '-1');
+    await scrollLeft(scroller, 200); // now back to the 100% scroll offset.
+    assert_equals(getComputedStyle(target).zIndex, '100');
   }, 'Horizontal view-timeline');
 </script>
 
@@ -197,6 +205,9 @@
     await scrollTop(scroller, 200); // 100% (exit 100%)
     assert_equals(getComputedStyle(target_v).zIndex, '100');
     assert_equals(getComputedStyle(target_h).zIndex, '-1');
+    await scrollTop(scroller, 201); // now over the 100% scroll offset, but "fill: forwards" lets the animation apply.
+    assert_equals(getComputedStyle(target_v).zIndex, '100');
+    assert_equals(getComputedStyle(target_h).zIndex, '-1');
     document.getElementById('target_v').getAnimations()[0].
         effect.updateTiming({ fill: 'none' });
     assert_equals(getComputedStyle(target_v).zIndex, '-1');
@@ -215,9 +226,17 @@
     await scrollLeft(scroller, 200); // 100% (exit 100%)
     assert_equals(getComputedStyle(target_v).zIndex, '-1');
     assert_equals(getComputedStyle(target_h).zIndex, '100');
+    await scrollLeft(scroller, 201); // now over the 100% scroll offset, but "fill: forwards" lets the animation apply.
+    assert_equals(getComputedStyle(target_v).zIndex, '-1');
+    assert_equals(getComputedStyle(target_h).zIndex, '100');
     document.getElementById('target_h').getAnimations()[0].
         effect.updateTiming({ fill: 'none' });
     assert_equals(getComputedStyle(target_v).zIndex, '-1');
     assert_equals(getComputedStyle(target_h).zIndex, '-1');
+
+    await scrollTop(scroller, 200);  // now back to the 100% scroll offset.
+    await scrollLeft(scroller, 200); // now back to the 100% scroll offset.
+    assert_equals(getComputedStyle(target_v).zIndex, '100');
+    assert_equals(getComputedStyle(target_h).zIndex, '100');
   }, 'Multiple view-timelines on the same element');
 </script>


### PR DESCRIPTION
#### 135ae254ab420b6e4d7db6f6303020ea1a70cdb1
<pre>
[scroll-animations] WPT test `scroll-animations/css/view-timeline-animation.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=287694">https://bugs.webkit.org/show_bug.cgi?id=287694</a>

Reviewed by Anne van Kesteren.

We were failing this test because it assumed that when a view timeline reaches a scroll position
that matches the end of its range (ie. the value returned by `endOffset`) it would yield a null
progress for attached animations if the animation was not forward-filling. However, this is
incorrect: scroll-driven animations have a progress of 1 when exactly at the end of their timeline
range (see <a href="https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary).">https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary).</a>

We update the test to explicitly test the effect of `fill: forwards` by scrolling one pixel past
the end of the view timeline range, and then back to it, testing the behavior of `fill: none` along
the way.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-animation.html:

Canonical link: <a href="https://commits.webkit.org/290400@main">https://commits.webkit.org/290400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d16cf0740aa5b438144c95e3838e5f3003995239

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69217 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26833 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81549 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49577 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7230 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96722 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17086 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78097 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77415 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21859 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20437 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10267 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/14121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17097 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20290 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18621 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->