### PR TITLE
[CoordinatedGraphics] Textures for imported DMABufs should not be acquired from the pool

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -99,6 +99,25 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
     glBindTexture(GL_TEXTURE_2D, boundTexture);
 }
 
+#if USE(GBM)
+BitmapTexture::BitmapTexture(EGLImage image, OptionSet<Flags> flags)
+    : m_flags(flags)
+{
+    GLint boundTexture = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
+
+    glGenTextures(1, &m_id);
+    glBindTexture(GL_TEXTURE_2D, m_id);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+
+    glBindTexture(GL_TEXTURE_2D, boundTexture);
+}
+#endif
+
 void BitmapTexture::swapTexture(BitmapTexture& other)
 {
     RELEASE_ASSERT(m_size == other.m_size);
@@ -143,8 +162,11 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 
     if (m_size != size) {
         m_size = size;
+        GLint boundTexture = 0;
+        glGetIntegerv(GL_TEXTURE_BINDING_2D, &boundTexture);
         glBindTexture(GL_TEXTURE_2D, m_id);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_size.width(), m_size.height(), 0, textureFormat, s_pixelDataType, nullptr);
+        glBindTexture(GL_TEXTURE_2D, boundTexture);
     }
 }
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -37,6 +37,8 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
+typedef void *EGLImage;
+
 namespace WebCore {
 
 class GraphicsLayer;
@@ -55,6 +57,13 @@ public:
     {
         return adoptRef(*new BitmapTexture(size, flags));
     }
+
+#if USE(GBM)
+    static Ref<BitmapTexture> create(EGLImage image, OptionSet<Flags> flags = { })
+    {
+        return adoptRef(*new BitmapTexture(image, flags));
+    }
+#endif
 
     WEBCORE_EXPORT ~BitmapTexture();
 
@@ -89,6 +98,9 @@ public:
 
 private:
     BitmapTexture(const IntSize&, OptionSet<Flags>);
+#if USE(GBM)
+    BitmapTexture(EGLImage, OptionSet<Flags>);
+#endif
 
     void clearIfNeeded();
     void createFboIfNeeded();

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -31,6 +31,8 @@
 #include "BitmapTexture.h"
 #include <wtf/RunLoop.h>
 
+typedef void *EGLImage;
+
 namespace WebCore {
 class BitmapTexturePool;
 }
@@ -51,6 +53,9 @@ public:
     BitmapTexturePool();
 
     Ref<BitmapTexture> acquireTexture(const IntSize&, OptionSet<BitmapTexture::Flags>);
+#if USE(GBM)
+    Ref<BitmapTexture> createTextureForImage(EGLImage, OptionSet<BitmapTexture::Flags>);
+#endif
     void releaseUnusedTexturesTimerFired();
 
 private:
@@ -71,6 +76,9 @@ private:
     void exitLimitExceededModeIfNeeded();
 
     Vector<Entry> m_textures;
+#if USE(GBM)
+    Vector<Ref<BitmapTexture>> m_imageTextures;
+#endif
     RunLoop::Timer m_releaseUnusedTexturesTimer;
     uint64_t m_poolSize { 0 };
     bool m_onLimitExceededMode { false };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -231,6 +231,13 @@ Ref<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size, Op
     return m_texturePool.acquireTexture(size, flags);
 }
 
+#if USE(GBM)
+Ref<BitmapTexture> TextureMapper::createTextureForImage(EGLImage image, OptionSet<BitmapTexture::Flags> flags)
+{
+    return m_texturePool.createTextureForImage(image, flags);
+}
+#endif
+
 #if USE(GRAPHICS_LAYER_WC)
 void TextureMapper::releaseUnusedTexturesNow()
 {

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -38,6 +38,8 @@
 // TextureMapper is a mechanism that enables hardware acceleration of CSS animations (accelerated compositing) without
 // a need for a platform specific scene-graph library like CoreAnimation.
 
+typedef void *EGLImage;
+
 namespace WebCore {
 
 class ClipPath;
@@ -95,6 +97,9 @@ public:
     RefPtr<BitmapTexture> applyFilters(RefPtr<BitmapTexture>&, const FilterOperations&, bool defersLastPass);
 
     WEBCORE_EXPORT Ref<BitmapTexture> acquireTextureFromPool(const IntSize&, OptionSet<BitmapTexture::Flags>);
+#if USE(GBM)
+    WEBCORE_EXPORT Ref<BitmapTexture> createTextureForImage(EGLImage, OptionSet<BitmapTexture::Flags>);
+#endif
 
 #if USE(GRAPHICS_LAYER_WC)
     WEBCORE_EXPORT void releaseUnusedTexturesNow();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -109,9 +109,7 @@ static RefPtr<BitmapTexture> importToTexture(const IntSize& size, const IntSize&
     if (!image)
         return nullptr;
 
-    auto texture = textureMapper.acquireTextureFromPool(size, textureFlags);
-    glBindTexture(GL_TEXTURE_2D, texture->id());
-    glEGLImageTargetTexture2DOES(GL_TEXTURE_2D, image);
+    auto texture = textureMapper.createTextureForImage(image, textureFlags);
     display.destroyEGLImage(image);
     return texture;
 }


### PR DESCRIPTION
#### 91fc1c8069203ee4a74fffafba8963b04f7131c7
<pre>
[CoordinatedGraphics] Textures for imported DMABufs should not be acquired from the pool
<a href="https://bugs.webkit.org/show_bug.cgi?id=287695">https://bugs.webkit.org/show_bug.cgi?id=287695</a>

Reviewed by Nikolas Zimmermann and Miguel Gomez.

We are allocating memory when the buffer is created that we don&apos;t need,
since the texture will be attached to a EGLImage. And those textures
can&apos;t be reused for other things either because allocated memory is
freed. For imported DMABufs we should always create a new texture
setting the image as target instead of allocating memory.

* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::createTextureForImage):
(WebCore::BitmapTexturePool::releaseUnusedTexturesTimerFired):
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::createTextureForImage):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::importToTexture):

Canonical link: <a href="https://commits.webkit.org/290475@main">https://commits.webkit.org/290475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6fe56c65d3d3c5d781cff74fa744774bd3ca661

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45086 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40945 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69419 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27021 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93170 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7727 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7451 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36168 "Found 60 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html fast/scrolling/latching/latched-scroll-into-nonfast-region.html fast/workers/worker-page-cache.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40076 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17357 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12757 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78417 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77622 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20674 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10612 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14175 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22693 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17108 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20560 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18892 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->