### PR TITLE
[GStreamer][MSE] Can GStreamer other handle state changes while an async is ongoing?

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -448,11 +448,6 @@ void MediaPlayerPrivateGStreamer::play()
         return;
     }
 
-    if (isPipelineWaitingPreroll()) {
-        GST_DEBUG_OBJECT(pipeline(), "pipeline is waiting preroll (after seek or flush), let's delay moving the pipeline to playing right now");
-        return;
-    }
-
     if (changePipelineState(GST_STATE_PLAYING) == ChangePipelineStateResult::Ok) {
         m_isEndReached = false;
         m_isDelayingLoad = false;
@@ -1045,10 +1040,6 @@ MediaPlayerPrivateGStreamer::ChangePipelineStateResult MediaPlayerPrivateGStream
 
     GstState currentState, pending;
     GstStateChangeReturn change = gst_element_get_state(m_pipeline.get(), &currentState, &pending, 0);
-    if (isPipelineWaitingPreroll(currentState, pending, change)) {
-        GST_DEBUG_OBJECT(pipeline(), "rejected state change during preroll");
-        return ChangePipelineStateResult::Rejected;
-    }
 
     GST_DEBUG_OBJECT(pipeline(), "Changing state change to %s from %s with %s pending", gst_element_state_get_name(newState),
         gst_element_state_get_name(currentState), gst_element_state_get_name(pending));

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -416,13 +416,11 @@ size_t MediaPlayerPrivateGStreamerMSE::extraMemoryCost() const
 
 void MediaPlayerPrivateGStreamerMSE::updateStates()
 {
-    bool isWaitingPreroll = isPipelineWaitingPreroll();
     bool shouldUpdatePlaybackState = false;
     bool shouldBePlaying = (!m_isPaused && !isPausedByViewport() && readyState() >= MediaPlayer::ReadyState::HaveFutureData && m_playbackRatePausedState != PlaybackRatePausedState::RatePaused)
         || m_playbackRatePausedState == PlaybackRatePausedState::ShouldMoveToPlaying;
-    GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s, is seeking %s", boolForPrinting(shouldBePlaying),
-        boolForPrinting(m_isPipelinePlaying), boolForPrinting(isWaitingPreroll));
-    if (!isWaitingPreroll && shouldBePlaying && !m_isPipelinePlaying) {
+    GST_DEBUG_OBJECT(pipeline(), "shouldBePlaying = %s, m_isPipelinePlaying = %s", boolForPrinting(shouldBePlaying), boolForPrinting(m_isPipelinePlaying));
+    if (shouldBePlaying && !m_isPipelinePlaying) {
         auto result = changePipelineState(GST_STATE_PLAYING);
         if (result == ChangePipelineStateResult::Failed)
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PLAYING failed");
@@ -430,7 +428,7 @@ void MediaPlayerPrivateGStreamerMSE::updateStates()
             m_playbackRatePausedState = PlaybackRatePausedState::Playing;
             shouldUpdatePlaybackState = true;
         }
-    } else if (!isWaitingPreroll && !shouldBePlaying && m_isPipelinePlaying) {
+    } else if (!shouldBePlaying && m_isPipelinePlaying) {
         auto result = changePipelineState(GST_STATE_PAUSED);
         if (result == ChangePipelineStateResult::Failed)
             GST_ERROR_OBJECT(pipeline(), "Setting the pipeline to PAUSED failed");


### PR DESCRIPTION
#### 4a987ca29dd4eadba29d433ecb2a943c5989e4ed
<pre>
[GStreamer][MSE] Can GStreamer other handle state changes while an async is ongoing?
<a href="https://bugs.webkit.org/show_bug.cgi?id=259775">https://bugs.webkit.org/show_bug.cgi?id=259775</a>

Reviewed by NOBODY (OOPS!).

Yes, it can. Checks for ongoing state changes during other state changes and seeks were removed.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::play):
(WebCore::MediaPlayerPrivateGStreamer::changePipelineState):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::updateStates):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a987ca29dd4eadba29d433ecb2a943c5989e4ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17718 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69229 "Found 1 new test failure: media/video-restricted-invisible-autoplay-not-allowed-source.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26844 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7518 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49585 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7243 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35938 "Found 6 new test failures: fast/html/process-end-tag-for-inbody-crash.html fullscreen/empty-anonymous-block-continuation-crash.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36984 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96731 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17095 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12551 "Found 1 new test failure: imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.sharedworker.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78175 "layout-tests (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/89493 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77432 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20452 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10284 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17106 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22431 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->