### PR TITLE
[WPE][GTK] `invalid use of non-static data member` error with GCC 12

### DIFF
--- a/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h
+++ b/Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h
@@ -42,7 +42,7 @@ template<typename Keyword> concept PrimitiveKeyword
 
 // Concept for use in generic contexts to filter on keywords that are valid for the provided `Keywords` list.
 template<typename Keyword, typename KeywordsList> concept ValidKeywordForList
-    = PrimitiveKeyword<Keyword> && (KeywordsList::isValidKeyword(Keyword()));
+    = KeywordsList::isValidKeyword(Keyword()) && PrimitiveKeyword<Keyword>;
 
 // MARK: - Primitive Keywords List
 


### PR DESCRIPTION
#### 691f82307e9a569363f7e3bdacba9ab82124f4e2
<pre>
[WPE][GTK] `invalid use of non-static data member` error with GCC 12
<a href="https://bugs.webkit.org/show_bug.cgi?id=287701">https://bugs.webkit.org/show_bug.cgi?id=287701</a>

Reviewed by Sam Weinig.

It seems to be a bug in GCC 12.

When `PrimitiveData(Raw raw)` is called, the compiler chooses
`PrimitiveDataIndex(ValidKeywordForList&lt;Keywords&gt; auto keyword)` index
constructor and evaluates `ValidKeywordForList` concept, which in turn
evaluates `PrimitiveKeyword` with `PrimitiveNumericRaw` as a
`Keyword` typename. The compiler then complains that its `value`
member is non-static.

Luckily, simply swapping `PrimitiveKeyword&lt;Keyword&gt;` and
`KeywordsList::isValidKeyword(Keyword())` makes the compiler happy.

I think, it works because `KeywordsList::isValidKeyword(Keyword())`
check fails and `PrimitiveKeyword&lt;Keyword&gt;` is not evaluated.

* Source/WebCore/css/values/primitives/CSSPrimitiveKeywordList.h:

Canonical link: <a href="https://commits.webkit.org/290410@main">https://commits.webkit.org/290410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2cf02cabd519fac02f31ebc2bd1a43e7c06394b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89911 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91963 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9827 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/17766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69233 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26848 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49589 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7247 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35943 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17098 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12552 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78204 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17358 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77424 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19125 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21871 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20302 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->