### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt
@@ -6,8 +6,8 @@ PASS animation-iteration-count: 0
 PASS animation-iteration-count: infinite
 PASS animation-direction: normal
 PASS animation-direction: reverse
-FAIL animation-direction: alternate assert_equals: expected "80px" but got "79.999992px"
-FAIL animation-direction: alternate-reverse assert_equals: expected "20px" but got "20.000008px"
+PASS animation-direction: alternate
+PASS animation-direction: alternate-reverse
 PASS animation-delay with a positive value
 PASS animation-delay with a negative value
 PASS animation-fill-mode

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative.html
@@ -30,6 +30,10 @@
 
 setup(assert_implements_animation_timeline);
 
+const assert_translate_equals = (target, expected, description) => {
+    assert_approx_equals(parseFloat(getComputedStyle(target).translate), parseFloat(expected), 0.0001, description);
+};
+
 const createTargetAndScroller = function(t) {
   let container = document.createElement('div');
   container.id = 'container';
@@ -77,7 +81,7 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25); // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '25px');
+  assert_translate_equals(target, '25px');
 }, 'animation-duration');
 
 promise_test(async t => {
@@ -86,7 +90,7 @@ promise_test(async t => {
   target.style.animationTimeline = 'scroll(nearest)';
 
   await scrollTop(scroller, 25); // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '100px');
+  assert_translate_equals(target, '100px');
 }, 'animation-duration: 0s');
 
 
@@ -102,17 +106,17 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25); // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '25px');
+  assert_translate_equals(target, '25px');
 
   // Let animation become 50% in the 1st iteration.
   target.style.animationIterationCount = '2';
   await waitForCSSScrollTimelineStyle();
-  assert_equals(getComputedStyle(target).translate, '50px');
+  assert_translate_equals(target, '50px');
 
   // Let animation become 0% in the 2nd iteration.
   target.style.animationIterationCount = '4';
   await waitForCSSScrollTimelineStyle();
-  assert_equals(getComputedStyle(target).translate, '0px');
+  assert_translate_equals(target, '0px');
 }, 'animation-iteration-count');
 
 promise_test(async t => {
@@ -124,7 +128,7 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25); // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '0px');
+  assert_translate_equals(target, '0px');
 }, 'animation-iteration-count: 0');
 
 promise_test(async t => {
@@ -136,7 +140,7 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25); // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '100px');
+  assert_translate_equals(target, '100px');
 }, 'animation-iteration-count: infinite');
 
 
@@ -152,7 +156,7 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25) // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '25px');
+  assert_translate_equals(target, '25px');
 }, 'animation-direction: normal');
 
 promise_test(async t => {
@@ -164,7 +168,7 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25); // 25% in the reversing direction.
-  assert_equals(getComputedStyle(target).translate, '75px');
+  assert_translate_equals(target, '75px');
 }, 'animation-direction: reverse');
 
 promise_test(async t => {
@@ -177,10 +181,10 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 10); // 20% in the 1st iteration.
-  assert_equals(getComputedStyle(target).translate, '20px');
+  assert_translate_equals(target, '20px');
 
   await scrollTop(scroller, 60); // 20% in the 2nd iteration (reversing direction).
-  assert_equals(getComputedStyle(target).translate, '80px');
+  assert_translate_equals(target, '80px');
 }, 'animation-direction: alternate');
 
 promise_test(async t => {
@@ -193,10 +197,10 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 10); // 20% in the 1st iteration (reversing direction).
-  assert_equals(getComputedStyle(target).translate, '80px');
+  assert_translate_equals(target, '80px');
 
   await scrollTop(scroller, 60); // 20% in the 2nd iteration.
-  assert_equals(getComputedStyle(target).translate, '20px');
+  assert_translate_equals(target, '20px');
 }, 'animation-direction: alternate-reverse');
 
 
@@ -212,7 +216,7 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25); // [0, 100].
-  assert_equals(getComputedStyle(target).translate, '25px');
+  assert_translate_equals(target, '25px');
 
   //    (start delay: 10s)    (duration: 10s)
   //         before              active
@@ -223,13 +227,13 @@ promise_test(async t => {
   // Let animation be in before phase.
   target.style.animationDelay = '10s';
   target.style.animationDelayStart = '10s'; // crbug.com/1375994
-  assert_equals(getComputedStyle(target).translate, 'none');
+  assert_translate_equals(target, 'none');
 
   await scrollTop(scroller, 50); // The animation enters active phase.
-  assert_equals(getComputedStyle(target).translate, '0px');
+  assert_translate_equals(target, '0px');
 
   await scrollTop(scroller, 75); // The ieration progress is 50%.
-  assert_equals(getComputedStyle(target).translate, '50px');
+  assert_translate_equals(target, '50px');
 }, 'animation-delay with a positive value');
 
 promise_test(async t => {
@@ -248,7 +252,7 @@ promise_test(async t => {
   target.style.animationDelay = '-5s';
   target.style.animationDelayStart = '-5s'; // crbug.com/1375994
   await waitForCSSScrollTimelineStyle();
-  assert_equals(getComputedStyle(target).translate, '60px');
+  assert_translate_equals(target, '60px');
 }, 'animation-delay with a negative value');
 
 
@@ -266,11 +270,11 @@ promise_test(async t => {
   });
 
   await scrollTop(scroller, 25);
-  assert_equals(getComputedStyle(target).translate, 'none');
+  assert_translate_equals(target, 'none');
 
   target.style.animationFillMode = 'backwards';
   await waitForCSSScrollTimelineStyle();
-  assert_equals(getComputedStyle(target).translate, '0px');
+  assert_translate_equals(target, '0px');
 }, 'animation-fill-mode');
 
 </script>


### PR DESCRIPTION
#### 3b6d2c3e475ae7701dbe9ee5daf1ead74869fffe
<pre>
[scroll-animations] WPT test `scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=287704">https://bugs.webkit.org/show_bug.cgi?id=287704</a>

Reviewed by Anne van Kesteren.

Use `assert_approx_equals()` instead of `assert_equals()` to add a 0.0001px tolerance.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/progress-based-animation-animation-longhand-properties.tentative.html:

Canonical link: <a href="https://commits.webkit.org/290422@main">https://commits.webkit.org/290422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af78a720ec76f25524f47577183b88991c6f1799

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44817 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40692 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69236 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26856 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81575 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49592 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7258 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35950 "Found 2 new test failures: fullscreen/full-screen-request-removed.html http/tests/security/file-system-access-via-dataTransfer.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39826 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36996 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96742 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17107 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78170 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77429 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21879 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10301 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14143 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17117 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->