### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/animation-timeline-view-functional-notation.tentative.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt
@@ -15,6 +15,6 @@ PASS animation-timeline: view(inline)
 PASS animation-timeline: view(x)
 PASS animation-timeline: view(y)
 PASS animation-timeline: view(x 50px)
-FAIL animation-timeline: view(), view(inline) assert_equals: At exit 0% inline expected "10px" but got "10.000001px"
+PASS animation-timeline: view(), view(inline)
 PASS animation-timeline: view(inline) changes to view(inline 50px)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative.html
@@ -462,12 +462,16 @@ promise_test(async t => {
     div.style.animationTimeline = "view(), view(inline)";
   });
 
+  const assert_font_size_equals = (expected, description) => {
+      assert_approx_equals(parseFloat(getComputedStyle(div).fontSize), parseFloat(expected), 0.0001, 'At exit 0% inline');
+  };
+
   await scrollLeft(container, 0);
-  assert_equals(getComputedStyle(div).fontSize, '10px', 'At exit 0% inline');
+  assert_font_size_equals('10px', 'At exit 0% inline');
   await scrollLeft(container, 50);
-  assert_equals(getComputedStyle(div).fontSize, '15px', 'At exit 50% inline');
+  assert_font_size_equals('15px', 'At exit 50% inline');
   await scrollLeft(container, 100);
-  assert_equals(getComputedStyle(div).fontSize, '20px', 'At exit 100% inline');
+  assert_font_size_equals('20px', 'At exit 100% inline');
 
   await scrollLeft(container, 0);
 
@@ -480,7 +484,7 @@ promise_test(async t => {
 
   await scrollLeft(container, 50);
   await scrollTop(container, 50);
-  assert_equals(getComputedStyle(div).fontSize, '15px', 'At exit 50% inline');
+  assert_font_size_equals('15px', 'At exit 50% inline');
   assert_equals(getComputedStyle(div).opacity, '0.5', 'At exit 50% block');
 }, 'animation-timeline: view(), view(inline)');
 


### PR DESCRIPTION
#### 03f96fe90ee3a8e5476d5e3aa7c4b06c2411015f
<pre>
[scroll-animations] WPT test `scroll-animations/css/animation-timeline-view-functional-notation.tentative.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=287705">https://bugs.webkit.org/show_bug.cgi?id=287705</a>

Reviewed by Anne van Kesteren.

Use `assert_approx_equals()` instead of `assert_equals()` to add a 0.0001px tolerance.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/animation-timeline-view-functional-notation.tentative.html:

Canonical link: <a href="https://commits.webkit.org/290423@main">https://commits.webkit.org/290423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e97ae7d5f3bdc5e3363299741c24eb7bc3d2ce4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44819 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40694 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69237 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92922 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7536 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7261 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35948 "Found 6 new test failures: fast/html/process-end-tag-for-inbody-crash.html fullscreen/empty-anonymous-block-continuation-crash.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39828 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/36994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96744 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17109 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12560 "Found 1 new test failure: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78171 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77430 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10303 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20312 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->