### PR TITLE
Update yocto compilation documentation with information about SDK compilation and rpi3

### DIFF
--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -143,6 +143,9 @@ This is an example on how to build and run WPE for development on the RPi:
 
 1. Build the image that will be flashed on the board:
 
+# NOTE: If you are using the **WebKit Container SDK** remember to unset the *LD_LIBRARY_PATH*
+# before building, if you don't it can cause problems with the yocto setup.
+
 ```
 user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bits-mesa --build-image
 ```
@@ -197,6 +200,9 @@ user@workstation $ sudo resize2fs /dev/mmcblk0p2
 user@workstation $ ssh root@192.168.X.Y
 root@raspberrypi3:~# git clone https://github.com/WebKit/WebKit.git --depth 1
 ````
+
+# NOTE: In the raspberrypi3 the clone can be too much, in that situation you need
+# to clone in the machine building the image and copy to the device after that.
 
 ### Build WPE for the target board
 


### PR DESCRIPTION
#### f4ad1dee144d1e98232745bcbb164afed0cddbef
<pre>
Update yocto compilation documentation with information about SDK compilation and rpi3
<a href="https://bugs.webkit.org/show_bug.cgi?id=287706">https://bugs.webkit.org/show_bug.cgi?id=287706</a>

Reviewed by Carlos Alberto Lopez Perez.

In the SDK we need to unset LD_LIBRARY_PATH and we can not clone WebKit in the rpi3 directly.
Added comments to make sure we have it properly documented.

* Tools/yocto/README.md:

Canonical link: <a href="https://commits.webkit.org/290426@main">https://commits.webkit.org/290426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5676739a443f6d9b7f4e0ee3ab5fb3a9b2acb14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/91975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49596 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7257 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/35958 "Found 3 new test failures: imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html media/modern-media-controls/invalid-placard/invalid-placard.html svg/as-image/img-preserveAspectRatio-support-2.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39830 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96746 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12565 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78176 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77433 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10305 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14147 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17121 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16862 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->