### PR TITLE
AX: Convert between DOM offsets and rendered-text offsets in ENABLE(AX_THREAD_TEXT_APIS) to avoid crashes and incorrect behavior

### DIFF
--- a/LayoutTests/accessibility/select-whitespace-collapsed-text-expected.txt
+++ b/LayoutTests/accessibility/select-whitespace-collapsed-text-expected.txt
@@ -1,0 +1,10 @@
+This test ensures setting text selection works.
+
+PASS: editable.selectedText === 'Charlie'
+PASS: editable.selectedText === 'Charlie Delta'
+PASS: editable.selectedText === 'Charlie Delta Ninja Kel'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Charlie Delta Ninja Kelly

--- a/LayoutTests/accessibility/select-whitespace-collapsed-text.html
+++ b/LayoutTests/accessibility/select-whitespace-collapsed-text.html
@@ -1,0 +1,51 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="text" contenteditable="true">  Charlie      Delta  Ninja  
+    Kelly</div>
+    
+<script>
+var output = "This test ensures setting text selection works.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    let range = document.createRange();
+    range.setStart(document.getElementById("text").firstChild, 2);
+    range.setEnd(document.getElementById("text").firstChild, 9);
+    window.getSelection().addRange(range);
+
+    var editable = accessibilityController.accessibleElementById("text");
+    var startMarker, endMarker, selectedMarkerRange;
+    setTimeout(async function() {
+        output += await expectAsync("editable.selectedText", "'Charlie'");
+
+        selectedMarkerRange = editable.selectedTextMarkerRange();
+        startMarker = editable.startTextMarkerForTextMarkerRange(selectedMarkerRange);
+        endMarker = editable.endTextMarkerForTextMarkerRange(selectedMarkerRange);
+
+        // Expand |endMarker| to encompass "Charlie Delta".
+        for (let i = 0; i < 6; i++)
+            endMarker = editable.nextTextMarker(endMarker);
+        editable.setSelectedTextMarkerRange(editable.textMarkerRangeForMarkers(startMarker, endMarker));
+        output += await expectAsync("editable.selectedText", "'Charlie Delta'");
+
+        // Expand |endMarker to encompass "Charlie Delta Ninja Kel"
+        for (let i = 0; i < 10; i++)
+            endMarker = editable.nextTextMarker(endMarker);
+        editable.setSelectedTextMarkerRange(editable.textMarkerRangeForMarkers(startMarker, endMarker));
+        output += await expectAsync("editable.selectedText", "'Charlie Delta Ninja Kel'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -709,6 +709,7 @@ accessibility/aria-labelledby-text.html [ Skip ]
 
 # Skipped because text marker APIs not implemented.
 accessibility/display-contents/end-text-marker.html [ Skip ]
+accessibility/select-whitespace-collapsed-text.html [ Skip ]
 
 # Need to implement AccessibilityUIElement::insertText.
 accessibility/insert-text-into-password-field.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -920,6 +920,8 @@ accessibility/dynamic-rowspan.html [ Skip ]
 accessibility/dynamic-colspan.html [ Skip ]
 accessibility/dynamic-table-descendants.html [ Skip ]
 
+accessibility/select-whitespace-collapsed-text.html [ Skip ]
+
 # Missing AccessibilityUIElement::isIndeterminate() implementation.
 accessibility/indeterminate-progressbar-custom-element.html [ Skip ]
 accessibility/progress-indeterminate-value.html [ Skip ]

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -448,6 +448,7 @@ public:
     WEBCORE_EXPORT static bool accessibilityEnhancedUserInterfaceEnabled();
 #if ENABLE(AX_THREAD_TEXT_APIS)
     static bool useAXThreadTextApis() { return gAccessibilityThreadTextApisEnabled && !isMainThread(); }
+    static bool shouldCreateAXThreadCompatibleMarkers() { return gAccessibilityThreadTextApisEnabled && isIsolatedTreeEnabled(); }
 #endif
 
     static bool forceInitialFrameCaching() { return gForceInitialFrameCaching; }

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -267,6 +267,7 @@ public:
     AXTextMarker toTextRunMarker(std::optional<AXID> stopAtID = std::nullopt) const;
     // True if this marker points to an object with non-empty text runs.
     bool isInTextRun() const;
+    AXTextMarker convertToDomOffset() const;
 
     // Find the next or previous marker, optionally stopping at the given ID and returning an invalid marker.
     AXTextMarker findMarker(AXDirection, CoalesceObjectBreaks = CoalesceObjectBreaks::Yes, IgnoreBRs = IgnoreBRs::No, std::optional<AXID> = std::nullopt) const;
@@ -410,6 +411,7 @@ public:
     // Returns the bounds (frame) of the text in this range relative to the viewport.
     // Analagous to AXCoreObject::relativeFrame().
     FloatRect viewportRelativeFrame() const;
+    AXTextMarkerRange convertToDomOffsetRange() const;
 #if PLATFORM(COCOA)
     RetainPtr<NSAttributedString> toAttributedString(AXCoreObject::SpellCheck) const;
 #endif // PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2485,6 +2485,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
 #if PLATFORM(MAC)
+
+#if ENABLE(AX_THREAD_TEXT_APIS)
+    if (AXObjectCache::useAXThreadTextApis()) {
+        if (AXObjectIsTextMarkerRange(value))
+            value = AXTextMarkerRange { (AXTextMarkerRangeRef)value }.convertToDomOffsetRange().platformData().bridgingAutorelease();
+    }
+#endif // ENABLE(AX_THREAD_TEXT_APIS)
+
     // In case anything we do by changing values causes an alert or other modal
     // behaviors, we need to return now, so that VoiceOver doesn't hang indefinitely.
     callOnMainThread([value = retainPtr(value), attributeName = retainPtr(attributeName), protectedSelf = retainPtr(self)] {


### PR DESCRIPTION
#### 188abd709f1f171c33ff528582e4b24272764d90
<pre>
AX: Convert between DOM offsets and rendered-text offsets in ENABLE(AX_THREAD_TEXT_APIS) to avoid crashes and incorrect behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=287707">https://bugs.webkit.org/show_bug.cgi?id=287707</a>
<a href="https://rdar.apple.com/144872799">rdar://144872799</a>

Reviewed by Chris Fleizach.

With this commit, we implement the ability to convert between offsets into rendered text, which is every offset for
text markers created off the main-thread, and offsets into DOM text, which is pre-whitespace-collapse, and the offset
that is expected for main-thread position types like VisiblePosition.

Without this, any text marker created on the main-thread, e.g. from a VisiblePosition, could point out-of-bounds of
rendered text, causing a crash, or at least incorrect behavior.

* LayoutTests/accessibility/select-whitespace-collapsed-text-expected.txt: Added.
* LayoutTests/accessibility/select-whitespace-collapsed-text.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::textMarkerDataForVisiblePosition):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
(WebCore::AXTextMarkerRange::intersectionWith const):
(WebCore::partialOrder):
(WebCore::AXTextMarkerRange::isConfinedTo const):
(WebCore::AXTextMarkerRange::viewportRelativeFrame const):
(WebCore::AXTextMarkerRange::toString const):
* Source/WebCore/accessibility/AXTextMarker.h:
* Source/WebCore/accessibility/AXTextRun.cpp:
(WebCore::AXTextRuns::substring const):
(WebCore::AXTextRuns::domOffset const):
* Source/WebCore/accessibility/AXTextRun.h:
(WebCore::AXTextRun::AXTextRun):
(WebCore::AXTextRun::domOffsets const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilitySetValue:forAttribute:]):

Canonical link: <a href="https://commits.webkit.org/290443@main">https://commits.webkit.org/290443@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb205f3e87853f4907e71c179b299a4c2415acc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95031 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40804 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69303 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26914 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49666 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7337 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36025 "Found 8 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html fast/html/process-end-tag-for-inbody-crash.html fullscreen/fullscreen-cancel-after-request-crash.html http/tests/webarchive/cross-origin-stylesheet-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/invalid-placard/invalid-placard-constrained-metrics.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html media/modern-media-controls/seek-forward-support/seek-forward-support.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39938 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96857 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12627 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78306 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77517 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19142 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21961 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20545 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22554 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16970 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20422 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->