### PR TITLE
AX: performDeferredCacheUpdate needs to check document.hasPendingStyleRecalc

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,7 +1,6 @@
 Modules/cookie-store/CookieStore.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/websockets/WorkerThreadableWebSocketChannel.cpp
-accessibility/AXObjectCache.cpp
 accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityObject.cpp
 accessibility/AccessibilityRenderObject.cpp


### PR DESCRIPTION
#### f4ed96d58ea8f73496c8a9ce6bd515bd80f09d90
<pre>
AX: performDeferredCacheUpdate needs to check document.hasPendingStyleRecalc
<a href="https://bugs.webkit.org/show_bug.cgi?id=287716">https://bugs.webkit.org/show_bug.cgi?id=287716</a>
<a href="https://rdar.apple.com/problem/144875397">rdar://problem/144875397</a>

Reviewed by Tyler Wilcock.

When AXObjectCache::performDeferredCacheUpdate is called, it checks to
see if the document needs layout first before updating the
accessibility tree. If this isn&apos;t done, walking the accessibility tree
can trigger a layout in the middle, leading to inconsistencies and
crashes.

However, if there&apos;s a pending style recalc, that can trigger a layout too,
so we need to check that and do a layout in that scenario too.

I wrote a layout test, but I&apos;m going to merge it in a follow-up because
it triggers a second assertion and needs an additional fix:
<a href="https://bugs.webkit.org/show_bug.cgi?id=287715">https://bugs.webkit.org/show_bug.cgi?id=287715</a>

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::documentNeedsLayoutOrStyleRecalc):
(WebCore::AXObjectCache::performDeferredCacheUpdate):

Canonical link: <a href="https://commits.webkit.org/290961@main">https://commits.webkit.org/290961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3dcaa7f4eb5acd665c6d4e10d47d2e7f8542904

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/632 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96537 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42254 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93618 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19525 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70317 "Failure limit exceed. At least found 2 new test failures: imported/w3c/web-platform-tests/css/css-transitions/properties-value-inherit-003.html imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27835 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50641 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8529 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/553 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41424 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98542 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18729 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78802 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78546 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19436 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23072 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11857 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18725 "Built successfully") | [💥 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24002 "An unexpected error occured. Recent messages:OS: Sequoia (15.3.1), Xcode: 16.2; Checked out pull request; Found 41956 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18435 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20202 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->