### PR TITLE
[visionOS] Add Netflix quirk to allow staying in fullscreen when transitioning between items in a playlist

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1090,7 +1090,7 @@ void HTMLMediaElement::pauseAfterDetachedTask()
 
     if (m_videoFullscreenMode != VideoFullscreenModePictureInPicture && m_networkState > NETWORK_EMPTY && !m_wasInterruptedForInvisibleAutoplay)
         pause();
-    if (m_videoFullscreenMode == VideoFullscreenModeStandard)
+    if (m_videoFullscreenMode == VideoFullscreenModeStandard && !document().quirks().needsNowPlayingFullscreenSwapQuirk())
         exitFullscreen();
 
     if (m_controlsState == ControlsState::Initializing || m_controlsState == ControlsState::Ready) {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -698,6 +698,7 @@ public:
 #endif
 
     void mediaSourceWasDetached();
+    WEBCORE_EXPORT void setFullscreenMode(VideoFullscreenMode);
 
 protected:
     HTMLMediaElement(const QualifiedName&, Document&, bool createdByParser);
@@ -782,7 +783,6 @@ private:
     bool canStartSelection() const override { return false; } 
     bool isInteractiveContent() const override;
 
-    void setFullscreenMode(VideoFullscreenMode);
     void willStopBeingFullscreenElement() override;
 
     // ActiveDOMObject.

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1787,6 +1787,11 @@ bool Quirks::needsLimitedMatroskaSupport() const
 #endif
 }
 
+bool Quirks::needsNowPlayingFullscreenSwapQuirk() const
+{
+    return needsQuirks() && m_quirksData.needsNowPlayingFullscreenSwapQuirk;
+}
+
 URL Quirks::topDocumentURL() const
 {
     if (UNLIKELY(!m_topDocumentURLForTesting.isEmpty()))
@@ -2397,6 +2402,10 @@ static void handleNetflixQuirks(QuirksData& quirksData, const URL& quirksURL, co
     quirksData.isNetflix = true;
     // netflix.com https://bugs.webkit.org/show_bug.cgi?id=173030
     quirksData.needsSeekingSupportDisabledQuirk = true;
+
+#if PLATFORM(VISION)
+    quirksData.needsNowPlayingFullscreenSwapQuirk = true;
+#endif
 }
 
 static void handlePandoraQuirks(QuirksData& quirksData, const URL& quirksURL, const String& quirksDomainString, const URL& documentURL)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -244,6 +244,8 @@ public:
 
     bool needsLimitedMatroskaSupport() const;
 
+    WEBCORE_EXPORT bool needsNowPlayingFullscreenSwapQuirk() const;
+
 private:
     bool needsQuirks() const;
     bool isDomain(const String&) const;

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -171,6 +171,8 @@ struct WEBCORE_EXPORT QuirksData {
     bool requiresUserGestureToPauseInPictureInPictureQuirk { false };
     bool shouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk { false };
 #endif
+
+    bool needsNowPlayingFullscreenSwapQuirk { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoReceiverEndpoint.h
+++ b/Source/WebCore/platform/VideoReceiverEndpoint.h
@@ -27,10 +27,14 @@
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 #include <wtf/OSObjectPtr.h>
+#include <wtf/ObjectIdentifier.h>
 #include <xpc/xpc.h>
 #endif
 
 namespace WebCore {
+
+struct VideoReceiverEndpointIdentifierType;
+using VideoReceiverEndpointIdentifier = ObjectIdentifier<VideoReceiverEndpointIdentifierType>;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 using VideoReceiverEndpoint = OSObjectPtr<xpc_object_t>;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -71,6 +71,7 @@ public:
 
     WEBCORE_EXPORT void handleEvent(WebCore::ScriptExecutionContext&, WebCore::Event&) final;
     void updateForEventName(const AtomString&);
+    WEBCORE_EXPORT void updateAll();
 
     WEBCORE_EXPORT void addClient(PlaybackSessionModelClient&);
     WEBCORE_EXPORT void removeClient(PlaybackSessionModelClient&);

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -145,6 +145,11 @@ void PlaybackSessionModelMediaElement::handleEvent(WebCore::ScriptExecutionConte
     updateForEventName(event.type());
 }
 
+void PlaybackSessionModelMediaElement::updateAll()
+{
+    updateForEventName(eventNameAll());
+}
+
 void PlaybackSessionModelMediaElement::updateForEventName(const WTF::AtomString& eventName)
 {
     if (m_clients.isEmpty())

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4123,6 +4123,7 @@ void MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged
     else if (RetainPtr videoTarget = std::exchange(m_videoTarget, nullptr)) {
         INFO_LOG(LOGIDENTIFIER, "Clearing videoTarget");
         [m_avPlayer removeVideoTarget:videoTarget.get()];
+        [m_videoLayer setPlayer:m_avPlayer.get()];
     }
 #else
     UNUSED_PARAM(isInFullscreenOrPictureInPicture);

--- a/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullPlaybackSessionInterface.h
@@ -69,6 +69,7 @@ public:
     void setMode(HTMLMediaElementEnums::VideoFullscreenMode, bool) { }
     bool pictureInPictureWasStartedWhenEnteringBackground() const { return false; }
     AVPlayerViewController *avPlayerViewController() const { return nullptr; }
+    void swapFullscreenModesWith(NullPlaybackSessionInterface&) { }
 
 private:
     NullPlaybackSessionInterface(PlaybackSessionModel& model)

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -89,6 +89,8 @@ public:
     // PlaybackSessionModelClient
     void externalPlaybackChanged(bool, PlaybackSessionModel::ExternalPlaybackTargetType, const String&) final { }
 
+    void swapFullscreenModesWith(NullVideoPresentationInterface&) { }
+
 private:
     NullVideoPresentationInterface(NullPlaybackSessionInterface& playbackSessionInterface)
         : m_playbackSessionInterface(playbackSessionInterface)

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h
@@ -85,6 +85,8 @@ public:
     virtual void startObservingNowPlayingMetadata();
     virtual void stopObservingNowPlayingMetadata();
 
+    virtual void swapFullscreenModesWith(PlaybackSessionInterfaceIOS&) { }
+
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -169,6 +169,8 @@ public:
     virtual LMPlayableViewController *playableViewController() { return nil; }
 #endif
 
+    virtual void swapFullscreenModesWith(VideoPresentationInterfaceIOS&) { }
+
 #if !RELEASE_LOG_DISABLED
     WEBCORE_EXPORT uint64_t logIdentifier() const;
     WEBCORE_EXPORT const Logger* loggerPtr() const;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -80,6 +80,8 @@ public:
     void beginScrubbing();
     void endScrubbing();
 
+    void swapFullscreenModesWith(PlaybackSessionInterfaceMac&) { }
+
     void invalidate();
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -109,6 +109,8 @@ public:
 
     WEBCORE_EXPORT void documentVisibilityChanged(bool) final;
 
+    void swapFullscreenModesWith(VideoPresentationInterfaceMac&) { }
+
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h
@@ -35,6 +35,7 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/ShareableBitmap.h>
+#include <WebCore/VideoTarget.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/Logger.h>
@@ -50,10 +51,6 @@
 #endif
 
 namespace WebKit {
-class VideoReceiverEndpointMessage;
-}
-
-namespace WebKit {
 
 class RemoteMediaPlayerProxy;
 struct RemoteMediaPlayerConfiguration;
@@ -61,6 +58,7 @@ struct RemoteMediaPlayerProxyConfiguration;
 struct SharedPreferencesForWebProcess;
 class RemoteMediaSourceProxy;
 class VideoReceiverEndpointMessage;
+class VideoReceiverSwapEndpointsMessage;
 
 class RemoteMediaPlayerManagerProxy
     : public RefCounted<RemoteMediaPlayerManagerProxy>, public IPC::MessageReceiver
@@ -94,8 +92,10 @@ public:
     std::optional<WebCore::ShareableBitmap::Handle> bitmapImageForCurrentTime(WebCore::MediaPlayerIdentifier);
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
+    WebCore::PlatformVideoTarget videoTargetForIdentifier(const std::optional<WebCore::VideoReceiverEndpointIdentifier>&);
     WebCore::PlatformVideoTarget takeVideoTargetForMediaElementIdentifier(WebCore::HTMLMediaElementIdentifier, WebCore::MediaPlayerIdentifier);
     void handleVideoReceiverEndpointMessage(const VideoReceiverEndpointMessage&);
+    void handleVideoReceiverSwapEndpointsMessage(const VideoReceiverSwapEndpointsMessage&);
 #endif
 
 #if ENABLE(MEDIA_SOURCE)
@@ -130,10 +130,10 @@ private:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
+    HashMap<WebCore::VideoReceiverEndpointIdentifier, WebCore::PlatformVideoTarget> m_videoTargetCache;
     struct VideoRecevierEndpointCacheEntry {
         Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;
-        WebCore::VideoReceiverEndpoint endpoint;
-        WebCore::PlatformVideoTarget videoTarget;
+        Markable<WebCore::VideoReceiverEndpointIdentifier> endpointIdentifier;
     };
     HashMap<WebCore::HTMLMediaElementIdentifier, VideoRecevierEndpointCacheEntry> m_videoReceiverEndpointCache;
 #endif

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h
@@ -73,6 +73,8 @@ public:
     void setSpatialVideoEnabled(bool enabled) { m_spatialVideoEnabled = enabled; }
     bool spatialVideoEnabled() const { return m_spatialVideoEnabled; }
 
+    void swapFullscreenModesWith(PlaybackSessionInterfaceIOS&);
+
 private:
     PlaybackSessionInterfaceLMK(WebCore::PlaybackSessionModel&);
 
@@ -80,6 +82,7 @@ private:
     RetainPtr<WKLinearMediaPlayerDelegate> m_playerDelegate;
     WebCore::NowPlayingMetadataObserver m_nowPlayingMetadataObserver;
     bool m_spatialVideoEnabled { false };
+    WebCore::VideoReceiverEndpoint m_videoReceiverEndpoint;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm
@@ -419,6 +419,14 @@ void PlaybackSessionInterfaceLMK::nowPlayingMetadataChanged(const WebCore::NowPl
     [m_player setArtwork:artworkData(metadata).get()];
 }
 
+void PlaybackSessionInterfaceLMK::swapFullscreenModesWith(PlaybackSessionInterfaceIOS& otherInterfaceIOS)
+{
+    auto& otherInterface = static_cast<PlaybackSessionInterfaceLMK&>(otherInterfaceIOS);
+    std::swap(m_player, otherInterface.m_player);
+    [m_player setDelegate:m_playerDelegate.get()];
+    [otherInterface.m_player setDelegate:otherInterface.m_playerDelegate.get()];
+}
+
 #if !RELEASE_LOG_DISABLED
 ASCIILiteral PlaybackSessionInterfaceLMK::logClassName() const
 {

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -79,6 +79,7 @@ private:
     void setupCaptionsLayer(CALayer *parent, const WebCore::FloatSize&) final;
     LMPlayableViewController *playableViewController() final;
     void setSpatialImmersive(bool) final;
+    void swapFullscreenModesWith(VideoPresentationInterfaceIOS&) final;
 
     WKSLinearMediaPlayer *linearMediaPlayer() const;
     void ensurePlayableViewController();

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -225,6 +225,18 @@ void VideoPresentationInterfaceLMK::ensurePlayableViewController()
     [m_playerViewController view].alpha = 0;
 }
 
+void VideoPresentationInterfaceLMK::swapFullscreenModesWith(VideoPresentationInterfaceIOS& otherInterfaceIOS)
+{
+    auto& otherInterface = static_cast<VideoPresentationInterfaceLMK&>(otherInterfaceIOS);
+    std::swap(m_playerViewController, otherInterface.m_playerViewController);
+
+    auto currentMode = mode();
+    auto previousMode = otherInterface.mode();
+
+    setMode(previousMode, true);
+    otherInterface.setMode(currentMode, true);
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(LINEAR_MEDIA_PLAYER)

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h
@@ -39,7 +39,7 @@ namespace WebKit {
 
 class VideoReceiverEndpointMessage {
 public:
-    VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier>, WebCore::HTMLMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier>, WebCore::VideoReceiverEndpoint);
+    VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier>, WebCore::HTMLMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier>, WebCore::VideoReceiverEndpoint, WebCore::VideoReceiverEndpointIdentifier);
 
     static ASCIILiteral messageName() { return "video-receiver-endpoint"_s; }
     static VideoReceiverEndpointMessage decode(xpc_object_t);
@@ -49,13 +49,38 @@ public:
     WebCore::HTMLMediaElementIdentifier mediaElementIdentifier() const { return m_mediaElementIdentifier; }
     std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
     const WebCore::VideoReceiverEndpoint& endpoint() const { return m_endpoint; }
+    WebCore::VideoReceiverEndpointIdentifier endpointIdentifier() const { return m_endpointIdentifier; }
 
 private:
     Markable<WebCore::ProcessIdentifier> m_processIdentifier;
     WebCore::HTMLMediaElementIdentifier m_mediaElementIdentifier;
     Markable<WebCore::MediaPlayerIdentifier> m_playerIdentifier;
     WebCore::VideoReceiverEndpoint m_endpoint;
+    WebCore::VideoReceiverEndpointIdentifier m_endpointIdentifier;
 };
+
+class VideoReceiverSwapEndpointsMessage {
+public:
+    VideoReceiverSwapEndpointsMessage(std::optional<WebCore::ProcessIdentifier>, WebCore::HTMLMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier>, WebCore::HTMLMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier>);
+
+    static ASCIILiteral messageName() { return "video-receiver-swap-endpoint"_s; }
+    static VideoReceiverSwapEndpointsMessage decode(xpc_object_t);
+    OSObjectPtr<xpc_object_t> encode() const;
+
+    std::optional<WebCore::ProcessIdentifier> processIdentifier() const { return m_processIdentifier; }
+    WebCore::HTMLMediaElementIdentifier sourceMediaElementIdentifier() const { return m_sourceMediaElementIdentifier; }
+    std::optional<WebCore::MediaPlayerIdentifier> sourceMediaPlayerIdentifier() const { return m_sourcePlayerIdentifier; }
+    WebCore::HTMLMediaElementIdentifier destinationMediaElementIdentifier() const { return m_destinationMediaElementIdentifier; }
+    std::optional<WebCore::MediaPlayerIdentifier> destinationMediaPlayerIdentifier() const { return m_destinationPlayerIdentifier; }
+
+private:
+    Markable<WebCore::ProcessIdentifier> m_processIdentifier;
+    WebCore::HTMLMediaElementIdentifier m_sourceMediaElementIdentifier;
+    Markable<WebCore::MediaPlayerIdentifier> m_sourcePlayerIdentifier;
+    WebCore::HTMLMediaElementIdentifier m_destinationMediaElementIdentifier;
+    Markable<WebCore::MediaPlayerIdentifier> m_destinationPlayerIdentifier;
+};
+
 
 } // namespace WebKit
 

--- a/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
+++ b/Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm
@@ -34,16 +34,22 @@
 namespace WebKit {
 
 static constexpr ASCIILiteral mediaElementIdentifierKey = "video-receiver-media-element-identifier"_s;
+static constexpr ASCIILiteral sourceMediaElementIdentifierKey = "video-receiver-source-media-element-identifier"_s;
+static constexpr ASCIILiteral sourcePlayerIdentifierKey = "video-receiver-source-player-identifier"_s;
+static constexpr ASCIILiteral destinationMediaElementIdentifierKey = "video-receiver-destination-media-element-identifier"_s;
+static constexpr ASCIILiteral destinationPlayerIdentifierKey = "video-receiver-destination-player-identifier"_s;
 static constexpr ASCIILiteral processIdentifierKey = "video-receiver-process-identifier"_s;
 static constexpr ASCIILiteral playerIdentifierKey = "video-receiver-player-identifier"_s;
 static constexpr ASCIILiteral endpointKey = "video-receiver-endpoint"_s;
+static constexpr ASCIILiteral endpointIdentifierKey = "video-receiver-endpoint-identifier"_s;
 static constexpr ASCIILiteral cacheCommandKey = "video-receiver-cache-command"_s;
 
-VideoReceiverEndpointMessage::VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier, WebCore::VideoReceiverEndpoint endpoint)
+VideoReceiverEndpointMessage::VideoReceiverEndpointMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier mediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier, WebCore::VideoReceiverEndpoint endpoint, WebCore::VideoReceiverEndpointIdentifier endpointIdentifier)
     : m_processIdentifier { WTFMove(processIdentifier) }
     , m_mediaElementIdentifier { WTFMove(mediaElementIdentifier) }
     , m_playerIdentifier { WTFMove(playerIdentifier) }
     , m_endpoint { WTFMove(endpoint) }
+    , m_endpointIdentifier { WTFMove(endpointIdentifier) }
 {
     RELEASE_ASSERT(!m_endpoint || xpc_get_type(m_endpoint.get()) == XPC_TYPE_DICTIONARY);
 }
@@ -54,12 +60,14 @@ VideoReceiverEndpointMessage VideoReceiverEndpointMessage::decode(xpc_object_t m
     auto mediaElementIdentifier = xpc_dictionary_get_uint64(message, mediaElementIdentifierKey.characters());
     auto playerIdentifier = xpc_dictionary_get_uint64(message, playerIdentifierKey.characters());
     auto endpoint = xpc_dictionary_get_value(message, endpointKey.characters());
+    auto endpointIdentifier = xpc_dictionary_get_uint64(message, endpointIdentifierKey.characters());
 
     return {
         processIdentifier ? std::optional { WebCore::ProcessIdentifier(processIdentifier) } : std::nullopt,
         WebCore::HTMLMediaElementIdentifier(mediaElementIdentifier),
         playerIdentifier ? std::optional { WebCore::MediaPlayerIdentifier(playerIdentifier) } : std::nullopt,
-        WebCore::VideoReceiverEndpoint(endpoint)
+        WebCore::VideoReceiverEndpoint(endpoint),
+        WebCore::VideoReceiverEndpointIdentifier(endpointIdentifier),
     };
 }
 
@@ -71,6 +79,45 @@ OSObjectPtr<xpc_object_t> VideoReceiverEndpointMessage::encode() const
     xpc_dictionary_set_uint64(message.get(), mediaElementIdentifierKey.characters(), m_mediaElementIdentifier.toUInt64());
     xpc_dictionary_set_uint64(message.get(), playerIdentifierKey.characters(), m_playerIdentifier ? m_playerIdentifier->toUInt64() : 0);
     xpc_dictionary_set_value(message.get(), endpointKey.characters(), m_endpoint.get());
+    xpc_dictionary_set_uint64(message.get(), endpointIdentifierKey.characters(), m_endpointIdentifier.toUInt64());
+    return message;
+}
+
+VideoReceiverSwapEndpointsMessage::VideoReceiverSwapEndpointsMessage(std::optional<WebCore::ProcessIdentifier> processIdentifier, WebCore::HTMLMediaElementIdentifier sourceMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> sourcePlayerIdentifier, WebCore::HTMLMediaElementIdentifier destinationMediaElementIdentifier, std::optional<WebCore::MediaPlayerIdentifier> destinationPlayerIdentifier)
+    : m_processIdentifier { WTFMove(processIdentifier) }
+    , m_sourceMediaElementIdentifier { WTFMove(sourceMediaElementIdentifier) }
+    , m_sourcePlayerIdentifier { WTFMove(sourcePlayerIdentifier) }
+    , m_destinationMediaElementIdentifier { WTFMove(destinationMediaElementIdentifier) }
+    , m_destinationPlayerIdentifier { WTFMove(destinationPlayerIdentifier) }
+{
+}
+
+VideoReceiverSwapEndpointsMessage VideoReceiverSwapEndpointsMessage::decode(xpc_object_t message)
+{
+    auto processIdentifier = xpc_dictionary_get_uint64(message, processIdentifierKey.characters());
+    auto sourceMediaElementIdentifier = xpc_dictionary_get_uint64(message, sourceMediaElementIdentifierKey.characters());
+    auto sourcePlayerIdentifier = xpc_dictionary_get_uint64(message, sourcePlayerIdentifierKey.characters());
+    auto destinationMediaElementIdentifier = xpc_dictionary_get_uint64(message, destinationMediaElementIdentifierKey.characters());
+    auto destinationPlayerIdentifier = xpc_dictionary_get_uint64(message, destinationPlayerIdentifierKey.characters());
+
+    return {
+        processIdentifier ? std::optional { WebCore::ProcessIdentifier(processIdentifier) } : std::nullopt,
+        WebCore::HTMLMediaElementIdentifier(sourceMediaElementIdentifier),
+        sourcePlayerIdentifier ? std::optional { WebCore::MediaPlayerIdentifier(sourcePlayerIdentifier) } : std::nullopt,
+        WebCore::HTMLMediaElementIdentifier(destinationMediaElementIdentifier),
+        destinationPlayerIdentifier ? std::optional { WebCore::MediaPlayerIdentifier(destinationPlayerIdentifier) } : std::nullopt,
+    };
+}
+
+OSObjectPtr<xpc_object_t> VideoReceiverSwapEndpointsMessage::encode() const
+{
+    OSObjectPtr message = adoptOSObject(xpc_dictionary_create(nullptr, nullptr, 0));
+    xpc_dictionary_set_string(message.get(), XPCEndpoint::xpcMessageNameKey, messageName().characters());
+    xpc_dictionary_set_uint64(message.get(), processIdentifierKey.characters(), m_processIdentifier ? m_processIdentifier->toUInt64() : 0);
+    xpc_dictionary_set_uint64(message.get(), sourceMediaElementIdentifierKey.characters(), m_sourceMediaElementIdentifier.toUInt64());
+    xpc_dictionary_set_uint64(message.get(), sourcePlayerIdentifierKey.characters(), m_sourcePlayerIdentifier ? m_sourcePlayerIdentifier->toUInt64() : 0);
+    xpc_dictionary_set_uint64(message.get(), destinationMediaElementIdentifierKey.characters(), m_destinationMediaElementIdentifier.toUInt64());
+    xpc_dictionary_set_uint64(message.get(), destinationPlayerIdentifierKey.characters(), m_destinationPlayerIdentifier ? m_destinationPlayerIdentifier->toUInt64() : 0);
     return message;
 }
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm
@@ -63,6 +63,19 @@ static void handleVideoReceiverEndpointMessage(xpc_object_t message)
     if (RefPtr webProcessConnection = GPUProcess::singleton().webProcessConnection(*endpointMessage.processIdentifier()))
         webProcessConnection->remoteMediaPlayerManagerProxy().handleVideoReceiverEndpointMessage(endpointMessage);
 }
+
+static void handleVideoReceiverSwapEndpointsMessage(xpc_object_t message)
+{
+    ASSERT(isMainRunLoop());
+    RELEASE_ASSERT(isInGPUProcess());
+
+    auto endpointMessage = VideoReceiverSwapEndpointsMessage::decode(message);
+    if (!endpointMessage.processIdentifier())
+        return;
+
+    if (RefPtr webProcessConnection = GPUProcess::singleton().webProcessConnection(*endpointMessage.processIdentifier()))
+        webProcessConnection->remoteMediaPlayerManagerProxy().handleVideoReceiverSwapEndpointsMessage(endpointMessage);
+}
 #endif
 
 void handleXPCEndpointMessage(xpc_object_t message, const String& messageName)
@@ -81,6 +94,13 @@ void handleXPCEndpointMessage(xpc_object_t message, const String& messageName)
     if (messageName == VideoReceiverEndpointMessage::messageName()) {
         RunLoop::protectedMain()->dispatch([message = OSObjectPtr(message)] {
             handleVideoReceiverEndpointMessage(message.get());
+        });
+        return;
+    }
+
+    if (messageName == VideoReceiverSwapEndpointsMessage::messageName()) {
+        RunLoop::main().dispatch([message = OSObjectPtr(message)] {
+            handleVideoReceiverSwapEndpointsMessage(message.get());
         });
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -52,6 +52,8 @@ messages -> PlaybackSessionManagerProxy {
     SetUpPlaybackControlsManagerWithID(WebKit::PlaybackSessionContextIdentifier contextId, bool isVideo)
     ClearPlaybackControlsManager()
 
+    SwapFullscreenModes(WebKit::PlaybackSessionContextIdentifier firstContextId, WebKit::PlaybackSessionContextIdentifier secondContextId)
+
     HandleControlledElementIDResponse(WebKit::PlaybackSessionContextIdentifier contextId, String id)
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -186,6 +186,8 @@ public:
     void willRemoveLayerForID(PlaybackSessionContextIdentifier);
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
+    void swapFullscreenModes(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
+
 private:
     friend class VideoPresentationModelContext;
 
@@ -268,6 +270,7 @@ private:
     HashMap<PlaybackSessionContextIdentifier, int> m_clientCounts;
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
     WeakHashSet<VideoInPictureInPictureDidChangeObserver> m_pipChangeObservers;
+    Markable<PlaybackSessionContextIdentifier> m_controlsManagerContextId;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -130,6 +130,7 @@ public:
     void mediaEngineChanged(WebCore::HTMLMediaElement&);
     PlaybackSessionContextIdentifier contextIdForMediaElement(WebCore::HTMLMediaElement&);
 
+    WebCore::HTMLMediaElement* mediaElementWithContextId(PlaybackSessionContextIdentifier) const;
     WebCore::HTMLMediaElement* currentPlaybackControlsElement() const;
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -150,6 +150,8 @@ public:
     void setupRemoteLayerHosting(WebCore::HTMLVideoElement&);
     void willRemoveLayerForID(PlaybackSessionContextIdentifier);
 
+    void swapFullscreenModes(WebCore::HTMLVideoElement&, WebCore::HTMLVideoElement&);
+
     // Interface to WebChromeClient
     bool canEnterVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
     bool supportsVideoFullscreen(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;


### PR DESCRIPTION
#### 1d2ae3a51815e1cdbd7b367a13989de7595137fd
<pre>
[visionOS] Add Netflix quirk to allow staying in fullscreen when transitioning between items in a playlist
<a href="https://rdar.apple.com/134980072">rdar://134980072</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287722">https://bugs.webkit.org/show_bug.cgi?id=287722</a>

Reviewed by Andy Estes.

When Netflix.com moves to the next item in a playlist, it pulls the current video out of the DOM
and replaces it with another video containing the next video content. Removing the video from
the DOM has the effect of closing any fullscreen presentation, including the &quot;Environment Docking&quot;
fullscreen mode on visionOS.

Add a quirk that allows the fullscreen presentation to stay open when its backing video is removed
from the DOM, and add a &quot;swap&quot; behavior that migrates all the fullscreen modes and state between
the two video elements at every level in the project. This includes moving the VideoReceiverEndpoint
and its VideoTarget, however that transition is tricky because only one VideoTarget ever can be
created from a single VideoReceiverEndpoint. Add another layer of caching of endpoints and targets
inside RemoteMediaPlayerManagerProxyCocoa by introducing the concept of VideoReceiverEndpointIdentifier.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::pauseAfterDetachedTask):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsNowPlayingFullscreenSwapQuirk const):
(WebCore::handleNetflixQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/platform/VideoReceiverEndpoint.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateAll):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::isInFullscreenOrPictureInPictureChanged):
* Source/WebCore/platform/ios/PlaybackSessionInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::swapFullscreenModesWith):
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.h:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerManagerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerManagerProxy::videoTargetForIdentifier):
(WebKit::RemoteMediaPlayerManagerProxy::takeVideoTargetForMediaElementIdentifier):
(WebKit::RemoteMediaPlayerManagerProxy::handleVideoReceiverEndpointMessage):
(WebKit::RemoteMediaPlayerManagerProxy::handleVideoReceiverSwapEndpointsMessage):
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.h:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceLMK.mm:
(WebKit::PlaybackSessionInterfaceLMK::swapFullscreenModesWith):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::swapFullscreenModesWith):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.h:
(WebKit::VideoReceiverEndpointMessage::endpointIdentifier const):
(WebKit::VideoReceiverSwapEndpointsMessage::messageName):
(WebKit::VideoReceiverSwapEndpointsMessage::processIdentifier const):
(WebKit::VideoReceiverSwapEndpointsMessage::sourceMediaElementIdentifier const):
(WebKit::VideoReceiverSwapEndpointsMessage::sourceMediaPlayerIdentifier const):
(WebKit::VideoReceiverSwapEndpointsMessage::destinationMediaElementIdentifier const):
(WebKit::VideoReceiverSwapEndpointsMessage::destinationMediaPlayerIdentifier const):
* Source/WebKit/Platform/ios/VideoReceiverEndpointMessage.mm:
(WebKit::VideoReceiverEndpointMessage::VideoReceiverEndpointMessage):
(WebKit::VideoReceiverEndpointMessage::decode):
(WebKit::VideoReceiverEndpointMessage::encode const):
(WebKit::VideoReceiverSwapEndpointsMessage::VideoReceiverSwapEndpointsMessage):
(WebKit::VideoReceiverSwapEndpointsMessage::decode):
(WebKit::VideoReceiverSwapEndpointsMessage::encode const):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCEndpointMessages.mm:
(WebKit::handleVideoReceiverSwapEndpointsMessage):
(WebKit::handleXPCEndpointMessage):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::setVideoReceiverEndpoint):
(WebKit::PlaybackSessionModelContext::swapVideoReceiverEndpointsWith):
(WebKit::PlaybackSessionManagerProxy::swapFullscreenModes):
(WebKit::PlaybackSessionManagerProxy::setVideoReceiverEndpoint):
(WebKit::PlaybackSessionManagerProxy::swapVideoReceiverEndpoints):
(WebKit::PlaybackSessionManagerProxy::uncacheVideoReceiverEndpoint): Deleted.
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::swapFullscreenModes):
* Source/WebKit/UIProcess/ios/WKVideoView.mm:
(-[WKVideoView removeFromSuperview]):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::setUpPlaybackControlsManager):
(WebKit::PlaybackSessionManager::mediaElementWithContextId const):
(WebKit::PlaybackSessionManager::currentPlaybackControlsElement const):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::swapFullscreenModes):

Canonical link: <a href="https://commits.webkit.org/290610@main">https://commits.webkit.org/290610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03b56bc676cd9ffed2985f9f8f7fe9f83515808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90442 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95452 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41224 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92494 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69627 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27195 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36400 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78004 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37482 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97282 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78612 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20898 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17644 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22976 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->