### PR TITLE
Address safer C++ static analysis warnings in TrackBuffer.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1090,7 +1090,6 @@ platform/graphics/ImageFrame.cpp
 platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/Path.cpp
 platform/graphics/SourceBufferPrivate.cpp
-platform/graphics/TrackBuffer.cpp
 platform/graphics/TransparencyLayerContextSwitcher.cpp
 platform/graphics/WidthIterator.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -615,7 +615,6 @@ platform/graphics/Image.cpp
 platform/graphics/Path.cpp
 platform/graphics/SourceBrush.cpp
 platform/graphics/SystemFallbackFontCache.cpp
-platform/graphics/TrackBuffer.cpp
 platform/graphics/WidthIterator.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -96,7 +96,7 @@ bool TrackBuffer::updateMinimumUpcomingPresentationTime()
         return false;
     }
 
-    m_minimumEnqueuedPresentationTime = minPts->second->presentationTime();
+    m_minimumEnqueuedPresentationTime = Ref { minPts->second }->presentationTime();
     return true;
 }
 
@@ -124,7 +124,7 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
     // Find the last sample, so long as the track is ended, and the presentation time is after the last sample.
     if (currentSamplePTSIterator == m_samples.presentationOrder().end() && isEnded) {
         auto lastSampleIterator = std::prev(currentSamplePTSIterator);
-        if (time >= lastSampleIterator->second->presentationEndTime())
+        if (time >= Ref { lastSampleIterator->second }->presentationEndTime())
             currentSamplePTSIterator = lastSampleIterator;
     }
 
@@ -132,7 +132,8 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
         return false;
 
     // Search backward for the previous sync sample.
-    DecodeOrderSampleMap::KeyType decodeKey(currentSamplePTSIterator->second->decodeTime(), currentSamplePTSIterator->second->presentationTime());
+    Ref sample = currentSamplePTSIterator->second;
+    DecodeOrderSampleMap::KeyType decodeKey(sample->decodeTime(), sample->presentationTime());
     auto currentSampleDTSIterator = m_samples.decodeOrder().findSampleWithDecodeKey(decodeKey);
     ASSERT(currentSampleDTSIterator != m_samples.decodeOrder().end());
 
@@ -143,7 +144,7 @@ bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& 
 
     // Fill the decode queue with the non-displaying samples.
     for (auto iter = reverseLastSyncSampleIter; iter != reverseCurrentSampleIter; --iter) {
-        auto copy = iter->second->createNonDisplayingCopy();
+        auto copy = Ref { iter->second }->createNonDisplayingCopy();
         DecodeOrderSampleMap::KeyType decodeKey(copy->decodeTime(), copy->presentationTime());
         m_decodeQueue.insert(DecodeOrderSampleMap::MapType::value_type(decodeKey, WTFMove(copy)));
     }
@@ -239,18 +240,18 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
         if (startIterator == m_samples.presentationOrder().rend())
             additionalErasedRanges.add(MediaTime::zeroTime(), erasedStart);
         else {
-            auto& previousSample = startIterator->second.get();
-            if (previousSample.presentationTime() + previousSample.duration() < erasedStart)
-                additionalErasedRanges.add(previousSample.presentationTime() + previousSample.duration(), erasedStart);
+            Ref previousSample = startIterator->second.get();
+            if (previousSample->presentationTime() + previousSample->duration() < erasedStart)
+                additionalErasedRanges.add(previousSample->presentationTime() + previousSample->duration(), erasedStart);
         }
 
         auto endIterator = m_samples.presentationOrder().findSampleStartingAfterPresentationTime(erasedStart);
         if (endIterator == m_samples.presentationOrder().end())
             additionalErasedRanges.add(erasedEnd, MediaTime::positiveInfiniteTime());
         else {
-            auto& nextSample = endIterator->second.get();
-            if (nextSample.presentationTime() > erasedEnd)
-                additionalErasedRanges.add(erasedEnd, nextSample.presentationTime());
+            Ref nextSample = endIterator->second.get();
+            if (nextSample->presentationTime() > erasedEnd)
+                additionalErasedRanges.add(erasedEnd, nextSample->presentationTime());
         }
     }
     if (additionalErasedRanges.length())
@@ -266,7 +267,7 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
 
 static WARN_UNUSED_RETURN bool decodeTimeComparator(const PresentationOrderSampleMap::MapType::value_type& a, const PresentationOrderSampleMap::MapType::value_type& b)
 {
-    return a.second->decodeTime() < b.second->decodeTime();
+    return Ref { a.second }->decodeTime() < Ref { b.second }->decodeTime();
 };
 
 int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime)
@@ -296,7 +297,7 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& 
         std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> replacementSamples = sample->divide(roundedTime);
         if (!replacementSamples.first || !replacementSamples.second)
             return;
-        DEBUG_LOG_IF(m_logger, LOGIDENTIFIER, "splitting sample ", sample.get(), " into ", *replacementSamples.first, " and ", *replacementSamples.second);
+        DEBUG_LOG_IF(m_logger, LOGIDENTIFIER, "splitting sample ", sample.get(), " into ", Ref { *replacementSamples.first }.get(), " and ", Ref { *replacementSamples.second }.get());
         m_samples.removeSample(sample);
         m_samples.addSample(replacementSamples.first.releaseNonNull());
         m_samples.addSample(replacementSamples.second.releaseNonNull());
@@ -315,10 +316,10 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& 
     // and the next sync sample frame are removed. But we must start from the first sample in decode order, not
     // presentation order.
     auto minmaxDecodeTimeIterPair = std::minmax_element(removePresentationStart, removePresentationEnd, decodeTimeComparator);
-    auto& firstSample = minmaxDecodeTimeIterPair.first->second.get();
-    auto& lastSample = minmaxDecodeTimeIterPair.second->second.get();
-    auto removeDecodeStart = m_samples.decodeOrder().findSampleWithDecodeKey({ firstSample.decodeTime(), firstSample.presentationTime() });
-    auto removeDecodeLast = m_samples.decodeOrder().findSampleWithDecodeKey({ lastSample.decodeTime(), lastSample.presentationTime() });
+    Ref firstSample = minmaxDecodeTimeIterPair.first->second.get();
+    Ref lastSample = minmaxDecodeTimeIterPair.second->second.get();
+    auto removeDecodeStart = m_samples.decodeOrder().findSampleWithDecodeKey({ firstSample->decodeTime(), firstSample->presentationTime() });
+    auto removeDecodeLast = m_samples.decodeOrder().findSampleWithDecodeKey({ lastSample->decodeTime(), lastSample->presentationTime() });
     auto removeDecodeEnd = m_samples.decodeOrder().findSyncSampleAfterDecodeIterator(removeDecodeLast);
 
     DecodeOrderSampleMap::MapType erasedSamples(removeDecodeStart, removeDecodeEnd);
@@ -361,7 +362,7 @@ int64_t TrackBuffer::codedFramesIntervalSize(const MediaTime& start, const Media
         std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> replacementSamples = sample->divide(roundedTime);
         if (!replacementSamples.first || !replacementSamples.second)
             return 0;
-        return dropFirstPart ? replacementSamples.first->sizeInBytes() : replacementSamples.second->sizeInBytes();
+        return dropFirstPart ? Ref { *replacementSamples.first }->sizeInBytes() : Ref { *replacementSamples.second }->sizeInBytes();
     };
 
     int64_t framesSize = 0;
@@ -369,16 +370,16 @@ int64_t TrackBuffer::codedFramesIntervalSize(const MediaTime& start, const Media
     framesSize -= divideSampleIfPossibleAtPresentationTime(end, false);
 
     auto minmaxDecodeTimeIterPair = std::minmax_element(removePresentationStart, removePresentationEnd, decodeTimeComparator);
-    auto& firstSample = minmaxDecodeTimeIterPair.first->second.get();
-    auto& lastSample = minmaxDecodeTimeIterPair.second->second.get();
-    auto removeDecodeStart = m_samples.decodeOrder().findSampleWithDecodeKey({ firstSample.decodeTime(), firstSample.presentationTime() });
-    auto removeDecodeLast = m_samples.decodeOrder().findSampleWithDecodeKey({ lastSample.decodeTime(), lastSample.presentationTime() });
+    Ref firstSample = minmaxDecodeTimeIterPair.first->second.get();
+    Ref lastSample = minmaxDecodeTimeIterPair.second->second.get();
+    auto removeDecodeStart = m_samples.decodeOrder().findSampleWithDecodeKey({ firstSample->decodeTime(), firstSample->presentationTime() });
+    auto removeDecodeLast = m_samples.decodeOrder().findSampleWithDecodeKey({ lastSample->decodeTime(), lastSample->presentationTime() });
     auto removeDecodeEnd = m_samples.decodeOrder().findSyncSampleAfterDecodeIterator(removeDecodeLast);
 
     DecodeOrderSampleMap::MapType erasedSamples(removeDecodeStart, removeDecodeEnd);
 
     for (auto& erasedPair : erasedSamples)
-        framesSize += erasedPair.second->sizeInBytes();
+        framesSize += Ref { erasedPair.second }->sizeInBytes();
 
     return framesSize;
 }


### PR DESCRIPTION
#### 99a35401035eb2aa3855aab36fbf29483c37d60f
<pre>
Address safer C++ static analysis warnings in TrackBuffer.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287730">https://bugs.webkit.org/show_bug.cgi?id=287730</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::updateMinimumUpcomingPresentationTime):
(WebCore::TrackBuffer::reenqueueMediaForTime):
(WebCore::TrackBuffer::removeSamples):
(WebCore::decodeTimeComparator):
(WebCore::TrackBuffer::removeCodedFrames):
(WebCore::TrackBuffer::codedFramesIntervalSize):

Canonical link: <a href="https://commits.webkit.org/290435@main">https://commits.webkit.org/290435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd9e4a1bdbca515f2c46a031ca1a4052b365acb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95042 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17860 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26916 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93043 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49674 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7348 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39949 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37106 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96868 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78313 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17486 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77503 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77519 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19136 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10424 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17240 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22565 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16981 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->