### PR TITLE
AX: Regression Safari 18.3: Gmail's new email compose field is inaccessible via VoiceOver

### DIFF
--- a/LayoutTests/accessibility/visibility-visible-inside-hidden-expected.txt
+++ b/LayoutTests/accessibility/visibility-visible-inside-hidden-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we don't ignore visibility:visible elements that have a visibility:hidden ancestor.
+
+PASS: button.role.toLowerCase().includes('button') === true
+PASS: button.isIgnored === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Press

--- a/LayoutTests/accessibility/visibility-visible-inside-hidden.html
+++ b/LayoutTests/accessibility/visibility-visible-inside-hidden.html
@@ -1,0 +1,27 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container" role="group" aria-label="foo" style="visibility: hidden">
+    <div style="visibility: visible">
+        <button id="button">Press</button>
+    </div>
+</div>
+
+<script>
+var output = "This test ensures we don't ignore visibility:visible elements that have a visibility:hidden ancestor.\n\n";
+
+if (window.accessibilityController) {
+    var button = accessibilityController.accessibleElementById("button");
+    output += expect("button.role.toLowerCase().includes('button')", "true");
+    output += expect("button.isIgnored", "false");
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2373,6 +2373,7 @@ accessibility/visible-character-range-basic.html [ Pass ]
 accessibility/visible-character-range-height-changes.html [ Pass ]
 accessibility/visible-character-range-vertical-rl.html [ Pass ]
 accessibility/visible-character-range-width-changes.html [ Pass ]
+accessibility/visibility-visible-inside-hidden.html [ Pass ]
 accessibility/ancestor-computation.html [ Pass ]
 
 # Enable "aria-current" tests for iOS.

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3970,8 +3970,14 @@ AccessibilityObjectInclusion AccessibilityObject::defaultObjectInclusion() const
     bool ignoreARIAHidden = isFocused();
     if (Accessibility::findAncestor<AccessibilityObject>(*this, false, [&] (const auto& object) {
         const auto* style = object.style();
-        if (style && WebCore::isRenderHidden(*style))
+        if (style && style->display() == DisplayType::None) {
+            // We don't want to use AccessibilityObject::isRenderHidden(), as that also checks and returns true
+            // for visibility:hidden, which would be wrong if |this| has a visibility:visible ancestor before
+            // this visibility:hidden ancestor (visibility:visible cancels out visibility:hidden).
+            //
+            // We check the isVisibilityHidden at the top of this method, so that covers us as far as visibility goes.
             return true;
+        }
 
         return (!ignoreARIAHidden && object.isARIAHidden()) || object.ariaRoleHasPresentationalChildren() || !object.canHaveChildren();
     }))


### PR DESCRIPTION
#### 5d76dffe6890099f2414cf95c4dd73ed83c29dde
<pre>
AX: Regression Safari 18.3: Gmail&apos;s new email compose field is inaccessible via VoiceOver
<a href="https://bugs.webkit.org/show_bug.cgi?id=287696">https://bugs.webkit.org/show_bug.cgi?id=287696</a>
<a href="https://rdar.apple.com/144855532">rdar://144855532</a>

Reviewed by Chris Fleizach.

In <a href="https://commits.webkit.org/287159@main">https://commits.webkit.org/287159@main</a>, we added an `isRenderHidden` check to the ancestry walk, returning
AccessibilityObjectInclusion::IgnoreObject if true. However, this is the wrong thing to do when the AccessibilityObject
is within a visibility:visible subtree, that in turn has a visibility:hidden ancestor, as we would ignore the object
once getting to the hidden ancestor, even though visibility:visible cancels out visibility:hidden.

Fix this by only checking for display:none in the ancestry walk.

* LayoutTests/accessibility/visibility-visible-inside-hidden-expected.txt: Added.
* LayoutTests/accessibility/visibility-visible-inside-hidden.html: Added.
* LayoutTests/platform/ios/TestExpectations: Enable new test.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::defaultObjectInclusion const):

Canonical link: <a href="https://commits.webkit.org/290442@main">https://commits.webkit.org/290442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4c985660b76318c778ca8dd22f70c7ea9880b8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/89992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44892 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/94992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69283 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26888 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/92993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7309 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36004 "Found 6 new test failures: fast/html/process-end-tag-for-inbody-crash.html fullscreen/empty-anonymous-block-continuation-crash.html fullscreen/full-screen-request-removed.html fullscreen/fullscreen-cancel-after-request-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77645 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96818 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17180 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78280 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77458 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77480 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19141 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22573 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16931 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->