### PR TITLE
[Cocoa] Expose SPI (for prototyping only) to get sampled colors at the edges of fixed-position containers

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7705,6 +7705,8 @@ imported/w3c/web-platform-tests/css/selectors/featureless-005.html [ ImageOnlyFa
 # Cocoa-only test.
 webkit.org/b/286318 http/tests/iframe-monitor [ Skip ]
 
+# Currently only supported on WK2 Cocoa ports.
+fast/page-color-sampling [ Skip ]
 
 # webkit.org/b/286934 REGRESSION(289634@main): [macOS iOS] ipc/create-media-source-wit h-invalid-constraints-crash .html is a constant crash (failure in EWS)
 ipc/create-media-source-with-invalid-constraints-crash.html [ Skip ]

--- a/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling-expected.txt
@@ -1,0 +1,8 @@
+PASS Sampled top container
+PASS Sampled left container
+PASS Sampled right container
+PASS Sampled bottom container
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
+++ b/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body, html {
+    font-family: system-ui;
+    font-size: 16px;
+    color: white;
+    background: rgb(42, 42, 42);
+}
+
+.blue {
+    background: rgb(0, 122, 255);
+}
+
+.green {
+    background: rgb(52, 199, 89);
+}
+
+.red {
+    background: rgb(255, 59, 48);
+}
+
+.fixed {
+    position: fixed;
+    z-index: 100;
+}
+
+.top, .left {
+    top: 0;
+    left: 0;
+}
+
+.right, .bottom {
+    bottom: 0;
+    right: 0;
+}
+
+.left, .right {
+    width: 32px;
+    height: 100%;
+}
+
+.top, .bottom {
+    width: 100%;
+    height: 32px;
+}
+
+.gradient {
+    background: linear-gradient(to left, red 0%, green 50%, blue 100%);
+}
+
+.hidden {
+    visibility: hidden;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+async function showContainer(edge, expectedColors) {
+    document.querySelector(`.${edge}`).classList.remove("hidden");
+    await UIHelper.renderingUpdate();
+    await UIHelper.waitForFixedContainerEdgeColors(expectedColors);
+    testPassed(`Sampled ${edge} container`);
+}
+
+addEventListener("load", async () => {
+    await showContainer("top", { top: "rgb(0, 122, 255)", left: null, right: null, bottom: null });
+
+    await showContainer("left", { top:
+        "rgb(0, 122, 255)",
+        left: "rgb(255, 59, 48)",
+        right: null,
+        bottom: null
+    });
+
+    await showContainer("right", {
+        top: "rgb(0, 122, 255)",
+        left: "rgb(255, 59, 48)",
+        right: "rgb(52, 199, 89)",
+        bottom: null
+    });
+
+    await showContainer("bottom", {
+        top: "rgb(0, 122, 255)",
+        left: "rgb(255, 59, 48)",
+        right: "rgb(52, 199, 89)",
+        bottom: "rgb(42, 42, 42)"
+    });
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="hidden top fixed blue"></div>
+    <div class="hidden left fixed red"></div>
+    <div class="hidden right fixed green"></div>
+    <div class="hidden bottom fixed gradient"></div>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -26,6 +26,7 @@ system-preview [ Pass ]
 remote-layer-tree [ Pass ]
 swipe [ Pass ]
 http/tests/swipe [ Pass ]
+fast/page-color-sampling [ Pass ]
 
 webkit.org/b/271780 fast/dom/Orientation/no-orientation-change-event-when-unparenting-view.html [ Pass Timeout ] # change back to pass when bug resolved
 fast/events/ios [ Pass ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -42,6 +42,7 @@ http/tests/pdf [ Pass ]
 [ Sonoma+ ] pdf [ Pass ]
 tiled-drawing [ Pass ]
 ipc/restrictedendpoints/mac [ Pass ]
+fast/page-color-sampling [ Pass ]
 
 fast/events/autoscroll-when-zoomed.html [ Pass ]
 fast/events/autoscroll-main-document.html [ Pass ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2195,6 +2195,30 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static fixedContainerEdgeColors()
+    {
+        if (!this.isWebKit2())
+            return { };
+
+        const script = "JSON.stringify(uiController.fixedContainerEdgeColors)";
+        return new Promise(resolve => testRunner.runUIScript(script, colors => {
+            resolve(JSON.parse(colors));
+        }));
+    }
+
+    static async waitForFixedContainerEdgeColors(expectedColors)
+    {
+        while (true) {
+            await this.renderingUpdate();
+            const colors = await this.fixedContainerEdgeColors();
+            for (const edge of ["top", "left", "right", "bottom"]) {
+                if (colors[edge] !== expectedColors[edge])
+                    continue;
+            }
+            break;
+        }
+    }
+
     static addChromeInputField()
     {
         return new Promise(resolve => testRunner.addChromeInputField(resolve));

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3076,6 +3076,20 @@ FilterLinkDecorationByDefaultEnabled:
     WebCore:
       default: true
 
+FixedContainerEdgeSamplingEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Fixed container edge sampling"
+  humanReadableDescription: "Enable fixed container edge sampling"
+  condition: PLATFORM(COCOA)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: WebKit::defaultFixedContainerEdgeSamplingEnabled()
+    WebCore:
+      default: false
+
 FixedFontFamily:
   type: String
   status: embedder

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -331,7 +331,7 @@ Color PageColorSampler::predominantColor(Page& page, const LayoutRect& absoluteR
         static constexpr auto maxDistanceSquaredForSimilarColors = 36;
         auto [redA, greenA, blueA, alphaA] = a.toResolvedColorComponentsInColorSpace(DestinationColorSpace::SRGB());
         auto [redB, greenB, blueB, alphaB] = b.toResolvedColorComponentsInColorSpace(DestinationColorSpace::SRGB());
-        auto distance = pow(redA - redB, 2) + pow(greenA - greenB, 2) + pow(blueA - blueB, 2);
+        auto distance = pow(255 * (redA - redB), 2) + pow(255 * (greenA - greenB), 2) + pow(255 * (blueA - blueB), 2);
         return distance <= maxDistanceSquaredForSimilarColors;
     };
 
@@ -364,7 +364,7 @@ Color PageColorSampler::predominantColor(Page& page, const LayoutRect& absoluteR
             return WTFMove(*mostFrequentColor);
     }
 
-    return { };
+    return page.pageExtendedBackgroundColor();
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -100,6 +100,13 @@ bool defaultUseSCContentSharingPicker()
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/WebPreferencesDefaultValuesCocoaAdditions.mm>)
 #import <WebKitAdditions/WebPreferencesDefaultValuesCocoaAdditions.mm>
+#else
+namespace WebKit {
+bool defaultFixedContainerEdgeSamplingEnabled()
+{
+    return false;
+}
+}
 #endif
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -137,6 +137,7 @@ header: "RemoteLayerBackingStore.h"
     WebCore::Color m_themeColor;
     WebCore::Color m_pageExtendedBackgroundColor;
     WebCore::Color m_sampledPageTopColor;
+    WebCore::FixedContainerEdges m_fixedContainerEdges;
 
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -33,6 +33,7 @@
 #include "RemoteLayerBackingStore.h"
 #include "TransactionID.h"
 #include <WebCore/Color.h>
+#include <WebCore/FixedContainerEdges.h>
 #include <WebCore/FloatPoint3D.h>
 #include <WebCore/FloatSize.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
@@ -257,6 +258,9 @@ public:
     void setAcceleratedTimelineTimeOrigin(Seconds timeOrigin) { m_acceleratedTimelineTimeOrigin = timeOrigin; }
 #endif
 
+    const WebCore::FixedContainerEdges& fixedContainerEdges() const { return m_fixedContainerEdges; }
+    void setFixedContainerEdges(WebCore::FixedContainerEdges&& edges) { m_fixedContainerEdges = WTFMove(edges); }
+
 private:
     friend struct IPC::ArgumentCoder<RemoteLayerTreeTransaction, void>;
 
@@ -284,6 +288,7 @@ private:
     WebCore::Color m_themeColor;
     WebCore::Color m_pageExtendedBackgroundColor;
     WebCore::Color m_sampledPageTopColor;
+    WebCore::FixedContainerEdges m_fixedContainerEdges;
 
 #if PLATFORM(MAC)
     Markable<WebCore::PlatformLayerIdentifier> m_pageScalingLayerID; // Only used for non-delegated scaling.

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1993,6 +1993,13 @@ header: <WebCore/RectEdges.h>
     bool left();
 }
 
+[CustomHeader] class WebCore::RectEdges<WebCore::Color> {
+    WebCore::Color top();
+    WebCore::Color right();
+    WebCore::Color bottom();
+    WebCore::Color left();
+}
+
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::Path {
     Vector<WebCore::PathSegment> segments();
 }
@@ -8986,3 +8993,8 @@ header: <WebCore/DocumentClasses.h>
 header: <WebCore/StageModeOperations.h>
 enum class WebCore::StageModeOperation : bool;
 #endif
+
+struct WebCore::FixedContainerEdges {
+    WebCore::RectEdges<WebCore::Color> predominantColors;
+    WebCore::RectEdges<bool> fixedEdges;
+};

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -93,10 +93,11 @@ bool defaultVideoFullscreenRequiresElementFullscreen();
 bool defaultScrollAnimatorEnabled();
 bool defaultPassiveWheelListenersAsDefaultOnDocument();
 bool defaultWheelEventGesturesBecomeNonBlocking();
+bool defaultAppleMailPaginationQuirkEnabled();
 #endif
 
-#if PLATFORM(MAC)
-bool defaultAppleMailPaginationQuirkEnabled();
+#if PLATFORM(COCOA)
+bool defaultFixedContainerEdgeSamplingEnabled();
 #endif
 
 #if ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -32,6 +32,7 @@
 #import "WKIntelligenceSmartReplyTextEffectCoordinator.h"
 #import "WKIntelligenceTextEffectCoordinator.h"
 #import "WKTextAnimationType.h"
+#import <WebCore/FixedContainerEdges.h>
 #import <WebKit/WKShareSheet.h>
 #import <WebKit/WKWebViewConfiguration.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -423,6 +424,8 @@ struct PerWebProcessState {
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
     BOOL _isScrollingWithOverlayRegion;
 #endif
+
+    WebCore::FixedContainerEdges _fixedContainerEdges;
 }
 
 - (BOOL)_isValid;
@@ -507,6 +510,8 @@ struct PerWebProcessState {
 - (void)_setAllowGamepadsAccess;
 #endif
 #endif
+
+- (void)_updateFixedContainerEdges:(const WebCore::FixedContainerEdges&)edges;
 
 - (WKPageRef)_pageForTesting;
 - (NakedPtr<WebKit::WebPageProxy>)_page;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -406,6 +406,18 @@ for this property.
 
 @property (nonatomic, readonly) BOOL _isSuspended;
 
+#if TARGET_OS_IPHONE
+@property (nonatomic, readonly) UIColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) UIColor *_sampledLeftFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) UIColor *_sampledBottomFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+@property (nonatomic, readonly) UIColor *_sampledRightFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+#else
+@property (nonatomic, readonly) NSColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) NSColor *_sampledLeftFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) NSColor *_sampledBottomFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+@property (nonatomic, readonly) NSColor *_sampledRightFixedPositionContentColor WK_API_AVAILABLE(macos(WK_MAC_TBA));
+#endif
+
 @property (nonatomic, readonly) BOOL _canTogglePictureInPicture;
 @property (nonatomic, readonly) BOOL _canToggleInWindow;
 @property (nonatomic, readonly) BOOL _canEnterFullscreen WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -46,6 +46,7 @@ struct AppHighlight;
 
 namespace WebKit {
 
+class RemoteLayerTreeTransaction;
 struct TextAnimationData;
 enum class TextAnimationType : uint8_t;
 
@@ -100,6 +101,8 @@ public:
 #if ENABLE(APP_HIGHLIGHTS)
     void storeAppHighlight(const WebCore::AppHighlight&) final;
 #endif
+
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&) override;
 
     void microphoneCaptureWillChange() final;
     void cameraCaptureWillChange() final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -26,11 +26,13 @@
 #import "config.h"
 #import "PageClientImplCocoa.h"
 
+#import "RemoteLayerTreeTransaction.h"
 #import "WKTextAnimationType.h"
 #import "WKWebViewInternal.h"
 #import "WebFullScreenManagerProxy.h"
 #import "WebPageProxy.h"
 #import <WebCore/AlternativeTextUIController.h>
+#import <WebCore/FixedContainerEdges.h>
 #import <WebCore/TextAnimationTypes.h>
 #import <WebCore/WritingToolsTypes.h>
 #import <WebKit/WKWebViewConfigurationPrivate.h>
@@ -420,5 +422,10 @@ void PageClientImplCocoa::setFullScreenClientForTesting(std::unique_ptr<WebFullS
     m_fullscreenClientForTesting = WTFMove(client);
 }
 #endif
+
+void PageClientImplCocoa::didCommitLayerTree(const RemoteLayerTreeTransaction& transaction)
+{
+    [webView() _updateFixedContainerEdges:transaction.fixedContainerEdges()];
+}
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -158,7 +158,7 @@ static bool exceedsRenderTreeSizeSizeThreshold(uint64_t thresholdSize, uint64_t 
     return committedSize > thresholdSize * thesholdSizeFraction;
 }
 
-void WebPageProxy::didCommitLayerTree(const WebKit::RemoteLayerTreeTransaction& layerTreeTransaction)
+void WebPageProxy::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction)
 {
     if (layerTreeTransaction.isMainFrameProcessTransaction()) {
         themeColorChanged(layerTreeTransaction.themeColor());

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -133,6 +133,7 @@ struct AppHighlight;
 struct DataDetectorElementInfo;
 struct DictionaryPopupInfo;
 struct ElementContext;
+struct FixedContainerEdges;
 struct TextIndicatorData;
 struct ShareDataWithParsedURL;
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -178,7 +178,7 @@ private:
     void commitPotentialTapFailed() override;
     void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) override;
 
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&) override;
+    void didCommitLayerTree(const RemoteLayerTreeTransaction&) final;
     void layerTreeCommitComplete() override;
         
     void didPerformDictionaryLookup(const WebCore::DictionaryPopupInfo&) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -651,6 +651,8 @@ void PageClientImpl::didGetTapHighlightGeometries(WebKit::TapIdentifier requestI
 
 void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction)
 {
+    PageClientImplCocoa::didCommitLayerTree(layerTreeTransaction);
+
     [contentView() _didCommitLayerTree:layerTreeTransaction];
 }
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1648,6 +1648,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _tearDownImageAnalysis];
 #endif
 
+    [_webView _updateFixedContainerEdges:WebCore::FixedContainerEdges { }];
+
     [self _removeContainerForContextMenuHintPreviews];
     [self _removeContainerForDragPreviews];
     [self _removeContainerForDropPreviews];

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -203,7 +203,6 @@ private:
 
     void setEditableElementIsFocused(bool) override;
 
-    void didCommitLayerTree(const RemoteLayerTreeTransaction&) override;
     void layerTreeCommitComplete() override;
 
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -781,10 +781,6 @@ void PageClientImpl::setEditableElementIsFocused(bool editableElementIsFocused)
     m_impl->setEditableElementIsFocused(editableElementIsFocused);
 }
 
-void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction)
-{
-}
-
 void PageClientImpl::layerTreeCommitComplete()
 {
 }

--- a/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
+++ b/Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm
@@ -30,6 +30,7 @@
 
 #if PLATFORM(MAC) && ENABLE(REVEAL)
 
+#import "WKWebView.h"
 #import "WebViewImpl.h"
 #import <wtf/RetainPtr.h>
 #import <wtf/WeakPtr.h>

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -220,7 +220,7 @@ class WebViewImpl final : public CanMakeWeakPtr<WebViewImpl>, public CanMakeChec
     WTF_MAKE_TZONE_ALLOCATED(WebViewImpl);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(WebViewImpl);
 public:
-    WebViewImpl(NSView <WebViewImplDelegate> *, WKWebView *outerWebView, WebProcessPool&, Ref<API::PageConfiguration>&&);
+    WebViewImpl(WKWebView *, WebProcessPool&, Ref<API::PageConfiguration>&&);
 
     ~WebViewImpl();
 
@@ -229,7 +229,7 @@ public:
     WebPageProxy& page() { return m_page.get(); }
     Ref<WebPageProxy> protectedPage() const;
 
-    NSView *view() const { return m_view.getAutoreleased(); }
+    WKWebView *view() const { return m_view.getAutoreleased(); }
 
     void processWillSwap();
     void processDidExit();
@@ -881,7 +881,7 @@ private:
 
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
 
-    WeakObjCPtr<NSView<WebViewImplDelegate>> m_view;
+    WeakObjCPtr<WKWebView> m_view;
     std::unique_ptr<PageClient> m_pageClient;
     Ref<WebPageProxy> m_page;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4951,6 +4951,7 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     if (!frameView)
         return;
 
+    Ref page = *corePage();
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
     if (auto* document = localRootFrame->document()) {
         if (CheckedPtr timelinesController = document->timelinesController()) {
@@ -4962,11 +4963,13 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
 
     layerTransaction.setContentsSize(frameView->contentsSize());
     layerTransaction.setScrollOrigin(frameView->scrollOrigin());
-    layerTransaction.setPageScaleFactor(corePage()->pageScaleFactor());
-    layerTransaction.setRenderTreeSize(corePage()->renderTreeSize());
-    layerTransaction.setThemeColor(corePage()->themeColor());
-    layerTransaction.setPageExtendedBackgroundColor(corePage()->pageExtendedBackgroundColor());
-    layerTransaction.setSampledPageTopColor(corePage()->sampledPageTopColor());
+    layerTransaction.setPageScaleFactor(page->pageScaleFactor());
+    layerTransaction.setRenderTreeSize(page->renderTreeSize());
+    layerTransaction.setThemeColor(page->themeColor());
+    layerTransaction.setPageExtendedBackgroundColor(page->pageExtendedBackgroundColor());
+    layerTransaction.setSampledPageTopColor(page->sampledPageTopColor());
+    if (page->settings().fixedContainerEdgeSamplingEnabled())
+        layerTransaction.setFixedContainerEdges(frameView->fixedContainerEdges());
 
     layerTransaction.setBaseLayoutViewportSize(frameView->baseLayoutViewportSize());
     layerTransaction.setMinStableLayoutViewportOrigin(frameView->minStableLayoutViewportOrigin());

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -397,6 +397,8 @@ interface UIScriptController {
 
     undefined setWebViewEditable(boolean editable);
 
+    readonly attribute object fixedContainerEdgeColors;
+
     // Only affects macOS.
     undefined setWebViewAllowsMagnification(boolean allowsMagnification);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -118,6 +118,8 @@ public:
     virtual void endInteractiveObscuredInsetsChange() { notImplemented(); }
     virtual void setObscuredInsets(double, double, double, double) { notImplemented(); }
 
+    virtual JSObjectRef fixedContainerEdgeColors() const { return nullptr; }
+
     // View Parenting and Visibility
 
     virtual void becomeFirstResponder() { notImplemented(); }

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -93,6 +93,8 @@ private:
     void requestRenderedTextForFrontmostTarget(int x, int y, JSValueRef callback) final;
     void adjustVisibilityForFrontmostTarget(int x, int y, JSValueRef callback) final;
     void resetVisibilityAdjustments(JSValueRef callback) final;
+
+    JSObjectRef fixedContainerEdgeColors() const final;
 };
 
 } // namespace WTR


### PR DESCRIPTION
#### 6c3e6c50a1785fda5ca163c1e89c6b9aee8e5b9d
<pre>
[Cocoa] Expose SPI (for prototyping only) to get sampled colors at the edges of fixed-position containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=287734">https://bugs.webkit.org/show_bug.cgi?id=287734</a>
<a href="https://rdar.apple.com/144839983">rdar://144839983</a>

Reviewed by Abrar Rahman Protyasha.

Add support for new SPI to get an `(NS|UI)Color` for each rect edge of the layout viewport, or null
if there is no fixed-position container near that edge. This color represents the predominant color
for that edge (in the case where there is a predominant color), and otherwise falls back to the
extended page background color.

This mechanism is fully gated behind a new runtime setting, `FixedContainerEdgeSamplingEnabled`,
which is currently off by default (but enabled in the new tests). See below for more details.

* LayoutTests/TestExpectations:
* LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html: Added.

Add a new layout test to exercise this SPI.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.fixedContainerEdgeColors):
(window.UIHelper.async waitForFixedContainerEdgeColors):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):

Make a couple of minor adjustments to the color sampling heuristic:

-   Fix a bug where all colors are considered similar to each other, since
    `toResolvedColorComponentsInColorSpace` returns values clamped between (0, 1), but the color
    distance math assumes the results are in the interval (0, 255).

-   Fall back to the page extended background color instead of an invalid color, in the case where
    there is no predominant color.

* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(defaultFixedContainerEdgeSamplingEnabled):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:

Plumb the new `FixedContainerEdges` data through remote layer tree transactions over to the UI
process, only if the new runtime setting is enabled.

(WebKit::RemoteLayerTreeTransaction::fixedContainerEdges const):
(WebKit::RemoteLayerTreeTransaction::setFixedContainerEdges):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView _sampledBottomFixedPositionContentColor:]):
(-[WKWebView _sampledLeftFixedPositionContentColor:]):
(-[WKWebView _sampledTopFixedPositionContentColor:]):
(-[WKWebView _sampledRightFixedPositionContentColor:]):
(-[WKWebView _sampledBottomFixedPositionContentColor]):
(-[WKWebView _sampledLeftFixedPositionContentColor]):
(-[WKWebView _sampledTopFixedPositionContentColor]):
(-[WKWebView _sampledRightFixedPositionContentColor]):

Implement the new properties.

(-[WKWebView _updateFixedContainerEdges:]):

Add a helper method to update current `_fixedContainerEdges`, dispatching KVO notifications in the
process if needed.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::didCommitLayerTree):

Refactor some of this code so that there&apos;s a common Cocoa implementation of `didCommitLayerTree` in
the page client that now updates fixed container edge data, and an iOS-specific override point that
additionally propagates the layer tree commit to `WKContentView`.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::didCommitLayerTree):
* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didCommitLayerTree):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView cleanUpInteraction]):

iOS: reset edge colors when the process terminates or swaps.

* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didCommitLayerTree): Deleted.
* Source/WebKit/UIProcess/mac/WKRevealItemPresenter.mm:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):

Change `m_view` into a `WKWebView` instead of an `NSView&lt;WebViewImplDelegate&gt;`, so that we can just
call directly into the `WKWebView` in `handleProcessSwapOrExit`. This view used to be either a
`WKWebView` or a `WKView`, but this abstraction hasn&apos;t been necessary for several years, since
`WKView` no longer has any clients.

Note that we also remove the `outerWebView` argument in the constructor here, since the only place
where we create a new `WebViewImpl` is from `WKWebView`, which just uses `self` as the
`outerWebView`.

(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::handleProcessSwapOrExit):

macOS: reset edge colors when the process terminates or swaps.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::willCommitLayerTree):

Set the fixed container edge data on the remote layer tree transaction (only if the new setting is
enabled).

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::fixedContainerEdgeColors const):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::fixedContainerEdgeColors const):

Add a new testing helper to retrieve the fixed container edge colors on all sides, and return it as
a JS object where each of the values is a string: `&quot;rgb(…)&quot;`.

Canonical link: <a href="https://commits.webkit.org/290447@main">https://commits.webkit.org/290447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/386123c62e6c115b4887445a422fff0f81b0c900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44934 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95033 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40806 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92085 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69311 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26912 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93034 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7613 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49673 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7340 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36031 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39940 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82836 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77672 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37102 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96859 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88811 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78312 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77518 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19145 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21967 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10415 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17231 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22556 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111302 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16972 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26644 "Found 15 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm.js.mini-mode, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20424 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->