### PR TITLE
AX: [AX-Thread Text APIs] OffsetFromRoot should explore all text objects, not just those with text runs

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/offset-from-root-outside-text-run-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/offset-from-root-outside-text-run-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we can get the index of a text marker that points to an object with no runs/text.
+
+PASS: pObject.indexForTextMarker(endMarker) === 11
+PASS: inputObject.indexForTextMarker(inputStart) === 11
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world

--- a/LayoutTests/accessibility/ax-thread-text-apis/offset-from-root-outside-text-run.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/offset-from-root-outside-text-run.html
@@ -1,0 +1,31 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- New test added while implementing AccessibilityThreadTextApisEnabled. Keep it when the feature is enabled by default. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="p" style="display: inline-block;">Hello world</p><input id="input" type="text" value="" style="display: inline-block;"/>
+
+<script>
+let output = "This test ensures we can get the index of a text marker that points to an object with no runs/text.\n\n";
+
+if (window.accessibilityController) {
+    var pObject = accessibilityController.accessibleElementById("p");
+    const range1 = pObject.textMarkerRangeForElement(pObject);
+    var endMarker = pObject.endTextMarkerForTextMarkerRange(range1);
+    output += expect("pObject.indexForTextMarker(endMarker)", "11");
+    
+    var inputObject = accessibilityController.accessibleElementById("input");
+    const range2 = inputObject.textMarkerRangeForElement(inputObject);
+    var inputStart = inputObject.endTextMarkerForTextMarkerRange(range2);
+    output += expect("inputObject.indexForTextMarker(inputStart)", "11");
+    
+    debug(output);
+}
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
#### b0fe6c1717f59766f7143a5222cbc6b5e4a9da6c
<pre>
AX: [AX-Thread Text APIs] OffsetFromRoot should explore all text objects, not just those with text runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=287736">https://bugs.webkit.org/show_bug.cgi?id=287736</a>
<a href="https://rdar.apple.com/144892240">rdar://144892240</a>

Reviewed by Tyler Wilcock.

ATs sometimes need to request the index of a text marker that is not part of an object with text runs.
For example, the start of a text input that has no text.

OffsetFromRoot used to assert in this scenario, since it only traversed text positions that were in text
runs. Now, we explore all objects, switching between navigating within runs and between objects when
necessary.

* LayoutTests/accessibility/ax-thread-text-apis/offset-from-root-outside-text-run-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/offset-from-root-outside-text-run.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::offsetFromRoot const):

Canonical link: <a href="https://commits.webkit.org/290445@main">https://commits.webkit.org/290445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7928df768892adb4016be915bd089112e9e7619a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44911 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40784 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26900 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81650 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7320 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39918 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77655 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17199 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78307 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77473 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77492 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19143 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21944 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Ventura-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10393 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17209 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22534 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/16950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18733 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->