### PR TITLE
Address some of the Safer CPP warnings in WebPage.cpp

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1358,7 +1358,7 @@ Vector<String> removeQueryParameters(URL& url, const UncheckedKeyHashSet<String>
     });
 }
 
-Vector<String> removeQueryParameters(URL& url, Function<bool(const String&)>&& shouldRemove) 
+Vector<String> removeQueryParameters(URL& url, NOESCAPE const Function<bool(const String&)>& shouldRemove)
 {
     if (!url.hasQuery())
         return { };

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -305,7 +305,7 @@ WTF_EXPORT_PRIVATE bool isEqualIgnoringQueryAndFragments(const URL&, const URL&)
 
 // Returns the parameters that were removed (including duplicates), in the order that they appear in the URL.
 WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const UncheckedKeyHashSet<String>&);
-WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, Function<bool(const String&)>&&);
+WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, NOESCAPE const Function<bool(const String&)>&);
 
 WTF_EXPORT_PRIVATE const URL& aboutBlankURL();
 WTF_EXPORT_PRIVATE const URL& aboutSrcDocURL();

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -66,7 +66,7 @@ DOMWrapperWorld& normalWorld(JSC::VM& vm)
 {
     VM::ClientData* clientData = vm.clientData;
     ASSERT(clientData);
-    return downcast<JSVMClientData>(clientData)->normalWorld();
+    return downcast<JSVMClientData>(clientData)->normalWorldSingleton();
 }
 
 DOMWrapperWorld& mainThreadNormalWorld()

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -126,7 +126,7 @@ public:
     
     WEBCORE_EXPORT static void initNormalWorld(JSC::VM*, WorkerThreadType);
 
-    DOMWrapperWorld& normalWorld() { return *m_normalWorld; }
+    DOMWrapperWorld& normalWorldSingleton() { return *m_normalWorld; }
 
     void getAllWorlds(Vector<Ref<DOMWrapperWorld>>&);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3612,6 +3612,11 @@ HighlightRegistry& Document::appHighlightRegistry()
     return *m_appHighlightRegistry;
 }
 
+Ref<HighlightRegistry> Document::protectedAppHighlightRegistry()
+{
+    return highlightRegistry();
+}
+
 AppHighlightStorage& Document::appHighlightStorage()
 {
     if (!m_appHighlightStorage)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1877,6 +1877,7 @@ public:
 #if ENABLE(APP_HIGHLIGHTS)
     HighlightRegistry* appHighlightRegistryIfExists() { return m_appHighlightRegistry.get(); }
     WEBCORE_EXPORT HighlightRegistry& appHighlightRegistry();
+    WEBCORE_EXPORT Ref<HighlightRegistry> protectedAppHighlightRegistry();
 
     WEBCORE_EXPORT AppHighlightStorage& appHighlightStorage();
     AppHighlightStorage* appHighlightStorageIfExists() const { return m_appHighlightStorage.get(); };
@@ -1896,8 +1897,8 @@ public:
 
     WEBCORE_EXPORT Editor& editor();
     WEBCORE_EXPORT const Editor& editor() const;
-    Ref<Editor> protectedEditor();
-    Ref<const Editor> protectedEditor() const;
+    WEBCORE_EXPORT Ref<Editor> protectedEditor();
+    WEBCORE_EXPORT Ref<const Editor> protectedEditor() const;
     FrameSelection& selection() { return m_selection; }
     const FrameSelection& selection() const { return m_selection; }
     CheckedRef<FrameSelection> checkedSelection();

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -182,7 +182,7 @@ public:
     WEBCORE_EXPORT DocumentLoader* activeDocumentLoader() const;
     RefPtr<DocumentLoader> protectedActiveDocumentLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
-    RefPtr<DocumentLoader> protectedDocumentLoader() const;
+    WEBCORE_EXPORT RefPtr<DocumentLoader> protectedDocumentLoader() const;
     DocumentLoader* policyDocumentLoader() const { return m_policyDocumentLoader.get(); }
     DocumentLoader* provisionalDocumentLoader() const { return m_provisionalDocumentLoader.get(); }
     RefPtr<DocumentLoader> protectedProvisionalDocumentLoader() const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4938,7 +4938,7 @@ JSC::JSGlobalObject* Page::serviceWorkerGlobalObject(DOMWrapperWorld& world)
         return nullptr;
 
     // FIXME: We currently do not support non-normal worlds in service workers.
-    RELEASE_ASSERT(&downcast<JSVMClientData>(serviceWorkerGlobalScope->vm().clientData)->normalWorld() == &world);
+    RELEASE_ASSERT(&downcast<JSVMClientData>(serviceWorkerGlobalScope->vm().clientData)->normalWorldSingleton() == &world);
     return scriptController->globalScopeWrapper();
 }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1419,7 +1419,7 @@ private:
     std::unique_ptr<PerformanceLoggingClient> m_performanceLoggingClient;
 
 #if ENABLE(SPEECH_SYNTHESIS)
-    RefPtr<SpeechSynthesisClient> m_speechSynthesisClient;
+    const RefPtr<SpeechSynthesisClient> m_speechSynthesisClient;
 #endif
 
     const UniqueRef<SpeechRecognitionProvider> m_speechRecognitionProvider;

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp
@@ -125,7 +125,7 @@ void ServiceWorkerGlobalScope::notifyServiceWorkerPageOfCreationIfNecessary()
 
     if (auto* localMainFrame = dynamicDowncast<LocalFrame>(serviceWorkerPage->mainFrame())) {
         // FIXME: We currently do not support non-normal worlds in service workers.
-        Ref normalWorld = downcast<JSVMClientData>(vm().clientData)->normalWorld();
+        Ref normalWorld = downcast<JSVMClientData>(vm().clientData)->normalWorldSingleton();
         localMainFrame->loader().client().dispatchServiceWorkerGlobalObjectAvailable(normalWorld);
     }
 }

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -18,8 +18,8 @@ UIProcess/ProvisionalFrameProxy.cpp
 UIProcess/SuspendedPageProxy.cpp
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp
 UIProcess/WebContextMenuProxy.cpp
-UIProcess/WebPageProxy.cpp
 UIProcess/WebEditCommandProxy.cpp
+UIProcess/WebPageProxy.cpp
 UIProcess/WebURLSchemeTask.cpp
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebViewImpl.mm
@@ -35,13 +35,11 @@ WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
 WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
 WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/mac/WebPopupMenuMac.mm
-WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/DrawingArea.cpp
 WebProcess/WebPage/FindController.cpp
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
 WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WebPageMac.mm
 WebProcess/cocoa/PlaybackSessionManager.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -14,6 +14,5 @@ WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
 WebProcess/WebPage/DrawingArea.cpp
 WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
-WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WebPageMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -392,7 +392,6 @@ WebProcess/WebCoreSupport/WebNotificationClient.cpp
 WebProcess/WebCoreSupport/WebPlatformStrategies.cpp
 WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
-WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
 WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
 WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -45,7 +45,6 @@ WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Storage/WebSWClientConnection.cpp
 WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
-WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/EventDispatcher.cpp
 WebProcess/WebPage/ViewUpdateDispatcher.cpp
 WebProcess/WebPage/WebFrame.cpp

--- a/Source/WebKit/Shared/AuxiliaryProcess.cpp
+++ b/Source/WebKit/Shared/AuxiliaryProcess.cpp
@@ -220,7 +220,7 @@ void AuxiliaryProcess::stopRunLoop()
 #if !PLATFORM(COCOA)
 void AuxiliaryProcess::platformStopRunLoop()
 {
-    RunLoop::main().stop();
+    RunLoop::protectedMain()->stop();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/C/playstation/WKRunLoop.cpp
+++ b/Source/WebKit/UIProcess/API/C/playstation/WKRunLoop.cpp
@@ -37,7 +37,7 @@ void WKRunLoopRunMain()
 
 void WKRunLoopStopMain()
 {
-    RunLoop::main().stop();
+    RunLoop::protectedMain()->stop();
 }
 
 void WKRunLoopCallOnMainThread(WKRunLoopCallback callback, void* userData)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
@@ -39,7 +39,7 @@
 
 + (WKWebProcessPlugInScriptWorld *)normalWorld
 {
-    return WebKit::wrapper(WebKit::InjectedBundleScriptWorld::normalWorld());
+    return WebKit::wrapper(WebKit::InjectedBundleScriptWorld::normalWorldSingleton());
 }
 
 - (void)dealloc

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -689,7 +689,7 @@ bool WKBundlePageIsSuspended(WKBundlePageRef pageRef)
 
 void WKBundlePageAddUserScript(WKBundlePageRef pageRef, WKStringRef source, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)
 {
-    WebKit::toImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorld(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
+    WebKit::toImpl(pageRef)->addUserScript(WebKit::toWTFString(source), WebKit::InjectedBundleScriptWorld::normalWorldSingleton(), WebKit::toUserContentInjectedFrames(injectedFrames), WebKit::toUserScriptInjectionTime(injectionTime));
 }
 
 void WKBundlePageAddUserScriptInWorld(WKBundlePageRef page, WKStringRef source, WKBundleScriptWorldRef scriptWorld, _WKUserScriptInjectionTime injectionTime, WKUserContentInjectedFrames injectedFrames)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp
@@ -43,7 +43,7 @@ WKBundleScriptWorldRef WKBundleScriptWorldCreateWorld()
 
 WKBundleScriptWorldRef WKBundleScriptWorldNormalWorld()
 {
-    return toAPI(&WebKit::InjectedBundleScriptWorld::normalWorld());
+    return toAPI(&WebKit::InjectedBundleScriptWorld::normalWorldSingleton());
 }
 
 void WKBundleScriptWorldClearWrappers(WKBundleScriptWorldRef scriptWorldRef)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp
@@ -113,7 +113,7 @@ static WebKitScriptWorld* webkitScriptWorldCreate(Ref<InjectedBundleScriptWorld>
 
 static gpointer createDefaultScriptWorld(gpointer)
 {
-    return webkitScriptWorldCreate(InjectedBundleScriptWorld::normalWorld());
+    return webkitScriptWorldCreate(InjectedBundleScriptWorld::normalWorldSingleton());
 }
 
 /**

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -64,7 +64,7 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::create(const String& n
 Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapperWorld& world)
 {
     if (&world == &mainThreadNormalWorld())
-        return normalWorld();
+        return normalWorldSingleton();
 
     if (auto existingWorld = allWorlds().get(world))
         return *existingWorld;
@@ -81,7 +81,7 @@ InjectedBundleScriptWorld* InjectedBundleScriptWorld::find(const String& name)
     return nullptr;
 }
 
-InjectedBundleScriptWorld& InjectedBundleScriptWorld::normalWorld()
+InjectedBundleScriptWorld& InjectedBundleScriptWorld::normalWorldSingleton()
 {
     static InjectedBundleScriptWorld& world = adoptRef(*new InjectedBundleScriptWorld(mainThreadNormalWorld(), String())).leakRef();
     return world;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -45,7 +45,7 @@ public:
     static Ref<InjectedBundleScriptWorld> create(const String& name, Type = Type::Internal);
     static Ref<InjectedBundleScriptWorld> getOrCreate(WebCore::DOMWrapperWorld&);
     static InjectedBundleScriptWorld* find(const String&);
-    static InjectedBundleScriptWorld& normalWorld();
+    static InjectedBundleScriptWorld& normalWorldSingleton();
 
     virtual ~InjectedBundleScriptWorld();
 

--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -66,7 +66,7 @@ typedef HashMap<ContentWorldIdentifier, std::pair<Ref<InjectedBundleScriptWorld>
 
 static WorldMap& worldMap()
 {
-    static NeverDestroyed<WorldMap> map(std::initializer_list<WorldMap::KeyValuePairType> { { pageContentWorldIdentifier(), std::make_pair(Ref { InjectedBundleScriptWorld::normalWorld() }, 1) } });
+    static NeverDestroyed<WorldMap> map(std::initializer_list<WorldMap::KeyValuePairType> { { pageContentWorldIdentifier(), std::make_pair(Ref { InjectedBundleScriptWorld::normalWorldSingleton() }, 1) } });
 
     return map;
 }

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -228,7 +228,7 @@ void WebPage::performDictionaryLookupAtLocation(const FloatPoint& floatPoint)
         return;
     // Find the frame the point is over.
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(localMainFrame->view()->windowToContents(roundedIntPoint(floatPoint)), hitType);
+    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(localMainFrame->protectedView()->windowToContents(roundedIntPoint(floatPoint)), hitType);
 
     RefPtr frame = result.innerNonSharedNode() ? result.innerNonSharedNode()->document().frame() : m_page->checkedFocusController()->focusedOrMainFrame();
     if (!frame)
@@ -273,7 +273,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
     DictionaryPopupInfo dictionaryPopupInfo;
 
-    IntRect rangeRect = frame.view()->contentsToWindow(quads[0].enclosingBoundingBox());
+    IntRect rangeRect = frame.protectedView()->contentsToWindow(quads[0].enclosingBoundingBox());
 
     const RenderStyle* style = range.startContainer().renderStyle();
     float scaledAscent = style ? style->metricsOfPrimaryFont().intAscent() * pageScaleFactor() : 0;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -266,6 +266,11 @@ WebCore::Frame* WebFrame::coreFrame() const
     return m_coreFrame.get();
 }
 
+RefPtr<WebCore::Frame> WebFrame::protectedCoreFrame() const
+{
+    return coreFrame();
+}
+
 FrameInfoData WebFrame::info() const
 {
     RefPtr parent = parentFrame();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -103,6 +103,7 @@ public:
     RefPtr<WebCore::LocalFrame> protectedCoreLocalFrame() const;
     WebCore::RemoteFrame* coreRemoteFrame() const;
     WebCore::Frame* coreFrame() const;
+    RefPtr<WebCore::Frame> protectedCoreFrame() const;
 
     void createProvisionalFrame(ProvisionalFrameCreationParameters&&);
     void commitProvisionalFrame();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1120,6 +1120,7 @@ public:
 
 #if ENABLE(CONTEXT_MENUS)
     WebContextMenu& contextMenu();
+    Ref<WebContextMenu> protectedContextMenu();
     WebContextMenu* contextMenuAtPointInWindow(WebCore::FrameIdentifier, const WebCore::IntPoint&);
 #endif
 
@@ -2500,7 +2501,7 @@ private:
 
     RefPtr<WebPageTesting> m_webPageTesting;
 
-    Ref<WebFrame> m_mainFrame;
+    const Ref<WebFrame> m_mainFrame;
 
     RefPtr<WebPageGroupProxy> m_pageGroup;
 
@@ -2645,7 +2646,7 @@ private:
     RefPtr<WebOpenPanelResultListener> m_activeOpenPanelResultListener;
     RefPtr<NotificationPermissionRequestManager> m_notificationPermissionRequestManager;
 
-    Ref<WebUserContentController> m_userContentController;
+    const Ref<WebUserContentController> m_userContentController;
 
 #if ENABLE(WK_WEB_EXTENSIONS) && PLATFORM(COCOA)
     RefPtr<WebExtensionControllerProxy> m_webExtensionController;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -536,8 +536,10 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
 
     SandboxExtension::consumePermanently(parameters.additionalSandboxExtensionHandles);
 
-    if (!parameters.injectedBundlePath.isEmpty())
-        m_injectedBundle = InjectedBundle::create(parameters, transformHandlesToObjects(parameters.initializationUserData.object()));
+    if (!parameters.injectedBundlePath.isEmpty()) {
+        if (RefPtr injectedBundle = InjectedBundle::create(parameters, transformHandlesToObjects(parameters.initializationUserData.object())))
+            lazyInitialize(m_injectedBundle, injectedBundle.releaseNonNull());
+    }
 
     for (auto& supplement : m_supplements.values())
         supplement->initialize(parameters);

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -727,7 +727,7 @@ private:
 
     HashMap<WebCore::PageIdentifier, RefPtr<WebPage>> m_pageMap;
     HashMap<PageGroupIdentifier, RefPtr<WebPageGroupProxy>> m_pageGroupMap;
-    RefPtr<InjectedBundle> m_injectedBundle;
+    const RefPtr<InjectedBundle> m_injectedBundle;
 
     EventDispatcher m_eventDispatcher;
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/TestControllerGtk.cpp
@@ -52,7 +52,7 @@ namespace WTR {
 
 void TestController::notifyDone()
 {
-    RunLoop::main().stop();
+    RunLoop::protectedMain()->stop();
 }
 
 void TestController::platformInitialize(const Options&)
@@ -71,7 +71,7 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
         TimeoutTimer(WTF::Seconds timeout, bool& timedOut)
             : m_timer(RunLoop::main(), [&timedOut] {
                 timedOut = true;
-                RunLoop::main().stop();
+                RunLoop::protectedMain()->stop();
             })
         {
             m_timer.setPriority(G_PRIORITY_DEFAULT_IDLE);

--- a/Tools/WebKitTestRunner/libwpe/PlatformWebViewClientLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/PlatformWebViewClientLibWPE.cpp
@@ -62,7 +62,7 @@ PlatformImage PlatformWebViewClientLibWPE::snapshot()
         public:
             TimeoutTimer()
                 : m_timer(RunLoop::main(), [] {
-                    RunLoop::main().stop();
+                    RunLoop::protectedMain()->stop();
                 })
             {
                 m_timer.startOneShot(1_s / 60);

--- a/Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp
+++ b/Tools/WebKitTestRunner/playstation/TestControllerPlayStation.cpp
@@ -33,7 +33,7 @@ namespace WTR {
 
 void TestController::notifyDone()
 {
-    RunLoop::main().stop();
+    RunLoop::protectedMain()->stop();
 }
 
 void TestController::platformInitialize(const Options&)
@@ -54,7 +54,7 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
         void fired()
         {
             timedOut = true;
-            RunLoop::main().stop();
+            RunLoop::protectedMain()->stop();
         }
 
         RunLoop::Timer timer;

--- a/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
+++ b/Tools/WebKitTestRunner/wpe/TestControllerWPE.cpp
@@ -48,7 +48,7 @@ namespace WTR {
 
 void TestController::notifyDone()
 {
-    RunLoop::main().stop();
+    RunLoop::protectedMain()->stop();
 }
 
 void TestController::setHidden(bool)
@@ -75,7 +75,7 @@ void TestController::platformRunUntil(bool& done, WTF::Seconds timeout)
         TimeoutTimer(WTF::Seconds timeout, bool& timedOut)
             : m_timer(RunLoop::main(), [&timedOut] {
                 timedOut = true;
-                RunLoop::main().stop();
+                RunLoop::protectedMain()->stop();
             })
         {
             m_timer.setPriority(G_PRIORITY_DEFAULT_IDLE);


### PR DESCRIPTION
#### 679569af875aed6e4bdca60c19114681b4ba10f9
<pre>
Address some of the Safer CPP warnings in WebPage.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287742">https://bugs.webkit.org/show_bug.cgi?id=287742</a>

Reviewed by Basuke Suzuki.

* Source/WTF/wtf/URL.cpp:
(WTF::removeQueryParameters):
* Source/WTF/wtf/URL.h:
* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::normalWorld):
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
(WebCore::JSVMClientData::normalWorldSingleton):
(WebCore::JSVMClientData::normalWorld): Deleted.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::serviceWorkerGlobalObject):
* Source/WebCore/page/Page.h:
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.cpp:
(WebCore::ServiceWorkerGlobalScope::notifyServiceWorkerPageOfCreationIfNecessary):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm:
(+[WKWebProcessPlugInScriptWorld normalWorld]):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageAddUserScript):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleScriptWorld.cpp:
(WKBundleScriptWorldNormalWorld):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitScriptWorld.cpp:
(createDefaultScriptWorld):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::getOrCreate):
(WebKit::InjectedBundleScriptWorld::normalWorldSingleton):
(WebKit::InjectedBundleScriptWorld::normalWorld): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::worldMap):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::performDictionaryLookupAtLocation):
(WebKit::WebPage::dictionaryPopupInfoForRange):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
(WebKit::WebPage::editorState const):
(WebKit::WebPage::changeFontAttributes):
(WebKit::WebPage::changeFont):
(WebKit::WebPage::updateEditorStateAfterLayoutIfEditabilityChanged):
(WebKit::WebPage::isTrackingRepaints const):
(WebKit::WebPage::trackedRepaintRects):
(WebKit::WebPage::executeEditingCommand):
(WebKit::WebPage::setEditable):
(WebKit::WebPage::increaseListLevel):
(WebKit::WebPage::decreaseListLevel):
(WebKit::WebPage::changeListType):
(WebKit::WebPage::setBaseWritingDirection):
(WebKit::WebPage::drawRect):
(WebKit::WebPage::accessibilitySettingsDidChange):
(WebKit::WebPage::screenSizeForFingerprintingProtections const):
(WebKit::WebPage::contextMenuForKeyEvent):
(WebKit::WebPage::handleKeyEventByRelinquishingFocusToChrome):
(WebKit::WebPage::validateCommand):
(WebKit::WebPage::requestFontAttributesAtSelectionStart):
(WebKit::WebPage::centerSelectionInVisibleArea):
(WebKit::WebPage::insertNewlineInQuotedContent):
(WebKit::WebPage::viewWillStartLiveResize):
(WebKit::WebPage::viewWillEndLiveResize):
(WebKit::WebPage::copyLinkWithHighlight):
(WebKit::WebPage::getSelectionOrContentsAsString):
(WebKit::WebPage::closeCurrentTypingCommand):
(WebKit::WebPage::advanceToNextMisspelling):
(WebKit::WebPage::hasRichlyEditableSelection const):
(WebKit::WebPage::changeSpellingToWord):
(WebKit::WebPage::capitalizeWord):
(WebKit::WebPage::clearSelection):
(WebKit::WebPage::restoreSelectionInFocusedEditableElement):
(WebKit::WebPage::setCaretAnimatorType):
(WebKit::WebPage::setCaretBlinkingSuspended):
(WebKit::WebPage::beginPrinting):
(WebKit::WebPage::handleAlternativeTextUIResult):
(WebKit::WebPage::setCompositionForTesting):
(WebKit::WebPage::hasCompositionForTesting):
(WebKit::WebPage::confirmCompositionForTesting):
(WebKit::pageContainsAnyHorizontalScrollbars):
(WebKit::WebPage::setTextAsync):
(WebKit::WebPage::insertTextAsync):
(WebKit::WebPage::hasMarkedText):
(WebKit::WebPage::getMarkedRangeAsync):
(WebKit::WebPage::getSelectedRangeAsync):
(WebKit::WebPage::characterIndexForPointAsync):
(WebKit::WebPage::firstRectForCharacterRangeAsync):
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::setWritingSuggestion):
(WebKit::WebPage::confirmCompositionAsync):
(WebKit::WebPage::didChangeSelectionOrOverflowScrollPosition):
(WebKit::WebPage::resetFocusedElementForFrame):
(WebKit::WebPage::didEndUserTriggeredSelectionChanges):
(WebKit::WebPage::setMinimumSizeForAutoLayout):
(WebKit::WebPage::setSizeToContentAutoSizeMaximumSize):
(WebKit::WebPage::setAutoSizingShouldExpandToViewHeight):
(WebKit::WebPage::setViewportSizeForCSSViewportUnits):
(WebKit::WebPage::canShowResponse const):
(WebKit::WebPage::canShowMIMEType const):
(WebKit::WebPage::sendEditorStateUpdate):
(WebKit::WebPage::flushPendingEditorStateUpdate):
(WebKit::WebPage::extendIncrementalRenderingSuppression):
(WebKit::WebPage::stopExtendingIncrementalRenderingSuppression):
(WebKit::WebPage::setScrollPinningBehavior):
(WebKit::WebPage::setScrollbarOverlayStyle):
(WebKit::WebPage::addUserStyleSheet):
(WebKit::WebPage::speakingErrorOccurred):
(WebKit::WebPage::boundaryEventOccurred):
(WebKit::WebPage::voicesDidChange):
(WebKit::WebPage::insertAttachment):
(WebKit::WebPage::createAppHighlightInSelectedRange):
(WebKit::WebPage::restoreAppHighlightsAndScrollToIndex):
(WebKit::WebPage::insertTextPlaceholder):
(WebKit::WebPage::updateLastNodeBeforeWritingSuggestions):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/290446@main">https://commits.webkit.org/290446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b03190ff0a2be34d3296cbf8c9846e6e052ff1c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/44984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95076 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40848 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92127 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/9991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17903 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69342 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/26945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93076 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49704 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7371 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39982 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/82878 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96901 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/88853 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17263 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12669 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77536 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19144 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/21997 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20589 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10469 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17273 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111344 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17014 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26657 "Found 188 jsc stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager ...") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20466 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->