### PR TITLE
Migrate AVOutputContext from WKKeyedCoder

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h
@@ -57,6 +57,11 @@ IGNORE_WARNINGS_END
 #endif
 #endif
 
+@interface AVOutputContext(WKSecureCoding)
+- (NSDictionary *)_webKitPropertyListData;
+- (instancetype)_initWithWebKitPropertyListData:(NSDictionary *)plist;
+@end
+
 #import <AVFoundation/AVAudioSession_Private.h>
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(AVFOUNDATION) && HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
+
+#include <wtf/ArgumentCoder.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/text/WTFString.h>
+
+OBJC_CLASS AVOutputContext;
+
+namespace WebKit {
+
+struct CoreIPCAVOutputContextData {
+    String contextID;
+    String contextType;
+};
+
+class CoreIPCAVOutputContext {
+    WTF_MAKE_TZONE_ALLOCATED(CoreIPCAVOutputContext);
+public:
+    CoreIPCAVOutputContext(AVOutputContext *);
+
+    CoreIPCAVOutputContext(CoreIPCAVOutputContextData&& data)
+        : m_data(WTFMove(data))
+    {
+    }
+
+    RetainPtr<id> toID() const;
+
+private:
+    friend struct IPC::ArgumentCoder<CoreIPCAVOutputContext, void>;
+
+    CoreIPCAVOutputContextData m_data;
+};
+
+} // namespace WebKit
+
+#endif // USE(AVFOUNDATION) && HAVE(HAVE_WK_SECURE_CODING_AVOUTPUTCONTEXT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if USE(AVFOUNDATION) && HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
+
+#import "config.h"
+#import "CoreIPCAVOutputContext.h"
+
+#import "Logging.h"
+#import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <pal/cocoa/AVFoundationSoftLink.h>
+
+namespace WebKit {
+
+CoreIPCAVOutputContext::CoreIPCAVOutputContext(AVOutputContext *context)
+{
+    RetainPtr dict = [context _webKitPropertyListData];
+
+    RetainPtr<NSString> contextID = [dict objectForKey:@"contextID"];
+    if (![contextID isKindOfClass:NSString.class]) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCAVOutputContext 'contextID' value is nil or not an NSString");
+        return;
+    }
+
+    RetainPtr<NSString> contextType = [dict objectForKey:@"contextType"];
+    if (![contextType isKindOfClass:NSString.class]) {
+        RELEASE_LOG_ERROR(IPC, "CoreIPCAVOutputContext 'contextType' value is nil or not an NSString");
+        return;
+    }
+    m_data = { (String)contextID.get(), (String)contextType.get() };
+}
+
+RetainPtr<id> CoreIPCAVOutputContext::toID() const
+{
+    RetainPtr dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:2]);
+    [dict setObject:(NSString *)m_data.contextID forKey:@"contextID"];
+    [dict setObject:(NSString *)m_data.contextType forKey:@"contextType"];
+    return adoptNS([[PAL::getAVOutputContextClass() alloc] _initWithWebKitPropertyListData:dict.get()]);
+}
+
+} // namespace WebKit
+
+#endif // USE(AVFOUNDATION) && HAVE(HAVE_WK_SECURE_CODING_AVOUTPUTCONTEXT)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Apple Inc. All rights reserved.
+# Copyright (C) 2023-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -20,13 +20,25 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#if USE(AVFOUNDATION)
+#if USE(AVFOUNDATION) && HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
+webkit_platform_headers: "CoreIPCAVOutputContext.h"
 
-# FIXME: Remove SupportWKKeyedCoder once AVOutputContext conforms to the WebKit Property List secure coding protocol, tracked by rdar://119289362
+header: "CoreIPCAVOutputContext.h"
+[CustomHeader, WebKitPlatform] struct WebKit::CoreIPCAVOutputContextData {
+    String contextID;
+    String contextType;
+};
 
+header: "CoreIPCAVOutputContext.h"
+[CustomHeader, WebKitPlatform] class WebKit::CoreIPCAVOutputContext {
+    WebKit::CoreIPCAVOutputContextData m_data;
+};
+#endif // USE(AVFOUNDATION) && HAVE(HAVE_WK_SECURE_CODING_AVOUTPUTCONTEXT)
+
+#if USE(AVFOUNDATION) && !HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)
 secure_coding_header: <pal/cocoa/AVFoundationSoftLink.h>
 [WebKitSecureCodingClass=PAL::getAVOutputContextClass(), SupportWKKeyedCoder] webkit_secure_coding AVOutputContext {
     AVOutputContextSerializationKeyContextID: String
     AVOutputContextSerializationKeyContextType: String
 }
-#endif // USE(AVFOUNDATION)
+#endif // USE(AVFOUNDATION) && !HAVE(WK_SECURE_CODING_AVOUTPUTCONTEXT)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2505,6 +2505,8 @@
 		F4ABDB662B01C68F00C5471A /* CoreIPCError.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4ABDB622B018C1B00C5471A /* CoreIPCError.mm */; };
 		F4ABDB732B0417AD00C5471A /* CoreIPCLocale.h in Headers */ = {isa = PBXBuildFile; fileRef = F4ABDB722B0417AD00C5471A /* CoreIPCLocale.h */; };
 		F4B021E72D0BAC2D00D9145E /* CoreIPCSecTrust.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */; };
+		F4B24AA72D5ED4D300725993 /* CoreIPCAVOutputContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */; };
+		F4B24AA82D5ED4DE00725993 /* CoreIPCAVOutputContext.h in Headers */ = {isa = PBXBuildFile; fileRef = F4B24AA52D5ED3CD00725993 /* CoreIPCAVOutputContext.h */; };
 		F4BA33F225757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */; };
 		F4BCBBEC2AC332AA00C1858D /* WKFormAccessoryView.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BCBBE62AC3295300C1858D /* WKFormAccessoryView.h */; };
 		F4BE0D7727AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = F4BE0D7627AAE1CB005F0323 /* PlaybackSessionContextIdentifier.h */; };
@@ -8339,6 +8341,8 @@
 		F4ABDB742B041FE900C5471A /* CoreIPCLocale.serialization.in */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CoreIPCLocale.serialization.in; sourceTree = "<group>"; };
 		F4AC655E22A3140E00A05607 /* WebPreferencesDefaultValuesIOS.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = WebPreferencesDefaultValuesIOS.mm; path = ios/WebPreferencesDefaultValuesIOS.mm; sourceTree = "<group>"; };
 		F4B021E62D0BAB6D00D9145E /* CoreIPCSecTrust.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCSecTrust.mm; sourceTree = "<group>"; };
+		F4B24AA52D5ED3CD00725993 /* CoreIPCAVOutputContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoreIPCAVOutputContext.h; sourceTree = "<group>"; };
+		F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCAVOutputContext.mm; sourceTree = "<group>"; };
 		F4B378D021DDBBAB0095A378 /* WebUndoStepID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebUndoStepID.h; sourceTree = "<group>"; };
 		F4B63E162C49586700BC59EF /* CoreIPCPlist.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = CoreIPCPlist.serialization.in; sourceTree = "<group>"; };
 		F4BA33F025757E89000A3CE8 /* WKImageAnalysisGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WKImageAnalysisGestureRecognizer.h; path = ios/WKImageAnalysisGestureRecognizer.h; sourceTree = "<group>"; };
@@ -12100,6 +12104,8 @@
 				5197FAD82AFD33B1009180C5 /* CoreIPCArray.serialization.in */,
 				FA39AE662B23972A008F93CD /* CoreIPCAuditToken.h */,
 				FA39AE672B23972A008F93CD /* CoreIPCAuditToken.serialization.in */,
+				F4B24AA52D5ED3CD00725993 /* CoreIPCAVOutputContext.h */,
+				F4B24AA62D5ED3CD00725993 /* CoreIPCAVOutputContext.mm */,
 				51E8284B2B2036DD009119F9 /* CoreIPCAVOutputContext.serialization.in */,
 				523475D32B68470D0029B9AE /* CoreIPCCFCharacterSet.h */,
 				523475D42B6849A70029B9AE /* CoreIPCCFCharacterSet.serialization.in */,
@@ -16704,6 +16710,7 @@
 				5106D7C418BDBE73000AB166 /* ContextMenuContextData.h in Headers */,
 				5197FAEB2AFD33CF009180C5 /* CoreIPCArray.h in Headers */,
 				FA39AE682B23972B008F93CD /* CoreIPCAuditToken.h in Headers */,
+				F4B24AA82D5ED4DE00725993 /* CoreIPCAVOutputContext.h in Headers */,
 				523475D52B6849D10029B9AE /* CoreIPCCFCharacterSet.h in Headers */,
 				5197FAE72AFD33CF009180C5 /* CoreIPCCFType.h in Headers */,
 				519F6F7C2B2D77E300559CB3 /* CoreIPCCFURL.h in Headers */,
@@ -19964,6 +19971,7 @@
 			files = (
 				51FFD3092AE9A9FC00B0AB70 /* ArgumentCodersCocoa.mm in Sources */,
 				5187BDEA2AFF5419008A6EE5 /* CoreIPCArray.mm in Sources */,
+				F4B24AA72D5ED4D300725993 /* CoreIPCAVOutputContext.mm in Sources */,
 				5C5786902B6EFA29005D51D5 /* CoreIPCCFArray.mm in Sources */,
 				5CFC9C812B71809600F8D289 /* CoreIPCCFDictionary.mm in Sources */,
 				FA1ED3F42B76B93700C90F3B /* CoreIPCCFType.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1713,6 +1713,14 @@ TEST(IPCSerialization, NSURLRequest)
     runTestNS({ urlRequest });
 }
 
+#if USE(AVFOUNDATION) && PLATFORM(MAC)
+TEST(IPCSerialization, AVOutputContext)
+{
+    RetainPtr<AVOutputContext> outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] init]);
+    runTestNS({ outputContext.get() });
+}
+#endif // USE(AVFOUNDATION) && PLATFORM(MAC)
+
 #if PLATFORM(MAC)
 
 static RetainPtr<DDScannerResult> fakeDataDetectorResultForTesting()
@@ -1771,12 +1779,6 @@ TEST(IPCSerialization, SecureCoding)
     [actionContext setHighlightFrame:NSMakeRect(1, 2, 3, 4)];
 
     runTestNS({ actionContext.get() });
-
-    // AVOutputContext
-#if USE(AVFOUNDATION)
-    RetainPtr<AVOutputContext> outputContext = adoptNS([[PAL::getAVOutputContextClass() alloc] init]);
-    runTestNS({ outputContext.get() });
-#endif // USE(AVFOUNDATION)
 
     // PKPaymentMerchantSession
     // This initializer doesn't exercise retryNonce or domain


### PR DESCRIPTION
#### e571f49cde86136cb8e4616c0b5b34f8635e7c94
<pre>
Migrate AVOutputContext from WKKeyedCoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=287750">https://bugs.webkit.org/show_bug.cgi?id=287750</a>
<a href="https://rdar.apple.com/137150503">rdar://137150503</a>

Reviewed by Sihui Liu.

* Source/WebCore/PAL/pal/spi/cocoa/AVFoundationSPI.h:
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.h: Added.
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.mm: Added.
(WebKit::CoreIPCAVOutputContext::CoreIPCAVOutputContext):
(WebKit::CoreIPCAVOutputContext::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCAVOutputContext.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, AVOutputContext)):
(TEST(IPCSerialization, SecureCoding)):

Canonical link: <a href="https://commits.webkit.org/291182@main">https://commits.webkit.org/291182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6e2c3754f211ad7457f710e6dbea7ad94e2bd2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42660 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94134 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28119 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83413 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50980 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8829 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99044 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79674 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19445 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78920 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19568 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23451 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12211 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24362 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->