### PR TITLE
[JSC] `RegExp.prototype`'s `@@match` and `@@replace` should use `flags` getter only

### DIFF
--- a/JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js
+++ b/JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.match].js
@@ -6,7 +6,7 @@ var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) {
 RegExp.prototype[Symbol.match].call(p);
 p.global = true;
 RegExp.prototype[Symbol.match].call(p);
-return get + '' === "global,exec,global,unicode,exec";
+return get + '' === "flags,exec,flags,exec";
       
 }
 

--- a/JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.replace].js
+++ b/JSTests/es6/Proxy_internal_get_calls_RegExp.prototype[Symbol.replace].js
@@ -6,7 +6,7 @@ var p = new Proxy({ exec: function() { return null; } }, { get: function(o, k) {
 RegExp.prototype[Symbol.replace].call(p);
 p.global = true;
 RegExp.prototype[Symbol.replace].call(p);
-return get + '' === "global,exec,global,unicode,exec";
+return get + '' === "flags,exec,flags,exec";
       
 }
 

--- a/JSTests/stress/regexp-match-proxy.js
+++ b/JSTests/stress/regexp-match-proxy.js
@@ -33,7 +33,7 @@ let getProxyNullExec = new Proxy({
 
 resetTracking();
 RegExp.prototype[Symbol.match].call(getProxyNullExec);
-assert('get == "global,exec"');
+assert('get == "flags,exec"');
 
 let getSetProxyNullExec = new Proxy(
     {
@@ -57,13 +57,13 @@ let getSetProxyNullExec = new Proxy(
         }
     });
 
-getSetProxyNullExec.global = true;
+getSetProxyNullExec.flags = "g";
 
 resetTracking();
 RegExp.prototype[Symbol.match].call(getSetProxyNullExec);
-assert('get == "global,unicode,exec"');
+assert('get == "flags,exec"');
 assert('set == "lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec"');
 
 let regExpGlobal_s = new RegExp("s", "g");
 let getSetProxyMatches_s = new Proxy(
@@ -88,13 +88,13 @@ let getSetProxyMatches_s = new Proxy(
         }
     });
 
-getSetProxyMatches_s.global = true;
+getSetProxyMatches_s.flags = "g";
 resetTracking();
 let matchResult = RegExp.prototype[Symbol.match].call(getSetProxyMatches_s, "This is a test");
 assert('matchResult == "s,s,s"');
-assert('get == "global,unicode,exec,exec,exec,exec"');
+assert('get == "flags,exec,exec,exec,exec"');
 assert('set == "lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,exec,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,exec,exec"');
 
 let regExpGlobal_tx_Greedy = new RegExp("[tx]*", "g");
 let getSetProxyMatches_tx_Greedy = new Proxy(
@@ -123,14 +123,14 @@ let getSetProxyMatches_tx_Greedy = new Proxy(
         }
     });
 
-getSetProxyMatches_tx_Greedy.global = true;
+getSetProxyMatches_tx_Greedy.flags = "g";
 
 resetTracking();
 matchResult = RegExp.prototype[Symbol.match].call(getSetProxyMatches_tx_Greedy, "testing");
 assert('matchResult == "t,,,t,,,,"');
-assert('get == "global,unicode,exec,exec,lastIndex,exec,lastIndex,exec,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec"');
+assert('get == "flags,exec,exec,lastIndex,exec,lastIndex,exec,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec,lastIndex,exec"');
 assert('set == "lastIndex,lastIndex,lastIndex,lastIndex,lastIndex,lastIndex,lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec,lastIndex,lastIndex,exec"');
 
 let regExpGlobalUnicode_digit_nonGreedy = new RegExp("\\d{0,1}", "gu");
 let getSetProxyMatchesUnicode_digit_nonGreedy = new Proxy(
@@ -159,12 +159,11 @@ let getSetProxyMatchesUnicode_digit_nonGreedy = new Proxy(
         }
     });
 
-getSetProxyMatchesUnicode_digit_nonGreedy.global = true;
-getSetProxyMatchesUnicode_digit_nonGreedy.unicode = true;
+getSetProxyMatchesUnicode_digit_nonGreedy.flags = "gu";
 
 resetTracking();
 matchResult = RegExp.prototype[Symbol.match].call(getSetProxyMatchesUnicode_digit_nonGreedy, "12X3\u{10400}4");
 assert('matchResult == "1,2,,3,,4,"');
-assert('get == "global,unicode,exec,exec,exec,lastIndex,exec,exec,lastIndex,exec,exec,lastIndex,exec"');
+assert('get == "flags,exec,exec,exec,lastIndex,exec,exec,lastIndex,exec,exec,lastIndex,exec"');
 assert('set == "lastIndex,lastIndex,lastIndex,lastIndex"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec"');

--- a/JSTests/stress/regexp-prototype-symbol-match-flags-effects.js
+++ b/JSTests/stress/regexp-prototype-symbol-match-flags-effects.js
@@ -1,0 +1,54 @@
+function sameValue(a, b) {
+  if (a !== b) {
+    throw new Error(`Expected ${a} to equal ${b}`);
+  }
+}
+
+{
+    const re = /abc/;
+
+    let flagsCount = 0;
+
+    Object.defineProperty(re, "flags", { get() { flagsCount++; return ""; }});
+
+    for (let i = 0; i < testLoopCount; i++) {
+        re[Symbol.match]("abc");
+    }
+
+    sameValue(flagsCount, testLoopCount);
+}
+
+{
+    const re = /abc/;
+
+    let globalCount = 0;
+    let hasIndicesCount = 0;
+    let ignoreCaseCount = 0;
+    let multilineCount = 0;
+    let stickyCount = 0;
+    let dotAllCount = 0;
+    let unicodeCount = 0;
+    let unicodeSetsCount = 0;
+
+    Object.defineProperty(re, "global", { get() { globalCount++; return false; }});
+    Object.defineProperty(re, "hasIndices", { get() { hasIndicesCount++; return false; }});
+    Object.defineProperty(re, "ignoreCase", { get() { ignoreCaseCount++; return false; }});
+    Object.defineProperty(re, "multiline", { get() { multilineCount++; return false; }});
+    Object.defineProperty(re, "sticky", { get() { stickyCount++; return false; }});
+    Object.defineProperty(re, "dotAll", { get() { dotAllCount++; return false; }});
+    Object.defineProperty(re, "unicode", { get() { unicodeCount++; return false; }});
+    Object.defineProperty(re, "unicodeSets", { get() { unicodeSetsCount++; return false; }});
+
+    for (let i = 0; i < testLoopCount; i++) {
+        re[Symbol.match]("abc");
+    }
+
+    sameValue(globalCount, testLoopCount);
+    sameValue(hasIndicesCount, testLoopCount);
+    sameValue(ignoreCaseCount, testLoopCount);
+    sameValue(multilineCount, testLoopCount);
+    sameValue(stickyCount, testLoopCount);
+    sameValue(dotAllCount, testLoopCount);
+    sameValue(unicodeCount, testLoopCount);
+    sameValue(unicodeSetsCount, testLoopCount);
+}

--- a/JSTests/stress/regexp-prototype-symbol-replace-flags-effects.js
+++ b/JSTests/stress/regexp-prototype-symbol-replace-flags-effects.js
@@ -1,0 +1,54 @@
+function sameValue(a, b) {
+  if (a !== b) {
+    throw new Error(`Expected ${a} to equal ${b}`);
+  }
+}
+
+{
+    const re = /abc/;
+
+    let flagsCount = 0;
+
+    Object.defineProperty(re, "flags", { get() { flagsCount++; return ""; }});
+
+    for (let i = 0; i < testLoopCount; i++) {
+        re[Symbol.replace]("abc");
+    }
+
+    sameValue(flagsCount, testLoopCount);
+}
+
+{
+    const re = /abc/;
+
+    let globalCount = 0;
+    let hasIndicesCount = 0;
+    let ignoreCaseCount = 0;
+    let multilineCount = 0;
+    let stickyCount = 0;
+    let dotAllCount = 0;
+    let unicodeCount = 0;
+    let unicodeSetsCount = 0;
+
+    Object.defineProperty(re, "global", { get() { globalCount++; return false; }});
+    Object.defineProperty(re, "hasIndices", { get() { hasIndicesCount++; return false; }});
+    Object.defineProperty(re, "ignoreCase", { get() { ignoreCaseCount++; return false; }});
+    Object.defineProperty(re, "multiline", { get() { multilineCount++; return false; }});
+    Object.defineProperty(re, "sticky", { get() { stickyCount++; return false; }});
+    Object.defineProperty(re, "dotAll", { get() { dotAllCount++; return false; }});
+    Object.defineProperty(re, "unicode", { get() { unicodeCount++; return false; }});
+    Object.defineProperty(re, "unicodeSets", { get() { unicodeSetsCount++; return false; }});
+
+    for (let i = 0; i < testLoopCount; i++) {
+        re[Symbol.replace]("abc");
+    }
+
+    sameValue(globalCount, testLoopCount);
+    sameValue(hasIndicesCount, testLoopCount);
+    sameValue(ignoreCaseCount, testLoopCount);
+    sameValue(multilineCount, testLoopCount);
+    sameValue(stickyCount, testLoopCount);
+    sameValue(dotAllCount, testLoopCount);
+    sameValue(unicodeCount, testLoopCount);
+    sameValue(unicodeSetsCount, testLoopCount);
+}

--- a/JSTests/stress/regexp-replace-proxy.js
+++ b/JSTests/stress/regexp-replace-proxy.js
@@ -31,7 +31,7 @@ let getProxyNullExec = new Proxy({
 
 resetTracking();
 RegExp.prototype[Symbol.replace].call(getProxyNullExec);
-assert('get == "global,exec"');
+assert('get == "flags,exec"');
 
 let getSetProxyNullExec = new Proxy(
     {
@@ -54,12 +54,12 @@ let getSetProxyNullExec = new Proxy(
         }
     });
 
-getSetProxyNullExec.global = true;
+getSetProxyNullExec.flags = "g";
 
 resetTracking();
 RegExp.prototype[Symbol.replace].call(getSetProxyNullExec);
-assert('get == "global,unicode,exec"');
-assert('getSet == "global,unicode,lastIndex,exec"');
+assert('get == "flags,exec"');
+assert('getSet == "flags,lastIndex,exec"');
 
 let regExpGlobal_comma = new RegExp(",", "g");
 let getSetProxyMatches_comma = new Proxy(
@@ -83,12 +83,12 @@ let getSetProxyMatches_comma = new Proxy(
         }
     });
 
-getSetProxyMatches_comma.global = true;
+getSetProxyMatches_comma.flags = "g";
 resetTracking();
 let replaceResult = RegExp.prototype[Symbol.replace].call(getSetProxyMatches_comma, "John,,Doe,121 Main St.,Anytown", ":");
 assert('replaceResult == "John::Doe:121 Main St.:Anytown"');
-assert('get == "global,unicode,exec,exec,exec,exec,exec"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,exec,exec,exec"');
+assert('get == "flags,exec,exec,exec,exec,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,exec,exec,exec"');
 
 let regExp_phoneNumber = new RegExp("(\\d{3})(\\d{3})(\\d{4})", "");
 let getSetProxyReplace_phoneNumber = new Proxy(
@@ -119,8 +119,8 @@ let getSetProxyReplace_phoneNumber = new Proxy(
 resetTracking();
 replaceResult = RegExp.prototype[Symbol.replace].call(getSetProxyReplace_phoneNumber, "8005551212", "$1-$2-$3");
 assert('replaceResult == "800-555-1212"');
-assert('get == "global,exec"');
-assert('getSet == "global,exec"');
+assert('get == "flags,exec"');
+assert('getSet == "flags,exec"');
 
 let regExpGlobalUnicode_digit_nonGreedy = new RegExp("\\d{0,1}", "gu");
 let getSetProxyReplaceUnicode_digit_nonGreedy = new Proxy(
@@ -148,11 +148,10 @@ let getSetProxyReplaceUnicode_digit_nonGreedy = new Proxy(
         }
     });
 
-getSetProxyReplaceUnicode_digit_nonGreedy.global = true;
-getSetProxyReplaceUnicode_digit_nonGreedy.unicode = true;
+getSetProxyReplaceUnicode_digit_nonGreedy.flags = "gu";
 
 resetTracking();
 replaceResult = RegExp.prototype[Symbol.replace].call(getSetProxyReplaceUnicode_digit_nonGreedy, "12X3\u{10400}4", "[$&]");
 assert('replaceResult == "[1][2][]X[3][]\u{10400}[4][]"');
-assert('get == "global,unicode,exec,exec,exec,lastIndex,exec,exec,lastIndex,exec,exec,lastIndex,exec"');
-assert('getSet == "global,unicode,lastIndex,exec,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec"');
+assert('get == "flags,exec,exec,exec,lastIndex,exec,exec,lastIndex,exec,exec,lastIndex,exec"');
+assert('getSet == "flags,lastIndex,exec,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec,exec,lastIndex,lastIndex,exec"');

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -97,24 +97,6 @@ test/built-ins/Proxy/construct/return-not-object-throws-undefined-realm.js:
 test/built-ins/Proxy/construct/trap-is-not-callable-realm.js:
   default: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
   strict mode: 'Test262Error: Expected a TypeError but got a different error constructor with the same name'
-test/built-ins/RegExp/prototype/Symbol.match/flags-tostring-error.js:
-  default: 'Test262Error: Expected a CustomError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
-test/built-ins/RegExp/prototype/Symbol.match/get-flags-err.js:
-  default: 'Test262Error: Expected a CustomError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
-test/built-ins/RegExp/prototype/Symbol.match/get-unicode-error.js:
-  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-test/built-ins/RegExp/prototype/Symbol.replace/flags-tostring-error.js:
-  default: 'Test262Error: Expected a CustomError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
-test/built-ins/RegExp/prototype/Symbol.replace/get-flags-err.js:
-  default: 'Test262Error: Expected a CustomError but got a Test262Error'
-  strict mode: 'Test262Error: Expected a CustomError but got a Test262Error'
-test/built-ins/RegExp/prototype/Symbol.replace/get-unicode-error.js:
-  default: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
-  strict mode: 'Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all'
 test/built-ins/Temporal/Duration/compare/compare-no-precision-loss.js:
   default: 'Test262Error: Expected SameValue(«0», «0») to be false'
   strict mode: 'Test262Error: Expected SameValue(«0», «0») to be false'

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -75,13 +75,32 @@ function hasObservableSideEffectsForRegExpMatch(regexp)
     if (regexpExec !== @regExpBuiltinExec)
         return true;
 
+    var regexpFlags = @tryGetById(regexp, "flags");
+    if (regexpFlags !== @regExpProtoFlagsGetter)
+        return true;
+
+    // These are accessed by the builtin flags getter.
     var regexpGlobal = @tryGetById(regexp, "global");
     if (regexpGlobal !== @regExpProtoGlobalGetter)
+        return true;
+    var regexpHasIndices = @tryGetById(regexp, "hasIndices");
+    if (regexpHasIndices !== @regExpProtoHasIndicesGetter)
+        return true;
+    var regexpIgnoreCase = @tryGetById(regexp, "ignoreCase");
+    if (regexpIgnoreCase !== @regExpProtoIgnoreCaseGetter)
+        return true;
+    var regexpMultiline = @tryGetById(regexp, "multiline");
+    if (regexpMultiline !== @regExpProtoMultilineGetter)
+        return true;
+    var regexpSticky = @tryGetById(regexp, "sticky");
+    if (regexpSticky !== @regExpProtoStickyGetter)
+        return true;
+    var regexpDotAll = @tryGetById(regexp, "dotAll");
+    if (regexpDotAll !== @regExpProtoDotAllGetter)
         return true;
     var regexpUnicode = @tryGetById(regexp, "unicode");
     if (regexpUnicode !== @regExpProtoUnicodeGetter)
         return true;
-
     var regexpUnicodeSets = @tryGetById(regexp, "unicodeSets");
     if (regexpUnicodeSets !== @regExpProtoUnicodeSetsGetter)
         return true;
@@ -94,10 +113,13 @@ function matchSlow(regexp, str)
 {
     "use strict";
 
-    if (!regexp.global)
+    var flags = @toString(regexp.flags);
+    var global = @stringIncludesInternal.@call(flags, "g");
+
+    if (!global)
         return @regExpExec(regexp, str);
     
-    var unicode = regexp.unicode;
+    var unicode = @stringIncludesInternal.@call(flags, "u") || @stringIncludesInternal.@call(flags, "v");
     regexp.lastIndex = 0;
     var resultList = [];
 
@@ -282,11 +304,12 @@ function replace(strArg, replace)
     if (!functionalReplace)
         replace = @toString(replace);
 
-    var global = regexp.global;
+    var flags = @toString(regexp.flags);
+    var global = @stringIncludesInternal.@call(flags, "g");
     var unicode = false;
 
     if (global) {
-        unicode = regexp.unicode;
+        unicode = @stringIncludesInternal.@call(flags, "u") || @stringIncludesInternal.@call(flags, "v");
         regexp.lastIndex = 0;
     }
 

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -226,14 +226,32 @@ function hasObservableSideEffectsForStringReplace(regexp, replacer)
     if (regexpExec !== @regExpBuiltinExec)
         return true;
 
+    var regexpFlags = @tryGetById(regexp, "flags");
+    if (regexpFlags !== @regExpProtoFlagsGetter)
+        return true;
+
+    // These are accessed by the builtin flags getter.
+    var regexpDotAll = @tryGetById(regexp, "dotAll");
+    if (regexpDotAll !== @regExpProtoDotAllGetter)
+        return true;
     var regexpGlobal = @tryGetById(regexp, "global");
     if (regexpGlobal !== @regExpProtoGlobalGetter)
         return true;
-
+    var regexpHasIndices = @tryGetById(regexp, "hasIndices");
+    if (regexpHasIndices !== @regExpProtoHasIndicesGetter)
+        return true;
+    var regexpIgnoreCase = @tryGetById(regexp, "ignoreCase");
+    if (regexpIgnoreCase !== @regExpProtoIgnoreCaseGetter)
+        return true;
+    var regexpMultiline = @tryGetById(regexp, "multiline");
+    if (regexpMultiline !== @regExpProtoMultilineGetter)
+        return true;
+    var regexpSticky = @tryGetById(regexp, "sticky");
+    if (regexpSticky !== @regExpProtoStickyGetter)
+        return true;
     var regexpUnicode = @tryGetById(regexp, "unicode");
     if (regexpUnicode !== @regExpProtoUnicodeGetter)
         return true;
-
     var regexpUnicodeSets = @tryGetById(regexp, "unicodeSets");
     if (regexpUnicodeSets !== @regExpProtoUnicodeSetsGetter)
         return true;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4030,7 +4030,25 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                     if (attemptToFold(m_vm.propertyNames->exec.impl(), globalObject->regExpProtoExecFunction()))
                         break;
 
+                    if (attemptToFold(m_vm.propertyNames->flags.impl(), globalObject->regExpProtoFlagsGetter()))
+                        break;
+
+                    if (attemptToFold(m_vm.propertyNames->dotAll.impl(), globalObject->regExpProtoDotAllGetter()))
+                        break;
+
                     if (attemptToFold(m_vm.propertyNames->global.impl(), globalObject->regExpProtoGlobalGetter()))
+                        break;
+
+                    if (attemptToFold(m_vm.propertyNames->hasIndices.impl(), globalObject->regExpProtoHasIndicesGetter()))
+                        break;
+
+                    if (attemptToFold(m_vm.propertyNames->ignoreCase.impl(), globalObject->regExpProtoIgnoreCaseGetter()))
+                        break;
+
+                    if (attemptToFold(m_vm.propertyNames->multiline.impl(), globalObject->regExpProtoMultilineGetter()))
+                        break;
+
+                    if (attemptToFold(m_vm.propertyNames->sticky.impl(), globalObject->regExpProtoStickyGetter()))
                         break;
 
                     if (attemptToFold(m_vm.propertyNames->unicode.impl(), globalObject->regExpProtoUnicodeGetter()))

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -4138,8 +4138,20 @@ private:
 
         // Check that searchRegExp.exec is the primordial RegExp.prototype.exec
         emitPrimordialCheckFor(globalObject->regExpProtoExecFunction(), vm().propertyNames->exec.impl());
+        // Check that searchRegExp.flags is the primordial RegExp.prototype.flags
+        emitPrimordialCheckFor(globalObject->regExpProtoFlagsGetter(), vm().propertyNames->flags.impl());
+        // Check that searchRegExp.dotAll is the primordial RegExp.prototype.dotAll
+        emitPrimordialCheckFor(globalObject->regExpProtoDotAllGetter(), vm().propertyNames->dotAll.impl());
         // Check that searchRegExp.global is the primordial RegExp.prototype.global
         emitPrimordialCheckFor(globalObject->regExpProtoGlobalGetter(), vm().propertyNames->global.impl());
+        // Check that searchRegExp.hasIndices is the primordial RegExp.prototype.hasIndices
+        emitPrimordialCheckFor(globalObject->regExpProtoHasIndicesGetter(), vm().propertyNames->hasIndices.impl());
+        // Check that searchRegExp.ignoreCase is the primordial RegExp.prototype.ignoreCase
+        emitPrimordialCheckFor(globalObject->regExpProtoIgnoreCaseGetter(), vm().propertyNames->ignoreCase.impl());
+        // Check that searchRegExp.multiline is the primordial RegExp.prototype.multiline
+        emitPrimordialCheckFor(globalObject->regExpProtoMultilineGetter(), vm().propertyNames->multiline.impl());
+        // Check that searchRegExp.sticky is the primordial RegExp.prototype.sticky
+        emitPrimordialCheckFor(globalObject->regExpProtoStickyGetter(), vm().propertyNames->sticky.impl());
         // Check that searchRegExp.unicode is the primordial RegExp.prototype.unicode
         emitPrimordialCheckFor(globalObject->regExpProtoUnicodeGetter(), vm().propertyNames->unicode.impl());
         // Check that searchRegExp.unicodeSets is the primordial RegExp.prototype.unicodeSets

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1918,8 +1918,20 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     {
         m_regExpPrototypeExecWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->exec), m_regExpPrimordialPropertiesWatchpointSet);
         m_regExpPrototypeExecWatchpoint->install(vm);
+        m_regExpPrototypeFlagsWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->flags), m_regExpPrimordialPropertiesWatchpointSet);
+        m_regExpPrototypeFlagsWatchpoint->install(vm);
+        m_regExpPrototypeDotAllWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->dotAll), m_regExpPrimordialPropertiesWatchpointSet);
+        m_regExpPrototypeDotAllWatchpoint->install(vm);
         m_regExpPrototypeGlobalWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->global), m_regExpPrimordialPropertiesWatchpointSet);
         m_regExpPrototypeGlobalWatchpoint->install(vm);
+        m_regExpPrototypeHasIndicesWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->hasIndices), m_regExpPrimordialPropertiesWatchpointSet);
+        m_regExpPrototypeHasIndicesWatchpoint->install(vm);
+        m_regExpPrototypeIgnoreCaseWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->ignoreCase), m_regExpPrimordialPropertiesWatchpointSet);
+        m_regExpPrototypeIgnoreCaseWatchpoint->install(vm);
+        m_regExpPrototypeMultilineWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->multiline), m_regExpPrimordialPropertiesWatchpointSet);
+        m_regExpPrototypeMultilineWatchpoint->install(vm);
+        m_regExpPrototypeStickyWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->sticky), m_regExpPrimordialPropertiesWatchpointSet);
+        m_regExpPrototypeStickyWatchpoint->install(vm);
         m_regExpPrototypeUnicodeWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicode), m_regExpPrimordialPropertiesWatchpointSet);
         m_regExpPrototypeUnicodeWatchpoint->install(vm);
         m_regExpPrototypeUnicodeSetsWatchpoint = makeUnique<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>>(this, setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicodeSets), m_regExpPrimordialPropertiesWatchpointSet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -512,7 +512,13 @@ public:
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_arrayPrototypeIsConcatSpreadableMissWatchpoint;
     std::unique_ptr<ObjectAdaptiveStructureWatchpoint> m_objectPrototypeIsConcatSpreadableMissWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeExecWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeFlagsWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeDotAllWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeGlobalWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeHasIndicesWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeIgnoreCaseWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeMultilineWatchpoint;
+    std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeStickyWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeUnicodeWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeUnicodeSetsWatchpoint;
     std::unique_ptr<ObjectPropertyChangeAdaptiveWatchpoint<InlineWatchpointSet>> m_regExpPrototypeSymbolReplaceWatchpoint;
@@ -748,7 +754,13 @@ public:
     JSFunction* performProxyObjectSetByValStrictFunction() const;
     JSFunction* performProxyObjectSetByValStrictFunctionConcurrently() const;
     JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
+    GetterSetter* regExpProtoFlagsGetter() const;
+    GetterSetter* regExpProtoDotAllGetter() const;
     GetterSetter* regExpProtoGlobalGetter() const;
+    GetterSetter* regExpProtoHasIndicesGetter() const;
+    GetterSetter* regExpProtoIgnoreCaseGetter() const;
+    GetterSetter* regExpProtoMultilineGetter() const;
+    GetterSetter* regExpProtoStickyGetter() const;
     GetterSetter* regExpProtoUnicodeGetter() const;
     GetterSetter* regExpProtoUnicodeSetsGetter() const;
     GetterSetter* throwTypeErrorArgumentsCalleeGetterSetter() const { return m_throwTypeErrorArgumentsCalleeGetterSetter.get(this); }

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -237,7 +237,13 @@ inline JSFunction* JSGlobalObject::performProxyObjectSetByValSloppyFunction() co
 inline JSFunction* JSGlobalObject::performProxyObjectSetByValSloppyFunctionConcurrently() const { return performProxyObjectSetByValSloppyFunction(); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetByValStrictFunction() const { return m_performProxyObjectSetByValStrictFunction.get(); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetByValStrictFunctionConcurrently() const { return performProxyObjectSetByValStrictFunction(); }
+inline GetterSetter* JSGlobalObject::regExpProtoFlagsGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoFlagsGetter)); }
+inline GetterSetter* JSGlobalObject::regExpProtoDotAllGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoDotAllGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoGlobalGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoGlobalGetter)); }
+inline GetterSetter* JSGlobalObject::regExpProtoHasIndicesGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoHasIndicesGetter)); }
+inline GetterSetter* JSGlobalObject::regExpProtoIgnoreCaseGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoIgnoreCaseGetter)); }
+inline GetterSetter* JSGlobalObject::regExpProtoMultilineGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoMultilineGetter)); }
+inline GetterSetter* JSGlobalObject::regExpProtoStickyGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoStickyGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoUnicodeGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoUnicodeGetter)); }
 inline GetterSetter* JSGlobalObject::regExpProtoUnicodeSetsGetter() const { return std::bit_cast<GetterSetter*>(linkTimeConstant(LinkTimeConstant::regExpProtoUnicodeSetsGetter)); }
 


### PR DESCRIPTION
#### 1ef50e669e8a90eb51fa4ffd1e0c9f0356189ea1
<pre>
[JSC] `RegExp.prototype`&apos;s `@@match` and `@@replace` should use `flags` getter only
<a href="https://bugs.webkit.org/show_bug.cgi?id=248605">https://bugs.webkit.org/show_bug.cgi?id=248605</a>

Reviewed by Yusuke Suzuki.

This patch implements recent spec change [1], aligning RegExp.prototype&apos;s
@@match / @@replace with @@split / @@matchAll to use only &quot;flags&quot; getter to
check for flags, which is observable.

This patch is based on the PR by Alexey Shvayka[2]. Also according to
the PR, no performance regressions.

[1]: <a href="https://github.com/tc39/ecma262/pull/2791">https://github.com/tc39/ecma262/pull/2791</a>
[2]: <a href="https://github.com/WebKit/WebKit/pull/7281">https://github.com/WebKit/WebKit/pull/7281</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
(linkTimeConstant.hasObservableSideEffectsForRegExpMatch):
(linkTimeConstant.matchSlow):
(overriddenName.string_appeared_here.replace):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(linkTimeConstant.hasObservableSideEffectsForStringReplace):

Canonical link: <a href="https://commits.webkit.org/290785@main">https://commits.webkit.org/290785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/965a5bec4a8707ba3e13f6ef0ac8f8df7fb0e439

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41887 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18988 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70033 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94128 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50359 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41022 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83948 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/152 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98112 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89896 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18329 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78394 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/78247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19335 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22753 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/99 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18332 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112464 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18056 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32657 "Found 328 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19833 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->