### PR TITLE
Try to Reuse FontCascadeFonts for "simple" CSSFontSelectors

### DIFF
--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -576,4 +576,9 @@ void CSSFontFaceSet::fontPropertyChanged(CSSFontFace& face, CSSValueList* oldFam
     });
 }
 
+bool CSSFontFaceSet::hasFontFaceForFamily(const AtomString& fontFamily)
+{
+    return m_facesLookupTable.find(fontFamily) != m_facesLookupTable.end();
+}
+
 }

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -103,6 +103,8 @@ public:
     // FIXME: Should this be implemented?
     void updateStyleIfNeeded(CSSFontFace&) final { }
 
+    bool hasFontFaceForFamily(const AtomString& family);
+
 private:
     CSSFontFaceSet(CSSFontSelector*);
 

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -86,6 +86,8 @@ public:
     void registerForInvalidationCallbacks(FontSelectorClient&) final;
     void unregisterForInvalidationCallbacks(FontSelectorClient&) final;
 
+    bool canUseGlobalWidthCache(const FontCascadeDescription&) const final;
+
     ScriptExecutionContext* scriptExecutionContext() const { return m_context.get(); }
 
     FontFaceSet* fontFaceSetIfExists();
@@ -108,8 +110,8 @@ private:
 
     std::optional<AtomString> resolveGenericFamily(const FontDescription&, const AtomString& family);
 
-    const FontPaletteValues& lookupFontPaletteValues(const AtomString& familyName, const FontDescription&);
-    RefPtr<FontFeatureValues> lookupFontFeatureValues(const AtomString& familyName);
+    const FontPaletteValues& lookupFontPaletteValues(const AtomString& familyName, const FontDescription&) const;
+    RefPtr<FontFeatureValues> lookupFontFeatureValues(const AtomString& familyName) const;
 
     // CSSFontFaceClient
     void fontLoaded(CSSFontFace&) final;

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -67,6 +67,9 @@ public:
 
     CSSFontFaceSet& backing() { return m_backing; }
 
+    // FIXME: is this necessary? I think faces here are added to its m_backing counterpart
+    // bool hasFontFaceForFamily(const AtomString& family) const;
+
     class Iterator {
     public:
         explicit Iterator(FontFaceSet&);

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -29,7 +29,7 @@
 
 #pragma once
 
-#include "FontCascadeFonts.h"
+// #include "FontCascadeFonts.h"
 #include "FontDescription.h"
 #include "FontTaggedSettings.h"
 #include <array>
@@ -41,13 +41,14 @@
 
 namespace WebCore {
 
+class FontCascadeFonts;
+class FontCascadeDescription;
+class FontSelector;
+
 struct FontDescriptionKeyRareData : public RefCounted<FontDescriptionKeyRareData> {
     WTF_MAKE_TZONE_ALLOCATED(FontDescriptionKeyRareData);
 public:
-    static Ref<FontDescriptionKeyRareData> create(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, FontSizeAdjust&& fontSizeAdjust)
-    {
-        return adoptRef(*new FontDescriptionKeyRareData(WTFMove(featureSettings), WTFMove(variationSettings), WTFMove(variantAlternates), WTFMove(fontPalette), WTFMove(fontSizeAdjust)));
-    }
+    WEBCORE_EXPORT static Ref<FontDescriptionKeyRareData> create(FontFeatureSettings&&, FontVariationSettings&&, FontVariantAlternates&&, FontPalette&&, FontSizeAdjust&&);
 
     const FontFeatureSettings& featureSettings() const
     {
@@ -84,7 +85,7 @@ public:
     }
 
 private:
-    FontDescriptionKeyRareData(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, FontSizeAdjust&& fontSizeAdjust)
+    WEBCORE_EXPORT FontDescriptionKeyRareData(FontFeatureSettings&& featureSettings, FontVariationSettings&& variationSettings, FontVariantAlternates&& variantAlternates, FontPalette&& fontPalette, FontSizeAdjust&& fontSizeAdjust)
         : m_featureSettings(WTFMove(featureSettings))
         , m_variationSettings(WTFMove(variationSettings))
         , m_variantAlternates(WTFMove(variantAlternates))
@@ -214,15 +215,15 @@ namespace WebCore {
 class FontFamilyName {
 public:
     FontFamilyName();
-    FontFamilyName(const AtomString&);
+    WEBCORE_EXPORT FontFamilyName(const AtomString&);
     const AtomString& string() const;
-    friend void add(Hasher&, const FontFamilyName&);
+    WEBCORE_EXPORT friend void add(Hasher&, const FontFamilyName&);
 
 private:
     AtomString m_name;
 };
 
-bool operator==(const FontFamilyName&, const FontFamilyName&);
+WEBCORE_EXPORT bool operator==(const FontFamilyName&, const FontFamilyName&);
 
 struct FontCascadeCacheKey {
     FontDescriptionKey fontDescriptionKey; // Shared with the lower level FontCache (caching Font objects)

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -32,7 +32,9 @@
 
 #include "FontCache.h"
 #include "FontCascade.h"
+#include "FontSelector.h"
 #include "GlyphPage.h"
+#include "WidthCache.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -571,6 +573,28 @@ void FontCascadeFonts::pruneSystemFallbacks()
     }
     m_systemFallbackFontSet.clear();
 }
+
+bool FontCascadeFonts::canUseGlobalWidthCache(const FontCascadeDescription& description) const
+{
+    auto selector = fontSelector();
+    if (!selector)
+        return true;
+    return selector->canUseGlobalWidthCache(description);
+}
+
+// WidthCache& FontCascadeFonts::widthCache(const FontCascadeDescription& description)
+// {
+//     if (canUseGlobalWidthCache(description))
+//         return WidthCache::globalWidthCache();
+//     return m_widthCache;
+// }
+
+// const WidthCache& FontCascadeFonts::widthCache(const FontCascadeDescription& description) const
+// {
+//     if (canUseGlobalWidthCache(description))
+//         return WidthCache::globalWidthCache();
+//     return m_widthCache;
+// }
 
 TextStream& operator<<(TextStream& ts, const FontCascadeFonts& fontCascadeFonts)
 {

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -76,6 +76,9 @@ public:
     unsigned fontSelectorVersion() const { return m_fontSelectorVersion; }
     unsigned generation() const { return m_generation; }
 
+    bool canUseGlobalWidthCache(const FontCascadeDescription&) const;
+    void clearLocalWidthCache() { m_widthCache.clear(); }
+
     WidthCache& widthCache() { return m_widthCache; }
     const WidthCache& widthCache() const { return m_widthCache; }
 

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -69,6 +69,9 @@ public:
 
     virtual unsigned uniqueId() const = 0;
     virtual unsigned version() const = 0;
+
+    virtual bool canUseGlobalWidthCache(const FontCascadeDescription&) const = 0;
+
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const FontSelector&);

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -231,7 +231,7 @@ public:
         return { };
     }
 
-    friend void add(Hasher&, const FontVariantAlternates&);
+    WEBCORE_EXPORT friend void add(Hasher&, const FontVariantAlternates&);
 
 private:
     Markable<Values> m_values;

--- a/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MonospaceFontTests.cpp
@@ -28,6 +28,8 @@
 #include <JavaScriptCore/InitializeThreading.h>
 #include <WebCore/ComplexTextController.h>
 #include <WebCore/FontCascade.h>
+#include <WebCore/FontCascadeCache.h>
+#include <WebCore/WidthCache.h>
 #include <WebCore/WidthIterator.h>
 #include <wtf/MainThread.h>
 #include <wtf/RunLoop.h>
@@ -65,9 +67,11 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
                     auto glyphData = fontCascade.glyphDataForCharacter(character, false);
                     if (!glyphData.isValid() || glyphData.font != fontCascade.primaryFont().ptr())
                         continue;
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->clearLocalWidthCache();
+                    WidthCache::globalWidthCache().clear();
                     float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->clearLocalWidthCache();
+                    WidthCache::globalWidthCache().clear();
                     float originalWidth = fontCascade.widthForTextUsingSimplifiedMeasuring(content);
                     EXPECT_EQ(originalWidth , width);
                 }
@@ -77,9 +81,11 @@ TEST(MonospaceFontsTest, EnsureMonospaceFontInvariants)
                     };
                     StringView content(characters);
                     constexpr bool whitespaceIsCollapsed = false;
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->clearLocalWidthCache();
+                    WidthCache::globalWidthCache().clear();
                     float width = fontCascade.widthForSimpleTextWithFixedPitch(content, whitespaceIsCollapsed);
-                    fontCascade.fonts()->widthCache().clear();
+                    fontCascade.fonts()->clearLocalWidthCache();
+                    WidthCache::globalWidthCache().clear();
                     float originalWidth = fontCascade.widthForTextUsingSimplifiedMeasuring(content);
                     EXPECT_EQ(originalWidth , width);
                 }


### PR DESCRIPTION
#### 449e7163e4470739582b1b0c307a36dffa483047
<pre>
Try to Reuse FontCascadeFonts for &quot;simple&quot; CSSFontSelectors
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/CSSCounterStyleRegistry.h:
(WebCore::CSSCounterStyleRegistry::hasAuthorCounterStyles const):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::hasFontFaceForFamily):
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::lookupFontPaletteValues const):
(WebCore::CSSFontSelector::lookupFontFeatureValues const):
(WebCore::CSSFontSelector::isSimpleFontSelectorForDescription const):
(WebCore::CSSFontSelector::lookupFontPaletteValues): Deleted.
(WebCore::CSSFontSelector::lookupFontFeatureValues): Deleted.
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::makeFontCascadeCacheKey):
(WebCore::FontCascadeCache::retrieveOrAddCachedFonts):
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::updateFontSelector):
* Source/WebCore/platform/graphics/FontSelector.h:
</pre>