### PR TITLE
Use smart pointers to store reference to Element in AttributeChangeInvalidation

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -91,7 +91,6 @@ rendering/TextBoxPainter.h
 rendering/style/StyleGeneratedImage.cpp
 rendering/svg/SVGTextLayoutAttributesBuilder.h
 rendering/updating/RenderTreeUpdater.h
-style/AttributeChangeInvalidation.h
 style/ChildChangeInvalidation.h
 style/ClassChangeInvalidation.cpp
 style/ElementRuleCollector.cpp

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -44,7 +44,7 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
     if (newValue == oldValue)
         return;
 
-    bool isHTML = m_element.isHTMLElement() && m_element.document().isHTMLDocument();
+    bool isHTML = m_element->isHTMLElement() && m_element->document().isHTMLDocument();
 
     bool shouldInvalidateCurrent = false;
     bool mayAffectStyleInShadowTree = false;
@@ -62,11 +62,11 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
 
     if (mayAffectStyleInShadowTree) {
         // FIXME: More fine-grained invalidation.
-        m_element.invalidateStyleForSubtree();
+        m_element->invalidateStyleForSubtree();
     }
 
     if (shouldInvalidateCurrent)
-        m_element.invalidateStyle();
+        m_element->invalidateStyle();
 
     auto collect = [&](auto& ruleSets, std::optional<MatchElement> onlyMatchElement = { }) {
         auto* invalidationRuleSets = ruleSets.attributeInvalidationRuleSets(attributeNameForLookups);
@@ -92,9 +92,9 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
         }
     };
 
-    collect(m_element.styleResolver().ruleSets());
+    collect(m_element->styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element.shadowRoot())
+    if (auto* shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 }
 

--- a/Source/WebCore/style/AttributeChangeInvalidation.h
+++ b/Source/WebCore/style/AttributeChangeInvalidation.h
@@ -33,7 +33,7 @@ namespace Style {
 
 class AttributeChangeInvalidation {
 public:
-    AttributeChangeInvalidation(Element&, const QualifiedName&, const AtomString& oldValue, const AtomString& newValue);
+    AttributeChangeInvalidation(Ref<Element>&&, const QualifiedName&, const AtomString& oldValue, const AtomString& newValue);
     ~AttributeChangeInvalidation();
 
 private:
@@ -41,14 +41,14 @@ private:
     void invalidateStyleWithRuleSets();
 
     const bool m_isEnabled;
-    Element& m_element;
+    Ref<Element> m_element;
 
     Invalidator::MatchElementRuleSets m_matchElementRuleSets;
 };
 
-inline AttributeChangeInvalidation::AttributeChangeInvalidation(Element& element, const QualifiedName& attributeName, const AtomString& oldValue, const AtomString& newValue)
-    : m_isEnabled(element.needsStyleInvalidation())
-    , m_element(element)
+inline AttributeChangeInvalidation::AttributeChangeInvalidation(Ref<Element>&& element, const QualifiedName& attributeName, const AtomString& oldValue, const AtomString& newValue)
+    : m_isEnabled(element->needsStyleInvalidation())
+    , m_element(WTFMove(element))
 {
     if (!m_isEnabled)
         return;


### PR DESCRIPTION
#### 85e5f0887c9b0aa4a6776e022e41eefe72be010e
<pre>
Use smart pointers to store reference to Element in AttributeChangeInvalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=287757">https://bugs.webkit.org/show_bug.cgi?id=287757</a>
<a href="https://rdar.apple.com/problem/144925334">rdar://problem/144925334</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning caused by using a raw reference to
store element in AttributeChangeInvalidation.

* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/AttributeChangeInvalidation.h:
(WebCore::Style::AttributeChangeInvalidation::AttributeChangeInvalidation):

Canonical link: <a href="https://commits.webkit.org/290460@main">https://commits.webkit.org/290460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c57ec3c45f2337c64de62982f46879902eb712a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95129 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69391 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49752 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7418 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77750 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96954 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17316 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12725 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78385 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77592 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20640 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10546 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17326 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22652 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17067 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20519 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18851 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->