### PR TITLE
[WebGPU] incorrect value passed to resolveCounters

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287761-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287761-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287761.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287761.html
@@ -1,0 +1,200 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'float32-blendable',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxStorageBuffersPerShaderStage: 8,
+    maxUniformBufferBindingSize: 46096858,
+    maxStorageBufferBindingSize: 157376405,
+    maxUniformBuffersPerShaderStage: 12,
+  },
+});
+// START
+texture2 = device0.createTexture({
+  size : {width : 10, },
+  dimension : '3d',
+  format : 'rg8sint',
+  usage : GPUTextureUsage.TEXTURE_BINDING});
+texture3 = device0.createTexture({
+  size : [],
+  dimension : '3d',
+  format : 'r32sint',
+  usage : GPUTextureUsage.STORAGE_BINDING});
+texture4 = device0.createTexture({
+  size : {width : 10, },
+  format : 'depth24plus-stencil8',
+  usage : GPUTextureUsage.TEXTURE_BINDING});
+textureView2 = texture3.createView();
+shaderModule0 = device0.createShaderModule({
+  code : ` struct T5 {
+           f0: atomic<u32>}
+         fn unconst_i32(v: i32) -> i32 {
+         return v;
+         }
+         @group(0) @binding(8) var st0: texture_storage_3d<r32sint, read_write>;
+         @compute @workgroup_size(51, ) fn compute0() {
+           textureStore(st0, vec3i(), vec4i());
+         }
+        `});
+veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 2,
+      visibility : GPUShaderStage.VERTEX,
+      texture :
+          {viewDimension : '3d', sampleType : 'sint', }},
+    {
+      binding : 4,
+      visibility : GPUShaderStage.FRAGMENT,
+      texture : {
+        viewDimension : 'cube-array',
+        sampleType : 'sint',
+        }},
+    {
+      binding : 8,
+      visibility : GPUShaderStage.COMPUTE,
+      storageTexture :
+          {format : 'r32sint', access : 'read-write', viewDimension : '3d'}},
+    {
+      binding : 70,
+      visibility : GPUShaderStage.FRAGMENT,
+      texture :
+          {sampleType : 'uint', },
+    }]});
+let textureView4 = texture4.createView();
+pipelineLayout1 = device0.createPipelineLayout(
+    {bindGroupLayouts : [ veryExplicitBindGroupLayout0 ]});
+texture7 = device0.createTexture({
+  size : [ 64, 64, 20 ],
+  format : 'r8sint',
+  usage : GPUTextureUsage.TEXTURE_BINDING});
+pipeline0 = await device0.createComputePipelineAsync({
+  layout : pipelineLayout1,
+  compute : {module : shaderModule0, }
+});
+textureView5 = texture7.createView({
+  dimension : 'cube-array',
+  arrayLayerCount : 6
+});
+textureView6 = texture2.createView();
+commandEncoder9 = device0.createCommandEncoder();
+commandEncoder15 = device0.createCommandEncoder();
+{
+}
+buffer16 = device0.createBuffer(
+    {size : 5828, usage : GPUBufferUsage.STORAGE});
+{
+}
+buffer18 = device0.createBuffer({
+  size : 217,
+  usage : GPUBufferUsage.QUERY_RESOLVE |
+              GPUBufferUsage});
+querySet2 = device0.createQuerySet({type : 'timestamp', count : 428});
+bindGroup7 = device0.createBindGroup({
+  layout : veryExplicitBindGroupLayout0,
+  entries : [
+    {binding : 2, resource : textureView6},
+    {binding : 70, resource : textureView4},
+    {binding : 4, resource : textureView5},
+    {binding : 8, resource : textureView2}]});
+{
+}
+let computePassEncoder20 = commandEncoder9.beginComputePass();
+try {
+  computePassEncoder20.setPipeline(pipeline0);
+computePassEncoder20.setBindGroup(0, bindGroup7)} catch {
+}
+try {
+  commandEncoder15.resolveQuerySet(querySet2, 0, 1, buffer18, 0)} catch {
+}
+commandBuffer0 = commandEncoder15.finish();
+try {
+  computePassEncoder20.dispatchWorkgroups(1)} catch {
+}
+  try {
+      device0.queue.submit([ commandBuffer0 ])
+  } catch {
+}
+try {
+  computePassEncoder20.end();
+} catch {
+}
+commandBuffer2 = commandEncoder9.finish();
+try {
+  device0.queue.submit([ commandBuffer2 ])} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -2221,7 +2221,7 @@ void CommandEncoder::resolveQuerySet(const QuerySet& querySet, uint32_t firstQue
         [m_commandBuffer encodeSignalEvent:workaround value:1];
         [m_commandBuffer encodeWaitForEvent:workaround value:1];
         ensureBlitCommandEncoder();
-        [m_blitCommandEncoder resolveCounters:querySet.counterSampleBuffer() inRange:NSMakeRange(0, querySet.count()) destinationBuffer:destination.buffer() destinationOffset:destinationOffset];
+        [m_blitCommandEncoder resolveCounters:querySet.counterSampleBuffer() inRange:NSMakeRange(firstQuery, queryCount) destinationBuffer:destination.buffer() destinationOffset:destinationOffset];
         break;
     }
     default:


### PR DESCRIPTION
#### 1487bfe01d6bee3def47d1042e26e54b9f00c242
<pre>
[WebGPU] incorrect value passed to resolveCounters
<a href="https://bugs.webkit.org/show_bug.cgi?id=287761">https://bugs.webkit.org/show_bug.cgi?id=287761</a>
<a href="https://rdar.apple.com/144921860">rdar://144921860</a>

Reviewed by Tadeu Zagallo.

We were passing [0, querySet.count()) instead of [firstQuery, queryCount)
as the JS API requires.

This was incorrect and led to data being copied into the output buffer
from the wrong location.

* LayoutTests/fast/webgpu/nocrash/fuzz-287761-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287761.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::resolveQuerySet):

Canonical link: <a href="https://commits.webkit.org/290472@main">https://commits.webkit.org/290472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7a86b0df3256574c54994d6614a3ffe1f410d53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26960 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7387 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36101 "Found 8 new test failures: fast/html/process-end-tag-for-inbody-crash.html fonts/monospace.html fonts/sans-serif.html fonts/serif.html fullscreen/empty-anonymous-block-continuation-crash.html media/modern-media-controls/fullscreen-button/fullscreen-button.html media/modern-media-controls/invalid-placard/invalid-placard.html media/modern-media-controls/placard-support/placard-support-airplay-fullscreen.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/39999 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77719 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78354 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77560 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10491 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14173 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22616 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17031 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->