### PR TITLE
Move network usage tracking from Network Process to Web Process.

### DIFF
--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -136,7 +136,7 @@ void ResourceMonitor::checkNetworkUsageExcessIfNecessary()
         if (!frame)
             return;
 
-        RESOURCEMONITOR_RELEASE_LOG("The frame exceeds the network usage threshold: used %ld", m_networkUsage.value());
+        RESOURCEMONITOR_RELEASE_LOG("The frame exceeds the network usage threshold: used %zu", m_networkUsage.hasOverflowed() ? std::numeric_limits<size_t>::max() : m_networkUsage.value());
 
         // If the frame has sticky user activation, don't do offloading.
         if (RefPtr protectedWindow = frame->window(); protectedWindow && protectedWindow->hasStickyActivation()) {

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -79,12 +79,14 @@ private:
     Ref<MessagePort> m_port;
     String m_identifierForInspector;
     URLKeepingBlobAlive m_blobURLExtension;
-    bool m_isActive { true };
-    bool m_isSuspendedForBackForwardCache { false };
+    size_t m_bytesTransferredOverNetwork { 0 };
 
 #if ENABLE(CONTENT_EXTENSIONS)
     RefPtr<ResourceMonitor> m_resourceMonitor;
 #endif
+
+    bool m_isActive { true };
+    bool m_isSuspendedForBackForwardCache { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -242,14 +242,4 @@ PendingDownload* NetworkDataTask::pendingDownload() const
     return m_pendingDownload.get();
 }
 
-size_t NetworkDataTask::calculateBytesTransferredOverNetworkDelta()
-{
-    if (m_totalBytesTransferredOverNetwork <= m_bytesTransferredOverNetworkReported)
-        return 0;
-
-    size_t delta = m_totalBytesTransferredOverNetwork - m_bytesTransferredOverNetworkReported;
-    m_bytesTransferredOverNetworkReported = m_totalBytesTransferredOverNetwork;
-    return delta;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -150,8 +150,7 @@ public:
 
     virtual void setTimingAllowFailedFlag() { }
 
-    size_t calculateBytesTransferredOverNetworkDelta();
-    size_t totalBytesTransferredOverNetwork() const { return m_totalBytesTransferredOverNetwork; }
+    size_t bytesTransferredOverNetwork() const { return m_bytesTransferredOverNetwork; }
 
 protected:
     NetworkDataTask(NetworkSession&, NetworkDataTaskClient&, const WebCore::ResourceRequest&, WebCore::StoredCredentialsPolicy, bool shouldClearReferrerOnHTTPSToHTTPRedirect, bool dataTaskIsForMainFrameNavigation);
@@ -165,7 +164,7 @@ protected:
     void scheduleFailure(FailureType);
 
     void restrictRequestReferrerToOriginIfNeeded(WebCore::ResourceRequest&);
-    void setTotalBytesTransferredOverNetwork(size_t bytes) { m_totalBytesTransferredOverNetwork = bytes; }
+    void setBytesTransferredOverNetwork(size_t bytes) { m_bytesTransferredOverNetwork = bytes; }
 
     WeakPtr<NetworkSession> m_session;
     WeakPtr<NetworkDataTaskClient> m_client;
@@ -181,8 +180,7 @@ protected:
     WebCore::ResourceRequest m_firstRequest;
     WebCore::ResourceRequest m_previousRequest;
     String m_suggestedFilename;
-    size_t m_totalBytesTransferredOverNetwork { 0 };
-    size_t m_bytesTransferredOverNetworkReported { 0 };
+    size_t m_bytesTransferredOverNetwork { 0 };
     bool m_shouldClearReferrerOnHTTPSToHTTPRedirect { true };
     bool m_dataTaskIsForMainFrameNavigation { false };
     bool m_failureScheduled { false };

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -357,10 +357,10 @@ RefPtr<NetworkDataTask> NetworkLoad::protectedTask()
     return m_task;
 }
 
-size_t NetworkLoad::bytesTransferredOverNetworkDelta() const
+size_t NetworkLoad::bytesTransferredOverNetwork() const
 {
     if (RefPtr task = m_task)
-        return task->calculateBytesTransferredOverNetworkDelta();
+        return task->bytesTransferredOverNetwork();
     return 0;
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -90,7 +90,7 @@ public:
     std::optional<WebCore::PageIdentifier> webPageID() const;
     Ref<NetworkProcess> networkProcess();
 
-    size_t bytesTransferredOverNetworkDelta() const;
+    size_t bytesTransferredOverNetwork() const;
 
 private:
     NetworkLoad(NetworkLoadClient&, NetworkLoadParameters&&, NetworkSession&);

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -285,8 +285,8 @@ private:
     bool shouldSendResourceLoadMessages() const;
 
     void sendDidReceiveDataMessage(const WebCore::FragmentedSharedBuffer&, size_t encodedDataLength);
-    void reportNetworkUsageToAllSharedWorkers(WebCore::SharedWorkerIdentifier, size_t bytesTransferredOverNetworkDelta);
-    uint64_t bytesTransferredOverNetworkDelta() const;
+    void updateBytesTransferredOverNetwork(size_t bytesTransferredOverNetwork);
+    void reportNetworkUsageToAllSharedWorkers(WebCore::SharedWorkerIdentifier, size_t bytesTransferredOverNetwork);
 
     NetworkResourceLoadParameters m_parameters;
 
@@ -307,6 +307,7 @@ private:
     bool m_didConsumeSandboxExtensions { false };
     bool m_isAllowedToAskUserForCredentials { false };
     size_t m_numBytesReceived { 0 };
+    size_t m_bytesTransferredOverNetwork { 0 };
 
     unsigned m_retrievedDerivedDataCount { 0 };
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -316,7 +316,7 @@ void WebSharedWorkerServer::terminateContextConnectionWhenPossible(const WebCore
     contextConnection->terminateWhenPossible();
 }
 
-void WebSharedWorkerServer::reportNetworkUsageToAllSharedWorkerClients(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, size_t bytesTransferredOverNetworkDelta)
+void WebSharedWorkerServer::reportNetworkUsageToAllSharedWorkerClients(WebCore::SharedWorkerIdentifier sharedWorkerIdentifier, size_t bytesTransferredOverNetwork)
 {
     auto* sharedWorker = WebSharedWorker::fromIdentifier(sharedWorkerIdentifier);
     RELEASE_LOG_ERROR(SharedWorker, "WebSharedWorkerServer::sendNetworkUsageToAllSharedWorkerClients: sharedWorkerIdentifier=%" PRIu64 ", sharedWorker=%p", sharedWorkerIdentifier.toUInt64(), sharedWorker);
@@ -325,7 +325,7 @@ void WebSharedWorkerServer::reportNetworkUsageToAllSharedWorkerClients(WebCore::
 
     sharedWorker->forEachSharedWorkerObject([&](auto sharedWorkerObjectIdentifier, auto&) {
         if (auto* serverConnection = m_connections.get(sharedWorkerObjectIdentifier.processIdentifier()))
-            serverConnection->reportNetworkUsageToWorkerObject(sharedWorkerObjectIdentifier, bytesTransferredOverNetworkDelta);
+            serverConnection->reportNetworkUsageToWorkerObject(sharedWorkerObjectIdentifier, bytesTransferredOverNetwork);
     });
 }
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h
@@ -82,7 +82,7 @@ public:
     void addConnection(Ref<WebSharedWorkerServerConnection>&&);
     void removeConnection(WebCore::ProcessIdentifier);
 
-    void reportNetworkUsageToAllSharedWorkerClients(WebCore::SharedWorkerIdentifier, size_t bytesTransferredOverNetworkDelta);
+    void reportNetworkUsageToAllSharedWorkerClients(WebCore::SharedWorkerIdentifier, size_t bytesTransferredOverNetwork);
 
 private:
     void createContextConnection(const WebCore::Site&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -146,10 +146,10 @@ void WebSharedWorkerServerConnection::postErrorToWorkerObject(WebCore::SharedWor
     send(Messages::WebSharedWorkerObjectConnection::PostErrorToWorkerObject { sharedWorkerObjectIdentifier, errorMessage, lineNumber, columnNumber, sourceURL, isErrorEvent });
 }
 
-void WebSharedWorkerServerConnection::reportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta)
+void WebSharedWorkerServerConnection::reportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetwork)
 {
-    CONNECTION_RELEASE_LOG("reportNetworkUsageToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING ", bytesTransferredOverNetworkDelta=%zu", sharedWorkerObjectIdentifier.toString().utf8().data(), bytesTransferredOverNetworkDelta);
-    send(Messages::WebSharedWorkerObjectConnection::ReportNetworkUsageToWorkerObject { sharedWorkerObjectIdentifier, bytesTransferredOverNetworkDelta });
+    CONNECTION_RELEASE_LOG("reportNetworkUsageToWorkerObject: sharedWorkerObjectIdentifier=%" PUBLIC_LOG_STRING ", bytesTransferredOverNetwork=%zu", sharedWorkerObjectIdentifier.toString().utf8().data(), bytesTransferredOverNetwork);
+    send(Messages::WebSharedWorkerObjectConnection::ReportNetworkUsageToWorkerObject { sharedWorkerObjectIdentifier, bytesTransferredOverNetwork });
 }
 
 #undef CONNECTION_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -75,7 +75,7 @@ public:
     void fetchScriptInClient(const WebSharedWorker&, WebCore::SharedWorkerObjectIdentifier, CompletionHandler<void(WebCore::WorkerFetchResult&&, WebCore::WorkerInitializationData&&)>&&);
     void notifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier, const WebCore::ResourceError&);
     void postErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier, const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL, bool isErrorEvent);
-    void reportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta);
+    void reportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier, size_t bytesTransferredOverNetwork);
 
 private:
     WebSharedWorkerServerConnection(NetworkProcess&, WebSharedWorkerServer&, IPC::Connection&, WebCore::ProcessIdentifier);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -387,15 +387,6 @@ void NetworkDataTaskCocoa::didNegotiateModernTLS(const URL& url)
 
 void NetworkDataTaskCocoa::didCompleteWithError(const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& networkLoadMetrics)
 {
-    if (networkLoadMetrics.responseBodyBytesReceived > totalBytesTransferredOverNetwork()) {
-        WTFEmitSignpost(m_task.get(), DataTask, "responseBodyBytesReceived (%llu bytes) exceeded totalBytesTransferredOverNetwork (%zu bytes)", networkLoadMetrics.responseBodyBytesReceived, totalBytesTransferredOverNetwork());
-
-        setTotalBytesTransferredOverNetwork(networkLoadMetrics.responseBodyBytesReceived);
-
-        if (m_client)
-            m_client->didReceiveData(WebCore::SharedBuffer::create());
-    }
-
     WTFEmitSignpost(m_task.get(), DataTask, "completed with error: %d", !error.isNull());
 
     if (m_client)
@@ -406,7 +397,7 @@ void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "received %zd bytes", data.size());
 
-    setTotalBytesTransferredOverNetwork([m_task _countOfBytesReceivedEncoded]);
+    setBytesTransferredOverNetwork([m_task _countOfBytesReceivedEncoded]);
 
     if (m_client)
         m_client->didReceiveData(data);

--- a/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp
@@ -211,9 +211,6 @@ void NetworkDataTaskCurl::curlDidReceiveData(CurlRequest&, Ref<SharedBuffer>&& b
         return;
     }
 
-    // FIXME: This should be exact network transferred size rather than decoded bytes.
-    setTotalBytesTransferredOverNetwork(totalBytesTransferredOverNetwork() + buffer->size());
-
     m_client->didReceiveData(buffer.get());
 }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -1048,10 +1048,6 @@ void NetworkDataTaskSoup::didRead(gssize bytesRead)
         writeDownload();
     } else {
         ASSERT(m_client);
-
-        // FIXME: This should be exact network transferred size rather than decoded bytes.
-        setTotalBytesTransferredOverNetwork(totalBytesTransferredOverNetwork() + bytesRead);
-
         m_client->didReceiveData(SharedBuffer::create(WTFMove(m_readBuffer)));
         read();
     }

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.h
@@ -107,11 +107,14 @@ private:
 #if ENABLE(CONTENT_FILTERING)
     void contentFilterDidBlockLoad(const WebCore::ContentFilterUnblockHandler&, String&& unblockRequestDeniedScript, const WebCore::ResourceError&, const URL& blockedPageURL, WebCore::SubstituteData&&);
 #endif
-    
+
+    void updateBytesTransferredOverNetwork(uint64_t bytesTransferredOverNetwork);
+
     RefPtr<WebCore::ResourceLoader> m_coreLoader;
     const TrackingParameters m_trackingParameters;
     WebResourceInterceptController m_interceptController;
     size_t m_numBytesReceived { 0 };
+    size_t m_bytesTransferredOverNetwork { 0 };
 
 #if ASSERT_ENABLED
     bool m_isProcessingNetworkResponse { false };

--- a/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in
@@ -28,5 +28,5 @@ messages -> WebSharedWorkerObjectConnection {
     FetchScriptInClient(URL url, WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, struct WebCore::WorkerOptions workerOptions) -> (struct WebCore::WorkerFetchResult fetchResult, struct WebCore::WorkerInitializationData initializationData)
     NotifyWorkerObjectOfLoadCompletion(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, WebCore::ResourceError error)
     PostErrorToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, String errorMessage, int lineNumber, int columnNumber, String sourceURL, bool isErrorEvent)
-    ReportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetworkDelta)
+    ReportNetworkUsageToWorkerObject(WebCore::SharedWorkerObjectIdentifier sharedWorkerObjectIdentifier, size_t bytesTransferredOverNetwork)
 }


### PR DESCRIPTION
#### 91a52b9e4a27d5081f03cc596e4b66cb3ca9a826
<pre>
Move network usage tracking from Network Process to Web Process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287762">https://bugs.webkit.org/show_bug.cgi?id=287762</a>
<a href="https://rdar.apple.com/144926267">rdar://144926267</a>

Reviewed by Ben Nham.

In 290353@main, we need to add workaround at the end of the communication, to catch up the correct bytes
transferred over network. By moving the tracking from Network process to Web Process, this workaround is
not required.

To make it happen, change the parameter passed to DidReceiveData message from delta to total usage of bytes
and tracking delta at the endpoint of ResourceMonitor.

* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::reportNetworkUsage):
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
(WebKit::NetworkDataTask::calculateBytesTransferredOverNetworkDelta): Deleted.
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
(WebKit::NetworkDataTask::bytesTransferredOverNetwork const):
(WebKit::NetworkDataTask::setBytesTransferredOverNetwork):
(WebKit::NetworkDataTask::totalBytesTransferredOverNetwork const): Deleted.
(WebKit::NetworkDataTask::setTotalBytesTransferredOverNetwork): Deleted.
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::bytesTransferredOverNetwork const):
(WebKit::NetworkLoad::bytesTransferredOverNetworkDelta const): Deleted.
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
(WebKit::NetworkResourceLoader::sendDidReceiveDataMessage):
(WebKit::NetworkResourceLoader::updateBytesTransferredOverNetwork):
(WebKit::NetworkResourceLoader::reportNetworkUsageToAllSharedWorkers):
(WebKit::NetworkResourceLoader::bytesTransferredOverNetworkDelta const): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp:
(WebKit::WebSharedWorkerServer::reportNetworkUsageToAllSharedWorkerClients):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServer.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::reportNetworkUsageToWorkerObject):
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didCompleteWithError):
(WebKit::NetworkDataTaskCocoa::didReceiveData):
* Source/WebKit/NetworkProcess/curl/NetworkDataTaskCurl.cpp:
(WebKit::NetworkDataTaskCurl::curlDidReceiveData):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::didRead):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveData):
(WebKit::WebResourceLoader::didFinishResourceLoad):
(WebKit::WebResourceLoader::updateBytesTransferredOverNetwork):
* Source/WebKit/WebProcess/Network/WebResourceLoader.h:
* Source/WebKit/WebProcess/Storage/WebSharedWorkerObjectConnection.messages.in:

Canonical link: <a href="https://commits.webkit.org/290459@main">https://commits.webkit.org/290459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11a7deb7d073191524dfc809364f2db290cec168

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92156 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10020 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69368 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26965 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49729 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7397 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36103 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77729 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96930 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17292 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12697 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78363 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77569 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19151 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22019 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20615 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10510 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22628 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->