### PR TITLE
[SwiftUI] (macOS) Add support for disabling rubber-banding if the content size is less than that of the scroll view size

### DIFF
--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1437,6 +1437,22 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.runUIScript(`uiController.setScrollViewKeyboardAvoidanceEnabled(${enabled})`, resolve));
     }
 
+    static async setAlwaysBounceVertical(enabled)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => testRunner.runUIScript(`uiController.setAlwaysBounceVertical(${enabled})`, resolve));
+    }
+
+    static async setAlwaysBounceHorizontal(enabled)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve();
+
+        return new Promise(resolve => testRunner.runUIScript(`uiController.setAlwaysBounceHorizontal(${enabled})`, resolve));
+    }
+
     static presentFindNavigator() {
         if (!this.isWebKit2() || !this.isIOSFamily())
             return Promise.resolve();

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-always-bounce-short-content-expected.txt
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-always-bounce-short-content-expected.txt
@@ -1,0 +1,33 @@
+Swipes should rubber-band on each side even if the content size does not exceed the scroll view size.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Swipe to the left
+PASS minXOffset < 0 is true
+PASS maxXOffset is 0
+PASS minYOffset is 0
+PASS maxYOffset is 0
+
+Swipe to the right
+PASS minXOffset is 0
+PASS maxXOffset > 0 is true
+PASS minYOffset is 0
+PASS maxYOffset is 0
+
+Swipe down
+PASS minXOffset is 0
+PASS maxXOffset is 0
+PASS minYOffset is 0
+PASS maxYOffset > 0 is true
+
+Swipe up
+PASS minXOffset is 0
+PASS maxXOffset is 0
+PASS minYOffset < 0 is true
+PASS maxYOffset is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-always-bounce-short-content.html
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-always-bounce-short-content.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        var minXOffset;
+        var maxXOffset;
+        var minYOffset;
+        var maxYOffset;
+
+        function reset()
+        {
+            window.scrollTo(0, 0);
+            minXOffset = 0;
+            maxXOffset = -1000;
+            minYOffset = 0;
+            maxYOffset = -1000;
+        }
+
+        async function scrollTest()
+        {
+            description('Swipes should rubber-band on each side even if the content size does not exceed the scroll view size.');
+
+            await UIHelper.setAlwaysBounceVertical(true);
+            await UIHelper.setAlwaysBounceHorizontal(true);
+        
+            window.addEventListener('scroll', () => {
+                minXOffset = Math.min(minXOffset, window.pageXOffset);
+                maxXOffset = Math.max(maxXOffset, window.pageXOffset);
+
+                minYOffset = Math.min(minYOffset, window.pageYOffset);
+                maxYOffset = Math.max(maxYOffset, window.pageYOffset);
+            }, false);
+
+
+            if (!window.eventSender) {
+                finishJSTest();
+                return;
+            }
+
+            reset();
+            debug('');
+            debug('Swipe to the left');
+            
+            await UIHelper.mouseWheelScrollAt(10, 10, 1, 0, 10, 0);
+            shouldBeTrue('minXOffset < 0');
+            shouldBe('maxXOffset', '0');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '0');
+
+            reset();
+            debug('');
+            debug('Swipe to the right');
+            await UIHelper.mouseWheelScrollAt(10, 10, -1, 0, -10, 0);
+            shouldBe('minXOffset', '0');
+            shouldBeTrue('maxXOffset > 0');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '0');
+
+            reset();
+            debug('');
+            debug('Swipe down');
+            await UIHelper.mouseWheelScrollAt(10, 10, 0, -1, 0, -10);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '0');
+            shouldBe('minYOffset', '0');
+            shouldBeTrue('maxYOffset > 0');
+
+            reset();
+            debug('');
+            debug('Swipe up');
+            await UIHelper.mouseWheelScrollAt(10, 10, 0, 1, 0, 10);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '0');
+            shouldBeTrue('minYOffset < 0');
+            shouldBe('maxYOffset', '0');
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            scrollTest();
+        }, false);
+    </script>
+</head>
+<body>
+    
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-short-content-expected.txt
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-short-content-expected.txt
@@ -1,0 +1,33 @@
+Swipes should not rubber-band on each side if the content size does not exceed the scroll view size.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Swipe to the left
+PASS minXOffset is 0
+PASS maxXOffset is -1000
+PASS minYOffset is 0
+PASS maxYOffset is -1000
+
+Swipe to the right
+PASS minXOffset is 0
+PASS maxXOffset is -1000
+PASS minYOffset is 0
+PASS maxYOffset is -1000
+
+Swipe down
+PASS minXOffset is 0
+PASS maxXOffset is -1000
+PASS minYOffset is 0
+PASS maxYOffset is -1000
+
+Swipe up
+PASS minXOffset is 0
+PASS maxXOffset is -1000
+PASS minYOffset is 0
+PASS maxYOffset is -1000
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-short-content.html
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-short-content.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        var minXOffset;
+        var maxXOffset;
+        var minYOffset;
+        var maxYOffset;
+
+        function reset()
+        {
+            window.scrollTo(0, 0);
+            minXOffset = 0;
+            maxXOffset = -1000;
+            minYOffset = 0;
+            maxYOffset = -1000;
+        }
+
+        async function scrollTest()
+        {
+            description('Swipes should not rubber-band on each side if the content size does not exceed the scroll view size.');
+
+            await UIHelper.setAlwaysBounceVertical(false);
+            await UIHelper.setAlwaysBounceHorizontal(false);
+        
+            window.addEventListener('scroll', () => {
+                minXOffset = Math.min(minXOffset, window.pageXOffset);
+                maxXOffset = Math.max(maxXOffset, window.pageXOffset);
+
+                minYOffset = Math.min(minYOffset, window.pageYOffset);
+                maxYOffset = Math.max(maxYOffset, window.pageYOffset);
+            }, false);
+
+
+            if (!window.eventSender) {
+                finishJSTest();
+                return;
+            }
+
+            reset();
+            debug('');
+            debug('Swipe to the left');
+            
+            await UIHelper.mouseWheelScrollAt(10, 10, 1, 0, 10, 0);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '-1000');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '-1000');
+
+            reset();
+            debug('');
+            debug('Swipe to the right');
+            await UIHelper.mouseWheelScrollAt(10, 10, -1, 0, -10, 0);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '-1000');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '-1000');
+
+            reset();
+            debug('');
+            debug('Swipe down');
+            await UIHelper.mouseWheelScrollAt(10, 10, 0, -1, 0, -10);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '-1000');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '-1000');
+
+            reset();
+            debug('');
+            debug('Swipe up');
+            await UIHelper.mouseWheelScrollAt(10, 10, 0, 1, 0, 10);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '-1000');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '-1000');
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            scrollTest();
+        }, false);
+    </script>
+</head>
+<body>
+    
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content-expected.txt
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content-expected.txt
@@ -1,0 +1,33 @@
+Swipes should rubber-band on each side since the content size is taller than the scroll view size.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Swipe to the left
+PASS minXOffset < 0 is true
+PASS maxXOffset is 0
+PASS minYOffset is 0
+PASS maxYOffset is 0
+
+Swipe to the right
+PASS minXOffset is 0
+PASS maxXOffset > 0 is true
+PASS minYOffset is 0
+PASS maxYOffset is 0
+
+Swipe down
+PASS minXOffset is 0
+PASS maxXOffset is 0
+PASS minYOffset is 0
+PASS maxYOffset > 0 is true
+
+Swipe up
+PASS minXOffset is 0
+PASS maxXOffset is 0
+PASS minYOffset < 0 is true
+PASS maxYOffset is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content.html
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    
+    <script>
+        jsTestIsAsync = true;
+
+        var minXOffset;
+        var maxXOffset;
+        var minYOffset;
+        var maxYOffset;
+
+        function reset()
+        {
+            window.scrollTo(0, 0);
+            minXOffset = 0;
+            maxXOffset = -1000;
+            minYOffset = 0;
+            maxYOffset = -1000;
+        }
+
+        async function scrollTest()
+        {
+            description('Swipes should rubber-band on each side since the content size is taller than the scroll view size.');
+
+            await UIHelper.setAlwaysBounceVertical(false);
+            await UIHelper.setAlwaysBounceHorizontal(false);
+        
+            window.addEventListener('scroll', () => {
+                minXOffset = Math.min(minXOffset, window.pageXOffset);
+                maxXOffset = Math.max(maxXOffset, window.pageXOffset);
+
+                minYOffset = Math.min(minYOffset, window.pageYOffset);
+                maxYOffset = Math.max(maxYOffset, window.pageYOffset);
+            }, false);
+
+
+            if (!window.eventSender) {
+                finishJSTest();
+                return;
+            }
+
+            reset();
+            debug('');
+            debug('Swipe to the left');
+            
+            await UIHelper.mouseWheelScrollAt(10, 10, 1, 0, 10, 0);
+            shouldBeTrue('minXOffset < 0');
+            shouldBe('maxXOffset', '0');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '0');
+
+            reset();
+            debug('');
+            debug('Swipe to the right');
+            await UIHelper.mouseWheelScrollAt(10, 10, -1, 0, -10, 0);
+            shouldBe('minXOffset', '0');
+            shouldBeTrue('maxXOffset > 0');
+            shouldBe('minYOffset', '0');
+            shouldBe('maxYOffset', '0');
+
+            reset();
+            debug('');
+            debug('Swipe down');
+            await UIHelper.mouseWheelScrollAt(10, 10, 0, -1, 0, -10);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '0');
+            shouldBe('minYOffset', '0');
+            shouldBeTrue('maxYOffset > 0');
+
+            reset();
+            debug('');
+            debug('Swipe up');
+            await UIHelper.mouseWheelScrollAt(10, 10, 0, 1, 0, 10);
+            shouldBe('minXOffset', '0');
+            shouldBe('maxXOffset', '0');
+            shouldBeTrue('minYOffset < 0');
+            shouldBe('maxYOffset', '0');
+            finishJSTest();
+        }
+
+        window.addEventListener('load', () => {
+            scrollTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div style="background-color: blue; width: 150vw; height: 150vh;"></div>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -893,14 +893,14 @@ void ScrollingTree::setMainFramePinnedState(RectEdges<bool> edgePinningState)
     m_swipeState.mainFramePinnedState = edgePinningState;
 }
 
-void ScrollingTree::setClientAllowedMainFrameRubberBandableEdges(RectEdges<bool> clientAllowedRubberBandableEdges)
+void ScrollingTree::setClientAllowedMainFrameRubberBandableEdges(RectEdges<RubberBandingBehavior> clientAllowedRubberBandableEdges)
 {
     Locker locker { m_swipeStateLock };
 
     m_swipeState.clientAllowedRubberBandableEdges = clientAllowedRubberBandableEdges;
 }
 
-bool ScrollingTree::clientAllowsMainFrameRubberBandingOnSide(BoxSide side)
+RubberBandingBehavior ScrollingTree::clientAllowsMainFrameRubberBandingOnSide(BoxSide side)
 {
     Locker locker { m_swipeStateLock };
     return m_swipeState.clientAllowedRubberBandableEdges.at(side);
@@ -953,13 +953,13 @@ bool ScrollingTree::willWheelEventStartSwipeGesture(const PlatformWheelEvent& wh
 
     Locker locker { m_swipeStateLock };
 
-    if (wheelEvent.deltaX() > 0 && m_swipeState.mainFramePinnedState.left() && !m_swipeState.clientAllowedRubberBandableEdges.left())
+    if (wheelEvent.deltaX() > 0 && m_swipeState.mainFramePinnedState.left() && m_swipeState.clientAllowedRubberBandableEdges.left() == RubberBandingBehavior::Never)
         return true;
-    if (wheelEvent.deltaX() < 0 && m_swipeState.mainFramePinnedState.right() && !m_swipeState.clientAllowedRubberBandableEdges.right())
+    if (wheelEvent.deltaX() < 0 && m_swipeState.mainFramePinnedState.right() && m_swipeState.clientAllowedRubberBandableEdges.right() == RubberBandingBehavior::Never)
         return true;
-    if (wheelEvent.deltaY() > 0 && m_swipeState.mainFramePinnedState.top() && !m_swipeState.clientAllowedRubberBandableEdges.top())
+    if (wheelEvent.deltaY() > 0 && m_swipeState.mainFramePinnedState.top() && m_swipeState.clientAllowedRubberBandableEdges.top() == RubberBandingBehavior::Never)
         return true;
-    if (wheelEvent.deltaY() < 0 && m_swipeState.mainFramePinnedState.bottom() && !m_swipeState.clientAllowedRubberBandableEdges.bottom())
+    if (wheelEvent.deltaY() < 0 && m_swipeState.mainFramePinnedState.bottom() && m_swipeState.clientAllowedRubberBandableEdges.bottom() == RubberBandingBehavior::Never)
         return true;
 
     return false;

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -173,8 +173,8 @@ public:
     void setMainFramePinnedState(RectEdges<bool>);
 
     // Can be called from any thread. Will update what edges allow rubber-banding.
-    WEBCORE_EXPORT void setClientAllowedMainFrameRubberBandableEdges(RectEdges<bool>);
-    bool clientAllowsMainFrameRubberBandingOnSide(BoxSide);
+    WEBCORE_EXPORT void setClientAllowedMainFrameRubberBandableEdges(RectEdges<RubberBandingBehavior>);
+    RubberBandingBehavior clientAllowsMainFrameRubberBandingOnSide(BoxSide);
 
     bool isHandlingProgrammaticScroll() const { return m_isHandlingProgrammaticScroll; }
     void setIsHandlingProgrammaticScroll(bool isHandlingProgrammaticScroll) { m_isHandlingProgrammaticScroll = isHandlingProgrammaticScroll; }
@@ -333,7 +333,7 @@ private:
     TreeState m_treeState WTF_GUARDED_BY_LOCK(m_treeStateLock);
 
     struct SwipeState {
-        RectEdges<bool> clientAllowedRubberBandableEdges  { true, true, true, true };
+        RectEdges<RubberBandingBehavior> clientAllowedRubberBandableEdges  { RubberBandingBehavior::Always, RubberBandingBehavior::Always, RubberBandingBehavior::Always, RubberBandingBehavior::Always };
         RectEdges<bool> mainFramePinnedState { true, true, true, true };
         ScrollPinningBehavior scrollPinningBehavior { ScrollPinningBehavior::DoNotPin };
     };

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -142,7 +142,9 @@ bool ScrollingTreeScrollingNode::shouldRubberBandOnSide(BoxSide side, RectEdges<
     if (!pinnedEdges[side])
         return false;
 
-    if (isRootNode() && !scrollingTree()->clientAllowsMainFrameRubberBandingOnSide(side))
+    auto mainFrameRubberBandingBehavior = scrollingTree()->clientAllowsMainFrameRubberBandingOnSide(side);
+
+    if (isRootNode() && mainFrameRubberBandingBehavior == RubberBandingBehavior::Never)
         return false;
 
     switch (side) {
@@ -152,8 +154,12 @@ bool ScrollingTreeScrollingNode::shouldRubberBandOnSide(BoxSide side, RectEdges<
             return false;
 
         // The root allows rubberbanding if it doesn't have enough content, but only if a scrollbar is allowed.
-        if (isRootNode() && canHaveVerticalScrollbar())
+        if (isRootNode() && canHaveVerticalScrollbar()) {
+            if (!allowsVerticalScrolling() && mainFrameRubberBandingBehavior == RubberBandingBehavior::BasedOnSize)
+                return false;
+
             return true;
+        }
 
         if (!allowsVerticalScrolling())
             return false;
@@ -166,8 +172,12 @@ bool ScrollingTreeScrollingNode::shouldRubberBandOnSide(BoxSide side, RectEdges<
             return false;
 
         // The root allows rubberbanding if it doesn't have enough content, but only if a scrollbar is allowed.
-        if (isRootNode() && canHaveHorizontalScrollbar())
+        if (isRootNode() && canHaveHorizontalScrollbar()) {
+            if (!allowsHorizontalScrolling() && mainFrameRubberBandingBehavior == RubberBandingBehavior::BasedOnSize)
+                return false;
+
             return true;
+        }
 
         if (!allowsHorizontalScrolling())
             return false;

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -99,6 +99,16 @@ TextStream& operator<<(TextStream& ts, ScrollElasticity behavior)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, RubberBandingBehavior behavior)
+{
+    switch (behavior) {
+    case RubberBandingBehavior::Always: ts << "always"; break;
+    case RubberBandingBehavior::Never: ts << "never"; break;
+    case RubberBandingBehavior::BasedOnSize: ts << "based on size"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, ScrollbarMode behavior)
 {
     switch (behavior) {

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -151,6 +151,13 @@ enum class ScrollElasticity : uint8_t {
     Allowed
 };
 
+// Determines if rubber-banding should be enabled if the content size is less than the scroll view size.
+enum class RubberBandingBehavior : uint8_t {
+    Always,
+    Never,
+    BasedOnSize
+};
+
 enum class ScrollbarOrientation : uint8_t {
     Horizontal,
     Vertical
@@ -385,6 +392,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollClamping);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehaviorForFixedElements);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollElasticity);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RubberBandingBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarMode);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollDirection);

--- a/Source/WebCore/platform/ScrollTypes.serialization.in
+++ b/Source/WebCore/platform/ScrollTypes.serialization.in
@@ -38,3 +38,9 @@ enum class WebCore::ScrollbarWidth : uint8_t {
     Thin,
     None,
 };
+
+enum class WebCore::RubberBandingBehavior : uint8_t {
+    Always,
+    Never,
+    BasedOnSize,
+};

--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -28,6 +28,7 @@
 
 #include "FloatRect.h"
 #include "GraphicsContext.h"
+#include "ImageBuffer.h"
 #include "ImageDecoderCG.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1042,6 +1042,7 @@ def headers_for_type(type):
         'WebCore::RenderingPurpose': ['<WebCore/RenderingMode.h>'],
         'WebCore::RequestStorageAccessResult': ['<WebCore/DocumentStorageAccess.h>'],
         'WebCore::RouteSharingPolicy': ['<WebCore/AudioSession.h>'],
+        'WebCore::RubberBandingBehavior': ['<WebCore/ScrollTypes.h>'],
         'WebCore::SameSiteStrictEnforcementEnabled': ['<WebCore/NetworkStorageSession.h>'],
         'WebCore::ScriptExecutionContextIdentifier': ['<WebCore/ProcessQualified.h>', '<WebCore/ScriptExecutionContextIdentifier.h>', '<wtf/ObjectIdentifier.h>'],
         'WebCore::ScheduleLocationChangeResult': ['<WebCore/NavigationScheduler.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2000,6 +2000,13 @@ header: <WebCore/RectEdges.h>
     WebCore::Color left();
 }
 
+[CustomHeader] class WebCore::RectEdges<WebCore::RubberBandingBehavior> {
+    WebCore::RubberBandingBehavior top();
+    WebCore::RubberBandingBehavior right();
+    WebCore::RubberBandingBehavior bottom();
+    WebCore::RubberBandingBehavior left();
+}
+
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::Path {
     Vector<WebCore::PathSegment> segments();
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -556,4 +556,9 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails&)
 
 @interface WKWebView (NonCpp)
 
+#if PLATFORM(MAC)
+@property (nonatomic, setter=_setAlwaysBounceVertical:) BOOL _alwaysBounceVertical;
+@property (nonatomic, setter=_setAlwaysBounceHorizontal:) BOOL _alwaysBounceHorizontal;
+#endif
+
 @end

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1431,6 +1431,26 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->setRubberBandingEnabled(state);
 }
 
+- (BOOL)_alwaysBounceVertical
+{
+    return _impl->alwaysBounceVertical();
+}
+
+- (void)_setAlwaysBounceVertical:(BOOL)value
+{
+    _impl->setAlwaysBounceVertical(value);
+}
+
+- (BOOL)_alwaysBounceHorizontal
+{
+    return _impl->alwaysBounceHorizontal();
+}
+
+- (void)_setAlwaysBounceHorizontal:(BOOL)value
+{
+    _impl->setAlwaysBounceHorizontal(value);
+}
+
 - (NSColor *)_backgroundColor
 {
     return _impl->backgroundColor();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -120,7 +120,7 @@ std::optional<RequestedScrollData> RemoteScrollingCoordinatorProxy::commitScroll
     return std::exchange(m_requestedScroll, { });
 }
 
-void RemoteScrollingCoordinatorProxy::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+void RemoteScrollingCoordinatorProxy::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
 #if !(PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING))
     auto platformWheelEvent = platform(wheelEvent);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -99,7 +99,7 @@ public:
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical);
 
     virtual void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&) { }
-    virtual void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    virtual void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
     void continueWheelEventHandling(const WebWheelEvent&, WebCore::WheelEventHandlingResult);
     virtual void wheelEventHandlingCompleted(const WebCore::PlatformWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>, bool /* wasHandled */) { }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -188,7 +188,7 @@ void RemoteLayerTreeEventDispatcher::willHandleWheelEvent(const WebWheelEvent& w
     m_wheelEventsBeingProcessed.append(wheelEvent);
 }
 
-void RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+void RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     ASSERT(isMainRunLoop());
 
@@ -208,7 +208,7 @@ void RemoteLayerTreeEventDispatcher::handleWheelEvent(const WebWheelEvent& wheel
     });
 }
 
-void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWheelEvent& webWheelEvent, RectEdges<bool> rubberBandableEdges)
+void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWheelEvent& webWheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     ASSERT(ScrollingThread::isCurrentThread());
     
@@ -260,7 +260,7 @@ void RemoteLayerTreeEventDispatcher::continueWheelEventHandling(WheelEventHandli
     m_scrollingCoordinator->continueWheelEventHandling(event, handlingResult);
 }
 
-OptionSet<WheelEventProcessingSteps> RemoteLayerTreeEventDispatcher::determineWheelEventProcessing(const PlatformWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+OptionSet<WheelEventProcessingSteps> RemoteLayerTreeEventDispatcher::determineWheelEventProcessing(const PlatformWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     auto scrollingTree = this->scrollingTree();
     if (!scrollingTree)
@@ -693,7 +693,7 @@ void RemoteLayerTreeEventDispatcher::endMomentumSignpostInterval()
 }
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-void RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent(PageIdentifier pageID, const WebWheelEvent& event, RectEdges<bool> rubberBandableEdges)
+void RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent(PageIdentifier pageID, const WebWheelEvent& event, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     ASSERT_UNUSED(pageID, m_pageIdentifier == pageID);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -81,7 +81,7 @@ public:
     
     void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);
 
-    void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
     void wheelEventHandlingCompleted(const WebCore::PlatformWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>, bool wasHandled);
 
     void setScrollingTree(RefPtr<RemoteScrollingTree>&&);
@@ -105,9 +105,9 @@ public:
 #endif
 
 private:
-    OptionSet<WebCore::WheelEventProcessingSteps> determineWheelEventProcessing(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    OptionSet<WebCore::WheelEventProcessingSteps> determineWheelEventProcessing(const WebCore::PlatformWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
 
-    void scrollingThreadHandleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void scrollingThreadHandleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
     WebCore::WheelEventHandlingResult internalHandleWheelEvent(const WebCore::PlatformWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>);
 
     WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent&);
@@ -146,7 +146,7 @@ private:
     void didStartRubberbanding();
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
-    void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
     void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID);
     void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -47,7 +47,7 @@ public:
 private:
     void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&) override;
 
-    void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
+    void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges) override;
     void wheelEventHandlingCompleted(const WebCore::PlatformWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>, bool wasHandled) override;
 
     bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -77,7 +77,7 @@ void RemoteScrollingCoordinatorProxyMac::cacheWheelEventScrollingAccelerationCur
 #endif
 }
 
-void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+void RemoteScrollingCoordinatorProxyMac::handleWheelEvent(const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
 #if ENABLE(SCROLLING_THREAD)
     m_eventDispatcher->handleWheelEvent(wheelEvent, rubberBandableEdges);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -218,6 +218,7 @@ enum class ReloadOption : uint8_t;
 enum class RenderAsTextFlag : uint16_t;
 enum class ResourceResponseSource : uint8_t;
 enum class RouteSharingPolicy : uint8_t;
+enum class RubberBandingBehavior : uint8_t;
 enum class SandboxFlag : uint16_t;
 enum class ScreenOrientationType : uint8_t;
 enum class ScrollbarMode : uint8_t;
@@ -1448,6 +1449,11 @@ public:
     void setRubberBandsAtRight(bool);
     void setRubberBandsAtTop(bool);
     void setRubberBandsAtBottom(bool);
+
+    bool alwaysBounceVertical() const;
+    void setAlwaysBounceVertical(bool);
+    bool alwaysBounceHorizontal() const;
+    void setAlwaysBounceHorizontal(bool);
 
     void setShouldUseImplicitRubberBandControl(bool shouldUseImplicitRubberBandControl) { m_shouldUseImplicitRubberBandControl = shouldUseImplicitRubberBandControl; }
     bool shouldUseImplicitRubberBandControl() const { return m_shouldUseImplicitRubberBandControl; }
@@ -3069,7 +3075,7 @@ private:
     void setRenderTreeSize(uint64_t treeSize) { m_renderTreeSize = treeSize; }
 
     void handleWheelEvent(const WebWheelEvent&);
-    void sendWheelEvent(WebCore::FrameIdentifier, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WebCore::RectEdges<bool> rubberBandableEdges, std::optional<bool> willStartSwipe, bool wasHandledForScrolling);
+    void sendWheelEvent(WebCore::FrameIdentifier, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges, std::optional<bool> willStartSwipe, bool wasHandledForScrolling);
     void handleWheelEventReply(const WebWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>, bool wasHandledForScrolling, bool wasHandledByWebProcess);
 
     void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -329,6 +329,8 @@ public:
     WebCore::MediaProducerMediaStateFlags reportedMediaCaptureState;
     RunLoop::Timer resetRecentCrashCountTimer;
     WebCore::RectEdges<bool> rubberBandableEdges { true, true, true, true };
+    bool alwaysBounceVertical { true };
+    bool alwaysBounceHorizontal { true };
     WebCore::Color sampledPageTopColor;
     WebCore::ScrollPinningBehavior scrollPinningBehavior { WebCore::ScrollPinningBehavior::DoNotPin };
     WebCore::IntSize sizeToContentAutoSizeMaximumSize;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -361,6 +361,11 @@ public:
     _WKRectEdge rubberBandingEnabled();
     void setRubberBandingEnabled(_WKRectEdge);
 
+    bool alwaysBounceVertical();
+    void setAlwaysBounceVertical(bool);
+    bool alwaysBounceHorizontal();
+    void setAlwaysBounceHorizontal(bool);
+
     void setOverlayScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle);
     std::optional<WebCore::ScrollbarOverlayStyle> overlayScrollbarStyle() const;
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2398,7 +2398,7 @@ WebCore::DestinationColorSpace WebViewImpl::colorSpace()
 
         if (!m_colorSpace)
             m_colorSpace = [NSScreen mainScreen].colorSpace;
-    
+
         if (!m_colorSpace)
             m_colorSpace = [NSColorSpace sRGBColorSpace];
     }
@@ -5855,6 +5855,26 @@ _WKRectEdge WebViewImpl::rubberBandingEnabled()
 void WebViewImpl::setRubberBandingEnabled(_WKRectEdge state)
 {
     m_page->setRubberBandableEdges(toRectEdges(state));
+}
+
+bool WebViewImpl::alwaysBounceVertical()
+{
+    return m_page->alwaysBounceVertical();
+}
+
+void WebViewImpl::setAlwaysBounceVertical(bool value)
+{
+    m_page->setAlwaysBounceVertical(value);
+}
+
+bool WebViewImpl::alwaysBounceHorizontal()
+{
+    return m_page->alwaysBounceHorizontal();
+}
+
+void WebViewImpl::setAlwaysBounceHorizontal(bool value)
+{
+    m_page->setAlwaysBounceHorizontal(value);
 }
 
 void WebViewImpl::mouseDown(NSEvent *event)

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp
@@ -116,7 +116,7 @@ void EventDispatcher::initializeConnection(IPC::Connection& connection)
     connection.addMessageReceiver(m_queue.get(), *this, Messages::EventDispatcher::messageReceiverName());
 }
 
-void EventDispatcher::internalWheelEvent(PageIdentifier pageID, const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges, WheelEventOrigin wheelEventOrigin)
+void EventDispatcher::internalWheelEvent(PageIdentifier pageID, const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges, WheelEventOrigin wheelEventOrigin)
 {
     auto processingSteps = OptionSet<WebCore::WheelEventProcessingSteps> { WheelEventProcessingSteps::SynchronousScrolling, WheelEventProcessingSteps::BlockingDOMEventDispatch };
 
@@ -195,7 +195,7 @@ void EventDispatcher::internalWheelEvent(PageIdentifier pageID, const WebWheelEv
 #endif
 }
 
-void EventDispatcher::wheelEvent(PageIdentifier pageID, const WebWheelEvent& wheelEvent, RectEdges<bool> rubberBandableEdges)
+void EventDispatcher::wheelEvent(PageIdentifier pageID, const WebWheelEvent& wheelEvent, RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     if (m_momentumEventDispatcher->handleWheelEvent(pageID, wheelEvent, rubberBandableEdges)) {
@@ -367,7 +367,7 @@ void EventDispatcher::setScrollingAccelerationCurve(PageIdentifier pageID, std::
     m_momentumEventDispatcher->setScrollingAccelerationCurve(pageID, curve);
 }
 
-void EventDispatcher::handleSyntheticWheelEvent(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event, WebCore::RectEdges<bool> rubberBandableEdges)
+void EventDispatcher::handleSyntheticWheelEvent(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     internalWheelEvent(pageIdentifier, event, rubberBandableEdges, WheelEventOrigin::MomentumEventDispatcher);
 }

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.h
@@ -115,7 +115,7 @@ private:
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
     // Message handlers
-    void wheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    void wheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>);
 #endif
@@ -130,7 +130,7 @@ private:
     void dispatchWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WheelEventOrigin);
     void dispatchWheelEventViaMainThread(WebCore::PageIdentifier, const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WheelEventOrigin);
 
-    void internalWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges, WheelEventOrigin);
+    void internalWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges, WheelEventOrigin);
 
 #if ENABLE(IOS_TOUCH_EVENTS)
     void dispatchTouchEvents();
@@ -151,7 +151,7 @@ private:
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     // EventDispatcher::Client
-    void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) override;
+    void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges) override;
     void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) override;
     void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) override;
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -25,7 +25,7 @@
     DispatchedTo=WebContent
 ]
 messages -> EventDispatcher {
-    WheelEvent(WebCore::PageIdentifier pageID, WebKit::WebWheelEvent event, WebCore::RectEdges<bool> rubberBandableEdges)
+    WheelEvent(WebCore::PageIdentifier pageID, WebKit::WebWheelEvent event, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 #if ENABLE(IOS_TOUCH_EVENTS)
     TouchEvent(WebCore::PageIdentifier pageID, WebCore::FrameIdentifier frameID, WebKit::WebTouchEvent event) -> (bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteTouchEventData) MainThreadCallback
 #endif

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -72,7 +72,7 @@ bool MomentumEventDispatcher::eventShouldStartSyntheticMomentumPhase(WebCore::Pa
     return true;
 }
 
-bool MomentumEventDispatcher::handleWheelEvent(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event, WebCore::RectEdges<bool> rubberBandableEdges)
+bool MomentumEventDispatcher::handleWheelEvent(WebCore::PageIdentifier pageIdentifier, const WebWheelEvent& event, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges)
 {
     m_lastRubberBandableEdges = rubberBandableEdges;
     m_lastIncomingEvent = event;

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h
@@ -45,6 +45,7 @@ namespace WebCore {
 struct DisplayUpdate;
 using FramesPerSecond = unsigned;
 using PlatformDisplayID = uint32_t;
+enum class RubberBandingBehavior : uint8_t;
 }
 
 namespace WebKit {
@@ -61,8 +62,8 @@ public:
         virtual ~Client() = default;
 
     private:
-        virtual void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges) = 0;
-        
+        virtual void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges) = 0;
+
         virtual void startDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) = 0;
         virtual void stopDisplayDidRefreshCallbacks(WebCore::PlatformDisplayID) = 0;
 
@@ -74,7 +75,7 @@ public:
     MomentumEventDispatcher(Client&);
     ~MomentumEventDispatcher();
 
-    bool handleWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<bool> rubberBandableEdges);
+    bool handleWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);
 
     void setScrollingAccelerationCurve(WebCore::PageIdentifier, std::optional<ScrollingAccelerationCurve>);
 
@@ -146,7 +147,7 @@ private:
 
     Markable<WallTime> m_lastScrollTimestamp;
     std::optional<WebWheelEvent> m_lastIncomingEvent;
-    WebCore::RectEdges<bool> m_lastRubberBandableEdges;
+    WebCore::RectEdges<WebCore::RubberBandingBehavior> m_lastRubberBandableEdges;
     bool m_isInOverriddenPlatformMomentumGesture { false };
 
     struct {

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -299,6 +299,9 @@ interface UIScriptController {
 
     undefined setScrollViewKeyboardAvoidanceEnabled(boolean enabled);
 
+    undefined setAlwaysBounceVertical(boolean value);
+    undefined setAlwaysBounceHorizontal(boolean value);
+
     undefined beginInteractiveObscuredInsetsChange();
     undefined endInteractiveObscuredInsetsChange();
     undefined setObscuredInsets(double top, double right, double bottom, double left);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -107,6 +107,8 @@ public:
 
     virtual void setScrollViewKeyboardAvoidanceEnabled(bool) { notImplemented(); }
 
+    virtual void setRubberBandingBehavior(JSStringRef, bool, bool) { notImplemented(); }
+
     virtual std::optional<bool> stableStateOverride() const { notImplemented(); return std::nullopt; }
     virtual void setStableStateOverride(std::optional<bool>) { notImplemented(); }
 
@@ -178,6 +180,9 @@ public:
     virtual JSRetainPtr<JSStringRef> caLayerTreeAsText() const { notImplemented(); return nullptr; }
     
     virtual JSRetainPtr<JSStringRef> scrollbarStateForScrollingNodeID(unsigned long long, unsigned long long, bool) const { notImplemented(); return nullptr; }
+
+    virtual void setAlwaysBounceVertical(bool) { notImplemented(); }
+    virtual void setAlwaysBounceHorizontal(bool) { notImplemented(); }
 
     // Touches
 

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.h
@@ -77,6 +77,9 @@ private:
     int64_t pasteboardChangeCount() const final;
 
     void setInlinePrediction(JSStringRef text, unsigned startIndex) final;
+
+    void setAlwaysBounceVertical(bool) final;
+    void setAlwaysBounceHorizontal(bool) final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -51,6 +51,13 @@
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
+@interface WKWebView (Internal_RubberBandingBehavior)
+
+@property (nonatomic, setter=_setAlwaysBounceVertical:) BOOL _alwaysBounceVertical;
+@property (nonatomic, setter=_setAlwaysBounceHorizontal:) BOOL _alwaysBounceHorizontal;
+
+@end
+
 namespace WTR {
 
 Ref<UIScriptController> UIScriptController::create(UIScriptContext& context)
@@ -489,6 +496,16 @@ void UIScriptControllerMac::setInlinePrediction(JSStringRef jsText, unsigned sta
     UNUSED_PARAM(jsText);
     UNUSED_PARAM(startIndex);
 #endif
+}
+
+void UIScriptControllerMac::setAlwaysBounceVertical(bool value)
+{
+    webView()._alwaysBounceVertical = value;
+}
+
+void UIScriptControllerMac::setAlwaysBounceHorizontal(bool value)
+{
+    webView()._alwaysBounceHorizontal = value;
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### 8bc5e1f0082a8335d68cfb2dd0913255e7cab7cd
<pre>
[SwiftUI] (macOS) Add support for disabling rubber-banding if the content size is less than that of the scroll view size
<a href="https://bugs.webkit.org/show_bug.cgi?id=287763">https://bugs.webkit.org/show_bug.cgi?id=287763</a>
<a href="https://rdar.apple.com/144929647">rdar://144929647</a>

Reviewed by Simon Fraser.

On iOS, clients may use the `alwaysBounceVertical` and `alwaysBounceHorizontal` properties on `WKWebView.scrollView`
to customize if rubber-banding/bouncing should be enabled if the content size is less than the scroll view size. The
default value of these properties in WebKit is `true`.

This PR brings support for this functionality to macOS by adding likewise, internal methods to WKWebView on macOS.

To facilitate this, the concept of &quot;rubber-bandable edges&quot; is slightly changed; instead of a particular edge being
either rubber-bandable or not, an edge now has three possible states: never rubber-bandable, always rubber-bandable,
and rubber-bandable only if the content size is greater than that of the scroll view size.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async setAlwaysBounceVertical):
(window.UIHelper.async setAlwaysBounceHorizontal):
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::setScrollBounceBehavior):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::setScrollBounceBehavior):
(WTR::UIScriptController::setAlwaysBounceVertical):
(WTR::UIScriptController::setAlwaysBounceHorizontal):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.h:
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::setAlwaysBounceVertical):
(WTR::UIScriptControllerMac::setAlwaysBounceHorizontal):

Test infrastructure.

* LayoutTests/scrollingcoordinator/mac/rubberbanding-always-bounce-short-content-expected.txt: Added.
* LayoutTests/scrollingcoordinator/mac/rubberbanding-always-bounce-short-content.html: Added.
* LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-short-content-expected.txt: Added.
* LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-short-content.html: Added.
* LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content-expected.txt: Added.
* LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content.html: Added.

Several new layout tests are added.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::setClientAllowedMainFrameRubberBandableEdges):
(WebCore::ScrollingTree::clientAllowsMainFrameRubberBandingOnSide):
(WebCore::ScrollingTree::willWheelEventStartSwipeGesture):
* Source/WebCore/page/scrolling/ScrollingTree.h:

Change the relevant boolean values to the new multiple-state enum value.

* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::shouldRubberBandOnSide const):

This contains the actual logic that resolves the three possible states into a binary decision of if
an edge should rubber-band while consulting if the content is scrollable.

* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollTypes.serialization.in:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Add a new enum type to represent the new multiple states.

* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:

Unified sources fix.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _alwaysBounceVertical]):
(-[WKWebView _setAlwaysBounceVertical:]):
(-[WKWebView _alwaysBounceHorizontal]):
(-[WKWebView _setAlwaysBounceHorizontal:]):

Exposes the new functionality in the internal WKWebView header interface.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::handleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::handleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::determineWheelEventProcessing):
(WebKit::RemoteLayerTreeEventDispatcher::handleSyntheticWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::handleWheelEvent):

Change the relevant boolean values to the new multiple-state enum value.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::resolvedScrollBounceBehaviorEdges):
(WebKit::WebPageProxy::handleWheelEvent):
(WebKit::WebPageProxy::continueWheelEventHandling):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::alwaysBounceVertical const):
(WebKit::WebPageProxy::setAlwaysBounceVertical):
(WebKit::WebPageProxy::alwaysBounceHorizontal const):
(WebKit::WebPageProxy::setAlwaysBounceHorizontal):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::colorSpace):
(WebKit::WebViewImpl::alwaysBounceVertical):
(WebKit::WebViewImpl::setAlwaysBounceVertical):
(WebKit::WebViewImpl::alwaysBounceHorizontal):
(WebKit::WebViewImpl::setAlwaysBounceHorizontal):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::internalWheelEvent):
(WebKit::EventDispatcher::wheelEvent):
(WebKit::EventDispatcher::handleSyntheticWheelEvent):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::MomentumEventDispatcher::handleWheelEvent):
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.h:

Change the relevant boolean values to the new multiple-state enum value, and propogate the values from the UI process to the web process.

Canonical link: <a href="https://commits.webkit.org/290494@main">https://commits.webkit.org/290494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97c787a41fb05fa069a5d406b74e8c26c93af996

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40997 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18063 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27059 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49817 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/89722 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7497 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40128 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97047 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17409 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17666 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19174 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10668 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17419 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20612 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->