### PR TITLE
Address safer C++ static analysis warnings in WebPage

### DIFF
--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -180,7 +180,7 @@ public:
     };
 
     SamplingProfiler(VM&, Ref<Stopwatch>&&);
-    ~SamplingProfiler();
+    JS_EXPORT_PRIVATE ~SamplingProfiler();
     void noticeJSLockAcquisition();
     void noticeVMEntry();
     void shutdown();

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.cpp
@@ -69,7 +69,7 @@ DOMWrapperWorld& normalWorld(JSC::VM& vm)
     return downcast<JSVMClientData>(clientData)->normalWorldSingleton();
 }
 
-DOMWrapperWorld& mainThreadNormalWorld()
+DOMWrapperWorld& mainThreadNormalWorldSingleton()
 {
     ASSERT(isMainThread());
     static DOMWrapperWorld& cachedNormalWorld = normalWorld(commonVM());

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -92,11 +92,11 @@ private:
 };
 
 DOMWrapperWorld& normalWorld(JSC::VM&);
-WEBCORE_EXPORT DOMWrapperWorld& mainThreadNormalWorld();
-inline Ref<DOMWrapperWorld> protectedMainThreadNormalWorld() { return mainThreadNormalWorld(); }
+WEBCORE_EXPORT DOMWrapperWorld& mainThreadNormalWorldSingleton();
+inline Ref<DOMWrapperWorld> protectedMainThreadNormalWorld() { return mainThreadNormalWorldSingleton(); }
 
-inline DOMWrapperWorld& debuggerWorld() { return mainThreadNormalWorld(); }
-inline DOMWrapperWorld& pluginWorld() { return mainThreadNormalWorld(); }
+inline DOMWrapperWorld& debuggerWorld() { return mainThreadNormalWorldSingleton(); }
+inline DOMWrapperWorld& pluginWorld() { return mainThreadNormalWorldSingleton(); }
 
 DOMWrapperWorld& currentWorld(JSC::JSGlobalObject&);
 DOMWrapperWorld& worldForDOMObject(JSC::JSObject&);

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -723,7 +723,7 @@ JSDOMWindow& mainWorldGlobalObject(LocalFrame& frame)
     // FIXME: What guarantees the result of jsWindowProxy() is non-null?
     // FIXME: What guarantees the result of window() is non-null?
     // FIXME: What guarantees the result of window() a JSDOMWindow?
-    return *jsCast<JSDOMWindow*>(frame.windowProxy().jsWindowProxy(mainThreadNormalWorld())->window());
+    return *jsCast<JSDOMWindow*>(frame.windowProxy().jsWindowProxy(mainThreadNormalWorldSingleton())->window());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -72,7 +72,7 @@ static TextPosition convertZeroToOne(const TextPosition& position)
 }
 
 JSLazyEventListener::JSLazyEventListener(CreationArguments&& arguments, const URL& sourceURL, const TextPosition& sourcePosition)
-    : JSEventListener(nullptr, arguments.wrapper, true, CreatedFromMarkup::Yes, mainThreadNormalWorld())
+    : JSEventListener(nullptr, arguments.wrapper, true, CreatedFromMarkup::Yes, mainThreadNormalWorldSingleton())
     , m_functionName(arguments.attributeName.localName().string())
     , m_functionParameters(functionParameters(arguments.shouldUseSVGEventName))
     , m_code(arguments.attributeValue)
@@ -231,7 +231,7 @@ RefPtr<JSLazyEventListener> JSLazyEventListener::create(LocalDOMWindow& window, 
     ASSERT(window.document());
     auto& document = *window.document();
     ASSERT(document.frame());
-    return create({ attributeName, attributeValue, document, nullptr, toJSDOMWindow(document.frame(), mainThreadNormalWorld()), document.isSVGDocument() });
+    return create({ attributeName, attributeValue, document, nullptr, toJSDOMWindow(document.frame(), mainThreadNormalWorldSingleton()), document.isSVGDocument() });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -187,7 +187,7 @@ ValueOrException ScriptController::evaluateInWorld(const ScriptSourceCode& sourc
 
 JSC::JSValue ScriptController::evaluateIgnoringException(const ScriptSourceCode& sourceCode)
 {
-    return evaluateInWorldIgnoringException(sourceCode, mainThreadNormalWorld());
+    return evaluateInWorldIgnoringException(sourceCode, mainThreadNormalWorldSingleton());
 }
 
 void ScriptController::loadModuleScriptInWorld(LoadableModuleScript& moduleScript, const URL& topLevelModuleURL, Ref<JSC::ScriptFetchParameters>&& topLevelFetchParameters, DOMWrapperWorld& world)
@@ -205,7 +205,7 @@ void ScriptController::loadModuleScriptInWorld(LoadableModuleScript& moduleScrip
 
 void ScriptController::loadModuleScript(LoadableModuleScript& moduleScript, const URL& topLevelModuleURL, Ref<JSC::ScriptFetchParameters>&& topLevelFetchParameters)
 {
-    loadModuleScriptInWorld(moduleScript, topLevelModuleURL, WTFMove(topLevelFetchParameters), mainThreadNormalWorld());
+    loadModuleScriptInWorld(moduleScript, topLevelModuleURL, WTFMove(topLevelFetchParameters), mainThreadNormalWorldSingleton());
 }
 
 void ScriptController::loadModuleScriptInWorld(LoadableModuleScript& moduleScript, const ScriptSourceCode& sourceCode, DOMWrapperWorld& world)
@@ -223,7 +223,7 @@ void ScriptController::loadModuleScriptInWorld(LoadableModuleScript& moduleScrip
 
 void ScriptController::loadModuleScript(LoadableModuleScript& moduleScript, const ScriptSourceCode& sourceCode)
 {
-    loadModuleScriptInWorld(moduleScript, sourceCode, mainThreadNormalWorld());
+    loadModuleScriptInWorld(moduleScript, sourceCode, mainThreadNormalWorldSingleton());
 }
 
 JSC::JSValue ScriptController::linkAndEvaluateModuleScriptInWorld(LoadableModuleScript& moduleScript, DOMWrapperWorld& world)
@@ -252,7 +252,7 @@ JSC::JSValue ScriptController::linkAndEvaluateModuleScriptInWorld(LoadableModule
 
 JSC::JSValue ScriptController::linkAndEvaluateModuleScript(LoadableModuleScript& moduleScript)
 {
-    return linkAndEvaluateModuleScriptInWorld(moduleScript, mainThreadNormalWorld());
+    return linkAndEvaluateModuleScriptInWorld(moduleScript, mainThreadNormalWorldSingleton());
 }
 
 JSC::JSValue ScriptController::evaluateModule(const URL& sourceURL, AbstractModuleRecord& moduleRecord, DOMWrapperWorld& world, JSC::JSValue awaitedValue, JSC::JSValue resumeMode)
@@ -289,7 +289,7 @@ JSC::JSValue ScriptController::evaluateModule(const URL& sourceURL, AbstractModu
 
 JSC::JSValue ScriptController::evaluateModule(const URL& sourceURL, AbstractModuleRecord& moduleRecord, JSC::JSValue awaitedValue, JSC::JSValue resumeMode)
 {
-    return evaluateModule(sourceURL, moduleRecord, mainThreadNormalWorld(), awaitedValue, resumeMode);
+    return evaluateModule(sourceURL, moduleRecord, mainThreadNormalWorldSingleton(), awaitedValue, resumeMode);
 }
 
 Ref<DOMWrapperWorld> ScriptController::createWorld(const String& name, WorldType type)
@@ -451,7 +451,7 @@ TextPosition ScriptController::eventHandlerPosition() const
 
 void ScriptController::setEvalEnabled(bool value, const String& errorMessage)
 {
-    auto* jsWindowProxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorld());
+    auto* jsWindowProxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorldSingleton());
     if (!jsWindowProxy)
         return;
     jsWindowProxy->window()->setEvalEnabled(value, errorMessage);
@@ -459,7 +459,7 @@ void ScriptController::setEvalEnabled(bool value, const String& errorMessage)
 
 void ScriptController::setWebAssemblyEnabled(bool value, const String& errorMessage)
 {
-    auto* jsWindowProxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorld());
+    auto* jsWindowProxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorldSingleton());
     if (!jsWindowProxy)
         return;
     jsWindowProxy->window()->setWebAssemblyEnabled(value, errorMessage);
@@ -467,7 +467,7 @@ void ScriptController::setWebAssemblyEnabled(bool value, const String& errorMess
 
 void ScriptController::setRequiresTrustedTypes(bool required)
 {
-    auto* proxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorld());
+    auto* proxy = windowProxy().existingJSWindowProxy(mainThreadNormalWorldSingleton());
     if (!proxy)
         return;
     proxy->window()->setRequiresTrustedTypes(required);
@@ -603,7 +603,7 @@ void ScriptController::clearScriptObjects()
 
 JSC::JSValue ScriptController::executeScriptIgnoringException(const String& script, JSC::SourceTaintedOrigin taintedness, bool forceUserGesture)
 {
-    return executeScriptInWorldIgnoringException(mainThreadNormalWorld(), script, taintedness, forceUserGesture);
+    return executeScriptInWorldIgnoringException(mainThreadNormalWorldSingleton(), script, taintedness, forceUserGesture);
 }
 
 JSC::JSValue ScriptController::executeScriptInWorldIgnoringException(DOMWrapperWorld& world, const String& script, JSC::SourceTaintedOrigin taintedness, bool forceUserGesture)
@@ -847,7 +847,7 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
     if (!frame->page())
         return;
 
-    JSDOMGlobalObject* globalObject = jsWindowProxy(mainThreadNormalWorld()).window();
+    JSDOMGlobalObject* globalObject = jsWindowProxy(mainThreadNormalWorldSingleton()).window();
 
     RefPtr scriptExecutionContext = globalObject->scriptExecutionContext();
     if (!scriptExecutionContext)
@@ -871,7 +871,7 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
     String decodedURL = PAL::decodeURLEscapeSequences(preNavigationCheckURLString);
     // FIXME: This probably needs to figure out if the origin is considered tainted.
     auto result = executeScriptIgnoringException(decodedURL.substring(javascriptSchemeLength), JSC::SourceTaintedOrigin::Untainted);
-    RELEASE_ASSERT(&vm == &jsWindowProxy(mainThreadNormalWorld()).window()->vm());
+    RELEASE_ASSERT(&vm == &jsWindowProxy(mainThreadNormalWorldSingleton()).window()->vm());
 
     // If executing script caused this frame to be removed from the page, we
     // don't want to try to replace its document!
@@ -923,7 +923,7 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
 
 void ScriptController::reportExceptionFromScriptError(LoadableScript::Error error, bool isModule)
 {
-    auto& world = mainThreadNormalWorld();
+    auto& world = mainThreadNormalWorldSingleton();
     JSC::VM& vm = world.vm();
     JSLockHolder lock(vm);
 
@@ -957,7 +957,7 @@ private:
 
 void ScriptController::registerImportMap(const ScriptSourceCode& sourceCode, const URL& baseURL)
 {
-    auto& world = mainThreadNormalWorld();
+    auto& world = mainThreadNormalWorldSingleton();
     JSC::VM& vm = world.vm();
     JSLockHolder lock(vm);
     JSDOMGlobalObject* globalObject = jsWindowProxy(world).window();

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.cpp
@@ -155,7 +155,7 @@ void JSVMClientData::getAllWorlds(Vector<Ref<DOMWrapperWorld>>& worlds)
     // is ready to start evaluating JavaScript. For example, Web Inspector waits for the main world
     // change to clear any injected scripts and debugger/breakpoint state.
 
-    auto& mainNormalWorld = mainThreadNormalWorld();
+    auto& mainNormalWorld = mainThreadNormalWorldSingleton();
 
     // Add main normal world.
     if (m_worldSet.contains(&mainNormalWorld))

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -10801,7 +10801,7 @@ void Document::dispatchSystemPreviewActionEvent(const SystemPreviewInfo& systemP
 HTMLVideoElement* Document::pictureInPictureElement() const
 {
     if (quirks().returnNullPictureInPictureElementDuringFullscreenChange()) {
-        auto* JSDOMWindowBase = toJSDOMWindow(frame(), mainThreadNormalWorld());
+        auto* JSDOMWindowBase = toJSDOMWindow(frame(), mainThreadNormalWorldSingleton());
 
         if (!JSDOMWindowBase)
             return m_pictureInPictureElement.get();

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3473,7 +3473,7 @@ void Element::childrenChanged(const ChildChange& change)
 
 void Element::setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& attributeValue)
 {
-    setAttributeEventListener(eventType, JSLazyEventListener::create(*this, attributeName, attributeValue), mainThreadNormalWorld());
+    setAttributeEventListener(eventType, JSLazyEventListener::create(*this, attributeName, attributeValue), mainThreadNormalWorldSingleton());
 }
 
 void Element::removeAllEventListeners()

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -646,7 +646,7 @@ JSC::JSGlobalObject* ScriptExecutionContext::globalObject() const
 {
     if (auto* document = dynamicDowncast<Document>(*this)) {
         auto frame = document->frame();
-        return frame ? frame->script().globalObject(mainThreadNormalWorld()) : nullptr;
+        return frame ? frame->script().globalObject(mainThreadNormalWorldSingleton()) : nullptr;
     }
 
     if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(*this)) {

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -187,7 +187,7 @@ ReplacementFragment::ReplacementFragment(RefPtr<DocumentFragment>&& inputFragmen
         return;
 
     RefPtr shadowHost { editableRoot->shadowHost() };
-    if (!editableRoot->attributeEventListener(eventNames().webkitBeforeTextInsertedEvent, mainThreadNormalWorld())
+    if (!editableRoot->attributeEventListener(eventNames().webkitBeforeTextInsertedEvent, mainThreadNormalWorldSingleton())
         && !(shadowHost && shadowHost->renderer() && shadowHost->renderer()->isRenderTextControl())
         && editableRoot->hasRichlyEditableStyle()) {
         removeInterchangeNodes(fragment.get());

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -154,14 +154,14 @@ void HTMLBodyElement::attributeChanged(const QualifiedName& name, const AtomStri
     case AttributeNames::onselectionchangeAttr:
         // FIXME: Emit "selectionchange" event at <input> / <textarea> elements and remove this special-case.
         // https://bugs.webkit.org/show_bug.cgi?id=234348
-        document().setAttributeEventListener(eventNames().selectionchangeEvent, name, newValue, mainThreadNormalWorld());
+        document().setAttributeEventListener(eventNames().selectionchangeEvent, name, newValue, mainThreadNormalWorldSingleton());
         return;
     default:
         break;
     }
 
     if (auto& eventName = eventNameForWindowEventHandlerAttribute(name); !eventName.isNull()) {
-        document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorld());
+        document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorldSingleton());
         return;
     }
 

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -87,7 +87,7 @@ void HTMLFrameSetElement::collectPresentationalHintsForAttribute(const Qualified
 void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     if (auto& eventName = HTMLBodyElement::eventNameForWindowEventHandlerAttribute(name); !eventName.isNull())
-        document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorld());
+        document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorldSingleton());
     else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 

--- a/Source/WebCore/inspector/InspectorController.cpp
+++ b/Source/WebCore/inspector/InspectorController.cpp
@@ -234,7 +234,7 @@ unsigned InspectorController::inspectionLevel() const
 
 void InspectorController::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
-    if (&world != &mainThreadNormalWorld())
+    if (&world != &mainThreadNormalWorldSingleton())
         return;
 
     if (frame.isMainFrame())

--- a/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp
@@ -113,7 +113,7 @@ JSDOMGlobalObject* InspectorFrontendAPIDispatcher::frontendGlobalObject()
     if (!localMainFrame)
         return nullptr;
     
-    return localMainFrame->script().globalObject(mainThreadNormalWorld());
+    return localMainFrame->script().globalObject(mainThreadNormalWorldSingleton());
 }
 
 static String expressionForEvaluatingCommand(const String& command, Vector<Ref<JSON::Value>>&& arguments)
@@ -267,7 +267,7 @@ ValueOrException InspectorFrontendAPIDispatcher::evaluateExpression(const String
     JSC::SuspendExceptionScope scope(m_frontendPage->inspectorController().vm());
 
     RefPtr localMainFrame = m_frontendPage->localMainFrame();
-    return localMainFrame->script().evaluateInWorld(ScriptSourceCode(expression, JSC::SourceTaintedOrigin::Untainted), mainThreadNormalWorld());
+    return localMainFrame->script().evaluateInWorld(ScriptSourceCode(expression, JSC::SourceTaintedOrigin::Untainted), mainThreadNormalWorldSingleton());
 }
 
 void InspectorFrontendAPIDispatcher::evaluateExpressionForTesting(const String& expression)

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -825,13 +825,13 @@ ExceptionOr<JSC::JSValue> InspectorFrontendHost::evaluateScriptInExtensionTab(HT
 
     Ref protectedFrame(*frame);
 
-    JSDOMGlobalObject* frameGlobalObject = frame->script().globalObject(mainThreadNormalWorld());
+    JSDOMGlobalObject* frameGlobalObject = frame->script().globalObject(mainThreadNormalWorldSingleton());
     if (!frameGlobalObject)
         return Exception { ExceptionCode::InvalidStateError, "Unable to find global object for <iframe>"_s };
 
 
     JSC::SuspendExceptionScope scope(frameGlobalObject->vm());
-    ValueOrException result = frame->script().evaluateInWorld(ScriptSourceCode(scriptSource, JSC::SourceTaintedOrigin::Untainted), mainThreadNormalWorld());
+    ValueOrException result = frame->script().evaluateInWorld(ScriptSourceCode(scriptSource, JSC::SourceTaintedOrigin::Untainted), mainThreadNormalWorldSingleton());
     
     if (!result)
         return Exception { ExceptionCode::InvalidStateError, result.error().message };

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -137,7 +137,7 @@ void PageDebugger::runEventLoopWhilePausedInternal()
 
 bool PageDebugger::isContentScript(JSGlobalObject* state) const
 {
-    return &currentWorld(*state) != &mainThreadNormalWorld() || JSC::Debugger::isContentScript(state);
+    return &currentWorld(*state) != &mainThreadNormalWorldSingleton() || JSC::Debugger::isContentScript(state);
 }
 
 void PageDebugger::reportException(JSGlobalObject* state, JSC::Exception* exception) const

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -1050,7 +1050,7 @@ void InspectorPageAgent::defaultAppearanceDidChange()
 
 void InspectorPageAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
-    if (&world != &mainThreadNormalWorld())
+    if (&world != &mainThreadNormalWorldSingleton())
         return;
 
     if (m_bootstrapScript.isEmpty())

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -163,7 +163,7 @@ InjectedScript PageDebuggerAgent::injectedScriptForEval(Inspector::Protocol::Err
 
 void PageDebuggerAgent::didClearWindowObjectInWorld(LocalFrame& frame, DOMWrapperWorld& world)
 {
-    if (!frame.isMainFrame() || &world != &mainThreadNormalWorld())
+    if (!frame.isMainFrame() || &world != &mainThreadNormalWorldSingleton())
         return;
 
     didClearGlobalObject();

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -149,7 +149,7 @@ void PageRuntimeAgent::reportExecutionContextCreation()
 
         // Always send the main world first.
         auto& mainGlobalObject = mainWorldGlobalObject(frame);
-        notifyContextCreated(frameId, &mainGlobalObject, mainThreadNormalWorld());
+        notifyContextCreated(frameId, &mainGlobalObject, mainThreadNormalWorldSingleton());
 
         for (auto& jsWindowProxy : frame.windowProxy().jsWindowProxiesAsVector()) {
             auto* globalObject = jsWindowProxy->window();

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -77,7 +77,7 @@ public:
     void updateForFrameLoadCompleted();
 
     HistoryItem* currentItem() const { return m_currentItem.get(); }
-    RefPtr<HistoryItem> protectedCurrentItem() const;
+    WEBCORE_EXPORT RefPtr<HistoryItem> protectedCurrentItem() const;
     WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
     void setCurrentItemTitle(const StringWithDirection&);
     bool currentItemShouldBeReplaced() const;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -439,6 +439,8 @@ public:
     // regardless of the settings.
     virtual bool allowsAcceleratedCompositing() const { return true; }
 
+    virtual bool isWebChromeClient() const { return false; }
+
     enum CompositingTrigger {
         ThreeDTransformTrigger = 1 << 0,
         VideoTrigger = 1 << 1,

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -61,6 +61,7 @@ public:
     Frame* focusedFrame() const { return m_focusedFrame.get(); }
     LocalFrame* focusedLocalFrame() const { return dynamicDowncast<LocalFrame>(m_focusedFrame.get()); }
     WEBCORE_EXPORT LocalFrame* focusedOrMainFrame() const;
+    RefPtr<LocalFrame> protectedFocusedOrMainFrame() const { return focusedOrMainFrame(); }
 
     WEBCORE_EXPORT bool setInitialFocus(FocusDirection, KeyboardEvent*);
     bool advanceFocus(FocusDirection, KeyboardEvent*, bool initialFocus = false);

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -154,7 +154,7 @@ public:
     Editor& editor() { return protectedDocument()->editor(); }
     const Editor& editor() const { return protectedDocument()->editor(); }
     WEBCORE_EXPORT Ref<Editor> protectedEditor();
-    Ref<const Editor> protectedEditor() const;
+    WEBCORE_EXPORT Ref<const Editor> protectedEditor() const;
 
     EventHandler& eventHandler() { return m_eventHandler; }
     const EventHandler& eventHandler() const { return m_eventHandler; }

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -54,6 +54,9 @@ public:
 #if PLATFORM(COCOA) && ENABLE(MEDIA_RECORDER)
     virtual std::unique_ptr<MediaRecorderPrivateWriter> createMediaRecorderPrivateWriter(const String&, MediaRecorderPrivateWriterListener&) const;
 #endif
+
+    virtual bool isWebMediaStrategy() const { return false; }
+
 protected:
     MediaStrategy();
     virtual ~MediaStrategy();

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.h
@@ -83,6 +83,8 @@ public:
     void setPortAllocatorRange(StringView);
     std::optional<std::pair<int, int>> portAllocatorRange() const;
 
+    virtual bool isLibWebRTCProvider() const { return false; }
+
 protected:
 #if ENABLE(WEB_RTC)
     std::optional<RTCRtpCapabilities>& audioDecodingCapabilities();

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -82,6 +82,8 @@ public:
 
     virtual void releaseMemory() { }
 
+    virtual bool isPluginView() const { return false; }
+
 protected:
     explicit PluginViewBase(PlatformWidget widget = 0) : Widget(widget) { }
 

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -35,7 +35,6 @@ WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
 WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/ViewGestureGeometryCollector.cpp
 WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/WebPageTesting.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WebPageMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -336,7 +336,6 @@ WebProcess/InjectedBundle/InjectedBundle.cpp
 WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
 WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
 WebProcess/InjectedBundle/InjectedBundlePageUIClient.cpp
-WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
 WebProcess/Inspector/RemoteWebInspectorUI.cpp
 WebProcess/Inspector/WebInspectorClient.cpp
 WebProcess/Inspector/WebInspectorInternal.cpp
@@ -395,7 +394,6 @@ WebProcess/WebCoreSupport/WebValidationMessageClient.cpp
 WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
 WebProcess/WebCoreSupport/mac/WebEditorClientMac.mm
-WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/DrawingArea.cpp
 WebProcess/WebPage/EventDispatcher.cpp
 WebProcess/WebPage/FindController.cpp
@@ -419,7 +417,6 @@ WebProcess/WebPage/WebPageInlines.h
 WebProcess/WebPage/WebPageOverlay.cpp
 WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
 WebProcess/WebPage/WebURLSchemeTaskProxy.cpp
-WebProcess/WebPage/WebUndoStep.h
 WebProcess/WebPage/mac/PageBannerMac.mm
 WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -102,7 +102,6 @@ WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
 WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
 WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
 WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
-WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/WebPage/EventDispatcher.cpp
 WebProcess/WebPage/FindController.cpp
 WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -111,7 +110,6 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
 WebProcess/WebPage/ViewGestureGeometryCollector.cpp
 WebProcess/WebPage/ViewUpdateDispatcher.cpp
 WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebPage.cpp
 WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
 WebProcess/WebPage/WebURLSchemeTaskProxy.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -96,7 +96,7 @@ public:
     bool hasDOMWrapperWorld(WebExtensionContentWorldType contentWorldType) const { return contentWorldType != WebExtensionContentWorldType::ContentScript || hasContentScriptWorld(); }
     Ref<WebCore::DOMWrapperWorld> toDOMWrapperWorld(WebExtensionContentWorldType) const;
 
-    static WebCore::DOMWrapperWorld& mainWorldSingleton() { return WebCore::mainThreadNormalWorld(); }
+    static WebCore::DOMWrapperWorld& mainWorldSingleton() { return WebCore::mainThreadNormalWorldSingleton(); }
 
     bool hasContentScriptWorld() const { return !!m_contentScriptWorld; }
     WebCore::DOMWrapperWorld& contentScriptWorld() const { RELEASE_ASSERT(hasContentScriptWorld()); return *m_contentScriptWorld; }

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -39,6 +39,8 @@ public:
 #endif
 
 private:
+    bool isWebMediaStrategy() const final { return true; }
+
 #if ENABLE(WEB_AUDIO)
     Ref<WebCore::AudioDestination> createAudioDestination(WebCore::AudioIOCallback&,
         const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) override;
@@ -58,3 +60,7 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebMediaStrategy) \
+    static bool isType(const WebCore::MediaStrategy& strategy) { return strategy.isWebMediaStrategy(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -170,7 +170,7 @@ WKArrayRef WKBundlePageCopyContextMenuAtPointInWindow(WKBundlePageRef pageRef, W
     if (!page)
         return nullptr;
 
-    WebKit::WebContextMenu* contextMenu = WebKit::toImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
+    RefPtr contextMenu = WebKit::toImpl(pageRef)->contextMenuAtPointInWindow(page->mainFrame().frameID(), WebKit::toIntPoint(point));
     if (!contextMenu)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
@@ -1054,14 +1054,14 @@ gboolean webkit_dom_dom_window_webkit_message_handlers_post_message(WebKitDOMDOM
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
     WebCore::LocalDOMWindow* domWindow = WebKit::core(window);
-    if (!domWindow->shouldHaveWebKitNamespaceForWorld(WebCore::mainThreadNormalWorld()))
+    if (!domWindow->shouldHaveWebKitNamespaceForWorld(WebCore::mainThreadNormalWorldSingleton()))
         return FALSE;
 
     auto webkitNamespace = domWindow->webkitNamespace();
     if (!webkitNamespace)
         return FALSE;
 
-    auto handler = webkitNamespace->messageHandlers()->namedItem(WebCore::mainThreadNormalWorld(), AtomString::fromUTF8(handlerName));
+    auto handler = webkitNamespace->messageHandlers()->namedItem(WebCore::mainThreadNormalWorldSingleton(), AtomString::fromUTF8(handlerName));
     if (!handler)
         return FALSE;
     
@@ -1069,7 +1069,7 @@ gboolean webkit_dom_dom_window_webkit_message_handlers_post_message(WebKitDOMDOM
     if (!scriptExecutionContext)
         return FALSE;
     
-    auto* globalObject = toJSDOMGlobalObject(*scriptExecutionContext, WebCore::mainThreadNormalWorld());
+    auto* globalObject = toJSDOMGlobalObject(*scriptExecutionContext, WebCore::mainThreadNormalWorldSingleton());
     if (!globalObject)
         return FALSE;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp
@@ -63,7 +63,7 @@ Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::create(const String& n
 
 Ref<InjectedBundleScriptWorld> InjectedBundleScriptWorld::getOrCreate(DOMWrapperWorld& world)
 {
-    if (&world == &mainThreadNormalWorld())
+    if (&world == &mainThreadNormalWorldSingleton())
         return normalWorldSingleton();
 
     if (auto existingWorld = allWorlds().get(world))
@@ -83,7 +83,7 @@ InjectedBundleScriptWorld* InjectedBundleScriptWorld::find(const String& name)
 
 InjectedBundleScriptWorld& InjectedBundleScriptWorld::normalWorldSingleton()
 {
-    static InjectedBundleScriptWorld& world = adoptRef(*new InjectedBundleScriptWorld(mainThreadNormalWorld(), String())).leakRef();
+    static InjectedBundleScriptWorld& world = adoptRef(*new InjectedBundleScriptWorld(mainThreadNormalWorldSingleton(), String())).leakRef();
     return world;
 }
 
@@ -134,6 +134,16 @@ void InjectedBundleScriptWorld::makeAllShadowRootsOpen()
 void InjectedBundleScriptWorld::disableOverrideBuiltinsBehavior()
 {
     m_world->disableLegacyOverrideBuiltInsBehavior();
+}
+
+Ref<const WebCore::DOMWrapperWorld> InjectedBundleScriptWorld::protectedCoreWorld() const
+{
+    return m_world;
+}
+
+Ref<WebCore::DOMWrapperWorld> InjectedBundleScriptWorld::protectedCoreWorld()
+{
+    return m_world;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -51,6 +51,8 @@ public:
 
     const WebCore::DOMWrapperWorld& coreWorld() const;
     WebCore::DOMWrapperWorld& coreWorld();
+    Ref<const WebCore::DOMWrapperWorld> protectedCoreWorld() const;
+    Ref<WebCore::DOMWrapperWorld> protectedCoreWorld();
 
     void clearWrappers();
     void setAllowAutofill();
@@ -63,7 +65,7 @@ public:
 private:
     InjectedBundleScriptWorld(WebCore::DOMWrapperWorld&, const String&);
 
-    Ref<WebCore::DOMWrapperWorld> m_world;
+    const Ref<WebCore::DOMWrapperWorld> m_world;
     String m_name;
 };
 

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -99,7 +99,7 @@ void RemoteWebInspectorUI::windowObjectCleared()
         m_frontendHost->disconnectClient();
 
     m_frontendHost = InspectorFrontendHost::create(this, m_page->protectedCorePage().get());
-    m_frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorld());
+    m_frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorldSingleton());
 }
 
 void RemoteWebInspectorUI::frontendLoaded()

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -105,7 +105,7 @@ void WebInspectorUI::windowObjectCleared()
         m_frontendHost->disconnectClient();
 
     m_frontendHost = InspectorFrontendHost::create(this, m_page->corePage());
-    m_frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorld());
+    m_frontendHost->addSelfToGlobalObjectInWorld(mainThreadNormalWorldSingleton());
 }
 
 void WebInspectorUI::frontendLoaded()

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -70,6 +70,8 @@ public:
     ~LibWebRTCProvider();
 
 private:
+    bool isLibWebRTCProvider() const final { return true; }
+
     std::unique_ptr<SuspendableSocketFactory> createSocketFactory(String&& /* userAgent */, WebCore::ScriptExecutionContextIdentifier, bool /* isFirstParty */, WebCore::RegistrableDomain&&) final;
 
     rtc::scoped_refptr<webrtc::PeerConnectionInterface> createPeerConnection(WebCore::ScriptExecutionContextIdentifier, webrtc::PeerConnectionObserver&, rtc::PacketSocketFactory*, webrtc::PeerConnectionInterface::RTCConfiguration&&) final;
@@ -111,3 +113,7 @@ inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage&)
 #endif // USE(LIBWEBRTC)
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::LibWebRTCProvider) \
+static bool isType(const WebCore::WebRTCProvider& provider) { return provider.isLibWebRTCProvider(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -167,6 +167,8 @@ private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);
     virtual ~PluginView();
 
+    bool isPluginView() const final { return true; }
+
     void initializePlugin();
 
     Ref<PDFPluginBase> protectedPlugin() const;
@@ -259,5 +261,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::PluginView) \
+    static bool isType(const WebCore::PluginViewBase& view) { return view.isPluginView(); } \
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -65,6 +65,7 @@ public:
 #endif
 
 private:
+    bool isWebChromeClient() const final { return true; }
     void chromeDestroyed() final;
     
     void setWindowRect(const WebCore::FloatRect&) final;
@@ -578,3 +579,7 @@ private:
 RefPtr<API::Object> userDataFromJSONData(JSON::Value&);
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebChromeClient) \
+    static bool isType(const WebCore::ChromeClient& client) { return client.isWebChromeClient(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -190,6 +190,12 @@ WebLocalFrameLoaderClient* WebFrame::localFrameLoaderClient() const
         return toWebLocalFrameLoaderClient(localFrame->loader().client());
     return nullptr;
 }
+
+RefPtr<WebLocalFrameLoaderClient> WebFrame::protectedLocalFrameLoaderClient() const
+{
+    return localFrameLoaderClient();
+}
+
 WebRemoteFrameClient* WebFrame::remoteFrameClient() const
 {
     if (auto* remoteFrame = dynamicDowncast<RemoteFrame>(m_coreFrame.get()))
@@ -847,7 +853,7 @@ JSGlobalContextRef WebFrame::jsContext()
     if (!localFrame)
         return nullptr;
 
-    return toGlobalRef(localFrame->script().globalObject(mainThreadNormalWorld()));
+    return toGlobalRef(localFrame->script().globalObject(mainThreadNormalWorldSingleton()));
 }
 
 JSGlobalContextRef WebFrame::jsContextForWorld(DOMWrapperWorld& world)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -211,6 +211,8 @@ public:
 #endif
 
     WebLocalFrameLoaderClient* localFrameLoaderClient() const;
+    RefPtr<WebLocalFrameLoaderClient> protectedLocalFrameLoaderClient() const;
+
     WebRemoteFrameClient* remoteFrameClient() const;
     WebFrameLoaderClient* frameLoaderClient() const;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -604,6 +604,7 @@ public:
 
 #if PLATFORM(IOS_FAMILY) || (PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE))
     PlaybackSessionManager& playbackSessionManager();
+    Ref<PlaybackSessionManager> protectedPlaybackSessionManager();
     void videoControlsManagerDidChange();
 #endif
 
@@ -1121,7 +1122,7 @@ public:
 #if ENABLE(CONTEXT_MENUS)
     WebContextMenu& contextMenu();
     Ref<WebContextMenu> protectedContextMenu();
-    WebContextMenu* contextMenuAtPointInWindow(WebCore::FrameIdentifier, const WebCore::IntPoint&);
+    RefPtr<WebContextMenu> contextMenuAtPointInWindow(WebCore::FrameIdentifier, const WebCore::IntPoint&);
 #endif
 
     static bool canHandleRequest(const WebCore::ResourceRequest&);

--- a/Source/WebKit/WebProcess/WebPage/WebUndoStep.h
+++ b/Source/WebKit/WebProcess/WebPage/WebUndoStep.h
@@ -37,6 +37,7 @@ public:
     ~WebUndoStep();
 
     WebCore::UndoStep& step() const { return m_step.get(); }
+    Ref<WebCore::UndoStep> protectedStep() const { return m_step; }
     WebUndoStepID stepID() const { return m_stepID; }
 
     void didRemoveFromUndoManager() { m_step->didRemoveFromUndoManager(); }
@@ -48,7 +49,7 @@ private:
     {
     }
 
-    Ref<WebCore::UndoStep> m_step;
+    const Ref<WebCore::UndoStep> m_step;
     WebUndoStepID m_stepID;
 };
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -738,6 +738,13 @@ void WebProcess::setHasSuspendedPageProxy(bool hasSuspendedPageProxy)
     m_hasSuspendedPageProxy = hasSuspendedPageProxy;
 }
 
+#if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
+Ref<RemoteImageDecoderAVFManager> WebProcess::protectedRemoteImageDecoderAVFManager()
+{
+    return m_remoteImageDecoderAVFManager;
+}
+#endif
+
 void WebProcess::setIsInProcessCache(bool isInProcessCache, CompletionHandler<void()>&& completionHandler)
 {
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -372,6 +372,7 @@ public:
 #endif
 #if ENABLE(GPU_PROCESS) && HAVE(AVASSETREADER)
     RemoteImageDecoderAVFManager& remoteImageDecoderAVFManager() { return m_remoteImageDecoderAVFManager.get(); }
+    Ref<RemoteImageDecoderAVFManager> protectedRemoteImageDecoderAVFManager();
 #endif
     WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -94,7 +94,6 @@ mac/DOM/DOMHTMLTitleElement.mm
 mac/DOM/DOMHTMLUListElement.mm
 mac/DOM/DOMHTMLVideoElement.mm
 mac/DOM/DOMImplementation.mm
-mac/DOM/DOMInternal.mm
 mac/DOM/DOMKeyboardEvent.mm
 mac/DOM/DOMMediaList.mm
 mac/DOM/DOMMouseEvent.mm

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -119,7 +119,7 @@ void removeDOMWrapper(DOMObjectInternal* impl)
         return;
 
     // The global object which should own this node - FIXME: does this need to be isolated-world aware?
-    WebCore::JSDOMGlobalObject* globalObject = frame->script().globalObject(WebCore::mainThreadNormalWorld());
+    auto* globalObject = frame->script().globalObject(WebCore::mainThreadNormalWorldSingleton());
 
     // Get (or create) a cached JS object for the DOM node.
     JSC::JSObject *scriptImp = asObject(WebCore::toJS(globalObject, globalObject, nodeImpl));

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1846,7 +1846,7 @@ void WebFrameLoaderClient::dispatchDidClearWindowObjectInWorld(WebCore::DOMWrapp
         return;
     }
 
-    if (&world != &WebCore::mainThreadNormalWorld())
+    if (&world != &WebCore::mainThreadNormalWorldSingleton())
         return;
 
     auto* frame = core(m_webFrame.get());

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -703,7 +703,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     
 #if PLATFORM(IOS_FAMILY)
     ASSERT(WebThreadIsLockedOrDisabled());
-    JSC::JSGlobalObject* lexicalGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorld());
+    auto* lexicalGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton());
     JSC::JSLockHolder jscLock(lexicalGlobalObject);
 #endif
 
@@ -719,7 +719,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return @"";
 
 #if !PLATFORM(IOS_FAMILY)
-    JSC::JSGlobalObject* lexicalGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorld());
+    auto* lexicalGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton());
     JSC::JSLockHolder lock(lexicalGlobalObject);
 #endif
     return result.toWTFString(lexicalGlobalObject);
@@ -2071,7 +2071,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
         return @"";
 
     // Start off with some guess at a frame and a global object, we'll try to do better...!
-    auto* anyWorldGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorld());
+    auto* anyWorldGlobalObject = _private->coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton());
 
     // The global object is probably a proxy object? - if so, we know how to use this!
     JSC::JSObject* globalObjectObj = toJS(globalObjectRef);
@@ -2097,7 +2097,7 @@ static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
     if (!result || (!result.isBoolean() && !result.isString() && !result.isNumber()))
         return @"";
 
-    JSC::JSGlobalObject* lexicalGlobalObject = anyWorldGlobalObject;
+    auto* lexicalGlobalObject = anyWorldGlobalObject;
     JSC::JSLockHolder lock(lexicalGlobalObject);
     return result.toWTFString(lexicalGlobalObject);
 }
@@ -2311,7 +2311,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return 0;
 
     auto* globalObject = coreFrame->script().globalObject(*core(world));
-    JSC::JSGlobalObject* lexicalGlobalObject = globalObject;
+    auto* lexicalGlobalObject = globalObject;
 
     JSC::JSLockHolder lock(lexicalGlobalObject);
     return toRef(lexicalGlobalObject, toJS(lexicalGlobalObject, globalObject, core(node)));
@@ -2580,7 +2580,7 @@ static NSURL *createUniqueWebDataURL()
     auto coreFrame = _private->coreFrame;
     if (!coreFrame)
         return 0;
-    return toGlobalRef(coreFrame->script().globalObject(WebCore::mainThreadNormalWorld()));
+    return toGlobalRef(coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton()));
 }
 
 #if JSC_OBJC_API_ENABLED

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -86,7 +86,7 @@ static WorldMap& allWorlds()
 
 + (WebScriptWorld *)standardWorld
 {
-    static WebScriptWorld *world = [[WebScriptWorld alloc] initWithWorld:WebCore::mainThreadNormalWorld()];
+    static WebScriptWorld *world = [[WebScriptWorld alloc] initWithWorld:WebCore::mainThreadNormalWorldSingleton()];
     return world;
 }
 
@@ -118,7 +118,7 @@ WebCore::DOMWrapperWorld* core(WebScriptWorld *world)
 
 + (WebScriptWorld *)findOrCreateWorld:(WebCore::DOMWrapperWorld&)world
 {
-    if (&world == &WebCore::mainThreadNormalWorld())
+    if (&world == &WebCore::mainThreadNormalWorldSingleton())
         return [self standardWorld];
 
     if (WebScriptWorld *existingWorld = allWorlds().get(world))

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -7501,8 +7501,8 @@ static NSAppleEventDescriptor* aeDescFromJSValue(JSC::JSGlobalObject* lexicalGlo
     JSC::JSValue result = coreFrame->script().executeScriptIgnoringException(script, JSC::SourceTaintedOrigin::Untainted, true);
     if (!result) // FIXME: pass errors
         return 0;
-    JSC::JSLockHolder lock(coreFrame->script().globalObject(WebCore::mainThreadNormalWorld()));
-    return aeDescFromJSValue(coreFrame->script().globalObject(WebCore::mainThreadNormalWorld()), result);
+    JSC::JSLockHolder lock(coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton()));
+    return aeDescFromJSValue(coreFrame->script().globalObject(WebCore::mainThreadNormalWorldSingleton()), result);
 }
 #endif
 


### PR DESCRIPTION
#### 8f62a68186896830b810974a5c1267ae03127970
<pre>
Address safer C++ static analysis warnings in WebPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=287760">https://bugs.webkit.org/show_bug.cgi?id=287760</a>

Reviewed by Darin Adler and Per Arne Vollan.

* Source/WebCore/bindings/js/DOMWrapperWorld.cpp:
(WebCore::mainThreadNormalWorldSingleton):
(WebCore::mainThreadNormalWorld): Deleted.
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::protectedMainThreadNormalWorld):
(WebCore::debuggerWorld):
(WebCore::pluginWorld):
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::mainWorldGlobalObject):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::JSLazyEventListener):
(WebCore::JSLazyEventListener::create):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::evaluateIgnoringException):
(WebCore::ScriptController::loadModuleScript):
(WebCore::ScriptController::linkAndEvaluateModuleScript):
(WebCore::ScriptController::evaluateModule):
(WebCore::ScriptController::setEvalEnabled):
(WebCore::ScriptController::setWebAssemblyEnabled):
(WebCore::ScriptController::setRequiresTrustedTypes):
(WebCore::ScriptController::executeScriptIgnoringException):
(WebCore::ScriptController::executeJavaScriptURL):
(WebCore::ScriptController::reportExceptionFromScriptError):
(WebCore::ScriptController::registerImportMap):
* Source/WebCore/bindings/js/WebCoreJSClientData.cpp:
(WebCore::JSVMClientData::getAllWorlds):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::pictureInPictureElement const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::setAttributeEventListener):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::globalObject const):
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::ReplacementFragment):
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::attributeChanged):
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::attributeChanged):
* Source/WebCore/inspector/InspectorController.cpp:
(WebCore::InspectorController::didClearWindowObjectInWorld):
* Source/WebCore/inspector/InspectorFrontendAPIDispatcher.cpp:
(WebCore::InspectorFrontendAPIDispatcher::frontendGlobalObject):
(WebCore::InspectorFrontendAPIDispatcher::evaluateExpression):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::evaluateScriptInExtensionTab):
* Source/WebCore/inspector/PageDebugger.cpp:
(WebCore::PageDebugger::isContentScript const):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::didClearWindowObjectInWorld):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::didClearWindowObjectInWorld):
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::PageRuntimeAgent::reportExecutionContextCreation):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::isWebChromeClient const):
* Source/WebCore/page/FocusController.h:
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/mediastream/WebRTCProvider.h:
* Source/WebCore/platform/mediastream/libwebrtc/LibWebRTCProvider.h:
(isType):
* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::isPluginView const):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
(isType):
* Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp:
(webkit_dom_dom_window_webkit_message_handlers_post_message):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.cpp:
(WebKit::InjectedBundleScriptWorld::getOrCreate):
(WebKit::InjectedBundleScriptWorld::normalWorldSingleton):
(WebKit::InjectedBundleScriptWorld::protectedCoreWorld const):
(WebKit::InjectedBundleScriptWorld::protectedCoreWorld):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::windowObjectCleared):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::windowObjectCleared):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
(isType):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
(isType):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
(WebKit::WebPage::requestActiveNowPlayingSessionInfo):
(WebKit::WebPage::performDictionaryLookupAtLocation):
(WebKit::WebPage::dictionaryPopupInfoForRange):
(WebKit::WebPage::insertDictatedTextAsync):
(WebKit::WebPage::addDictationAlternative):
(WebKit::WebPage::dictationAlternativesAtSelection):
(WebKit::WebPage::clearDictationAlternatives):
(WebKit::WebPage::getContentsAsAttributedString):
(WebKit::WebPage::getPlatformEditorStateCommon const):
(WebKit::WebPage::getPDFFirstPageSize):
(WebKit::WebPage::replaceImageForRemoveBackground):
(WebKit::WebPage::readSelectionFromPasteboard):
(WebKit::elementHasHiddenVisibility):
(WebKit::WebPage::createTextIndicatorForElementWithID):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::protectedLocalFrameLoaderClient const):
(WebKit::WebFrame::jsContext):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::SendStopResponsivenessTimer::~SendStopResponsivenessTimer):
(WebKit::m_textAnimationController):
(WebKit::WebPage::requestMediaPlaybackState):
(WebKit::WebPage::pauseAllMediaPlayback):
(WebKit::WebPage::suspendAllMediaPlayback):
(WebKit::WebPage::resumeAllMediaPlayback):
(WebKit::WebPage::suspendAllMediaBuffering):
(WebKit::WebPage::resumeAllMediaBuffering):
(WebKit::WebPage::~WebPage):
(WebKit::WebPage::editorState const):
(WebKit::WebPage::shouldDispatchSyntheticMouseEventsWhenModifyingSelection const):
(WebKit::WebPage::renderTreeExternalRepresentation const):
(WebKit::WebPage::renderTreeExternalRepresentationForPrinting const):
(WebKit::WebPage::renderTreeSize const):
(WebKit::WebPage::pluginViewForFrame):
(WebKit::WebPage::executeEditingCommand):
(WebKit::WebPage::setEditable):
(WebKit::WebPage::setBaseWritingDirection):
(WebKit::WebPage::close):
(WebKit::WebPage::tryClose):
(WebKit::WebPage::suspendForProcessSwap):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::loadDataImpl):
(WebKit::WebPage::fromCorePage):
(WebKit::WebPage::setSize):
(WebKit::WebPage::didScalePage):
(WebKit::WebPage::setDeviceScaleFactor):
(WebKit::WebPage::screenPropertiesDidChange):
(WebKit::WebPage::listenForLayoutMilestones):
(WebKit::WebPage::setSuppressScrollbarAnimations):
(WebKit::WebPage::setEnableVerticalRubberBanding):
(WebKit::WebPage::setEnableHorizontalRubberBanding):
(WebKit::WebPage::setPaginationMode):
(WebKit::WebPage::setPaginationBehavesLikeColumns):
(WebKit::WebPage::setPageLength):
(WebKit::WebPage::setGapBetweenPages):
(WebKit::WebPage::postInjectedBundleMessage):
(WebKit::WebPage::setUnderPageBackgroundColorOverride):
(WebKit::WebPage::setHeaderPageBanner):
(WebKit::WebPage::setFooterPageBanner):
(WebKit::WebPage::setHeaderBannerHeight):
(WebKit::WebPage::setFooterBannerHeight):
(WebKit::snapshotColorSpace):
(WebKit::WebPage::pageStoppedScrolling):
(WebKit::WebPage::contextMenuAtPointInWindow):
(WebKit::WebPage::updateDrawingAreaLayerTreeFreezeState):
(WebKit::WebPage::mouseEvent):
(WebKit::WebPage::setLastKnownMousePosition):
(WebKit::WebPage::wheelEvent):
(WebKit::WebPage::keyEvent):
(WebKit::WebPage::validateCommand):
(WebKit::WebPage::requestFontAttributesAtSelectionStart):
(WebKit::WebPage::setObscuredContentInsets):
(WebKit::WebPage::setInitialFocus):
(WebKit::WebPage::setCanStartMediaTimerFired):
(WebKit::WebPage::updateIsInWindow):
(WebKit::WebPage::windowActivityDidChange):
(WebKit::WebPage::setActivityState):
(WebKit::WebPage::setNeedsDOMWindowResizeEvent):
(WebKit::WebPage::setUserAgent):
(WebKit::WebPage::suspendActiveDOMObjectsAndAnimations):
(WebKit::WebPage::resumeActiveDOMObjectsAndAnimations):
(WebKit::WebPage::suspend):
(WebKit::WebPage::resume):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::runJavaScriptInFrameInScriptWorld):
(WebKit::frameWithSelection):
(WebKit::WebPage::getMainResourceDataOfFrame):
(WebKit::WebPage::preferencesDidChange):
(WebKit::WebPage::updatePreferences):
(WebKit::WebPage::layoutIfNeeded):
(WebKit::WebPage::updateRendering):
(WebKit::WebPage::shouldTriggerRenderingUpdate const):
(WebKit::WebPage::protectedPlaybackSessionManager):
(WebKit::WebPage::videoPresentationManager):
(WebKit::WebPage::videoControlsManagerDidChange):
(WebKit::WebPage::addConsoleMessage):
(WebKit::WebPage::notifyReportObservers):
(WebKit::WebPage::sendReportToEndpoints):
(WebKit::WebPage::performDragControllerAction):
(WebKit::WebPage::dragEnded):
(WebKit::WebPage::mayPerformUploadDragDestinationAction):
(WebKit::WebPage::unapplyEditCommand):
(WebKit::WebPage::reapplyEditCommand):
(WebKit::WebPage::voiceActivityDetected):
(WebKit::WebPage::changeSpellingToWord):
(WebKit::WebPage::unmarkAllMisspellings):
(WebKit::WebPage::unmarkAllBadGrammar):
(WebKit::WebPage::uppercaseWord):
(WebKit::WebPage::lowercaseWord):
(WebKit::WebPage::setTextForActivePopupMenu):
(WebKit::WebPage::replaceSelectionWithText):
(WebKit::WebPage::mainFrameDidLayout):
(WebKit::WebPage::dispatchMessage):
(WebKit::WebPage::scrollingCoordinator const):
(WebKit::WebPage::SandboxExtensionTracker::didFailProvisionalLoad):
(WebKit::WebPage::pdfDocumentForPrintingFrame):
(WebKit::WebPage::setUseColorAppearance):
(WebKit::WebPage::setMediaVolume):
(WebKit::WebPage::setMuted):
(WebKit::WebPage::stopMediaCapture):
(WebKit::pageContainsAnyHorizontalScrollbars):
(WebKit::WebPage::localMainFrame const):
(WebKit::WebPage::localTopDocument const):
(WebKit::WebPage::mainFrameView const):
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::setWritingSuggestion):
(WebKit::WebPage::setAlwaysShowsHorizontalScroller):
(WebKit::WebPage::setAlwaysShowsVerticalScroller):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::didSameDocumentNavigationForFrame):
(WebKit::WebPage::currentSelectionAsRange):
(WebKit::WebPage::scheduleFullEditorStateUpdate):
(WebKit::WebPage::updateWebsitePolicies):
(WebKit::WebPage::notifyUserScripts):
(WebKit::WebPage::getSamplingProfilerOutput):
(WebKit::WebPage::postMessageWithAsyncReply):
(WebKit::WebPage::postSynchronousMessageForTesting):
(WebKit::WebPage::setUserInterfaceLayoutDirection):
(WebKit::WebPage::registerURLSchemeHandler):
(WebKit::WebPage::setIsSuspended):
(WebKit::WebPage::requestStorageAccess):
(WebKit::WebPage::didLoadFromRegistrableDomain):
(WebKit::WebPage::requestAttachmentIcon):
(WebKit::WebPage::textAutoSizingAdjustmentTimerFired):
(WebKit::WebPage::setOverriddenMediaType):
(WebKit::WebPage::updateCORSDisablingPatterns):
(WebKit::WebPage::requestTextRecognition):
(WebKit::WebPage::startVisualTranslation):
(WebKit::WebPage::requestImageBitmap):
(WebKit::WebPage::setAppHighlightsVisibility):
(WebKit::WebPage::insertTextPlaceholder):
(WebKit::WebPage::removeTextPlaceholder):
(WebKit::WebPage::updateImageAnimationEnabled):
(WebKit::WebPage::pauseAllAnimations):
(WebKit::WebPage::playAllAnimations):
(WebKit::WebPage::useRedirectionForCurrentNavigation):
(WebKit::WebPage::remotePostMessage):
(WebKit::WebPage::updateLastNodeBeforeWritingSuggestions):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebUndoStep.h:
(WebKit::WebUndoStep::protectedStep const):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::protectedRemoteImageDecoderAVFManager):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKitLegacy/mac/DOM/DOMInternal.mm:
(-[WebScriptObject _initializeScriptDOMNodeImp]):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchDidClearWindowObjectInWorld):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _stringByEvaluatingJavaScriptFromString:forceUserGesture:]):
(-[WebFrame _stringByEvaluatingJavaScriptFromString:withGlobalObject:inScriptWorld:]):
(-[WebFrame globalContext]):
* Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm:
(+[WebScriptWorld standardWorld]):
(+[WebScriptWorld findOrCreateWorld:]):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView aeDescByEvaluatingJavaScriptFromString:]):

Canonical link: <a href="https://commits.webkit.org/290504@main">https://commits.webkit.org/290504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2af8d13f9350604f23aa8bd2e6b61faae2f12929

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90253 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95256 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41029 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18099 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93254 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7795 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49836 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7520 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36248 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40160 "Hash 2af8d13f for PR 40678 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83057 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97081 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89031 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17441 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78476 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17698 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77682 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/19185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22144 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17451 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111522 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17192 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/26688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20644 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->