### PR TITLE
[text-wrap-style:pretty] Refactor line width calculations.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
@@ -42,6 +42,8 @@ public:
     std::optional<Vector<LayoutUnit>> computeParagraphLevelConstraints(TextWrapStyle);
 
 private:
+    friend struct SlidingWidth;
+
     void initialize();
     void updateCachedWidths();
     void checkCanConstrainInlineItems();
@@ -62,37 +64,37 @@ private:
     const HorizontalConstraints& m_horizontalConstraints;
 
     Vector<InlineItemRange> m_originalLineInlineItemRanges;
-    Vector<float> m_originalLineWidths;
+    Vector<LayoutUnit> m_originalLineConstraints;
+    LayoutUnit m_maximumLineWidthConstraint { 0 };
     Vector<bool> m_originalLineEndsWithForcedBreak;
     Vector<InlineLayoutUnit> m_inlineItemWidths;
     Vector<InlineLayoutUnit> m_firstLineStyleInlineItemWidths;
     size_t m_numberOfLinesInOriginalLayout { 0 };
     size_t m_numberOfInlineItems { 0 };
-    double m_maximumLineWidth { 0 };
     bool m_cannotConstrainContent { false };
     bool m_hasSingleLineVisibleContent { false };
     bool m_hasValidInlineItemWidthCache { false };
+};
 
-    struct SlidingWidth {
-        SlidingWidth(const InlineContentConstrainer&, const InlineItemList&, size_t start, size_t end, bool useFirstLineStyle, bool isFirstLineInChunk);
-        InlineLayoutUnit width();
-        void advanceStart();
-        void advanceStartTo(size_t newStart);
-        void advanceEnd();
-        void advanceEndTo(size_t newEnd);
+struct SlidingWidth {
+    SlidingWidth(const InlineContentConstrainer&, const InlineItemList&, size_t start, size_t end, bool useFirstLineStyle, bool isFirstLineInChunk);
+    InlineLayoutUnit width();
+    void advanceStart();
+    void advanceStartTo(size_t newStart);
+    void advanceEnd();
+    void advanceEndTo(size_t newEnd);
 
-    private:
-        const InlineContentConstrainer& m_inlineContentConstrainer;
-        const InlineItemList& m_inlineItemList;
-        size_t m_start { 0 };
-        size_t m_end { 0 };
-        bool m_useFirstLineStyle { false };
-        bool m_isFirstLineInChunk { false };
-        InlineLayoutUnit m_totalWidth { 0 };
-        InlineLayoutUnit m_leadingTrimmableWidth { 0 };
-        InlineLayoutUnit m_trailingTrimmableWidth { 0 };
-        std::optional<size_t> m_firstLeadingNonTrimmedItem;
-    };
+private:
+    const InlineContentConstrainer& m_inlineContentConstrainer;
+    const InlineItemList& m_inlineItemList;
+    size_t m_start { 0 };
+    size_t m_end { 0 };
+    bool m_useFirstLineStyle { false };
+    bool m_isFirstLineInChunk { false };
+    InlineLayoutUnit m_totalWidth { 0 };
+    InlineLayoutUnit m_leadingTrimmableWidth { 0 };
+    InlineLayoutUnit m_trailingTrimmableWidth { 0 };
+    std::optional<size_t> m_firstLeadingNonTrimmedItem;
 };
 
 }


### PR DESCRIPTION
#### 26548fe7a849e8be3133d0b9ff2022e992fddb7b
<pre>
[text-wrap-style:pretty] Refactor line width calculations.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287764">https://bugs.webkit.org/show_bug.cgi?id=287764</a>
&lt;<a href="https://rdar.apple.com/144930453">rdar://144930453</a>&gt;

Reviewed by Alan Baradlay.

This PR refactors out the logic for computing line width from sliding width and
updates text-wrap-style:pretty and text-wrap-style:balance to use correct widths
of the inline items when performing cost/raggedness calculations.

This will also remove duplicate code and functionality. This will also enable use to
backtrack line widths for text-wrap-style:pretty.

Finally, line width backtracking is necessary to enable hyphenation: these will be
landed in a follow up PR.

* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::InlineContentConstrainer::balanceRangeWithLineRequirement):
(WebCore::Layout::InlineContentConstrainer::balanceRangeWithNoLineRequirement):

Canonical link: <a href="https://commits.webkit.org/290500@main">https://commits.webkit.org/290500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4985417c5e8f02afd92b5cfb3eb763029f09dd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41004 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92280 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69460 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27062 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7782 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81857 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49820 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7505 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40135 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77836 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97054 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17416 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77663 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19180 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22130 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20733 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10675 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17426 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17167 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->