### PR TITLE
[GStreamer][WebCodecs] Simplify audio encoder handling

### DIFF
--- a/Source/WebCore/platform/AudioEncoder.cpp
+++ b/Source/WebCore/platform/AudioEncoder.cpp
@@ -42,13 +42,7 @@ namespace WebCore {
 Ref<AudioEncoder::CreatePromise> AudioEncoder::create(const String& codecName, const Config& config, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
 #if USE(GSTREAMER)
-    CreatePromise::Producer producer;
-    Ref promise = producer.promise();
-    CreateCallback callback = [producer = WTFMove(producer)] (auto&& result) mutable {
-        producer.settle(WTFMove(result));
-    };
-    GStreamerAudioEncoder::create(codecName, config, WTFMove(callback), WTFMove(descriptionCallback), WTFMove(outputCallback));
-    return promise;
+    return GStreamerAudioEncoder::create(codecName, config, WTFMove(descriptionCallback), WTFMove(outputCallback));
 #elif USE(AVFOUNDATION)
     return AudioEncoderCocoa::create(codecName, config, WTFMove(descriptionCallback), WTFMove(outputCallback));
 #else

--- a/Source/WebCore/platform/AudioEncoder.h
+++ b/Source/WebCore/platform/AudioEncoder.h
@@ -34,7 +34,6 @@
 #include "BitrateMode.h"
 #include "WebCodecsAudioInternalData.h"
 #include <span>
-#include <wtf/CompletionHandler.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Vector.h>
 
@@ -79,12 +78,11 @@ public:
         int64_t timestamp { 0 };
         std::optional<uint64_t> duration { };
     };
-    using CreateResult = Expected<Ref<AudioEncoder>, String>;
+
     using CreatePromise = NativePromise<Ref<AudioEncoder>, String>;
 
     using DescriptionCallback = Function<void(ActiveConfiguration&&)>;
     using OutputCallback = Function<void(EncodedFrame&&)>;
-    using CreateCallback = Function<void(CreateResult&&)>;
 
     static Ref<CreatePromise> create(const String&, const Config&, DescriptionCallback&&, OutputCallback&&);
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp
@@ -81,7 +81,7 @@ private:
     GRefPtr<GstCaps> m_inputCaps;
 };
 
-void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::Config& config, CreateCallback&& callback, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
+Ref<AudioEncoder::CreatePromise> GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::Config& config, DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback)
 {
     static std::once_flag debugRegisteredFlag;
     std::call_once(debugRegisteredFlag, [] {
@@ -91,39 +91,28 @@ void GStreamerAudioEncoder::create(const String& codecName, const AudioEncoder::
     GRefPtr<GstElement> element;
     if (codecName.startsWith("pcm-"_s)) {
         auto components = codecName.split('-');
-        if (components.size() != 2) {
-            auto errorMessage = makeString("Invalid LPCM codec string: "_s, codecName);
-            callback(makeUnexpected(WTFMove(errorMessage)));
-            return;
-        }
+        if (components.size() != 2)
+            return CreatePromise::createAndReject(makeString("Invalid LPCM codec string: "_s, codecName));
         element = gst_element_factory_make("identity", nullptr);
     } else {
         auto& scanner = GStreamerRegistryScanner::singleton();
         auto lookupResult = scanner.isCodecSupported(GStreamerRegistryScanner::Configuration::Encoding, codecName);
-        if (!lookupResult) {
-            auto errorMessage = makeString("No GStreamer encoder found for codec "_s, codecName);
-            callback(makeUnexpected(WTFMove(errorMessage)));
-            return;
-        }
+        if (!lookupResult)
+            return CreatePromise::createAndReject(makeString("No GStreamer encoder found for codec "_s, codecName));
         element = gst_element_factory_create(lookupResult.factory.get(), nullptr);
     }
-    Ref encoder = adoptRef(*new GStreamerAudioEncoder(WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(element)));
-    Ref internalEncoder = encoder->m_internalEncoder;
+    auto internalEncoder = GStreamerInternalAudioEncoder::create(WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(element));
     auto error = internalEncoder->initialize(codecName, config);
     if (!error.isEmpty()) {
         GST_WARNING("Error creating encoder: %s", error.ascii().data());
-        callback(makeUnexpected(makeString("GStreamer encoding initialization failed with error: "_s, error)));
-        return;
+        return CreatePromise::createAndReject(makeString("GStreamer encoding initialization failed with error: "_s, codecName));
     }
-    gstEncoderWorkQueue().dispatch([callback = WTFMove(callback), encoder = WTFMove(encoder)]() mutable {
-        auto internalEncoder = encoder->m_internalEncoder;
-        GST_DEBUG("Encoder created");
-        callback(Ref<AudioEncoder> { WTFMove(encoder) });
-    });
+    auto encoder = adoptRef(*new GStreamerAudioEncoder(WTFMove(internalEncoder)));
+    return CreatePromise::createAndResolve(WTFMove(encoder));
 }
 
-GStreamerAudioEncoder::GStreamerAudioEncoder(DescriptionCallback&& descriptionCallback, OutputCallback&& outputCallback, GRefPtr<GstElement>&& element)
-    : m_internalEncoder(GStreamerInternalAudioEncoder::create(WTFMove(descriptionCallback), WTFMove(outputCallback), WTFMove(element)))
+GStreamerAudioEncoder::GStreamerAudioEncoder(Ref<GStreamerInternalAudioEncoder>&& internalEncoder)
+    : m_internalEncoder(WTFMove(internalEncoder))
 {
 }
 

--- a/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h
@@ -23,7 +23,6 @@
 
 #include "AudioEncoder.h"
 
-#include "GRefPtrGStreamer.h"
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
@@ -34,12 +33,12 @@ class GStreamerInternalAudioEncoder;
 class GStreamerAudioEncoder : public AudioEncoder {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerAudioEncoder);
 public:
-    static void create(const String& codecName, const Config&, CreateCallback&&, DescriptionCallback&&, OutputCallback&&);
+    static Ref<CreatePromise> create(const String& codecName, const Config&, DescriptionCallback&&, OutputCallback&&);
 
     ~GStreamerAudioEncoder();
 
 private:
-    GStreamerAudioEncoder(DescriptionCallback&&,  OutputCallback&&, GRefPtr<GstElement>&&);
+    GStreamerAudioEncoder(Ref<GStreamerInternalAudioEncoder>&&);
 
     Ref<EncodePromise> encode(RawFrame&&) final;
     Ref<GenericPromise> flush() final;


### PR DESCRIPTION
#### 7d133d8d64caeea8da5f6f02891fd5370417a489
<pre>
[GStreamer][WebCodecs] Simplify audio encoder handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=287770">https://bugs.webkit.org/show_bug.cgi?id=287770</a>

Reviewed by Xabier Rodriguez-Calvar.

Make the GStreamerAudioEncoder::create() function return a promise. This is the same approach as for
the Cocoa encoder.

* Source/WebCore/platform/AudioEncoder.cpp:
(WebCore::AudioEncoder::create):
* Source/WebCore/platform/AudioEncoder.h:
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.cpp:
(WebCore::GStreamerAudioEncoder::create):
(WebCore::GStreamerAudioEncoder::GStreamerAudioEncoder):
* Source/WebCore/platform/audio/gstreamer/AudioEncoderGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/290528@main">https://commits.webkit.org/290528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4d539cf0b2fe93d14bb586bae8a728e726caca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9645 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/26980 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49740 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7408 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36115 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40023 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17304 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12722 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78374 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77579 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19194 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10526 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22640 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17055 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20507 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->