### PR TITLE
[intersection-observer] Implement support for scrollMargin

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-and-root-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-and-root-margin-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_true: isIntersecting expected true got false
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-4-val-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-4-val-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-clip-path-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-clip-path-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0.4000000059604645
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Test no initial scroll margin intersection
-FAIL Test scroll margin intersection after scrolling assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection after scrolling
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-horizontal-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-horizontal-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-iframe-expected.txt
@@ -1,5 +1,5 @@
 
 
 PASS Observer with the implicit root; target in a same-origin iframe.
-FAIL Test scroll margin intersection assert_true: isIntersecting expected true got false
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-nested-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-nested-2-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.4 +/- 0.001 but got 0.20000000298023224
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-nested-3-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-nested-3-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-nested-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-nested-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-percent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/scroll-margin-percent-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test scroll margin intersection assert_approx_equals: intersectionRatio expected 0.2 +/- 0.001 but got 0
+PASS Test scroll margin intersection
 

--- a/LayoutTests/intersection-observer/intersection-observer-interface-expected.txt
+++ b/LayoutTests/intersection-observer/intersection-observer-interface-expected.txt
@@ -1,12 +1,17 @@
 
 PASS Constructor0
 PASS DefaultRootMargin
+PASS DefaultScrollMargin
 PASS DefaultRoot
 PASS DefaultThresholds
 PASS ExplicitOneArgumentRootMargin
 PASS ExplicitTwoArgumentRootMargin
 PASS ExplicitThreeArgumentRootMargin
 PASS ExplicitFourArgumentRootMargin
+PASS ExplicitOneArgumentScrollMargin
+PASS ExplicitTwoArgumentScrollMargin
+PASS ExplicitThreeArgumentScrollMargin
+PASS ExplicitFourArgumentScrollMargin
 PASS ExplicitRoot
 PASS ExplicitThreshold
 PASS ExplicitThresholds

--- a/LayoutTests/intersection-observer/intersection-observer-interface.html
+++ b/LayoutTests/intersection-observer/intersection-observer-interface.html
@@ -19,6 +19,10 @@
     },'DefaultRootMargin');
     test(function() {
         var observer = new IntersectionObserver(function() {});
+        assert_equals(observer.scrollMargin, '0px 0px 0px 0px');
+    },'DefaultScrollMargin');
+    test(function() {
+        var observer = new IntersectionObserver(function() {});
         assert_equals(observer.root, null);
     },'DefaultRoot');
     test(function() {
@@ -41,6 +45,22 @@
         var observer = new IntersectionObserver(function() {}, { rootMargin: '33% 10px -120px 3%' });
         assert_equals(observer.rootMargin, '33% 10px -120px 3%');
     },'ExplicitFourArgumentRootMargin');
+    test(function() {
+        var observer = new IntersectionObserver(function() {}, { scrollMargin: '33%' });
+        assert_equals(observer.scrollMargin, '33% 33% 33% 33%');
+    },'ExplicitOneArgumentScrollMargin');
+    test(function() {
+        var observer = new IntersectionObserver(function() {}, { scrollMargin: '33% 10px' });
+        assert_equals(observer.scrollMargin, '33% 10px 33% 10px');
+    },'ExplicitTwoArgumentScrollMargin');
+    test(function() {
+        var observer = new IntersectionObserver(function() {}, { scrollMargin: '33% 10px -120px' });
+        assert_equals(observer.scrollMargin, '33% 10px -120px 10px');
+    },'ExplicitThreeArgumentScrollMargin');
+    test(function() {
+        var observer = new IntersectionObserver(function() {}, { scrollMargin: '33% 10px -120px 3%' });
+        assert_equals(observer.scrollMargin, '33% 10px -120px 3%');
+    },'ExplicitFourArgumentScrollMargin');
     test(function() {
         var observer = new IntersectionObserver(function() {}, { root: document.body });
         assert_equals(observer.root, document.body);

--- a/LayoutTests/intersection-observer/scroll-margin-expected.txt
+++ b/LayoutTests/intersection-observer/scroll-margin-expected.txt
@@ -1,0 +1,3 @@
+
+PASS IntersectionObserver's scroll margin
+

--- a/LayoutTests/intersection-observer/scroll-margin.html
+++ b/LayoutTests/intersection-observer/scroll-margin.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<link rel="help" href="https://www.w3.org/TR/intersection-observer/#intersection-observer-interface">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+#target {
+    height: 40px;
+    width: 40px;
+    background-color: green;
+}
+
+#scroller {
+    box-sizing: border-box;
+    width: 100px;
+    height: 100px;
+    overflow: hidden;
+    padding-top: 100px;
+}
+</style>
+
+<div id="scroller">
+    <div id="target"></div>
+</div>
+
+<script>
+    async_test((t) =>  {
+        let options = {
+            scrollMargin: '20px',
+            threshold: [0]
+        }
+        let observer = new IntersectionObserver(t.step_func_done((entries) => {
+            assert_true(entries[0].isIntersecting, "isIntersecting");
+            assert_approx_equals(entries[0].intersectionRatio, 0.5, 0.001);
+        }), options);
+        observer.observe(document.getElementById("target"));
+    }, "IntersectionObserver's scroll margin");
+</script>

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -102,7 +102,7 @@ IntersectionObserver* ContentVisibilityDocumentState::intersectionObserver(Docum
 {
     if (!m_observer) {
         auto callback = ContentVisibilityIntersectionObserverCallback::create(document);
-        IntersectionObserver::Init options { &document, { }, { } };
+        IntersectionObserver::Init options { &document, { }, { }, { } };
         auto includeObscuredInsets = document.settings().contentInsetBackgroundFillEnabled() ? IncludeObscuredInsets::Yes : IncludeObscuredInsets::No;
         auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options), includeObscuredInsets);
         if (observer.hasException())

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -109,7 +109,7 @@ IntersectionObserver* LazyLoadFrameObserver::intersectionObserver(Document& docu
 {
     if (!m_observer) {
         auto callback = LazyFrameLoadIntersectionObserverCallback::create(document);
-        IntersectionObserver::Init options { std::nullopt, emptyString(), { } };
+        IntersectionObserver::Init options { std::nullopt, emptyString(), emptyString(), { } };
         auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
         if (observer.hasException())
             return nullptr;

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -94,7 +94,7 @@ IntersectionObserver* LazyLoadImageObserver::intersectionObserver(Document& docu
     if (!m_observer) {
         auto callback = LazyImageLoadIntersectionObserverCallback::create(document);
         static NeverDestroyed<const String> lazyLoadingRootMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
-        IntersectionObserver::Init options { &document, lazyLoadingRootMarginFallback, { } };
+        IntersectionObserver::Init options { &document, lazyLoadingRootMarginFallback, emptyString(), { } };
         auto observer = IntersectionObserver::create(document, WTFMove(callback), WTFMove(options));
         if (observer.hasException())
             return nullptr;

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -73,6 +73,7 @@ public:
     struct Init {
         std::optional<std::variant<RefPtr<Element>, RefPtr<Document>>> root;
         String rootMargin;
+        String scrollMargin;
         std::variant<double, Vector<double>> threshold;
     };
 
@@ -84,7 +85,9 @@ public:
 
     ContainerNode* root() const { return m_root.get(); }
     String rootMargin() const;
+    String scrollMargin() const;
     const LengthBox& rootMarginBox() const { return m_rootMargin; }
+    const LengthBox& scrollMarginBox() const { return m_scrollMargin; }
     const Vector<double>& thresholds() const { return m_thresholds; }
     const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& observationTargets() const { return m_observationTargets; }
     bool hasObservationTargets() const { return m_observationTargets.size(); }
@@ -115,7 +118,7 @@ public:
     bool isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor&) const;
 
 private:
-    IntersectionObserver(Document&, Ref<IntersectionObserverCallback>&&, ContainerNode* root, LengthBox&& parsedRootMargin, Vector<double>&& thresholds, IncludeObscuredInsets);
+    IntersectionObserver(Document&, Ref<IntersectionObserverCallback>&&, ContainerNode* root, LengthBox&& parsedRootMargin, LengthBox&& parsedScrollMargin, Vector<double>&& thresholds, IncludeObscuredInsets);
 
     bool removeTargetRegistration(Element&);
     void removeAllTargets();
@@ -137,6 +140,7 @@ private:
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_implicitRootDocument;
     WeakPtr<ContainerNode, WeakPtrImplWithEventTargetData> m_root;
     LengthBox m_rootMargin;
+    LengthBox m_scrollMargin;
     Vector<double> m_thresholds;
     RefPtr<IntersectionObserverCallback> m_callback;
     Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_observationTargets;

--- a/Source/WebCore/page/IntersectionObserver.idl
+++ b/Source/WebCore/page/IntersectionObserver.idl
@@ -34,6 +34,7 @@
 
     readonly attribute Node? root;
     readonly attribute DOMString rootMargin;
+    readonly attribute DOMString scrollMargin;
     readonly attribute FrozenArray<double> thresholds;
 
     undefined observe(Element target);
@@ -45,5 +46,6 @@
 dictionary IntersectionObserverInit {
     (Element or Document)? root = null;
     DOMString rootMargin = "0px";
+    DOMString scrollMargin = "0px";
     (double or sequence<double>) threshold = 0.0;
 };

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1241,6 +1241,22 @@ bool RenderBox::applyCachedClipAndScrollPosition(RepaintRects& rects, const Rend
     if (effectiveOverflowY() == Overflow::Visible)
         clipRect.expandToInfiniteY();
 
+    if (context.scrollMargin && (isScrollContainerX() || isScrollContainerY())) {
+        auto borderWidths = this->borderWidths();
+        clipRect.contract(borderWidths);
+
+        auto scrollMargin = context.scrollMargin.value();
+
+        auto scrollMarginEdges = LayoutBoxExtent {
+            valueForLength(scrollMargin.top(), clipRect.height()),
+            valueForLength(scrollMargin.right(), clipRect.width()),
+            valueForLength(scrollMargin.bottom(), clipRect.height()),
+            valueForLength(scrollMargin.left(), clipRect.width())
+        };
+
+        clipRect.expand(scrollMarginEdges);
+    }
+
     bool intersects;
     if (context.options.contains(VisibleRectContextOption::UseEdgeInclusiveIntersection))
         intersects = rects.edgeInclusiveIntersect(clipRect);

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -911,10 +911,11 @@ public:
         CalculateAccurateRepaintRect        = 1 << 4,
     };
     struct VisibleRectContext {
-        VisibleRectContext(bool hasPositionFixedDescendant = false, bool dirtyRectIsFlipped = false, OptionSet<VisibleRectContextOption> options = { })
+        VisibleRectContext(bool hasPositionFixedDescendant = false, bool dirtyRectIsFlipped = false, OptionSet<VisibleRectContextOption> options = { }, const std::optional<LengthBox>& scrollMargin = std::nullopt)
             : hasPositionFixedDescendant(hasPositionFixedDescendant)
             , dirtyRectIsFlipped(dirtyRectIsFlipped)
             , options(options)
+            , scrollMargin(scrollMargin)
             {
             }
 
@@ -927,6 +928,7 @@ public:
         bool dirtyRectIsFlipped { false };
         bool descendantNeedsEnclosingIntRect { false };
         OptionSet<VisibleRectContextOption> options;
+        std::optional<LengthBox> scrollMargin;
     };
 
     struct RepaintRects {


### PR DESCRIPTION
#### 2c343cbdfcb8cd93a339a8848981af3a7768f348
<pre>
[intersection-observer] Implement support for scrollMargin
<a href="https://bugs.webkit.org/show_bug.cgi?id=263370">https://bugs.webkit.org/show_bug.cgi?id=263370</a>

Reviewed by Simon Fraser

This change adds support for scrollMargin to IntersectionObserver and IntersectionObserverInit.
It reuses the existing rootMargin implementation for parsing and serializing.

An optional scrollMargin is added to VisibleRectContext and passed to RenderBox::applyCachedClipAndScrollPosition()
where it is applied to every scrollport.
The scrollMargin is also applied to the root bounds, and frame rects.

Canonical link: <a href="https://commits.webkit.org/293306@main">https://commits.webkit.org/293306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97e3f3a8b8150a07ee2bc2c11d2fcad6d6731b6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49033 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74980 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32137 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101504 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13976 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6927 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83712 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105994 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83952 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21079 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28084 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5755 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/19257 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30729 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25366 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26941 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->