### PR TITLE
Add WebCore::PlatformDynamicRangeLimit

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2206,6 +2206,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/PlatformAudioTrackConfiguration.h
     platform/graphics/PlatformColorSpace.h
     platform/graphics/PlatformDisplay.h
+    platform/graphics/PlatformDynamicRangeLimit.h
     platform/graphics/PlatformGraphicsContext.h
     platform/graphics/PlatformImage.h
     platform/graphics/PlatformLayer.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2555,6 +2555,7 @@ platform/graphics/PixelBuffer.cpp
 platform/graphics/PixelBufferConversion.cpp
 platform/graphics/PixelBufferFormat.cpp
 platform/graphics/PixelFormat.cpp
+platform/graphics/PlatformDynamicRangeLimit.cpp
 platform/graphics/PlatformTimeRanges.cpp
 platform/graphics/PositionedGlyphs.cpp
 platform/graphics/Region.cpp

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformDynamicRangeLimit.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+float PlatformDynamicRangeLimit::normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent)
+{
+    if (!std::isfinite(standardPercent) || standardPercent < 0 || standardPercent > 100 || !std::isfinite(constrainedHighPercent) || constrainedHighPercent < 0 || constrainedHighPercent > 100 || !std::isfinite(noLimitPercent) || noLimitPercent < 0 || noLimitPercent > 100) {
+        ASSERT(std::isfinite(standardPercent));
+        ASSERT(standardPercent >= 0);
+        ASSERT(standardPercent <= 100);
+        ASSERT(std::isfinite(constrainedHighPercent));
+        ASSERT(constrainedHighPercent >= 0);
+        ASSERT(constrainedHighPercent <= 100);
+        ASSERT(std::isfinite(noLimitPercent));
+        ASSERT(noLimitPercent >= 0);
+        ASSERT(noLimitPercent <= 100);
+        // Unexpected value -> Clamp HDR down to prevent misuses.
+        return standardValue;
+    }
+
+    float sum = standardPercent + constrainedHighPercent + noLimitPercent;
+    if (!sum) {
+        ASSERT(sum);
+        return standardValue;
+    }
+
+    float weightedSum = standardPercent * standardValue + constrainedHighPercent * constrainedHighValue + noLimitPercent * noLimitValue;
+    float weightedAverage = WTF::safeFPDivision(weightedSum, sum);
+    return std::clamp(weightedAverage, 0.0f, 1.0f);
+}
+
+TextStream& operator<<(TextStream& ts, PlatformDynamicRangeLimit dynamicRangeLimit)
+{
+    ts << dynamicRangeLimit.value();
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <wtf/ArgumentCoder.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+namespace Style {
+struct DynamicRangeLimit;
+}
+
+class PlatformDynamicRangeLimit {
+public:
+    constexpr PlatformDynamicRangeLimit() = default;
+
+    static constexpr PlatformDynamicRangeLimit standard() { return PlatformDynamicRangeLimit(standardValue); }
+    static constexpr PlatformDynamicRangeLimit constrainedHigh() { return PlatformDynamicRangeLimit(constrainedHighValue); }
+    static constexpr PlatformDynamicRangeLimit noLimit() { return PlatformDynamicRangeLimit(noLimitValue); }
+
+    // `dynamic-range-limit` mapped to PlatformDynamicRangeLimit.value():
+    // ["standard", "constrainedHigh"] -> [standard().value(), constrainedHigh().value()],
+    // ["constrainedHigh", "noLimit"] -> [constrainedHigh().value(), noLimit().value()]
+    constexpr float value() const { return m_value; }
+
+    constexpr auto operator<=>(const PlatformDynamicRangeLimit&) const = default;
+
+private:
+    friend struct IPC::ArgumentCoder<WebCore::PlatformDynamicRangeLimit, void>;
+    friend Style::DynamicRangeLimit;
+
+    constexpr PlatformDynamicRangeLimit(float value) : m_value(std::clamp(value, 0.0f, 1.0f)) { }
+
+    constexpr PlatformDynamicRangeLimit(float standardPercent, float constrainedHighPercent, float noLimitPercent) : m_value(normalizedAverage(standardPercent, constrainedHighPercent, noLimitPercent)) { }
+
+    static float normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent);
+
+    static constexpr float standardValue = 0;
+    static constexpr float constrainedHighValue = 0.5;
+    static constexpr float noLimitValue = 1;
+
+    float m_value { noLimitValue };
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformDynamicRangeLimit);
+
+} // namespace WebCore

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
@@ -29,6 +29,7 @@
 #include "AnimationUtilities.h"
 #include "CSSDynamicRangeLimit.h"
 #include "CSSDynamicRangeLimitMix.h"
+#include "PlatformDynamicRangeLimit.h"
 #include "StyleDynamicRangeLimitMix.h"
 #include <wtf/text/TextStream.h>
 
@@ -98,6 +99,22 @@ auto Blending<DynamicRangeLimit>::blend(const DynamicRangeLimit& from, const Dyn
     addWeightedLimitTo(function, to, toMixPercentage);
 
     return resolve(WTFMove(function));
+}
+
+// MARK: - Conversion to platform object
+
+PlatformDynamicRangeLimit DynamicRangeLimit::toPlatformDynamicRangeLimit() const
+{
+    return WTF::switchOn(*this, [&]<typename Kind>(const Kind& kind) -> PlatformDynamicRangeLimit {
+        if constexpr (std::is_same_v<Kind, CSS::Keyword::Standard>)
+            return PlatformDynamicRangeLimit::standard();
+        else if constexpr (std::is_same_v<Kind, CSS::Keyword::ConstrainedHigh>)
+            return PlatformDynamicRangeLimit::constrainedHigh();
+        else if constexpr (std::is_same_v<Kind, CSS::Keyword::NoLimit>)
+            return PlatformDynamicRangeLimit::noLimit();
+        else if constexpr (std::is_same_v<Kind, Style::DynamicRangeLimitMixFunction>)
+            return PlatformDynamicRangeLimit(float(kind->standard.value), float(kind->constrainedHigh.value), float(kind->noLimit.value));
+    });
 }
 
 // MARK: - Logging

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+class PlatformDynamicRangeLimit;
+
 namespace CSS {
 struct DynamicRangeLimit;
 }
@@ -51,6 +53,8 @@ struct DynamicRangeLimit {
     DynamicRangeLimit& operator=(const DynamicRangeLimit&);
 
     template<typename... F> decltype(auto) switchOn(F&&...) const;
+
+    WEBCORE_EXPORT PlatformDynamicRangeLimit toPlatformDynamicRangeLimit() const;
 
     bool operator==(const DynamicRangeLimit&) const = default;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1836,6 +1836,10 @@ enum class WebCore::ContentsFormat : uint8_t {
 #endif
 };
 
+class WebCore::PlatformDynamicRangeLimit {
+    float m_value;
+};
+
 enum class WebCore::RotationDirection : bool
 
 #if ENABLE(CONTENT_FILTERING)

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -220,6 +220,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/ParsedContentRange.cpp
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PixelBufferConversionTests.cpp
+        Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		7A7B0E7F1EAFE4C3006AB8AE /* LimitTitleSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A7B0E7E1EAFE454006AB8AE /* LimitTitleSize.mm */; };
 		7A89BB682331643A0042CB1E /* BundleFormDelegatePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A89BB662331635D0042CB1E /* BundleFormDelegatePlugIn.mm */; };
 		7A909A7D1D877480007E10F8 /* AffineTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A6F1D877475007E10F8 /* AffineTransform.cpp */; };
+		7A909A801D877480007E10F9 /* PlatformDynamicRangeLimitTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A721D877475007E10F9 /* PlatformDynamicRangeLimitTests.cpp */; };
 		7A909A7E1D877480007E10F8 /* FloatPointTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A701D877475007E10F8 /* FloatPointTests.cpp */; };
 		7A909A7F1D877480007E10F8 /* FloatRectTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A711D877475007E10F8 /* FloatRectTests.cpp */; };
 		7A909A801D877480007E10F8 /* FloatSizeTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A721D877475007E10F8 /* FloatSizeTests.cpp */; };
@@ -3038,6 +3039,7 @@
 		7A89BB662331635D0042CB1E /* BundleFormDelegatePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleFormDelegatePlugIn.mm; sourceTree = "<group>"; };
 		7A89BB69233165650042CB1E /* BundleFormDelegateProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BundleFormDelegateProtocol.h; sourceTree = "<group>"; };
 		7A909A6F1D877475007E10F8 /* AffineTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AffineTransform.cpp; sourceTree = "<group>"; };
+		7A909A721D877475007E10F9 /* PlatformDynamicRangeLimitTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDynamicRangeLimitTests.cpp; sourceTree = "<group>"; };
 		7A909A701D877475007E10F8 /* FloatPointTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatPointTests.cpp; sourceTree = "<group>"; };
 		7A909A711D877475007E10F8 /* FloatRectTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatRectTests.cpp; sourceTree = "<group>"; };
 		7A909A721D877475007E10F8 /* FloatSizeTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatSizeTests.cpp; sourceTree = "<group>"; };
@@ -4806,6 +4808,7 @@
 				AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */,
 				0F5EC8BB2C7F76B900B8051B /* PathTests.cpp */,
 				7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */,
+				7A909A721D877475007E10F9 /* PlatformDynamicRangeLimitTests.cpp */,
 				6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */,
 				041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */,
 				EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */,
@@ -7237,6 +7240,7 @@
 				7C83E0531D0A643A00FEBCF3 /* PendingAPIRequestURL.cpp in Sources */,
 				E325C90723E3870200BC7D3B /* PictureInPictureSupport.mm in Sources */,
 				7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */,
+				7A909A801D877480007E10F9 /* PlatformDynamicRangeLimitTests.cpp in Sources */,
 				7CCE7EA61A411A0F00447C4C /* PlatformUtilitiesMac.mm in Sources */,
 				7CCE7EA71A411A1300447C4C /* PlatformWebViewMac.mm in Sources */,
 				F4010B8324DA267F00A876E2 /* PoseAsClass.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/PlatformDynamicRangeLimit.h>
+
+#include <WebCore/StyleDynamicRangeLimit.h>
+
+namespace TestWebKitAPI {
+
+// Tests rely on these assumptions:
+static_assert(WebCore::PlatformDynamicRangeLimit::standard().value() == 0.0f);
+static_assert(WebCore::PlatformDynamicRangeLimit::constrainedHigh().value() == 0.5f);
+static_assert(WebCore::PlatformDynamicRangeLimit::noLimit().value() == 1.0f);
+
+TEST(PlatformDynamicRangeLimit, DefaultConstruction)
+{
+    auto def = WebCore::PlatformDynamicRangeLimit();
+    EXPECT_EQ(def.value(), 1.0f);
+
+    static_assert(WebCore::PlatformDynamicRangeLimit().value() == 1);
+}
+
+static WebCore::PlatformDynamicRangeLimit mix(float standard, float constrainedHigh, float noLimit)
+{
+    return WebCore::Style::DynamicRangeLimit { WebCore::Style::DynamicRangeLimitMixFunction { WebCore::Style::DynamicRangeLimitMixParameters { .standard = standard, .constrainedHigh = constrainedHigh, .noLimit = noLimit } } }.toPlatformDynamicRangeLimit();
+}
+
+TEST(PlatformDynamicRangeLimit, FromStyleDynamicRangeLimit)
+{
+    struct Test {
+        WebCore::PlatformDynamicRangeLimit dynamicRangeLimit;
+        float expectedValue;
+    };
+    Test tests[] = {
+        // Keywords.
+        { WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit(), 0 },
+        { WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit(), 0.5 },
+        { WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit(), 1 },
+
+        // Mixes equivalent to keywords.
+        { mix(100, 0, 0), 0 },
+        { mix(0, 100, 0), 0.5 },
+        { mix(0, 0, 100), 1 },
+
+        // Other mixes.
+        { mix(80, 20, 0), 0.1 },
+        { mix(50, 0, 50), 0.5 },
+        { mix(10, 10, 80), 0.85 },
+    };
+
+    int testIndex = 0;
+    for (const auto& test : tests) {
+        SCOPED_TRACE(testIndex++);
+        auto dynamicRangeLimit = test.dynamicRangeLimit;
+        EXPECT_FLOAT_EQ(dynamicRangeLimit.value(), test.expectedValue);
+    }
+}
+
+TEST(PlatformDynamicRangeLimit, StaticValues)
+{
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::standard(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::constrainedHigh(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::noLimit(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit());
+}
+
+#if ASSERT_ENABLED
+TEST(PlatformDynamicRangeLimit, DISABLED_FromNonsense)
+#else
+TEST(PlatformDynamicRangeLimit, FromNonsense)
+#endif
+{
+    WebCore::PlatformDynamicRangeLimit tests[] = {
+        mix(0, 0, 0),
+        mix(-1, 0, 0),
+        mix(-1, 0, 2),
+        mix(1, 0, -2),
+        mix(-1, 0, -2),
+        mix(3, 0, -2),
+        mix(0, -1, 3),
+        mix(0, 0, std::numeric_limits<float>::max()),
+        mix(0, 0, std::numeric_limits<float>::infinity()),
+        mix(0, 0, std::numeric_limits<float>::quiet_NaN()),
+    };
+
+    int testIndex = 0;
+    for (const auto& dynamicRangeLimit : tests) {
+        SCOPED_TRACE(testIndex++);
+        // The actual result doesn't matter, but it has to be valid.
+        EXPECT_TRUE(std::isfinite(dynamicRangeLimit.value()));
+        EXPECT_GE(dynamicRangeLimit.value(), 0.0f);
+        EXPECT_LE(dynamicRangeLimit.value(), 1.0f);
+    }
+}
+
+TEST(PlatformDynamicRangeLimit, Comparisons)
+{
+    WebCore::PlatformDynamicRangeLimit sortedTests[] = {
+        WebCore::PlatformDynamicRangeLimit::standard(),
+        WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit(),
+        mix(1, 0, 0),
+
+        mix(99, 1, 0),
+
+        mix(80, 20, 0),
+
+        mix(1, 99, 0),
+
+        WebCore::PlatformDynamicRangeLimit::constrainedHigh(),
+        WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit(),
+        mix(0, 1, 0),
+        mix(50, 0, 50),
+
+        mix(0, 99, 1),
+
+        mix(10, 10, 80),
+
+        mix(0, 1, 99),
+
+        WebCore::PlatformDynamicRangeLimit::noLimit(),
+        WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit(),
+        mix(0, 0, 1),
+    };
+
+    int lhsIndex = 0;
+    for (const auto& lhs : sortedTests) {
+        SCOPED_TRACE(lhsIndex++);
+        SCOPED_TRACE(lhs.value());
+        int rhsIndex = 0;
+        for (const auto& rhs : sortedTests) {
+            SCOPED_TRACE(rhsIndex++);
+            SCOPED_TRACE(rhs.value());
+            EXPECT_EQ(lhs == rhs, lhs.value() == rhs.value());
+            EXPECT_EQ(lhs != rhs, lhs.value() != rhs.value());
+            EXPECT_EQ(lhs < rhs, lhs.value() < rhs.value());
+            EXPECT_EQ(lhs <= rhs, lhs.value() <= rhs.value());
+            EXPECT_EQ(lhs >= rhs, lhs.value() >= rhs.value());
+            EXPECT_EQ(lhs > rhs, lhs.value() > rhs.value());
+            EXPECT_EQ(lhs <=> rhs, lhs.value() <=> rhs.value());
+
+            if (rhsIndex == lhsIndex + 1) {
+                EXPECT_LE(lhs, rhs);
+                EXPECT_GE(rhs, lhs);
+            }
+        }
+    }
+}
+
+}


### PR DESCRIPTION
#### b982e9c075259148d4e1a1dfe448a101c8d40886
<pre>
Add WebCore::PlatformDynamicRangeLimit
<a href="https://bugs.webkit.org/show_bug.cgi?id=287776">https://bugs.webkit.org/show_bug.cgi?id=287776</a>
<a href="https://rdar.apple.com/144952110">rdar://144952110</a>

Reviewed by Simon Fraser.

PlatformDynamicRangeLimit interprets the `dynamic-range-limit`
CSS property, and stores it in a single [0,1] float.

Combined changes:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp: Added.
(WebCore::PlatformDynamicRangeLimit::normalizedAverage):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h: Added.
(WebCore::PlatformDynamicRangeLimit::standard):
(WebCore::PlatformDynamicRangeLimit::constrainedHigh):
(WebCore::PlatformDynamicRangeLimit::noLimit):
(WebCore::PlatformDynamicRangeLimit::value const):
(WebCore::PlatformDynamicRangeLimit::PlatformDynamicRangeLimit):
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp:
(WebCore::Style::DynamicRangeLimit::toPlatformDynamicRangeLimit const):
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp: Added.
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, DefaultConstruction)):
(TestWebKitAPI::mix):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, FromStyleDynamicRangeLimit)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, StaticValues)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, FromNonsense)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, Comparisons)):

Canonical link: <a href="https://commits.webkit.org/290795@main">https://commits.webkit.org/290795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5977e9f267bd60dfcde33b1f6beaf9b94774650

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41874 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70017 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27546 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94111 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8429 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50343 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8200 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/121 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78522 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98095 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18312 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79031 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78233 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22736 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/91 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23644 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18039 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->