### PR TITLE
[SwiftUI] Update WebPage.NavigationDeciding to latest interface

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift
@@ -26,14 +26,14 @@
 import Foundation
 internal import WebKit_Private
 
-fileprivate struct DefaultNavigationDecider: NavigationDeciding {
+fileprivate struct DefaultNavigationDecider: WebPage.NavigationDeciding {
 }
 
 @MainActor
 final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
     init(
         downloadProgressContinuation: AsyncStream<WebPage.DownloadEvent>.Continuation,
-        navigationDecider: (any NavigationDeciding)?
+        navigationDecider: (any WebPage.NavigationDeciding)?
     ) {
         self.downloadProgressContinuation = downloadProgressContinuation
         self.navigationDecider = navigationDecider ?? DefaultNavigationDecider()
@@ -42,7 +42,7 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
     weak var owner: WebPage? = nil
 
     private let downloadProgressContinuation: AsyncStream<WebPage.DownloadEvent>.Continuation
-    private let navigationDecider: any NavigationDeciding
+    private let navigationDecider: any WebPage.NavigationDeciding
 
     // MARK: Navigation progress reporting
 

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift
@@ -27,19 +27,23 @@ import Foundation
 internal import WebKit_Internal
 
 extension WebPage {
+    /// A type that contains information about a frame on a webpage.
     @MainActor
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)
-    public struct FrameInfo: Sendable {
+    public struct FrameInfo {
         init(_ wrapped: WKFrameInfo) {
             self.wrapped = wrapped
         }
 
+        /// Indicates whether the frame is the web site's main frame or a subframe.
         public var isMainFrame: Bool { wrapped.isMainFrame }
 
+        /// The frame’s current request.
         public var request: URLRequest { wrapped.request }
 
+        /// The frame’s security origin.
         public var securityOrigin: WKSecurityOrigin { wrapped.securityOrigin }
 
         var wrapped: WKFrameInfo

--- a/Source/WebKit/_WebKit_SwiftUI/WebPageNavigationAction+SwiftUI.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebPageNavigationAction+SwiftUI.swift
@@ -26,6 +26,8 @@ public import SwiftUI
 @_spi(Private) @_spi(CrossImportOverlay) import WebKit
 
 extension WebPage.NavigationAction {
+    /// The modifier keys that were pressed at the time of the navigation request.
+    @_spi(Private)
     public var modifierFlags: EventModifiers { EventModifiers(wrapped.modifierFlags) }
 }
 

--- a/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
@@ -26,7 +26,7 @@ import Foundation
 @_spi(Private) import _WebKit_SwiftUI
 
 @MainActor
-final class NavigationDecider: NavigationDeciding {
+final class NavigationDecider: WebPage.NavigationDeciding {
     weak var owner: BrowserViewModel? = nil
 
     func decidePolicy(for action: WebPage.NavigationAction, preferences: inout WebPage.NavigationPreferences) async -> WKNavigationActionPolicy {

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
@@ -59,7 +59,7 @@ extension WebPage.NavigationEvent: @retroactive Equatable {
 // MARK: Supporting test types
 
 @MainActor
-fileprivate class TestNavigationDecider: NavigationDeciding {
+fileprivate class TestNavigationDecider: WebPage.NavigationDeciding {
     init() {
         (self.navigationActionStream, self.navigationActionContinuation) = AsyncStream.makeStream(of: WebPage.NavigationAction.self)
         (self.navigationResponseStream, self.navigationResponseContinuation) = AsyncStream.makeStream(of: WebPage.NavigationResponse.self)


### PR DESCRIPTION
#### 00944a4915bc2e49f00f1150532ca78c0330e955
<pre>
[SwiftUI] Update WebPage.NavigationDeciding to latest interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=287780">https://bugs.webkit.org/show_bug.cgi?id=287780</a>
<a href="https://rdar.apple.com/144962759">rdar://144962759</a>

Reviewed by Abrar Rahman Protyasha.

Update various definitions/declarations for WebPage.NavigationDeciding.

* Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+FrameInfo.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:
(NavigationDeciding.decidePolicy(for:preferences:)):
(NavigationDeciding.decidePolicy(for:)):
(NavigationDeciding.decideAuthenticationChallengeDisposition(for:URLCredential:)):
* Source/WebKit/_WebKit_SwiftUI/WebPageNavigationAction+SwiftUI.swift:
* Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift:

Canonical link: <a href="https://commits.webkit.org/290468@main">https://commits.webkit.org/290468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc81b2ed1487bfa6792c02af2b1afa716b0a7739

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10069 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/17991 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69410 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49771 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7440 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40060 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96979 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17341 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77611 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22064 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20662 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10584 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14170 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->