### PR TITLE
[Cookie Store API] [ITP] Cap expiry of script-written cookies to 24h after cross-site navigation with link decorations

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https-expected.txt
@@ -1,0 +1,11 @@
+Check that cookies created by JavaScript using CookieStore after a cross-site navigation with link query get capped to 24 hours.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS The short-lived cookie doesn't expire after more than 43230 seconds.
+PASS The long-lived cookie doesn't expire after more than 86430 seconds.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/js-test-resources/ui-helper.js"></script>
+    <script src="/cookies/resources/cookie-utilities.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body>
+<script>
+    description("Check that cookies created by JavaScript using CookieStore after a cross-site navigation with link query get capped to 24 hours.");
+    jsTestIsAsync = true;
+
+    const twelveHoursInSeconds = 12 * 60 * 60;
+    const oneDayInSeconds = 2 * twelveHoursInSeconds;
+    const twoDaysInSeconds = 2 * oneDayInSeconds;
+    const twelveHoursAsExpiresDate = createExpiresDateFromMaxAge(twelveHoursInSeconds);
+    const twoDaysAsExpiresDate = createExpiresDateFromMaxAge(twoDaysInSeconds);
+    const overTwelveHoursInSeconds = twelveHoursInSeconds + 30;
+    const overOneDayInSeconds = oneDayInSeconds + 30;
+
+    async function testCookies() {
+        let passedTests = 0;
+        function checkThatCookieDoesNotExpireAfter(cookieData, maxAgeInSeconds) {
+            let now = new Date();
+            let maxExpiryDateInMilliseconds = now.getTime() + (maxAgeInSeconds * 1000);
+
+            if (maxExpiryDateInMilliseconds > cookieData["expires"])
+                ++passedTests;
+            else
+                testFailed("Cookie named " + cookieData["name"] + " expires in more than " + maxAgeInSeconds + " seconds.");
+        }
+
+        await cookieStore.set({ name: "shortLivedCookieExpires", value: "foo", expires: Date.now() + (1000 * twelveHoursInSeconds) });
+        await cookieStore.set({ name: "longLivedCookieExpires", value: "foo", expires: Date.now() + (1000 * twoDaysInSeconds) });
+
+        const cookies = await UIHelper.cookiesForDomain("localhost");
+        if (!cookies.length)
+            testFailed("No cookies found.");
+        for (let cookie of cookies) {
+            switch (cookie.name) {
+                case "shortLivedCookieExpires":
+                    checkThatCookieDoesNotExpireAfter(cookie, overTwelveHoursInSeconds);
+                    break;
+                case "longLivedCookieExpires":
+                    checkThatCookieDoesNotExpireAfter(cookie, overOneDayInSeconds);
+                    break;
+            }
+        }
+
+        resetCookiesForCurrentOrigin();
+
+        if (passedTests === 2) {
+            testPassed("The short-lived cookie doesn't expire after more than " + overTwelveHoursInSeconds + " seconds.");
+            testPassed("The long-lived cookie doesn't expire after more than " + overOneDayInSeconds + " seconds.");
+        } else if (cookies.length)
+            testFailed("At least one cookie's expiry attribute was beyond the test thresholds.");
+
+        setEnableFeature(false, finishJSTest);
+    }
+
+    function navigateCrossOrigin() {
+        location.href = location.href.replace("127.0.0.1", "localhost") + "?clickid=b4db33fc47c4f3";
+    }
+
+    addEventListener("load", async () => {
+        await UIHelper.renderingUpdate();
+        if (location.href.includes("clickid"))
+            return await testCookies();
+
+        setEnableFeature(true, () => {
+            const prevalentResourceOrigin = location.origin;
+            testRunner.setStatisticsPrevalentResource(prevalentResourceOrigin, true, function() {
+                if (!testRunner.isStatisticsPrevalentResource(prevalentResourceOrigin))
+                    testFailed("Host did not get set as prevalent resource.");
+                testRunner.statisticsUpdateCookieBlocking(navigateCrossOrigin);
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2818,6 +2818,7 @@ http/tests/resourceLoadStatistics/cap-cache-max-age-for-prevalent-resource.html 
 http/tests/storageAccess/has-storage-access-false-by-default.https.html [ Pass ]
 http/tests/storageAccess/has-storage-access-false-by-default-ephemeral.https.html [ Pass ]
 http/tests/storageAccess/has-storage-access-true-if-third-party-has-cookies.https.html [ Pass Timeout ]
+http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html [ Pass ]
 
 # Enable on appropriate platforms: rdar://140222322
 http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-blocking-with-partitioned-cookies.https.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -866,6 +866,7 @@ http/tests/resourceLoadStatistics/grandfathering.html [ Pass ]
 http/tests/resourceLoadStatistics/strip-referrer-to-origin-for-third-party-redirects.html [ Pass ]
 http/tests/resourceLoadStatistics/strip-referrer-to-origin-for-third-party-requests.html [ Pass ]
 http/tests/resourceLoadStatistics/cap-cache-max-age-for-prevalent-resource.html [ Pass ]
+http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html [ Pass ]
 
 # The SameSite cookie API is only available in macOS Catalina and above.
 #http/tests/resourceLoadStatistics/set-all-cookies-to-same-site-strict.html [ Pass ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -694,6 +694,7 @@ http/tests/resourceLoadStatistics/add-blocking-to-redirect.html [ Skip ]
 http/tests/resourceLoadStatistics/do-not-remove-blocking-in-redirect.https.html [ Skip ]
 http/tests/resourceLoadStatistics/non-prevalent-resources-can-access-cookies-in-a-third-party-context.html [ Skip ]
 http/tests/resourceLoadStatistics/cap-cache-max-age-for-prevalent-resource.html [ Skip ]
+http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html [ Skip ]
 
 # This feature is currently disabled by default and unfinished <rdar://problem/38925077>.
 http/tests/navigation/process-swap-window-open.html [ Skip ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2211,6 +2211,22 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async cookiesForDomain(domain)
+    {
+        if (!this.isWebKit2())
+            return Promise.resolve([ ]);
+
+        const script = `uiController.cookiesForDomain("${domain}", cookieData => {
+            uiController.uiScriptComplete(JSON.stringify(cookieData));
+        });`;
+
+        return new Promise(resolve => {
+            testRunner.runUIScript(script, cookieData => {
+                resolve(JSON.parse(cookieData));
+            });
+        });
+    }
+
     static fixedContainerEdgeColors()
     {
         if (!this.isWebKit2())

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -459,18 +459,8 @@ std::pair<String, bool> NetworkStorageSession::cookieRequestHeaderFieldValue(con
     return cookiesForSession(headerFieldProxy.firstParty, headerFieldProxy.sameSiteInfo, headerFieldProxy.url, headerFieldProxy.frameID, headerFieldProxy.pageID, IncludeHTTPOnly, headerFieldProxy.includeSecureCookies, ApplyTrackingPrevention::Yes, ShouldRelaxThirdPartyCookieBlocking::No);
 }
 
-static NSHTTPCookie *parseDOMCookie(String cookieString, NSURL* cookieURL, std::optional<Seconds> cappedLifetime, const String& partition)
+static NSHTTPCookie *adjustScriptWrittenCookie(NSHTTPCookie *initialCookie, std::optional<Seconds> cappedLifetime)
 {
-    // <rdar://problem/5632883> On 10.5, NSHTTPCookieStorage would store an empty cookie,
-    // which would be sent as "Cookie: =".
-    if (cookieString.isEmpty())
-        return nil;
-
-    // <http://bugs.webkit.org/show_bug.cgi?id=6531>, <rdar://4409034>
-    // cookiesWithResponseHeaderFields doesn't parse cookies without a value
-    cookieString = cookieString.contains('=') ? cookieString : makeString(cookieString, '=');
-
-    NSHTTPCookie *initialCookie = [NSHTTPCookie _cookieForSetCookieString:cookieString forURL:cookieURL partition:nsStringNilIfEmpty(partition)];
     if (!initialCookie)
         return nil;
 
@@ -497,6 +487,20 @@ static NSHTTPCookie *parseDOMCookie(String cookieString, NSURL* cookieURL, std::
         return NetworkStorageSession::capExpiryOfPersistentCookie(cookie, *cappedLifetime);
 
     return cookie;
+}
+
+static NSHTTPCookie *parseDOMCookie(String cookieString, NSURL* cookieURL, std::optional<Seconds> cappedLifetime, const String& partition)
+{
+    // <rdar://problem/5632883> On 10.5, NSHTTPCookieStorage would store an empty cookie,
+    // which would be sent as "Cookie: =".
+    if (cookieString.isEmpty())
+        return nil;
+
+    // <http://bugs.webkit.org/show_bug.cgi?id=6531>, <rdar://4409034>
+    // cookiesWithResponseHeaderFields doesn't parse cookies without a value
+    cookieString = cookieString.contains('=') ? cookieString : makeString(cookieString, '=');
+
+    return adjustScriptWrittenCookie([NSHTTPCookie _cookieForSetCookieString:cookieString forURL:cookieURL partition:nsStringNilIfEmpty(partition)], cappedLifetime);
 }
 
 void NetworkStorageSession::setCookiesFromDOM(const URL& firstParty, const SameSiteInfo& sameSiteInfo, const URL& url, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, ApplyTrackingPrevention applyTrackingPrevention, const String& cookieString, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking) const
@@ -536,11 +540,12 @@ bool NetworkStorageSession::setCookieFromDOM(const URL& firstParty, const SameSi
     if (applyTrackingPrevention == ApplyTrackingPrevention::Yes && shouldBlockCookies(firstParty, url, frameID, pageID, shouldRelaxThirdPartyCookieBlocking))
         return false;
 
-    NSHTTPCookie *nshttpCookie = (NSHTTPCookie *)cookie;
+    auto expiryCap = clientSideCookieCap(RegistrableDomain { firstParty }, pageID);
+    RetainPtr nshttpCookie = adjustScriptWrittenCookie((NSHTTPCookie *)cookie, expiryCap);
     if (!nshttpCookie)
         return false;
 
-    setHTTPCookiesForURL(cookieStorage().get(), @[nshttpCookie], (NSURL *)url, firstParty, sameSiteInfo);
+    setHTTPCookiesForURL(cookieStorage().get(), @[ nshttpCookie.get() ], (NSURL *)url, firstParty, sameSiteInfo);
     return true;
 
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -402,6 +402,8 @@ interface UIScriptController {
 
     readonly attribute object fixedContainerEdgeColors;
 
+    undefined cookiesForDomain(DOMString domain, object callback);
+
     // Only affects macOS.
     undefined setWebViewAllowsMagnification(boolean allowsMagnification);
 

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -122,6 +122,8 @@ public:
 
     virtual JSObjectRef fixedContainerEdgeColors() const { return nullptr; }
 
+    virtual void cookiesForDomain(JSStringRef, JSValueRef) { notImplemented(); }
+
     // View Parenting and Visibility
 
     virtual void becomeFirstResponder() { notImplemented(); }

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -94,6 +94,8 @@ private:
     void adjustVisibilityForFrontmostTarget(int x, int y, JSValueRef callback) final;
     void resetVisibilityAdjustments(JSValueRef callback) final;
 
+    void cookiesForDomain(JSStringRef, JSValueRef callback) final;
+
     JSObjectRef fixedContainerEdgeColors() const final;
 };
 


### PR DESCRIPTION
#### 3aca45066b63246da4995f601a2a008a0fa28bdf
<pre>
[Cookie Store API] [ITP] Cap expiry of script-written cookies to 24h after cross-site navigation with link decorations
<a href="https://bugs.webkit.org/show_bug.cgi?id=287782">https://bugs.webkit.org/show_bug.cgi?id=287782</a>
<a href="https://rdar.apple.com/145016528">rdar://145016528</a>

Reviewed by Charlie Wolfe.

Apply the &quot;24h script-written cookie expiry cap after cross-site navigation with link decorations&quot;
rule to cookies set using the new CookieStore API, for consistency with using `document.cookie`. See
below for more details.

* LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/capped-lifetime-for-cookie-set-with-link-query-using-cookiestore-api.https.html: Added.

Add a new test to exercise this change:

-   Navigate from `127.0.0.1` to `localhost`, marking `127.0.0.1` as a prevalent resource domain and
    updating ITP cookie blocking data in the process.
-   Set cookies on `localhost` using the CookieStore API, with expiries of both under and over 24h.
-   Read back the stored cookies, and verify that expiry is capped to 24h.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:

Enable the new test on WK2 Cocoa ports only, where the `ENABLE(JS_COOKIE_CHECKING)` feature is
enabled and expiry capping after cross-site navigation is enabled.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async cookiesForDomain):

Add a new helper method to read properties of cookies matching the given domain, by going through
`WKHTTPCookieStore`.

* Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
(WebCore::adjustScriptWrittenCookie):
(WebCore::parseDOMCookie):

Implement the main fix here: split `parseDOMCookie` out into two parts: (1) the first part that
actually parses the cookie from the raw string, and (2) `adjustScriptWrittenCookie`, which adjusts
the resulting `NSHTTPCookie` by applying the `SetInJavaScript` flag and capping expiry if needed.

(WebCore::NetworkStorageSession::setCookieFromDOM const):

Use `adjustScriptWrittenCookie` on the incoming `NSHTTPCookie` to apply cookie expiry mitigations.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::cookiesForDomain):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::propertyDictionaryForJS):
(WTR::UIScriptControllerCocoa::cookiesForDomain):

Canonical link: <a href="https://commits.webkit.org/290527@main">https://commits.webkit.org/290527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7011436324c573aaba29eefc3da77547fc66812

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41083 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69512 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27099 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7835 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81920 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7562 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36288 "Found 4 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html http/tests/security/file-system-access-via-dataTransfer.html imported/w3c/web-platform-tests/content-security-policy/reporting/report-original-url-on-mixed-content-frame.https.sub.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40214 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97135 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17495 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12862 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77718 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19193 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22180 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10754 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17505 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22832 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->