### PR TITLE
[SwiftUI] Support customizing the background color for WebView

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
@@ -43,6 +43,9 @@ extension EnvironmentValues {
 
     @Entry
     var webViewContextMenuContext: ContextMenuContext? = nil
+
+    @Entry
+    var webViewContentBackground: Visibility = .automatic
 }
 
 extension View {
@@ -99,6 +102,11 @@ extension View {
 #else
         return self
 #endif
+    }
+
+    @_spi(Private)
+    public func webViewContentBackground(_ visibility: Visibility) -> some View {
+        environment(\.webViewContentBackground, visibility)
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-public import SwiftUI
+internal import SwiftUI
 @_spi(Private) @_spi(CrossImportOverlay) import WebKit
 internal import WebKit_Internal
 
@@ -51,6 +51,12 @@ struct WebViewRepresentable {
 
         webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures.value != .disabled
         webView.allowsLinkPreview = environment.webViewAllowsLinkPreview.value != .disabled
+
+#if os(macOS)
+        webView._drawsBackground = environment.webViewContentBackground != .hidden
+#else
+        webView.isOpaque = environment.webViewContentBackground != .hidden
+#endif
 
         webView.configuration.preferences.isTextInteractionEnabled = environment.webViewTextSelection
         webView.configuration.preferences.isElementFullscreenEnabled = environment.webViewAllowsElementFullscreen


### PR DESCRIPTION
#### ca00a7c427587c20f1aaebc664283cefac5c49df
<pre>
[SwiftUI] Support customizing the background color for WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=287783">https://bugs.webkit.org/show_bug.cgi?id=287783</a>
<a href="https://rdar.apple.com/144740155">rdar://144740155</a>

Reviewed by Abrar Rahman Protyasha.

Expose functionality on WebView to allow eliding drawing the background of the webpage, similar to
the existing `isOpaque` and `_drawsBackground` functions.

* Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift:
(View.webViewBackgroundRemoved(_:)):
* Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):

Canonical link: <a href="https://commits.webkit.org/290470@main">https://commits.webkit.org/290470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd989e152a0d0cbb91545197b6977f946894f32f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95165 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18002 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69415 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27014 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93165 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7722 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49776 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40071 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/37219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/96990 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17352 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17609 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10604 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14171 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22688 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17103 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->