### PR TITLE
REGRESSION(289552@main): [GTK] Web page content sometimes does not display

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -250,6 +250,8 @@ void DrawingAreaCoordinatedGraphics::backgroundColorDidChange()
 void DrawingAreaCoordinatedGraphics::setDeviceScaleFactor(float deviceScaleFactor, CompletionHandler<void()>&& completionHandler)
 {
     Ref { m_webPage.get() }->setDeviceScaleFactor(deviceScaleFactor);
+    if (m_layerTreeHost)
+        m_layerTreeHost->sizeDidChange();
     completionHandler();
 }
 
@@ -358,7 +360,7 @@ void DrawingAreaCoordinatedGraphics::updateGeometry(const IntSize& size, Complet
     webPage->layoutIfNeeded();
 
     if (m_layerTreeHost)
-        m_layerTreeHost->sizeDidChange(webPage->size());
+        m_layerTreeHost->sizeDidChange();
     else {
         m_dirtyRegion = IntRect(IntPoint(), size);
         UpdateInfo updateInfo;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -197,6 +197,7 @@ void LayerTreeHost::flushLayers()
     page->finalizeRenderingUpdate(flags);
 
     if (m_pendingResize) {
+        m_compositor->setSize(page->size(), page->deviceScaleFactor());
         auto& rootLayer = m_sceneState->rootLayer();
         Locker locker { rootLayer.lock() };
         rootLayer.setSize(page->size());
@@ -345,7 +346,7 @@ void LayerTreeHost::ensureDrawing()
 }
 #endif
 
-void LayerTreeHost::sizeDidChange(const IntSize& size)
+void LayerTreeHost::sizeDidChange()
 {
     m_pendingResize = true;
     if (m_isWaitingForRenderer)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -102,7 +102,7 @@ public:
 
     void forceRepaint();
     void forceRepaintAsync(CompletionHandler<void()>&&);
-    void sizeDidChange(const WebCore::IntSize&);
+    void sizeDidChange();
 
     void pauseRendering();
     void resumeRendering();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp
@@ -221,11 +221,12 @@ void LayerTreeHost::forceRepaintAsync(CompletionHandler<void()>&& completionHand
     completionHandler();
 }
 
-void LayerTreeHost::sizeDidChange(const WebCore::IntSize& newSize)
+void LayerTreeHost::sizeDidChange()
 {
     if (!enabled())
         return;
 
+    const auto& newSize = m_webPage.size();
     if (m_rootLayer->size() == newSize)
         return;
     m_rootLayer->setSize(newSize);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h
@@ -77,7 +77,7 @@ public:
     void scrollNonCompositedContents(const WebCore::IntRect&);
     void forceRepaint();
     void forceRepaintAsync(CompletionHandler<void()>&&);
-    void sizeDidChange(const WebCore::IntSize& newSize);
+    void sizeDidChange();
     void pauseRendering();
     void resumeRendering();
     WebCore::GraphicsLayerFactory* graphicsLayerFactory();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -79,6 +79,7 @@ public:
     void preferredBufferFormatsDidChange();
 #endif
 
+    void setSize(const WebCore::IntSize&, float);
     uint32_t requestComposition();
     void scheduleUpdate();
     RunLoop* runLoop();
@@ -131,7 +132,6 @@ private:
         Lock lock;
         WebCore::IntSize viewportSize;
         float deviceScaleFactor { 1 };
-        uint32_t compositionRequestID { 0 };
 
 #if !HAVE(DISPLAY_LINK)
         bool clientRendersNextFrame { false };
@@ -146,6 +146,7 @@ private:
     std::unique_ptr<WebCore::TextureMapperDamageVisualizer> m_damageVisualizer;
 #endif
 
+    std::atomic<uint32_t> m_compositionRequestID { 0 };
 #if HAVE(DISPLAY_LINK)
     std::atomic<uint32_t> m_compositionResponseID { 0 };
     RunLoop::Timer m_didRenderFrameTimer;


### PR DESCRIPTION
#### 629c3dbe2f99a36ca562e33ec800a54cff8d5506
<pre>
REGRESSION(289552@main): [GTK] Web page content sometimes does not display
<a href="https://bugs.webkit.org/show_bug.cgi?id=287404">https://bugs.webkit.org/show_bug.cgi?id=287404</a>

Reviewed by Alejandro G. Castro.

The old proxy could only schedule a composition on new buffer after
the first composition. The new one doesn&apos;t have that limitation, but we
end up calling ThreadedCompositor::scheduleUpdate() before
ThreadedCompositor::requestComposition() so attributes are not
initialized. Then a composition is run, but it does nothing because the
view port size is empty, and the compositing run loop keeps blocked
because updateCompleted is never called. We should always update the
size attributes when the web page size or device scale factor change.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::setDeviceScaleFactor):
(WebKit::DrawingAreaCoordinatedGraphics::updateGeometry):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::flushLayers):
(WebKit::LayerTreeHost::sizeDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::sizeDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::setSize):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::requestComposition):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/290780@main">https://commits.webkit.org/290780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b494801a5147b85607a04e292f76e007d05924a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41671 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27406 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93879 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8219 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50216 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7991 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40793 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78325 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97871 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18073 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13276 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78902 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78086 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22569 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11379 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14376 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23427 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17821 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21277 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->