### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/view-timeline-inset-animation.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-height-with-flex-item-margin-inline-end-rtl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-height-with-flex-item-margin-inline-end-rtl-expected.txt
@@ -1,0 +1,10 @@
+
+FAIL Check scrollHeight with overflow: auto assert_equals: expected 950 but got 100
+FAIL Check scrollHeight with overflow: scroll assert_equals: expected 950 but got 85
+FAIL Check scrollHeight with overflow: hidden assert_equals: expected 950 but got 100
+PASS Check scrollHeight with overflow: clip
+PASS Check scrollHeight with overflow: visible
+PASS Check scrollHeight with overflowX: visible, overflowY: clip
+FAIL Check scrollHeight with overflowX: visible, overflowY: hidden assert_equals: expected 950 but got 100
+FAIL Check scrollHeight with overflowX: visible, overflowY: auto assert_equals: expected 950 but got 100
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-height-with-flex-item-margin-inline-end-rtl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-height-with-flex-item-margin-inline-end-rtl.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<title>CSS Overflow: Scrollable overflow from flex item with margin-inline-end and "direction: rtl"</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollable" />
+<meta name="assert" content="Flex item contribute its margin-end to parent scroller's scrollable overflow.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #container {
+    width: 100px;
+    height: 100px;
+    display: flex;
+    overflow: scroll;
+    outline: 1px solid red;
+    writing-mode: vertical-lr;
+    direction: rtl;
+  }
+
+  .item {
+    outline: 2px solid green;
+    width: 50px;
+    height: 50px;
+    margin-inline-end: 950px;
+  }
+</style>
+
+<div id=container>
+  <div class=item></div>
+</div>
+<script>
+  test(() => {
+    container.style.overflow = "auto";
+    assert_equals(container.scrollHeight, 950);
+  }, "Check scrollHeight with overflow: auto");
+
+  test(() => {
+    container.style.overflow = "scroll";
+    assert_equals(container.scrollHeight, 950);
+  }, "Check scrollHeight with overflow: scroll");
+
+  test(() => {
+    container.style.overflow = "hidden";
+    assert_equals(container.scrollHeight, 950);
+  }, "Check scrollHeight with overflow: hidden");
+
+  test(() => {
+    container.style.overflow = "clip";
+    assert_equals(container.scrollHeight, 100);
+  }, "Check scrollHeight with overflow: clip");
+
+  test(() => {
+    container.style.overflow = "visible";
+    assert_equals(container.scrollHeight, 100);
+  }, "Check scrollHeight with overflow: visible");
+
+  test(() => {
+    container.style.overflowX = "visible";
+    container.style.overflowY = "clip";
+    assert_equals(container.scrollHeight, 100);
+  }, "Check scrollHeight with overflowX: visible, overflowY: clip");
+
+  test(() => {
+    container.style.overflowX = "visible";
+    container.style.overflowY = "hidden";
+    assert_equals(container.scrollHeight, 950);
+  }, "Check scrollHeight with overflowX: visible, overflowY: hidden");
+
+  test(() => {
+    container.style.overflowX = "visible";
+    container.style.overflowY = "auto";
+    assert_equals(container.scrollHeight, 950);
+  }, "Check scrollHeight with overflowX: visible, overflowY: auto");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt
@@ -13,14 +13,14 @@ PASS view-timeline-inset:auto, block, vertical-rl
 PASS view-timeline-inset:auto, inline
 PASS view-timeline-inset:auto, inline, vertical-rl
 PASS view-timeline-inset:auto, inline, vertical-lr
-FAIL view-timeline-inset:auto, inline, rtl assert_equals: expected "50" but got "30"
-FAIL view-timeline-inset:auto, inline, vertical-rl, rtl assert_equals: expected "50" but got "25"
-FAIL view-timeline-inset:auto, inline, vertical-lr, rtl assert_equals: expected "50" but got "25"
+PASS view-timeline-inset:auto, inline, rtl
+PASS view-timeline-inset:auto, inline, vertical-rl, rtl
+PASS view-timeline-inset:auto, inline, vertical-lr, rtl
 PASS view-timeline-inset:auto, y
 PASS view-timeline-inset:auto, y, vertical-rl
-FAIL view-timeline-inset:auto, y, vertical-rl, rtl assert_equals: expected "50" but got "25"
+PASS view-timeline-inset:auto, y, vertical-rl, rtl
 PASS view-timeline-inset:auto, x
-FAIL view-timeline-inset:auto, x, rtl assert_equals: expected "50" but got "30"
+PASS view-timeline-inset:auto, x, rtl
 PASS view-timeline-inset:auto, x, vertical-lr
 PASS view-timeline-inset:auto, x, vertical-rl
 PASS view-timeline-inset:auto, mix

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation.html
@@ -16,8 +16,17 @@
     width: 80px;
     height: 100px;
   }
+
+  #container {
+    position: relative;
+    width: 350px;
+    height: 350px;
+  }
+
   #target {
-    margin: 150px;
+    position: absolute;
+    left: 150px;
+    top: 150px;
     width: 50px;
     height: 50px;
     z-index: -1;
@@ -55,13 +64,13 @@
   Please note the following:
 
    - The scroller has a width x height of 80x100px.
-   - The content is 50x50px with a 150px margin on all sides.
-     In other words, the size of the scroller content is 200x200px.
+   - The content is 350x350px
+   - The subject is 50x50px centered within the content.
 
   This means that, for vertical direction scrolling, assuming no insets:
 
    - The start offset is 50px (scroller height + 50px is 150px, which consumes
-     exactly the margin of the content).
+     exactly the white space of the content).
    - The end offset is 200px (this is where the bottom edge of the scroller has
      just cleared the content).
    - The halfway point is (50px + 200px) / 2 = 125px.
@@ -69,7 +78,7 @@
   For horizontal direction scrolling, assuming no insets:
 
    - The start offset is 70px (scroller width + 70px is 150px, which consumes
-     exactly the margin of the content).
+     exactly the white space of the content).
    - The end offset is 200px (this is where the left edge of the scroller has
      just cleared the content).
    - The halfway point is (70px + 200px) / 2 = 135px.
@@ -98,7 +107,9 @@
     }
   </style>
   <div id=scroller class=vertical>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -120,7 +131,9 @@
     }
   </style>
   <div id=scroller class=vertical>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -144,7 +157,9 @@
     }
   </style>
   <div id=scroller class=vertical>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -168,7 +183,9 @@
     }
   </style>
   <div id=scroller class=vertical>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -191,7 +208,9 @@
     }
   </style>
   <div id=scroller class=vertical>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -214,7 +233,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -237,7 +258,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -260,7 +283,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -286,7 +311,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -313,7 +340,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -340,7 +369,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -367,7 +398,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -394,7 +427,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -421,7 +456,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -448,7 +485,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -476,7 +515,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -504,7 +545,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -530,7 +573,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -557,7 +602,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -585,7 +632,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -611,7 +660,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -638,7 +689,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -665,7 +718,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -692,7 +747,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>
@@ -719,7 +776,9 @@
     }
   </style>
   <div id=scroller>
-    <div id=target></div>
+    <div id="container">
+      <div id=target></div>
+    </div>
   </div>
 </template>
 <script>


### PR DESCRIPTION
#### bf12caa476dbd8ee4dfb76b1b4568f874fe85a30
<pre>
[scroll-animations] WPT test `scroll-animations/css/view-timeline-inset-animation.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=287790">https://bugs.webkit.org/show_bug.cgi?id=287790</a>

Reviewed by Anne van Kesteren.

We were failing the test `scroll-animations/css/view-timeline-inset-animation.html` because of how we handle `margin`
values to determine the offset width and height of the scrollable content. But the expected behavior is not strictly
specified by the css-overflow spec, per <a href="https://drafts.csswg.org/css-overflow-3/#scrollable">https://drafts.csswg.org/css-overflow-3/#scrollable</a>:

&gt; The UA may additionally include the margin areas of other boxes for which the box establishes
&gt; a containing block; however, the conditions under which such margin areas are included is
&gt; undefined in this level.

Additionally, the use of `margin` itself is not directly relevant to the test, but was just a test authoring decision
to easily place the view timeline subject in the center of a scrollable region. So we rewrite this WPT test to use
absolute positioning for the subject and explicit scrollable content sizing with an intermediate `#container` element.

Note that bringing our `margin` handling in line with Chrome and Firefox for interoperability reasons is covered by
<a href="https://bugs.webkit.org/show_bug.cgi?id=287802.">https://bugs.webkit.org/show_bug.cgi?id=287802.</a> A new WPT test is being added to `css/css-overflow` to cover such cases
so that we don&apos;t lose test coverage.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-height-with-flex-item-margin-inline-end-rtl-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/scrollable-overflow-height-with-flex-item-margin-inline-end-rtl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-inset-animation.html:

Canonical link: <a href="https://commits.webkit.org/290603@main">https://commits.webkit.org/290603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bc4a5d8726ef6e795e3501eaf4382c316b1786

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8018 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50058 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7766 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40501 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97430 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17781 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78732 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77932 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20993 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14255 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17791 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17530 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->