### PR TITLE
[Screen Time Refactoring] WKWebView shrinks when added to a stack view

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -409,6 +409,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
 #endif // PLATFORM(MAC)
 
 #if ENABLE(SCREEN_TIME)
+
 - (void)_installScreenTimeWebpageController
 {
     if (!PAL::isScreenTimeFrameworkAvailable())
@@ -432,14 +433,8 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
         RetainPtr screenTimeView = [_screenTimeWebpageController view];
 
         if ([_configuration _showsSystemScreenTimeBlockingView]) {
-            [screenTimeView setTranslatesAutoresizingMaskIntoConstraints:NO];
+            [screenTimeView setFrame:self.bounds];
             [self addSubview:screenTimeView.get()];
-            [NSLayoutConstraint activateConstraints:@[
-                [[screenTimeView widthAnchor] constraintEqualToAnchor:self.widthAnchor],
-                [[screenTimeView heightAnchor] constraintEqualToAnchor:self.heightAnchor],
-                [[screenTimeView leadingAnchor] constraintEqualToAnchor:self.leadingAnchor],
-                [[screenTimeView topAnchor] constraintEqualToAnchor:self.topAnchor]
-            ]];
         }
     }
 }
@@ -457,6 +452,13 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     [[_screenTimeWebpageController view] removeFromSuperview];
     [_screenTimeWebpageController removeObserver:self forKeyPath:@"URLIsBlocked" context:&screenTimeWebpageControllerBlockedKVOContext];
     _screenTimeWebpageController = nil;
+}
+
+- (void)_updateScreenTimeViewGeometry
+{
+    auto bounds = self.bounds;
+    [_screenTimeBlurredSnapshot setFrame:bounds];
+    [[_screenTimeWebpageController view] setFrame:bounds];
 }
 
 - (void)_updateScreenTimeShieldVisibilityForWindow
@@ -510,14 +512,8 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
                 RetainPtr blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleSystemUltraThinMaterial];
                 _screenTimeBlurredSnapshot = adoptNS([[UIVisualEffectView alloc] initWithEffect:blurEffect.get()]);
 #endif
-                [_screenTimeBlurredSnapshot setTranslatesAutoresizingMaskIntoConstraints:NO];
+                [_screenTimeBlurredSnapshot setFrame:self.bounds];
                 [self addSubview:_screenTimeBlurredSnapshot.get()];
-                [NSLayoutConstraint activateConstraints:@[
-                    [[_screenTimeBlurredSnapshot widthAnchor] constraintEqualToAnchor:self.widthAnchor],
-                    [[_screenTimeBlurredSnapshot heightAnchor] constraintEqualToAnchor:self.heightAnchor],
-                    [[_screenTimeBlurredSnapshot leadingAnchor] constraintEqualToAnchor:self.leadingAnchor],
-                    [[_screenTimeBlurredSnapshot topAnchor] constraintEqualToAnchor:self.topAnchor]
-                ]];
             } else if (_screenTimeBlurredSnapshot) {
                 [_screenTimeBlurredSnapshot removeFromSuperview];
                 _screenTimeBlurredSnapshot = nil;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -452,6 +452,8 @@ struct PerWebProcessState {
 #if ENABLE(SCREEN_TIME)
 - (void)_installScreenTimeWebpageController;
 - (void)_uninstallScreenTimeWebpageController;
+
+- (void)_updateScreenTimeViewGeometry;
 - (void)_updateScreenTimeShieldVisibilityForWindow;
 #endif
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -180,6 +180,10 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
 
 - (void)layoutSubviews
 {
+#if ENABLE(SCREEN_TIME)
+    [self _updateScreenTimeViewGeometry];
+#endif
+
     [_warningView setFrame:self.bounds];
     [super layoutSubviews];
     [self _frameOrBoundsMayHaveChanged];

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -211,6 +211,10 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)renewGState
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
+#if ENABLE(SCREEN_TIME)
+    [self _updateScreenTimeViewGeometry];
+#endif
+
     if (_impl)
         _impl->renewGState();
     [super renewGState];


### PR DESCRIPTION
#### c48c498ba0e6117510137abb70af9202c8dbbeaa
<pre>
[Screen Time Refactoring] WKWebView shrinks when added to a stack view
<a href="https://bugs.webkit.org/show_bug.cgi?id=287800">https://bugs.webkit.org/show_bug.cgi?id=287800</a>
<a href="https://rdar.apple.com/144728151">rdar://144728151</a>

Reviewed by Wenson Hsieh.

Currently, `WKWebView` sizes `STWebpageView` using Auto Layout, applying
equal top, leading, width, and height constraints to ensure the Screen Time view
covers the web view.

However, this approach results in the `WKWebView` shrinking down to a width of
480pt when it is added to a stack view. This is due to the presence of an
`NSRemoteView` subview, inside `STWebpageView`, with an intrinsic content size
of (480, 272).

By default, stack views add a greater than or equal trailing constraint to
their arranged subviews. Specifically, the stack view&apos;s trailing edge must
be greater than or equal to the web view&apos;s trailing edge. Additionally, a lower
priority constraint that enforces equality between the stack view&apos;s trailing
edge and the web view&apos;s trailing edge is added.

Thus the following constraints are present:
- `NSStackView`&apos;s trailing edge &gt;= `WKWebView`&apos;s trailing edge (high priority)
- `WKWebView`&apos;s edges == `STWebpageView`&apos;s edges (high priority)
- `STWebpageView`&apos;s edges == `NSRemoteView`&apos;s edges (high priority)
- `NSRemoteView`&apos;s width == 480 (high priority)
- `NSStackView`&apos;s trailing edge == `WKWebView`&apos;s trailing edge (low priority)

Consequently, a satisfying layout for all high priority constraints is to size
the `WKWebView` down to 480pt, and have the `STWebpageView` (and `NSRemoteView`)
fill the web view&apos;s frame.

To fix, stop using Auto Layout to size the `STWebpageView` and use manual,
frame-based layout. By giving the `STWebpageView` an explicit frame, the
intrinsic content size constraint on the `NSRemoteView` becomes unsatisfiable,
and both the `STWebpageView` and `NSRemoteView` can simply fill the
`WKWebView`&apos;s frame.

Note that on iOS, the same issue does not exist, as the remote view does not
have an intrinsic content size. However, the same change is applied on iOS to
share code.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageController]):
(-[WKWebView _updateScreenTimeViewGeometry]):

Ensure the Screen Time view covers the web view by setting its frame equal to
the web view&apos;s bounds.

(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):

Use manual layout for WebKit&apos;s own blocking view to keep logic similar.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView layoutSubviews]):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView renewGState]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(webViewForScreenTimeTests):
(TEST(ScreenTime, WKWebViewFillsStackView)):

Add a test which puts a `WKWebView` with Screen Time enabled, inside a stack
view, and asserts the web view is sized to fill the stack view.

Prior to this fix, the test fails, as the web view&apos;s width is shrunk to 480pt.

Canonical link: <a href="https://commits.webkit.org/290501@main">https://commits.webkit.org/290501@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e314e7e700990ad9b1b5ce41297b23c78b56bb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41011 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69465 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27066 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7784 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7508 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40142 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97061 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17423 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77669 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22134 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20737 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10682 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14188 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17433 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17174 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->