### PR TITLE
REGRESSION(290473@main): HTTPServer wants all requests to be accounted for

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm
@@ -98,7 +98,8 @@ static constexpr auto mainBody =
 TEST(IconLoading, DefaultFavicon)
 {
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { mainBody } }
+        { "/"_s, { mainBody } },
+        { "/favicon.ico"_s, { "Actual response is immaterial."_s } },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -138,7 +139,8 @@ TEST(IconLoading, AlreadyCachedIcon)
 
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { "Oh, hello there!"_s } },
-        { "/favicon.ico"_s, { iconDataFromDisk.get() } }
+        { "/favicon.ico"_s, { iconDataFromDisk.get() } },
+        { "/main"_s, { "Main? Yes."_s } }
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### 776e5c3812bed7e505e61993d2ef3266fcb140f7
<pre>
REGRESSION(290473@main): HTTPServer wants all requests to be accounted for
<a href="https://bugs.webkit.org/show_bug.cgi?id=287801">https://bugs.webkit.org/show_bug.cgi?id=287801</a>
<a href="https://rdar.apple.com/144990932">rdar://144990932</a>

Reviewed by Jonathan Bedard.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IconLoadingDelegate.mm:
(TEST(IconLoading, DefaultFavicon)):
(TEST(IconLoading, AlreadyCachedIcon)):

Canonical link: <a href="https://commits.webkit.org/290498@main">https://commits.webkit.org/290498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d11363a120e4eda7763c34b5b6d116522724702

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40982 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27046 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49804 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7484 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36216 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40113 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77816 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97032 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17394 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12794 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78449 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77665 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77654 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22107 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20719 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10653 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17404 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->