### PR TITLE
Fix crash in VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -195,14 +195,15 @@ void VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing()
     if (placardHeight < 100)
         [pipLabel setHidden:YES];
 
-    UIView *parentView = layerHostView().superview;
-    [parentView.superview insertSubview:pipPlacard.get() atIndex:0];
-    [NSLayoutConstraint activateConstraints:@[
-        [parentView.leadingAnchor constraintEqualToAnchor:[pipPlacard leadingAnchor]],
-        [parentView.trailingAnchor constraintEqualToAnchor:[pipPlacard trailingAnchor]],
-        [parentView.topAnchor constraintEqualToAnchor:[pipPlacard topAnchor]],
-        [parentView.bottomAnchor constraintEqualToAnchor:[pipPlacard bottomAnchor]],
-    ]];
+    if (UIView *parentView = layerHostView().superview) {
+        [parentView.superview insertSubview:pipPlacard.get() atIndex:0];
+        [NSLayoutConstraint activateConstraints:@[
+            [parentView.leadingAnchor constraintEqualToAnchor:[pipPlacard leadingAnchor]],
+            [parentView.trailingAnchor constraintEqualToAnchor:[pipPlacard trailingAnchor]],
+            [parentView.topAnchor constraintEqualToAnchor:[pipPlacard topAnchor]],
+            [parentView.bottomAnchor constraintEqualToAnchor:[pipPlacard bottomAnchor]],
+        ]];
+    }
 
     m_pipPlacard = pipPlacard;
 }


### PR DESCRIPTION
#### 3b9317ac0643e0a9a2e11771100455dec32ba8fc
<pre>
Fix crash in VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing
<a href="https://bugs.webkit.org/show_bug.cgi?id=287804">https://bugs.webkit.org/show_bug.cgi?id=287804</a>
<a href="https://rdar.apple.com/143843623">rdar://143843623</a>

Reviewed by Eric Carlson.

289188@main added some code that creates an array of constraints.
If the parentView is null, though, we crash with NSInvalidArgumentException.
This adds a check.  If there is nothing to add constraints to, don&apos;t crash.

* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing):

Canonical link: <a href="https://commits.webkit.org/290531@main">https://commits.webkit.org/290531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/607a501f4e905078980ceaecc8a042b4516eb4a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90209 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40985 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69464 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27050 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7768 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49824 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7491 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36212 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-masking/clip-path/animations/clip-path-animation-font-size-mixed-change.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40116 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77823 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97035 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78442 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77647 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20715 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10656 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14205 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22734 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17148 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18932 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->