### PR TITLE
JS: Address Safer CPP bot warnings in ScriptController

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -355,6 +355,11 @@ void JSDOMGlobalObject::finishCreation(VM& vm, JSObject* thisValue)
 #endif
 }
 
+RefPtr<ScriptExecutionContext> JSDOMGlobalObject::protectedScriptExecutionContext() const
+{
+    return scriptExecutionContext();
+}
+
 ScriptExecutionContext* JSDOMGlobalObject::scriptExecutionContext() const
 {
     if (inherits<JSDOMWindowBase>())

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -78,6 +78,7 @@ public:
     inline JSDOMStructureMap& structures(NoLockingNecessaryTag);
     inline DOMGuardedObjectSet& guardedObjects(NoLockingNecessaryTag);
 
+    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
     ScriptExecutionContext* scriptExecutionContext() const;
 
     static String codeForEval(JSC::JSGlobalObject*, JSC::JSValue);

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -183,6 +183,7 @@ private:
 
     void disconnectPlatformScriptObjects();
 
+    Ref<WindowProxy> protectedWindowProxy() { return windowProxy(); }
     WEBCORE_EXPORT WindowProxy& windowProxy();
     WEBCORE_EXPORT JSWindowProxy& jsWindowProxy(DOMWrapperWorld&);
 


### PR DESCRIPTION
#### f6dd5d303553b10fd1b6da1fa30846bbdf903ab7
<pre>
JS: Address Safer CPP bot warnings in ScriptController
<a href="https://bugs.webkit.org/show_bug.cgi?id=287805">https://bugs.webkit.org/show_bug.cgi?id=287805</a>

Reviewed by Chris Dumez.

Use protected methods and/or smart pointers where appropriate
to avoid warnings from the static analyzer.

* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::protectedScriptExecutionContext const):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::evaluateInWorld):
(WebCore::ScriptController::evaluateModule):
(WebCore::ScriptController::jsWindowProxy):
(WebCore::ScriptController::eventHandlerPosition const):
(WebCore::ScriptController::setEvalEnabled):
(WebCore::ScriptController::setWebAssemblyEnabled):
(WebCore::ScriptController::setRequiresTrustedTypes):
(WebCore::ScriptController::canAccessFromCurrentOrigin):
(WebCore::ScriptController::updateDocument):
(WebCore::ScriptController::collectIsolatedContexts):
(WebCore::ScriptController::cleanupScriptObjectsForPlugin):
(WebCore::ScriptController::clearScriptObjects):
(WebCore::ScriptController::executeScriptInWorld):
(WebCore::ScriptController::callInWorld):
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/bindings/js/ScriptController.h:

Canonical link: <a href="https://commits.webkit.org/290532@main">https://commits.webkit.org/290532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a873543e8a1e0b36f8816bdae017f25e7e2d7b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41136 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69556 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27138 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93361 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7867 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36334 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40267 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97192 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12907 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78548 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77768 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19199 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22219 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10813 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22885 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17299 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19083 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->