### PR TITLE
[scroll-animations] several WPT tests under `scroll-animations/view-timelines` are incorrectly expecting an animation not to apply at the "at progress timeline boundary"

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with container having vertical-rl layout assert_equals: Opacity with fill none at effect end time expected "1" but got "0.7"
+PASS View timeline with container having vertical-rl layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative.html
@@ -80,7 +80,7 @@
     assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Opacity with fill forwards at effect end time');
     anim.effect.updateTiming({ fill: 'none' });
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Opacity with fill none at effect end time');
 
     // Advance to the scroll limit.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
-FAIL View timeline does not clamp starting scroll offset at 0 assert_equals: Effect inactive at the end offset expected "1" but got "0.7"
+PASS View timeline with start and end scroll offsets that do not align with the scroll boundaries
+PASS View timeline does not clamp starting scroll offset at 0
 PASS View timeline  does not clamp end scroll offset at max scroll
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative.html
@@ -76,7 +76,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.
@@ -133,7 +133,7 @@
                           "Timeline's current time at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's current time at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect inactive at the end offset');
 
     // Advance to scroll limit.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL View timeline with subject that is not a direct descendant of the scroll container assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
+PASS View timeline with subject that is not a direct descendant of the scroll container
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html
@@ -92,7 +92,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL View timeline with start and end scroll offsets that do not align with the scroll boundaries assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
-FAIL View timeline does not clamp starting scroll offset at 0 assert_equals: Effect at the end of the active phase expected "1" but got "0.7"
+PASS View timeline with start and end scroll offsets that do not align with the scroll boundaries
+PASS View timeline does not clamp starting scroll offset at 0
 PASS View timeline does not clamp end scroll offset at max scroll
-FAIL View timeline with container having RTL layout assert_equals: Effect is in the after phase at effect end time expected "1" but got "0.7"
+PASS View timeline with container having RTL layout
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative.html
@@ -91,7 +91,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.
@@ -154,7 +154,7 @@
                           "Timeline's current time at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's current time at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect at the end of the active phase');
 
     // Advance to scroll limit.
@@ -282,7 +282,7 @@
                           "Timeline's currentTime at end offset");
     assert_percents_equal(anim.currentTime, 100,
                           "Animation's currentTime at end offset");
-    assert_equals(getComputedStyle(target).opacity, '1',
+    assert_equals(getComputedStyle(target).opacity, '0.7',
                   'Effect is in the after phase at effect end time');
 
     // Advance to the scroll limit.


### PR DESCRIPTION
#### 3f56da4fbe5ba8049ccc4b419ab03b4768658c35
<pre>
[scroll-animations] several WPT tests under `scroll-animations/view-timelines` are incorrectly expecting an animation not to apply at the &quot;at progress timeline boundary&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=287806">https://bugs.webkit.org/show_bug.cgi?id=287806</a>

Reviewed by Dean Jackson.

Several tests make the incorrect assumption that when &quot;at progress timeline boundary&quot; the animation does not apply,
which is not true for animations associated with a progress-based timeline, such as a view timeline. The relevant
spec here is <a href="https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary.">https://drafts.csswg.org/web-animations-2/#at-progress-timeline-boundary.</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time-vertical-rl.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-current-time.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/block-view-timeline-nested-subject.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/inline-view-timeline-current-time.tentative.html:

Canonical link: <a href="https://commits.webkit.org/290525@main">https://commits.webkit.org/290525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a7cd55040ef1e98e08e8ead9ed7d086bb1e6344

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95214 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/40989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69450 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49810 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7495 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36219 "Found 3 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78448 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17658 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77668 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77653 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10660 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14202 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17411 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17152 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->