### PR TITLE
Fix internal iOS builds following 290280@main

### DIFF
--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
@@ -40,6 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_UI_ACTOR
 @interface WKMaterialHostingSupport : NSObject
 
++ (BOOL)isMaterialHostingAvailable;
+
 + (CALayer *)createHostingLayer;
 + (void)updateHostingLayer:(CALayer *)hostingLayer cornerRadius:(CGFloat)cornerRadius;
 + (nullable CALayer *)contentLayerForMaterialHostingLayer:(CALayer *)hostingLayer;

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -26,9 +26,9 @@
 internal import WebKit_Internal
 
 #if canImport(UIKit)
-@_spi(Private) @_spi(ForUIKitOnly) internal import SwiftUI
+@_weakLinked @_spi(Private) @_spi(ForUIKitOnly) internal import SwiftUI
 #else
-@_spi(Private) @_spi(ForAppKitOnly) internal import SwiftUI
+@_weakLinked @_spi(Private) @_spi(ForAppKitOnly) internal import SwiftUI
 #endif
 
 #if canImport(UIKit)
@@ -113,6 +113,14 @@ private extension CALayer {
 }
 
 @objc @implementation extension WKMaterialHostingSupport {
+    class func isMaterialHostingAvailable() -> Bool {
+        guard #_hasSymbol(Material.self) else {
+            return false
+        }
+
+        return true;
+    }
+
     class func createHostingLayer() -> CALayer {
         let contentLayer = CALayer()
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm
@@ -475,8 +475,12 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
 #endif
 
 #if HAVE(MATERIAL_HOSTING)
-    case PlatformCALayer::LayerType::LayerTypeMaterialHostingLayer:
+    case PlatformCALayer::LayerType::LayerTypeMaterialHostingLayer: {
+        if (![WKMaterialHostingSupport isMaterialHostingAvailable])
+            return makeWithLayer(adoptNS([[CALayer alloc] init]));
+
         return makeWithLayer(adoptNS([WKMaterialHostingSupport createHostingLayer]));
+    }
 #endif
 
     case PlatformCALayer::LayerType::LayerTypeCustom:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm
@@ -88,6 +88,9 @@ RefPtr<RemoteLayerTreeNode> RemoteLayerTreeHost::makeNode(const RemoteLayerTreeT
 
 #if HAVE(MATERIAL_HOSTING)
     case PlatformCALayer::LayerType::LayerTypeMaterialHostingLayer: {
+        if (![WKMaterialHostingSupport isMaterialHostingAvailable])
+            return makeWithView(adoptNS([[WKCompositingView alloc] init]));
+
         return makeWithView([[WKMaterialHostingView alloc] init]);
     }
 #endif


### PR DESCRIPTION
#### dfce27af3c4a97d6ca3dc23636f43501a0a68bc2
<pre>
Fix internal iOS builds following 290280@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=287807">https://bugs.webkit.org/show_bug.cgi?id=287807</a>
<a href="https://rdar.apple.com/144991668">rdar://144991668</a>

Reviewed by Abrar Rahman Protyasha.

SwiftUI.framework is unavailable in some images where WebKit.framework is
available. Weak link SwiftUI to avoid build failures in those places.

* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h:

Introduce an availability check to avoid crashing in places where SwiftUI
is unavailable.

* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
(WKMaterialHostingSupport.isMaterialHostingAvailable):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.mm:
(WebKit::RemoteLayerTreeHost::makeNode):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeHostIOS.mm:
(WebKit::RemoteLayerTreeHost::makeNode):

Canonical link: <a href="https://commits.webkit.org/290493@main">https://commits.webkit.org/290493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae6a2239618cd654997ae09167a5adb032e1953b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95226 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41001 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18067 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93226 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/49818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97051 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17413 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78454 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77659 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17423 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/18948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->