### PR TITLE
[Materials] Add support for a more translucent hosted material

### DIFF
--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2021,6 +2021,8 @@ constexpr CSSValueID toCSSValueID(AppleVisualEffect effect)
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
         return CSSValueAppleSystemHostedBlurMaterial;
+    case AppleVisualEffect::HostedThinBlurMaterial:
+        return CSSValueAppleSystemHostedThinBlurMaterial;
 #endif
     case AppleVisualEffect::VibrancyLabel:
         return CSSValueAppleSystemVibrancyLabel;
@@ -2061,6 +2063,8 @@ template<> constexpr AppleVisualEffect fromCSSValueID(CSSValueID valueID)
 #if HAVE(MATERIAL_HOSTING)
     case CSSValueAppleSystemHostedBlurMaterial:
         return AppleVisualEffect::HostedBlurMaterial;
+    case CSSValueAppleSystemHostedThinBlurMaterial:
+        return AppleVisualEffect::HostedThinBlurMaterial;
 #endif
     case CSSValueAppleSystemVibrancyLabel:
         return AppleVisualEffect::VibrancyLabel;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp
@@ -45,6 +45,7 @@ static bool isKeywordValidForAppleVisualEffect(CSSValueID keyword)
     case CSSValueID::CSSValueAppleSystemBlurMaterialUltraThin:
 #if HAVE(MATERIAL_HOSTING)
     case CSSValueID::CSSValueAppleSystemHostedBlurMaterial:
+    case CSSValueID::CSSValueAppleSystemHostedThinBlurMaterial:
 #endif
     case CSSValueID::CSSValueAppleSystemVibrancyFill:
     case CSSValueID::CSSValueAppleSystemVibrancyLabel:

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -44,6 +44,7 @@ bool appleVisualEffectNeedsBackdrop(AppleVisualEffect effect)
     case AppleVisualEffect::None:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::HostedThinBlurMaterial:
 #endif
     case AppleVisualEffect::VibrancyLabel:
     case AppleVisualEffect::VibrancySecondaryLabel:
@@ -71,6 +72,7 @@ bool appleVisualEffectAppliesFilter(AppleVisualEffect effect)
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::HostedThinBlurMaterial:
 #endif
         return false;
     case AppleVisualEffect::VibrancyLabel:
@@ -93,6 +95,7 @@ bool appleVisualEffectIsHostedMaterial(AppleVisualEffect effect)
 {
     switch (effect) {
     case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::HostedThinBlurMaterial:
         return true;
     case AppleVisualEffect::None:
     case AppleVisualEffect::BlurUltraThinMaterial:
@@ -140,6 +143,9 @@ TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
         ts << "hosted-blur-material";
+        break;
+    case AppleVisualEffect::HostedThinBlurMaterial:
+        ts << "hosted-thin-blur-material";
         break;
 #endif
     case AppleVisualEffect::VibrancyLabel:

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -44,6 +44,7 @@ enum class AppleVisualEffect : uint8_t {
     BlurChromeMaterial,
 #if HAVE(MATERIAL_HOSTING)
     HostedBlurMaterial,
+    HostedThinBlurMaterial,
 #endif
     VibrancyLabel,
     VibrancySecondaryLabel,

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
@@ -35,6 +35,12 @@
 @class UIView;
 #endif
 
+typedef NS_ENUM(NSInteger, WKHostedMaterialEffectType) {
+    WKHostedMaterialEffectTypeNone,
+    WKHostedMaterialEffectTypeBlur,
+    WKHostedMaterialEffectTypeThinBlur,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_UI_ACTOR
@@ -43,12 +49,12 @@ NS_SWIFT_UI_ACTOR
 + (BOOL)isMaterialHostingAvailable;
 
 + (CALayer *)createHostingLayer;
-+ (void)updateHostingLayer:(CALayer *)hostingLayer cornerRadius:(CGFloat)cornerRadius;
++ (void)updateHostingLayer:(CALayer *)hostingLayer materialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius;
 + (nullable CALayer *)contentLayerForMaterialHostingLayer:(CALayer *)hostingLayer;
 
 #if PLATFORM(IOS_FAMILY)
 + (UIView *)createHostingView:(UIView *)contentView;
-+ (void)updateHostingView:(UIView *)hostingView contentView:(UIView *)contentView cornerRadius:(CGFloat)cornerRadius;
++ (void)updateHostingView:(UIView *)hostingView contentView:(UIView *)contentView materialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius;
 #endif
 
 @end

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -167,6 +167,7 @@ static MTCoreMaterialRecipe materialRecipeForAppleVisualEffect(AppleVisualEffect
         return PAL::get_CoreMaterial_MTCoreMaterialRecipeNone();
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::HostedThinBlurMaterial:
 #endif
     case AppleVisualEffect::VibrancyLabel:
     case AppleVisualEffect::VibrancySecondaryLabel:
@@ -205,6 +206,7 @@ static MTCoreMaterialVisualStyle materialVisualStyleForAppleVisualEffect(AppleVi
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::HostedThinBlurMaterial:
 #endif
         ASSERT_NOT_REACHED();
         return nil;
@@ -232,11 +234,42 @@ static MTCoreMaterialVisualStyleCategory materialVisualStyleCategoryForAppleVisu
     case AppleVisualEffect::BlurChromeMaterial:
 #if HAVE(MATERIAL_HOSTING)
     case AppleVisualEffect::HostedBlurMaterial:
+    case AppleVisualEffect::HostedThinBlurMaterial:
 #endif
         ASSERT_NOT_REACHED();
         return nil;
     }
 }
+
+#if HAVE(MATERIAL_HOSTING)
+
+static WKHostedMaterialEffectType hostedMaterialEffectTypeForAppleVisualEffect(AppleVisualEffect effect)
+{
+    switch (effect) {
+    case AppleVisualEffect::HostedBlurMaterial:
+        return WKHostedMaterialEffectTypeBlur;
+    case AppleVisualEffect::HostedThinBlurMaterial:
+        return WKHostedMaterialEffectTypeThinBlur;
+    case AppleVisualEffect::None:
+    case AppleVisualEffect::BlurUltraThinMaterial:
+    case AppleVisualEffect::BlurThinMaterial:
+    case AppleVisualEffect::BlurMaterial:
+    case AppleVisualEffect::BlurThickMaterial:
+    case AppleVisualEffect::BlurChromeMaterial:
+    case AppleVisualEffect::VibrancyLabel:
+    case AppleVisualEffect::VibrancySecondaryLabel:
+    case AppleVisualEffect::VibrancyTertiaryLabel:
+    case AppleVisualEffect::VibrancyQuaternaryLabel:
+    case AppleVisualEffect::VibrancyFill:
+    case AppleVisualEffect::VibrancySecondaryFill:
+    case AppleVisualEffect::VibrancyTertiaryFill:
+    case AppleVisualEffect::VibrancySeparator:
+        ASSERT_NOT_REACHED();
+        return WKHostedMaterialEffectTypeNone;
+    }
+}
+
+#endif
 
 static void applyVisualStylingToLayer(CALayer *layer, AppleVisualEffect material, AppleVisualEffect visualStyling)
 {
@@ -295,11 +328,11 @@ static void updateAppleVisualEffect(CALayer *layer, RemoteLayerTreeNode* layerTr
 #if PLATFORM(IOS_FAMILY)
         if (layerTreeNode) {
             if (RetainPtr materialHostingView = dynamic_objc_cast<WKMaterialHostingView>(layerTreeNode->uiView()))
-                [materialHostingView updateCornerRadius:cornerRadius];
+                [materialHostingView updateMaterialEffectType:hostedMaterialEffectTypeForAppleVisualEffect(effectData.effect) cornerRadius:cornerRadius];
         }
 #endif
 
-        [WKMaterialHostingSupport updateHostingLayer:layer cornerRadius:cornerRadius];
+        [WKMaterialHostingSupport updateHostingLayer:layer materialEffectType:hostedMaterialEffectTypeForAppleVisualEffect(effectData.effect) cornerRadius:cornerRadius];
     }
 #endif // HAVE(MATERIAL_HOSTING)
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8027,6 +8027,7 @@ enum class WebCore::AppleVisualEffect : uint8_t {
     BlurChromeMaterial,
 #if HAVE(MATERIAL_HOSTING)
     HostedBlurMaterial,
+    HostedThinBlurMaterial,
 #endif
     VibrancyLabel,
     VibrancySecondaryLabel,

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -27,6 +27,9 @@
 
 #import "UIKitSPI.h"
 #import "WKBaseScrollView.h"
+#if HAVE(MATERIAL_HOSTING)
+#import "WKMaterialHostingSupport.h"
+#endif
 #import <wtf/OptionSet.h>
 
 OBJC_CLASS UIScrollView;
@@ -74,7 +77,7 @@ class WebPageProxy;
 @property (nonatomic, readonly) UIView *contentView;
 
 - (void)updateHostingSize:(WebCore::FloatSize)size;
-- (void)updateCornerRadius:(CGFloat)cornerRadius;
+- (void)updateMaterialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius;
 
 @end
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -45,10 +45,6 @@
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-#if HAVE(MATERIAL_HOSTING)
-#import "WKMaterialHostingSupport.h"
-#endif
-
 namespace WTF {
 
 static std::optional<RetainPtr<UIView>> makeVectorElement(const RetainPtr<UIView>*, UIView *arrayElement)
@@ -427,9 +423,9 @@ static Class scrollViewScrollIndicatorClass()
     [_hostingView setFrame:CGRectMake(0, 0, size.width(), size.height())];
 }
 
-- (void)updateCornerRadius:(CGFloat)cornerRadius
+- (void)updateMaterialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius
 {
-    [WKMaterialHostingSupport updateHostingView:_hostingView.get() contentView:_contentView.get() cornerRadius:cornerRadius];
+    [WKMaterialHostingSupport updateHostingView:_hostingView.get() contentView:_contentView.get() materialEffectType:materialEffectType cornerRadius:cornerRadius];
 }
 
 @end


### PR DESCRIPTION
#### 17938d9bea0a62be0d39331598dd4929aa8407d4
<pre>
[Materials] Add support for a more translucent hosted material
<a href="https://bugs.webkit.org/show_bug.cgi?id=287818">https://bugs.webkit.org/show_bug.cgi?id=287818</a>
<a href="https://rdar.apple.com/145005735">rdar://145005735</a>

Reviewed by Abrar Rahman Protyasha.

Introduce support for another type of hosted material, which is more translucent
than the material introduced in 290280@main.

* Source/WebCore/css/CSSPrimitiveValueMappings.h:
(WebCore::toCSSValueID):
(WebCore::fromCSSValueID):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+AppleVisualEffect.cpp:
(WebCore::CSSPropertyParserHelpers::isKeywordValidForAppleVisualEffect):
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::appleVisualEffectNeedsBackdrop):
(WebCore::appleVisualEffectAppliesFilter):
(WebCore::appleVisualEffectIsHostedMaterial):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h:

Introduce an enum to configure the type of hosted material.

* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
(MaterialHostingView.resolvedMaterialEffect(for:)):

Resolve the material type into a SwiftUI material.

(MaterialHostingView.body):

Apply the now-configurable material effect.

(CALayer.materialHostingContentLayer):

Drive-by fix. Remove unnecessary guard statement.

(WKMaterialHostingSupport.updateHostingLayer(_:materialEffectType:cornerRadius:)):
(WKMaterialHostingSupport.updateHostingView(_:contentView:materialEffectType:cornerRadius:)):
(WKMaterialHostingSupport.updateHostingLayer(_:cornerRadius:)): Deleted.
(WKMaterialHostingSupport.updateHostingView(_:contentView:cornerRadius:)): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::materialVisualStyleForAppleVisualEffect):
(WebKit::materialVisualStyleCategoryForAppleVisualEffect):
(WebKit::hostedMaterialEffectTypeForAppleVisualEffect):
(WebKit::updateAppleVisualEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(-[WKMaterialHostingView updateMaterialEffectType:cornerRadius:]):
(-[WKMaterialHostingView updateCornerRadius:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/290537@main">https://commits.webkit.org/290537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee63691d827ac6cb7bd205c5f39b7e1b4d1c28e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9775 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95249 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41022 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69473 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27070 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49833 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36241 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40153 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77845 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBSuspendImminently (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97074 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12829 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78471 "Failed to checkout and rebase branch from PR 40720") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77729 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22142 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10693 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14210 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17444 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22771 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18969 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->