### PR TITLE
Address unexpected safer CPP static analysis failure in ClassChangeInvalidation on the bot

### DIFF
--- a/Source/WebCore/style/ClassChangeInvalidation.cpp
+++ b/Source/WebCore/style/ClassChangeInvalidation.cpp
@@ -106,11 +106,11 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
 
     if (mayAffectStyleInShadowTree) {
         // FIXME: We should do fine-grained invalidation for shadow tree.
-        m_element.invalidateStyleForSubtree();
+        m_element->invalidateStyleForSubtree();
     }
 
     if (shouldInvalidateCurrent)
-        m_element.invalidateStyle();
+        m_element->invalidateStyle();
 
     auto invalidateBeforeAndAfterChange = [](MatchElement matchElement) {
         switch (matchElement) {
@@ -168,9 +168,9 @@ void ClassChangeInvalidation::computeInvalidation(const SpaceSplitString& oldCla
         }
     };
 
-    collect(m_element.styleResolver().ruleSets());
+    collect(m_element->styleResolver().ruleSets());
 
-    if (auto* shadowRoot = m_element.shadowRoot())
+    if (auto* shadowRoot = m_element->shadowRoot())
         collect(shadowRoot->styleScope().resolver().ruleSets(), MatchElement::Host);
 }
 

--- a/Source/WebCore/style/ClassChangeInvalidation.h
+++ b/Source/WebCore/style/ClassChangeInvalidation.h
@@ -37,7 +37,7 @@ namespace Style {
 
 class ClassChangeInvalidation {
 public:
-    ClassChangeInvalidation(Element&, const SpaceSplitString& oldClasses, const SpaceSplitString& newClasses);
+    ClassChangeInvalidation(Ref<Element>&&, const SpaceSplitString& oldClasses, const SpaceSplitString& newClasses);
     ~ClassChangeInvalidation();
 
 private:
@@ -46,15 +46,15 @@ private:
     void invalidateAfterChange();
 
     const bool m_isEnabled;
-    Element& m_element;
+    const Ref<Element> m_element;
 
     Invalidator::MatchElementRuleSets m_beforeChangeRuleSets;
     Invalidator::MatchElementRuleSets m_afterChangeRuleSets;
 };
 
-inline ClassChangeInvalidation::ClassChangeInvalidation(Element& element, const SpaceSplitString& oldClasses, const SpaceSplitString& newClasses)
-    : m_isEnabled(element.needsStyleInvalidation())
-    , m_element(element)
+inline ClassChangeInvalidation::ClassChangeInvalidation(Ref<Element>&& element, const SpaceSplitString& oldClasses, const SpaceSplitString& newClasses)
+    : m_isEnabled(element->needsStyleInvalidation())
+    , m_element(WTFMove(element))
 
 {
     if (!m_isEnabled)


### PR DESCRIPTION
#### 630aa3f1d40ffd14d64c6e7f51ba183a11f4474f
<pre>
Address unexpected safer CPP static analysis failure in ClassChangeInvalidation on the bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=287821">https://bugs.webkit.org/show_bug.cgi?id=287821</a>

Reviewed by Basuke Suzuki and Ryosuke Niwa.

* Source/WebCore/style/ClassChangeInvalidation.cpp:
(WebCore::Style::ClassChangeInvalidation::computeInvalidation):
* Source/WebCore/style/ClassChangeInvalidation.h:
(WebCore::Style::ClassChangeInvalidation::ClassChangeInvalidation):

Canonical link: <a href="https://commits.webkit.org/290505@main">https://commits.webkit.org/290505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c35f014ccec2050a3252cb4dd3b268cb73cb599f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45171 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92300 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93249 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81873 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49834 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7514 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77843 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17436 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77680 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19181 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20748 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17446 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20639 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->