### PR TITLE
Remove SPI that returns a DownloadProxy wrapper synchronously

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKContext.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKContext.cpp
@@ -256,16 +256,6 @@ void WKContextSetDownloadClient(WKContextRef context, const WKContextDownloadCli
     WebKit::toImpl(context)->setLegacyDownloadClient(adoptRef(*new LegacyDownloadClient(wkClient, context)));
 }
 
-WKDownloadRef WKContextDownloadURLRequest(WKContextRef, WKURLRequestRef)
-{
-    return nullptr;
-}
-
-WKDownloadRef WKContextResumeDownload(WKContextRef, WKDataRef, WKStringRef)
-{
-    return nullptr;
-}
-
 void WKContextSetInitializationUserDataForInjectedBundle(WKContextRef contextRef,  WKTypeRef userDataRef)
 {
     WebKit::toImpl(contextRef)->setInjectedBundleInitializationUserData(WebKit::toImpl(userDataRef));

--- a/Source/WebKit/UIProcess/API/C/WKContext.h
+++ b/Source/WebKit/UIProcess/API/C/WKContext.h
@@ -163,9 +163,6 @@ WK_EXPORT void WKContextSetInjectedBundleClient(WKContextRef context, const WKCo
 WK_EXPORT void WKContextSetHistoryClient(WKContextRef context, const WKContextHistoryClientBase* client);
 WK_EXPORT void WKContextSetDownloadClient(WKContextRef context, const WKContextDownloadClientBase* client) WK_C_API_DEPRECATED_WITH_REPLACEMENT(WKDownload);
 
-WK_EXPORT WKDownloadRef WKContextDownloadURLRequest(WKContextRef context, WKURLRequestRef request) WK_C_API_DEPRECATED;
-WK_EXPORT WKDownloadRef WKContextResumeDownload(WKContextRef context, WKDataRef resumeData, WKStringRef path) WK_C_API_DEPRECATED;
-
 WK_EXPORT void WKContextSetInitializationUserDataForInjectedBundle(WKContextRef context, WKTypeRef userData);
 WK_EXPORT void WKContextPostMessageToInjectedBundle(WKContextRef context, WKStringRef messageName, WKTypeRef messageBody);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -585,16 +585,6 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 }
 #endif // PLATFORM(IOS_FAMILY)
 
-- (_WKDownload *)_downloadURLRequest:(NSURLRequest *)request websiteDataStore:(WKWebsiteDataStore *)dataStore originatingWebView:(WKWebView *)webView
-{
-    return [_WKDownload downloadWithDownload:wrapper(_processPool->download(*dataStore->_websiteDataStore, [webView _page], request)).get()];
-}
-
-- (_WKDownload *)_resumeDownloadFromData:(NSData *)resumeData websiteDataStore:(WKWebsiteDataStore *)dataStore  path:(NSString *)path originatingWebView:(WKWebView *)webView
-{
-    return [_WKDownload downloadWithDownload:wrapper(_processPool->resumeDownload(*dataStore->_websiteDataStore, [webView _page], API::Data::createWithoutCopying(resumeData).get(), path, WebKit::CallDownloadDidStart::No)).get()];
-}
-
 - (void)_getActivePagesOriginsInWebProcessForTesting:(pid_t)pid completionHandler:(void(^)(NSArray<NSString *> *))completionHandler
 {
     _processPool->activePagesOriginsInWebProcessForTesting(pid, [completionHandler = makeBlockPtr(completionHandler)] (Vector<String>&& activePagesOrigins) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -122,9 +122,6 @@ WK_CLASS_AVAILABLE(macos(14.5), ios(17.5), visionos(1.2))
 - (void)_registerURLSchemeAsBypassingContentSecurityPolicy:(NSString *)scheme WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (void)_setDomainRelaxationForbiddenForURLScheme:(NSString *)scheme WK_API_AVAILABLE(macos(12.0), ios(15.0));
 
-- (_WKDownload *)_downloadURLRequest:(NSURLRequest *)request websiteDataStore:(WKWebsiteDataStore *)dataStore originatingWebView:(WKWebView *)webView WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebView _downloadRequest", macos(10.10, 12.0), ios(8.0, 15.0));
-- (_WKDownload *)_resumeDownloadFromData:(NSData *)resumeData websiteDataStore:(WKWebsiteDataStore *)dataStore  path:(NSString *)path originatingWebView:(WKWebView *)webView WK_API_DEPRECATED_WITH_REPLACEMENT("WKWebView.resumeDownloadFromResumeData:completionHandler:", macos(10.10, 12.0), ios(8.0, 15.0));
-
 + (void)_setLinkedOnOrAfterEverything WK_API_AVAILABLE(macos(13.0), ios(16.0));
 
 // Test only. Should be called only while no web content processes are running.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm
@@ -46,7 +46,6 @@
 enum class DownloadStartType {
     ConvertLoadToDownload,
     StartFromNavigationAction,
-    StartInProcessPool,
 };
 
 @interface DownloadProgressTestRunner : NSObject <WKNavigationDelegate, _WKDownloadDelegate>
@@ -256,9 +255,6 @@ static void* progressObservingContext = &progressObservingContext;
     case DownloadStartType::StartFromNavigationAction:
         [m_webView loadRequest:request.get()];
         break;
-    case DownloadStartType::StartInProcessPool:
-        [m_webView.get().configuration.processPool _downloadURLRequest:request.get() websiteDataStore:[WKWebsiteDataStore defaultDataStore] originatingWebView:nullptr];
-        break;
     }
 
     TestWebKitAPI::Util::run(&m_downloadStarted);
@@ -432,21 +428,6 @@ TEST(DownloadProgress, StartDownloadFromNavigationAction)
     auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
 
     [testRunner.get() startDownload:DownloadStartType::StartFromNavigationAction expectedLength:100];
-    [testRunner.get() publishProgress];
-    [testRunner.get() subscribeAndWaitForProgress];
-    [testRunner.get() receiveData:100];
-    [testRunner.get() finishDownloadTask];
-    [testRunner.get() waitForDownloadFinished];
-    [testRunner.get() waitToLoseProgress];
-
-    [testRunner.get() tearDown];
-}
-
-TEST(DownloadProgress, StartDownloadInProcessPool)
-{
-    auto testRunner = adoptNS([[DownloadProgressTestRunner alloc] init]);
-
-    [testRunner.get() startDownload:DownloadStartType::StartInProcessPool expectedLength:100];
     [testRunner.get() publishProgress];
     [testRunner.get() subscribeAndWaitForProgress];
     [testRunner.get() receiveData:100];


### PR DESCRIPTION
#### 5da6fad1731a883b7509969a04421c52750ffa41
<pre>
Remove SPI that returns a DownloadProxy wrapper synchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=287822">https://bugs.webkit.org/show_bug.cgi?id=287822</a>
<a href="https://rdar.apple.com/145007201">rdar://145007201</a>

Reviewed by Per Arne Vollan.

There are 4 ways to make a download:
1. WKWebView.startDownloadUsingRequest
2. WKWebView.resumeDownloadFromResumeData
3. WKNavigationActionPolicyDownload
4. WKNavigationResponsePolicyDownload
They all give the API surface the download object asynchronously.
We have some unused SPI that returns the download synchronously.
Let&apos;s get rid of them.  This will allow me to do some needed cleanup.

* Source/WebKit/UIProcess/API/C/WKContext.cpp:
(WKContextDownloadURLRequest): Deleted.
(WKContextResumeDownload): Deleted.
* Source/WebKit/UIProcess/API/C/WKContext.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _downloadURLRequest:websiteDataStore:originatingWebView:]): Deleted.
(-[WKProcessPool _resumeDownloadFromData:websiteDataStore:path:originatingWebView:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(-[DownloadObserver observeValueForKeyPath:ofObject:change:context:]):
(-[DownloadCancelingDelegate download:decideDestinationUsingResponse:suggestedFilename:completionHandler:]):
(-[AuthenticationChallengeHandlingDelegate download:decideDestinationUsingResponse:suggestedFilename:completionHandler:]):
(-[AuthenticationChallengeHandlingDelegate download:didReceiveAuthenticationChallenge:completionHandler:]):
(-[AuthenticationChallengeHandlingDelegate downloadDidFinish:]):
(TEST(WKDownload, ResumedDownloadCanHandleAuthenticationChallenge)):
(TEST(WKDownload, Resume)):
(-[DownloadCancelingDelegate _download:decideDestinationWithSuggestedFilename:completionHandler:]): Deleted.
(-[DownloadCancelingDelegate _download:didReceiveData:]): Deleted.
(-[DownloadCancelingDelegate _downloadDidCancel:]): Deleted.
(-[AuthenticationChallengeHandlingDelegate _download:didReceiveAuthenticationChallenge:completionHandler:]): Deleted.
(-[AuthenticationChallengeHandlingDelegate _downloadDidFinish:]): Deleted.
(TEST(_WKDownload, ResumedDownloadCanHandleAuthenticationChallenge)): Deleted.
(TEST(_WKDownload, Resume)): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DownloadProgress.mm:
(-[DownloadProgressTestRunner startDownload:expectedLength:]):
(TEST(DownloadProgress, StartDownloadInProcessPool)): Deleted.

Canonical link: <a href="https://commits.webkit.org/290510@main">https://commits.webkit.org/290510@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6ad8e9b16706afedb01643459cb6aa6879f7e2d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95255 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41028 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92304 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27074 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93253 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7796 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49837 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36251 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40159 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97080 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17440 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78475 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77681 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20754 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10699 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14192 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17450 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17191 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/18975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->