### PR TITLE
[iOS] Add TestWKWebViewHostWindow to TestWebKitAPI.app's UIWindowScene

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/HostWindowManager.mm
+++ b/Tools/TestWebKitAPI/cocoa/HostWindowManager.mm
@@ -57,6 +57,7 @@ void HostWindowManager::OnTestEnd(const testing::TestInfo&)
         [hostWindow close];
 #else
         [hostWindow setHidden:YES];
+        [hostWindow setWindowScene:nil];
 #endif
     }
 }

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -930,6 +930,17 @@ static InputSessionChangeCount nextInputSessionChangeCount()
     return self;
 }
 
+#if PLATFORM(IOS_FAMILY)
+static UIWindowScene *windowScene()
+{
+    for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+        if ([scene isKindOfClass:UIWindowScene.class])
+            return (UIWindowScene *)scene;
+    }
+    return nil;
+}
+#endif
+
 - (instancetype)initWithFrame:(CGRect)frame configuration:(WKWebViewConfiguration *)configuration processPoolConfiguration:(_WKProcessPoolConfiguration *)processPoolConfiguration
 {
     [configuration setProcessPool:adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration]).get()];
@@ -950,6 +961,8 @@ static InputSessionChangeCount nextInputSessionChangeCount()
     [hostWindow makeKeyAndOrderFront:self];
 #else
     hostWindow = adoptNS([[TestWKWebViewHostWindow alloc] initWithWebView:self frame:frame]);
+    if (UIWindowScene *windowScene = ::windowScene())
+        [hostWindow setWindowScene:windowScene];
     [hostWindow setHidden:NO];
     [hostWindow addSubview:self];
 #endif

--- a/Tools/TestWebKitAPI/mac/app/main.mm
+++ b/Tools/TestWebKitAPI/mac/app/main.mm
@@ -30,7 +30,6 @@
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
 + (instancetype)sharedAppDelegate;
-@property (nonatomic, strong) NSWindow *window;
 @end
 
 @implementation AppDelegate
@@ -43,15 +42,6 @@
         sharedAppDelegate = [[AppDelegate alloc] init];
     });
     return sharedAppDelegate;
-}
-
-- (void)applicationDidFinishLaunching:(NSNotification *)notification
-{
-    NSWindow *window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600) styleMask:NSWindowStyleMaskTitled backing:NSBackingStoreBuffered defer:NO];
-    window.title = @"TestWebKitAPI";
-    [window makeKeyAndOrderFront:nil];
-
-    self.window = window;
 }
 
 @end


### PR DESCRIPTION
#### a16dbe4f2e97dce9e4606e2288fa15d3e3229f68
<pre>
[iOS] Add TestWKWebViewHostWindow to TestWebKitAPI.app&apos;s UIWindowScene
<a href="https://bugs.webkit.org/show_bug.cgi?id=287827">https://bugs.webkit.org/show_bug.cgi?id=287827</a>
<a href="https://rdar.apple.com/145009790">rdar://145009790</a>

Reviewed by Abrar Rahman Protyasha.

Added newly-created TestWKWebViewHostWindows to the UIApplication&apos;s first connected UIWindowScene,
if one exists (it will in TestWebKitAPI.app but not in TestWebKitAPI). While here, removed the
placeholder window created when TestWebKitAPI.app finishes launching on macOS, since each test
is responsible for creating a window if it wants one.

* Tools/TestWebKitAPI/cocoa/HostWindowManager.mm:
(TestWebKitAPI::HostWindowManager::OnTestEnd):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(windowScene):
(-[TestWKWebView _setUpTestWindow:]):
* Tools/TestWebKitAPI/mac/app/main.mm:
(-[AppDelegate applicationDidFinishLaunching:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/290594@main">https://commits.webkit.org/290594@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5ffbef46935b4ca2f94d0ce40de359294f1f17d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90564 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95575 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18415 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69688 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50039 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40476 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97404 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17756 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19238 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22350 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17766 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19289 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->