### PR TITLE
REGRESSION(288455@main): Crash in WebCore::ImageBackingStore::clearRect when opening emoji chooser on Slack

### DIFF
--- a/Source/WebCore/platform/graphics/ImageBackingStore.h
+++ b/Source/WebCore/platform/graphics/ImageBackingStore.h
@@ -99,8 +99,9 @@ public:
 
         auto pixels = pixelsStartingAt(rect.x(), rect.y());
         for (int i = 0; i < rect.height(); ++i) {
+            if (i)
+                skip(pixels, m_size.width());
             zeroSpan(pixels.first(rect.width()));
-            skip(pixels, m_size.width());
         }
     }
 
@@ -112,9 +113,10 @@ public:
         auto pixels = pixelsStartingAt(rect.x(), rect.y());
         uint32_t pixelValue = this->pixelValue(r, g, b, a);
         for (int i = 0; i < rect.height(); ++i) {
+            if (i)
+                skip(pixels, m_size.width());
             for (int j = 0; j < rect.width(); ++j)
                 pixels[j] = pixelValue;
-            skip(pixels, m_size.width());
         }
     }
 
@@ -127,8 +129,9 @@ public:
         auto destinationPixels = sourcePixels.subspan(m_size.width());
         auto sourceRow = sourcePixels.first(rect.width());
         for (int i = 1; i < rect.height(); ++i) {
+            if (i != 1)
+                skip(destinationPixels, m_size.width());
             memcpySpan(destinationPixels, sourceRow);
-            skip(destinationPixels, m_size.width());
         }
     }
 


### PR DESCRIPTION
#### 32dd4c71d022ac4461a37ac5cc039c68f485006d
<pre>
REGRESSION(288455@main): Crash in WebCore::ImageBackingStore::clearRect when opening emoji chooser on Slack
<a href="https://bugs.webkit.org/show_bug.cgi?id=286477">https://bugs.webkit.org/show_bug.cgi?id=286477</a>

Reviewed by Chris Dumez.

The original code here would skip past the bounds of the array on the
final loop iteration, which was previously fine because we did not
actually dereference the array out of bounds. Now that we have switched
to span, it&apos;s no longer fine: creating a subspan out of bounds triggers
an assertion failure when built with stdlib assertions enabled.

* Source/WebCore/platform/graphics/ImageBackingStore.h:
(WebCore::ImageBackingStore::clearRect):
(WebCore::ImageBackingStore::fillRect):
(WebCore::ImageBackingStore::repeatFirstRow):

Canonical link: <a href="https://commits.webkit.org/290611@main">https://commits.webkit.org/290611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4505730e6699fec04b53cc9293944f9dd2f3044

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69642 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27210 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49990 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7694 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36423 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-auto-fill-columns-001.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40402 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78012 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17682 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12999 "Found 1 new test failure: imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78631 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77858 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19248 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20921 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17692 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23024 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17431 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20886 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->