### PR TITLE
[css-anchor-position-1] Trigger evaluation of default anchor when it's used for anchor-center

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7577,7 +7577,6 @@ webkit.org/b/282024 fast/text/text-box-edge-with-margin-padding-border-simple.ht
 # -- Anchor Positioning -- #
 
 # general failures
-imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-scroll.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-position-top-layer-005.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-offset-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-offset-change-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Anchored initially have the same width as the anchor assert_equals: expected 0 but got 100
-FAIL Increase the height of the anchor to move the anchor-center offset assert_equals: expected 50 but got 200
+PASS Anchored initially have the same width as the anchor
+PASS Increase the height of the anchor to move the anchor-center offset
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9574,7 +9574,8 @@
             "codegen-properties": {
                 "converter": "PositionAnchor",
                 "parser-grammar": "auto | <dashed-ident>",
-                "settings-flag": "cssAnchorPositioningEnabled"
+                "settings-flag": "cssAnchorPositioningEnabled",
+                "high-priority": true
             },
             "specification": {
                 "category": "css-anchor-position",

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2651,7 +2651,7 @@ void Element::invalidateForQueryContainerSizeChange()
 
 void Element::invalidateForAnchorRectChange()
 {
-    Node::invalidateStyle(Style::Validity::ElementInvalid);
+    Node::invalidateStyle(Style::Validity::ElementInvalid, Style::InvalidationMode::RebuildRenderer);
 }
 
 void Element::invalidateForResumingQueryContainerResolution()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -255,6 +255,10 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
             showRenderTree(renderView());
 #endif
     }
+
+    if (document())
+        Style::AnchorPositionEvaluator::updateAnchorPositioningStatesAfterInterleavedLayout(*document());
+
     {
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InViewSizeAdjust);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1874,7 +1874,7 @@ inline String BuilderConverter::convertSVGURIReference(BuilderState& builderStat
     return emptyString();
 }
 
-inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentData(BuilderState&, const CSSValue& value)
+inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentData(BuilderState& state, const CSSValue& value)
 {
     auto alignmentData = RenderStyle::initialSelfAlignment();
     if (value.isPair()) {
@@ -1891,6 +1891,10 @@ inline StyleSelfAlignmentData BuilderConverter::convertSelfOrDefaultAlignmentDat
         }
     } else
         alignmentData.setPosition(fromCSSValue<ItemPosition>(value));
+
+    if (alignmentData.position() == ItemPosition::AnchorCenter)
+        Style::AnchorPositionEvaluator::findAnchorAndAttemptResolution(state, { });
+
     return alignmentData;
 }
 


### PR DESCRIPTION
#### d52bf2b46c35b31e0beffdbbd12731cc3b823f4f
<pre>
[css-anchor-position-1] Trigger evaluation of default anchor when it&apos;s used for anchor-center
<a href="https://rdar.apple.com/140124449">rdar://140124449</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=283295">https://bugs.webkit.org/show_bug.cgi?id=283295</a>

Reviewed by NOBODY (OOPS!).

The way anchor positioning is implemented requires the anchor to be determined
at initial style resolution run, so that anchor can then be positioned at
initial layout run, which makes it available for use at the next style resolution
run. This works because anchor()/anchor-size() is implemented in both style
resolution and (indirectly) layout:
* at style resolution, anchor()/anchor-size() is evaluated, so we could collect
  the anchor used
* at layout, the collected anchors are positioned
* at the next style resolution, anchor()/anchor-size() is evaluated again, and
  the anchors are positioned, so they get resolved to an actual value
* at the next layout, the value of the expression that uses anchor()/anchor-size()
  changes, which triggers re-layout for that element.

anchor-center is purely implemented at layout stage only, so it doesn&apos;t have a
chance to inform the anchor positioning machinary about the dependency at style
resolution time. When it&apos;s time for layout, the layout code doesn&apos;t see
the anchor required for anchor-center.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-center-offset-change-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::invalidateForAnchorRectChange):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertSelfOrDefaultAlignmentData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d52bf2b46c35b31e0beffdbbd12731cc3b823f4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95283 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18126 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69502 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27091 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93281 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7817 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49863 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7541 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36271 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/import/struct-dom-08-f-manual.svg (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40187 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97108 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17468 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78504 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/89865 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77729 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77714 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20772 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10727 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22805 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17219 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->