### PR TITLE
[Grid] Crash in gridAreaPositionForOutOfFlowGridItem during consecutive occurrences of simplified layout

### DIFF
--- a/LayoutTests/fast/css-grid-layout/simplified-layout-consecutive-with-oof-children-crash-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/simplified-layout-consecutive-with-oof-children-crash-expected.txt
@@ -1,0 +1,2 @@
+This test passes if it does not crash.
+

--- a/LayoutTests/fast/css-grid-layout/simplified-layout-consecutive-with-oof-children-crash.html
+++ b/LayoutTests/fast/css-grid-layout/simplified-layout-consecutive-with-oof-children-crash.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<style>
+  .grid {
+    display: grid;
+    position: relative;
+    transform: translate(10px);
+  }
+  .abspos {
+    position: absolute;
+  }
+  .removeFromGrid {
+    grid-column: 1;
+  }
+</style>
+<body>
+  This test passes if it does not crash.
+    <div class="grid">
+      <div class="removeFromGrid abspos"></div>
+      <div class="removeFromGrid abspos"></div>
+      <div class="removeFromGrid abspos"></div>
+    </div>
+<script>
+let grid = document.querySelector(".grid");
+
+for (let i = 0; i < 100; ++i) {
+  let newElement = document.createElement("div");
+  newElement.classList += "abspos";
+  grid.appendChild(newElement);
+}
+document.body.offsetHeight;
+
+let elementsToRemove = Array.from(document.getElementsByClassName("removeFromGrid"));
+
+grid.removeChild(elementsToRemove.pop());
+document.body.offsetHeight;
+
+elementsToRemove.forEach(elementToRemove => {
+  grid.removeChild(elementToRemove);
+});
+document.body.offsetHeight;
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -39,6 +39,7 @@
 #include "RenderLayoutState.h"
 #include "RenderTreeBuilder.h"
 #include "RenderView.h"
+#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -312,6 +313,11 @@ void RenderGrid::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
 {
     ASSERT(needsLayout());
 
+    auto postLayoutTasks = WTF::makeScopeExit([&] {
+        m_outOfFlowItemColumn.clear();
+        m_outOfFlowItemRow.clear();
+    });
+
     if (relayoutChildren ==RelayoutChildren::No && simplifiedLayout())
         return;
 
@@ -439,8 +445,6 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
         else
             layoutPositionedObjects(relayoutChildren);
 
-        m_outOfFlowItemColumn.clear();
-        m_outOfFlowItemRow.clear();
         m_trackSizingAlgorithm.reset();
 
         computeOverflow(layoutOverflowLogicalBottom(*this));
@@ -577,8 +581,6 @@ void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
         else
             layoutPositionedObjects(relayoutChildren);
 
-        m_outOfFlowItemColumn.clear();
-        m_outOfFlowItemRow.clear();
         m_trackSizingAlgorithm.reset();
 
         computeOverflow(layoutOverflowLogicalBottom(*this));


### PR DESCRIPTION
#### a2043fd47c108e0a5a7ef9a96de6d963356f4224
<pre>
[Grid] Crash in gridAreaPositionForOutOfFlowGridItem during consecutive occurrences of simplified layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=287832">https://bugs.webkit.org/show_bug.cgi?id=287832</a>
<a href="https://rdar.apple.com/144491217">rdar://144491217</a>

Reviewed by Alan Baradlay.

In 289863@main, we fixed a bug where we hit a RELEASE_ASSERT when going from performing
grid layout to subsequently performing simplified layout due to some content mutation.
This was because we have a HashMap that uses a WeakRef&lt;const RenderBox&gt; and were not
properly cleaning it up at the end of layout.

This patch fixes another variation of that same bug, but this time the content mutation
ends up causing us to perform simplified layout consecutively. Since we do not clear the
map at the end of simplified layout, we end up running into the exact same bug. To fix this
(and hopefully any other variations of this bug), we can create a &quot;postLayoutTasks,&quot;
ScopeExit at the beginning of RenderGrid::layoutBlock to handle any sort of cleanup that
we need to do at the end of grid layout. As of now, clearing these maps is the only thing
it is responsible for.

* LayoutTests/fast/css-grid-layout/simplified-layout-consecutive-with-oof-children-crash-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/simplified-layout-consecutive-with-oof-children-crash.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutBlock):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):

Canonical link: <a href="https://commits.webkit.org/290546@main">https://commits.webkit.org/290546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d12708a5aa24b281be6b864dfb17b52e19ee601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95401 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41171 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10312 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69581 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27160 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49940 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7624 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36358 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40303 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77966 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97233 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17583 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78574 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77797 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19214 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22248 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20856 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10850 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17593 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17334 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20786 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->