### PR TITLE
[SwiftUI] Support the `.scrollBounceBehavior` view modifier on WebView

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -68,6 +68,59 @@ extension WebPageWebView {
     }
 }
 
+extension WebPageWebView {
+    // MARK: Platform-agnostic scrolling capabilities
+
+#if canImport(UIKit)
+    @_spi(CrossImportOverlay)
+    public var alwaysBounceVertical: Bool {
+        get { scrollView.alwaysBounceVertical }
+        set { scrollView.alwaysBounceVertical = newValue }
+    }
+
+    @_spi(CrossImportOverlay)
+    public var alwaysBounceHorizontal: Bool {
+        get { scrollView.alwaysBounceHorizontal }
+        set { scrollView.alwaysBounceHorizontal = newValue }
+    }
+
+    @_spi(CrossImportOverlay)
+    public var bouncesVertically: Bool {
+        get { scrollView.bouncesVertically }
+        set { scrollView.bouncesVertically = newValue }
+    }
+
+    @_spi(CrossImportOverlay)
+    public var bouncesHorizontally: Bool {
+        get { scrollView.bouncesHorizontally }
+        set { scrollView.bouncesHorizontally = newValue }
+    }
+#else
+    @_spi(CrossImportOverlay)
+    public var alwaysBounceVertical: Bool {
+        get { self._alwaysBounceVertical }
+        set { self._alwaysBounceVertical = newValue }
+    }
+
+    @_spi(CrossImportOverlay)
+    public var alwaysBounceHorizontal: Bool {
+        get { self._alwaysBounceHorizontal }
+        set { self._alwaysBounceHorizontal = newValue }
+    }
+
+    @_spi(CrossImportOverlay)
+    public var bouncesVertically: Bool {
+        get { self._rubberBandingEnabled.contains(.top) && self._rubberBandingEnabled.contains(.bottom) }
+        set { self._rubberBandingEnabled.formUnion([.top, .bottom]) }
+    }
+
+    @_spi(CrossImportOverlay)
+    public var bouncesHorizontally: Bool {
+        get { self._rubberBandingEnabled.contains(.left) && self._rubberBandingEnabled.contains(.right) }
+        set { self._rubberBandingEnabled.formUnion([.left, .right]) }
+    }
+#endif
+}
 
 /// An object that controls and manages the behavior of interactive web content.
 @MainActor

--- a/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
@@ -27,4 +27,5 @@ enum AppStorageKeys {
     static let homepage = "homepage"
     static let orientationAndMotionAuthorization = "orientationAndMotionAuthorization2"
     static let mediaCaptureAuthorization = "mediaCaptureAuthorization2"
+    static let scrollBounceBehaviorBasedOnSize = "scrollBounceBehaviorBasedOnSize"
 }

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -216,6 +216,8 @@ struct ContentView: View {
     @Environment(\.openWindow) private var openWindow
     @Environment(BrowserViewModel.self) private var viewModel
 
+    @AppStorage(AppStorageKeys.scrollBounceBehaviorBasedOnSize) private var scrollBounceBehaviorBasedOnSize: Bool?
+
     #if os(iOS)
     private static let navigationToolbarItemPlacement = ToolbarItemPlacement.bottomBar
     #else
@@ -272,6 +274,7 @@ struct ContentView: View {
                     DownloadsList(downloads: viewModel.downloadCoordinator.downloads)
                         .presentationDetents([.medium, .large])
                 }
+                .scrollBounceBehavior(scrollBounceBehaviorBasedOnSize == true ? .basedOnSize : .automatic)
                 .webViewContextMenu { element in
                     if let url = element.linkURL {
                         Button("Open Link in New Window") {

--- a/Tools/SwiftBrowser/Source/Views/SettingsView.swift
+++ b/Tools/SwiftBrowser/Source/Views/SettingsView.swift
@@ -40,11 +40,26 @@ private struct PermissionDecisionView: View {
     }
 }
 
+private struct ScrollBounceBehaviorPicker: View {
+    @Binding var basedOnSize: Bool
+
+    var body: some View {
+        Picker(selection: $basedOnSize) {
+            Text("Automatic").tag(false)
+            Text("Based on Size").tag(true)
+        } label: {
+            Text("Scroll Bounce Behavior")
+        }
+    }
+}
+
 struct GeneralSettingsView: View {
     @AppStorage(AppStorageKeys.homepage) private var homepage = "https://www.webkit.org"
 
     @AppStorage(AppStorageKeys.orientationAndMotionAuthorization) private var orientationAndMotionAuthorization = WKPermissionDecision.prompt
     @AppStorage(AppStorageKeys.mediaCaptureAuthorization) private var mediaCaptureAuthorization = WKPermissionDecision.prompt
+
+    @AppStorage(AppStorageKeys.scrollBounceBehaviorBasedOnSize) private var scrollBounceBehaviorBasedOnSize = false
 
     let currentURL: URL?
 
@@ -73,6 +88,11 @@ struct GeneralSettingsView: View {
                     permissionDecision: $orientationAndMotionAuthorization,
                     label: "Allow sites to access sensors:"
                 )
+            }
+
+            Section {
+                ScrollBounceBehaviorPicker(basedOnSize: $scrollBounceBehaviorBasedOnSize)
+                    .padding(.top)
             }
         }
     }


### PR DESCRIPTION
#### c3e1a196e805cbc5014c5545930665766600ef0d
<pre>
[SwiftUI] Support the `.scrollBounceBehavior` view modifier on WebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=287849">https://bugs.webkit.org/show_bug.cgi?id=287849</a>
<a href="https://rdar.apple.com/145027003">rdar://145027003</a>

Reviewed by Aditya Keerthi.

Add support to make the `.scrollBounceBehavior` view modifier work for WebView, and use the functionality in SwiftBrowser.

For the implementation, the existing `verticalScrollBounceBehavior` and `horizontalScrollBounceBehavior` environment values
are used, both of which are `ScrollBounceBehavior` values. This type is an enum-like struct which does not conform to the
`Equatable` protocol. Consequently, a temporary workaround to test equality is used instead.

Platform-agnostic properties are added to `WebPageWebView` to propogate the values from the environment to either the UIScrollView
(iOS) or the WKWebView directly (macOS).

* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(WebPageWebView.alwaysBounceVertical):
(WebPageWebView.alwaysBounceHorizontal):
(WebPageWebView.bouncesVertically):
(WebPageWebView.bouncesHorizontally):
* Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
(WebViewRepresentable.sizeThatFits(_:platformView:context:)):
(WebViewRepresentable.sizeThatFits(_:uiView:context:)):
(WebViewRepresentable.sizeThatFits(_:nsView:context:)):
* Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift:
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.scrollBounceBehaviorBasedOnSize):
(ContentView.body):
* Tools/SwiftBrowser/Source/Views/SettingsView.swift:
(ScrollBounceBehaviorPicker.basedOnSize):
(ScrollBounceBehaviorPicker.body):
(GeneralSettingsView.body):

Canonical link: <a href="https://commits.webkit.org/290524@main">https://commits.webkit.org/290524@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1ed20880374c98d497e2270c37d201c2a43248a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90335 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95339 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92387 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18182 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/81944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/49894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40242 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/37380 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97163 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17780 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14201 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17533 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17274 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20726 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->