### PR TITLE
[macOS] Add infrastructure for drawing vector-based form controls

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8140,6 +8140,20 @@ VP9DecoderEnabled:
     WebKit:
       default: true
 
+VectorBasedControlsOnMacEnabled:
+  type: bool
+  status: internal
+  humanReadableName: "Vector based controls on macOS"
+  humanReadableDescription: "Enable vector based controls on macOS"
+  condition: ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+  defaultValue:
+    WebKit:
+      default: false
+    WebKitLegacy:
+      default: false
+    WebCore:
+      default: false
+
 VerifyWindowOpenUserGestureFromUIProcess:
   type: bool
   status: testable

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -49,6 +49,75 @@ protected:
     Color platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const override;
     Color platformGrammarMarkerColor(OptionSet<StyleColorOptions>) const override;
 
+    void adjustCheckboxStyle(RenderStyle&, const Element*) const override;
+    bool paintCheckbox(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustRadioStyle(RenderStyle&, const Element*) const override;
+    bool paintRadio(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustButtonStyle(RenderStyle&, const Element*) const override;
+    bool paintButton(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustColorWellStyle(RenderStyle&, const Element*) const override;
+    bool paintColorWell(const RenderObject&, const PaintInfo&, const IntRect&) override;
+    void paintColorWellDecorations(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustInnerSpinButtonStyle(RenderStyle&, const Element*) const override;
+
+    void adjustTextFieldStyle(RenderStyle&, const Element*) const override;
+    bool paintTextField(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    void paintTextFieldDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustTextAreaStyle(RenderStyle&, const Element*) const override;
+    bool paintTextArea(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    void paintTextAreaDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustMenuListStyle(RenderStyle&, const Element*) const override;
+    bool paintMenuList(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    void paintMenuListDecorations(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustMenuListButtonStyle(RenderStyle&, const Element*) const override;
+    void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustMeterStyle(RenderStyle&, const Element*) const override;
+    bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustListButtonStyle(RenderStyle&, const Element*) const override;
+    bool paintListButton(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+
+    void adjustProgressBarStyle(RenderStyle&, const Element*) const override;
+    bool paintProgressBar(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSliderTrackStyle(RenderStyle&, const Element*) const override;
+    bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSliderThumbStyle(RenderStyle&, const Element*) const override;
+    bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSearchFieldStyle(RenderStyle&, const Element*) const override;
+    bool paintSearchField(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    void paintSearchFieldDecorations(const RenderBox&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSearchFieldCancelButtonStyle(RenderStyle&, const Element*) const override;
+    bool paintSearchFieldCancelButton(const RenderBox&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSearchFieldDecorationPartStyle(RenderStyle&, const Element*) const override;
+    bool paintSearchFieldDecorationPart(const RenderObject&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSearchFieldResultsDecorationPartStyle(RenderStyle&, const Element*) const override;
+    bool paintSearchFieldResultsDecorationPart(const RenderBox&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const override;
+    bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const IntRect&) override;
+
+    void adjustSwitchStyle(RenderStyle&, const Element*) const override;
+    bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+    bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/RenderThemeCocoaAdditions.h>
+#endif
+
 private:
     void purgeCaches() override;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -293,4 +293,458 @@ Color RenderThemeCocoa::platformGrammarMarkerColor(OptionSet<StyleColorOptions> 
     return useDarkMode ? SRGBA<uint8_t> { 50, 215, 75, 217 } : SRGBA<uint8_t> { 25, 175, 50, 191 };
 }
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/RenderThemeCocoaAdditions.mm>
+#endif
+
+void RenderThemeCocoa::adjustCheckboxStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustCheckboxStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustCheckboxStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintCheckbox(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintCheckboxForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintCheckbox(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustRadioStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustRadioStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustRadioStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintRadio(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintRadioForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintRadio(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustButtonStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustButtonStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustButtonStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintButton(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintButtonForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintButton(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustColorWellStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustColorWellStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustColorWellStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintColorWell(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintColorWellForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintColorWell(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::paintColorWellDecorations(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintColorWellDecorationsForVectorBasedControls(box, paintInfo, rect))
+        return;
+#endif
+
+    RenderTheme::paintColorWellDecorations(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustInnerSpinButtonStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustInnerSpinButtonStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustInnerSpinButtonStyle(style, element);
+}
+
+void RenderThemeCocoa::adjustTextFieldStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustTextFieldStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustTextFieldStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintTextField(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintTextFieldForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintTextField(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::paintTextFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintTextFieldDecorationsForVectorBasedControls(box, paintInfo, rect))
+        return;
+#endif
+
+    RenderTheme::paintTextFieldDecorations(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustTextAreaStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustTextAreaStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustTextAreaStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintTextArea(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintTextAreaForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintTextArea(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::paintTextAreaDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintTextAreaDecorationsForVectorBasedControls(box, paintInfo, rect))
+        return;
+#endif
+
+    RenderTheme::paintTextAreaDecorations(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustMenuListStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustMenuListStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustMenuListStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintMenuList(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintMenuListForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintMenuList(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::paintMenuListDecorations(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintMenuListDecorationsForVectorBasedControls(box, paintInfo, rect))
+        return;
+#endif
+
+    RenderTheme::paintMenuListDecorations(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustMenuListButtonStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustMenuListButtonStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustMenuListButtonStyle(style, element);
+}
+
+void RenderThemeCocoa::paintMenuListButtonDecorations(const RenderBox& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintMenuListButtonDecorationsForVectorBasedControls(box, paintInfo, rect))
+        return;
+#endif
+
+    RenderTheme::paintMenuListButtonDecorations(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustMeterStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustMeterStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustMeterStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintMeter(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintMeterForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintMeter(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustListButtonStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustListButtonStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustListButtonStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintListButton(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintListButtonForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintListButton(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustProgressBarStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustProgressBarStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustProgressBarStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintProgressBar(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintProgressBarForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintProgressBar(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSliderTrackStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSliderTrackStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSliderTrackStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSliderTrackForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSliderTrack(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSliderThumbStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSliderThumbStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSliderThumbStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSliderThumb(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSliderThumbForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSliderThumb(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSearchFieldStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSearchFieldStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSearchFieldStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSearchField(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSearchFieldForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSearchField(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::paintSearchFieldDecorations(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSearchFieldDecorationsForVectorBasedControls(box, paintInfo, rect))
+        return;
+#endif
+
+    RenderTheme::paintSearchFieldDecorations(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSearchFieldCancelButtonStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSearchFieldCancelButtonStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSearchFieldCancelButtonStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSearchFieldCancelButton(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSearchFieldCancelButtonForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSearchFieldCancelButton(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSearchFieldDecorationPartStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSearchFieldDecorationPartStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSearchFieldDecorationPartStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSearchFieldDecorationPart(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSearchFieldDecorationPartForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSearchFieldDecorationPart(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSearchFieldResultsDecorationPartStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSearchFieldResultsDecorationPartStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSearchFieldResultsDecorationPartStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSearchFieldResultsDecorationPart(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSearchFieldResultsDecorationPartForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSearchFieldResultsDecorationPart(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSearchFieldResultsButtonStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSearchFieldResultsButtonStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSearchFieldResultsButtonStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSearchFieldResultsButton(const RenderBox& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSearchFieldResultsButtonForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSearchFieldResultsButton(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSwitchStyle(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSwitchStyleForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSwitchStyle(style, element);
+}
+
+bool RenderThemeCocoa::paintSwitchThumb(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSwitchThumbForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSwitchThumb(box, paintInfo, rect);
+}
+
+bool RenderThemeCocoa::paintSwitchTrack(const RenderObject& box, const PaintInfo& paintInfo, const FloatRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintSwitchTrackForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintSwitchTrack(box, paintInfo, rect);
+}
+
 }

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -607,7 +607,7 @@ void RenderThemeIOS::adjustSliderTrackStyle(RenderStyle& style, const Element* e
         return;
 #endif
 
-    RenderTheme::adjustSliderTrackStyle(style, element);
+    RenderThemeCocoa::adjustSliderTrackStyle(style, element);
 
     // FIXME: We should not be relying on border radius for the appearance of our controls <rdar://problem/7675493>.
     int radius = static_cast<int>(kTrackRadius);
@@ -880,7 +880,7 @@ void RenderThemeIOS::adjustSearchFieldStyle(RenderStyle& style, const Element* e
         return;
 #endif
 
-    RenderTheme::adjustSearchFieldStyle(style, element);
+    RenderThemeCocoa::adjustSearchFieldStyle(style, element);
 
     if (!element)
         return;

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -190,6 +190,11 @@ RenderThemeMac::RenderThemeMac()
 
 bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& renderer) const
 {
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (renderer.settings().vectorBasedControlsOnMacEnabled())
+        return RenderThemeCocoa::canCreateControlPartForRendererForVectorBasedControls(renderer);
+#endif
+
     auto type = renderer.style().usedAppearance();
     return type == StyleAppearance::Button
         || type == StyleAppearance::Checkbox
@@ -222,6 +227,11 @@ bool RenderThemeMac::canCreateControlPartForRenderer(const RenderObject& rendere
 
 bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& renderer) const
 {
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (renderer.settings().vectorBasedControlsOnMacEnabled())
+        return RenderThemeCocoa::canCreateControlPartForBorderOnlyForVectorBasedControls(renderer);
+#endif
+
     auto appearance = renderer.style().usedAppearance();
     return appearance == StyleAppearance::Listbox
         || appearance == StyleAppearance::TextArea
@@ -230,6 +240,11 @@ bool RenderThemeMac::canCreateControlPartForBorderOnly(const RenderObject& rende
 
 bool RenderThemeMac::canCreateControlPartForDecorations(const RenderObject& renderer) const
 {
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (renderer.settings().vectorBasedControlsOnMacEnabled())
+        return RenderThemeCocoa::canCreateControlPartForDecorationsForVectorBasedControls(renderer);
+#endif
+
     return renderer.style().usedAppearance() == StyleAppearance::MenulistButton;
 }
 
@@ -980,7 +995,7 @@ static std::span<const IntSize, 4> menuListButtonSizes()
 
 void RenderThemeMac::adjustMenuListStyle(RenderStyle& style, const Element* e) const
 {
-    RenderTheme::adjustMenuListStyle(style, e);
+    RenderThemeCocoa::adjustMenuListStyle(style, e);
     NSControlSize controlSize = controlSizeForFont(style);
 
     style.resetBorder();
@@ -1077,7 +1092,7 @@ void RenderThemeMac::adjustSliderTrackStyle(RenderStyle& style, const Element*) 
 
 void RenderThemeMac::adjustSliderThumbStyle(RenderStyle& style, const Element* element) const
 {
-    RenderTheme::adjustSliderThumbStyle(style, element);
+    RenderThemeCocoa::adjustSliderThumbStyle(style, element);
     style.setBoxShadow(nullptr);
 }
 


### PR DESCRIPTION
#### 586566172f22dcf68ded6de69a84b02bec239d5c
<pre>
[macOS] Add infrastructure for drawing vector-based form controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=287853">https://bugs.webkit.org/show_bug.cgi?id=287853</a>
<a href="https://rdar.apple.com/145032318">rdar://145032318</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

Introduce an experiment to draw vector-based controls on macOS, rather than
cell-based drawing via AppKit.

This is desirable for two reasons:
- Cells can only be rendered at fixed sizes, resulting in web compat issues
- Cell drawing can be expensive

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::adjustCheckboxStyle const):
(WebCore::RenderThemeCocoa::paintCheckbox):
(WebCore::RenderThemeCocoa::adjustRadioStyle const):
(WebCore::RenderThemeCocoa::paintRadio):
(WebCore::RenderThemeCocoa::adjustButtonStyle const):
(WebCore::RenderThemeCocoa::paintButton):
(WebCore::RenderThemeCocoa::adjustColorWellStyle const):
(WebCore::RenderThemeCocoa::paintColorWell):
(WebCore::RenderThemeCocoa::paintColorWellDecorations):
(WebCore::RenderThemeCocoa::adjustInnerSpinButtonStyle const):
(WebCore::RenderThemeCocoa::adjustTextFieldStyle const):
(WebCore::RenderThemeCocoa::paintTextField):
(WebCore::RenderThemeCocoa::paintTextFieldDecorations):
(WebCore::RenderThemeCocoa::adjustTextAreaStyle const):
(WebCore::RenderThemeCocoa::paintTextArea):
(WebCore::RenderThemeCocoa::paintTextAreaDecorations):
(WebCore::RenderThemeCocoa::adjustMenuListStyle const):
(WebCore::RenderThemeCocoa::paintMenuList):
(WebCore::RenderThemeCocoa::paintMenuListDecorations):
(WebCore::RenderThemeCocoa::adjustMenuListButtonStyle const):
(WebCore::RenderThemeCocoa::paintMenuListButtonDecorations):
(WebCore::RenderThemeCocoa::adjustMeterStyle const):
(WebCore::RenderThemeCocoa::paintMeter):
(WebCore::RenderThemeCocoa::adjustListButtonStyle const):
(WebCore::RenderThemeCocoa::paintListButton):
(WebCore::RenderThemeCocoa::adjustProgressBarStyle const):
(WebCore::RenderThemeCocoa::paintProgressBar):
(WebCore::RenderThemeCocoa::adjustSliderTrackStyle const):
(WebCore::RenderThemeCocoa::paintSliderTrack):
(WebCore::RenderThemeCocoa::adjustSliderThumbStyle const):
(WebCore::RenderThemeCocoa::paintSliderThumb):
(WebCore::RenderThemeCocoa::adjustSearchFieldStyle const):
(WebCore::RenderThemeCocoa::paintSearchField):
(WebCore::RenderThemeCocoa::paintSearchFieldDecorations):
(WebCore::RenderThemeCocoa::adjustSearchFieldCancelButtonStyle const):
(WebCore::RenderThemeCocoa::paintSearchFieldCancelButton):
(WebCore::RenderThemeCocoa::adjustSearchFieldDecorationPartStyle const):
(WebCore::RenderThemeCocoa::paintSearchFieldDecorationPart):
(WebCore::RenderThemeCocoa::adjustSearchFieldResultsDecorationPartStyle const):
(WebCore::RenderThemeCocoa::paintSearchFieldResultsDecorationPart):
(WebCore::RenderThemeCocoa::adjustSearchFieldResultsButtonStyle const):
(WebCore::RenderThemeCocoa::paintSearchFieldResultsButton):
(WebCore::RenderThemeCocoa::adjustSwitchStyle const):
(WebCore::RenderThemeCocoa::paintSwitchThumb):
(WebCore::RenderThemeCocoa::paintSwitchTrack):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::adjustSliderTrackStyle const):
(WebCore::RenderThemeIOS::adjustSearchFieldStyle const):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::canCreateControlPartForRenderer const):
(WebCore::RenderThemeMac::canCreateControlPartForBorderOnly const):
(WebCore::RenderThemeMac::canCreateControlPartForDecorations const):
(WebCore::RenderThemeMac::adjustMenuListStyle const):
(WebCore::RenderThemeMac::adjustSliderThumbStyle const):

Canonical link: <a href="https://commits.webkit.org/290539@main">https://commits.webkit.org/290539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/481547237e9f676ae68c1e5e4bb1afebfcee7f96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41115 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92391 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18186 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69537 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27120 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49900 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36346 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40246 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83143 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97168 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89117 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12882 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78533 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17784 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77753 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20812 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10786 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14212 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22864 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111608 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17278 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/26702 "Found 293 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate, microbenchmarks/memcpy-wasm-large.js.eager-jettison-no-cjit, microbenchmarks/memcpy-wasm-large.js.mini-mode, microbenchmarks/memcpy-wasm-large.js.no-cjit-collect-continuously, microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->