### PR TITLE
[GStreamer][LibWebRTC] Rename video encoder classes

### DIFF
--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp
@@ -86,15 +86,15 @@ protected:
     RefPtr<GstMappedOwnedBuffer> m_mappedBuffer;
 };
 
-class GStreamerVideoEncoder : public webrtc::VideoEncoder {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(GStreamerVideoEncoder);
+class LibWebRTCGStreamerVideoEncoder : public webrtc::VideoEncoder {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(LibWebRTCGStreamerVideoEncoder);
 public:
-    GStreamerVideoEncoder(const webrtc::SdpVideoFormat&)
-        : GStreamerVideoEncoder()
+    LibWebRTCGStreamerVideoEncoder(const webrtc::SdpVideoFormat&)
+        : LibWebRTCGStreamerVideoEncoder()
     {
     }
 
-    GStreamerVideoEncoder()
+    LibWebRTCGStreamerVideoEncoder()
         : m_firstFramePts(GST_CLOCK_TIME_NONE)
         , m_restrictionCaps(adoptGRef(gst_caps_new_empty_simple("video/x-raw")))
     {
@@ -343,9 +343,9 @@ private:
     GRefPtr<GstElement> m_sink;
 };
 
-class GStreamerH264Encoder : public GStreamerVideoEncoder {
+class LibWebRTCGStreamerVideoEncoderH264 : public LibWebRTCGStreamerVideoEncoder {
 public:
-    GStreamerH264Encoder() { }
+    LibWebRTCGStreamerVideoEncoderH264() { }
 
     int KeyframeInterval(const webrtc::VideoCodec* codecSettings) final
     {
@@ -388,7 +388,7 @@ std::unique_ptr<webrtc::VideoEncoder> GStreamerVideoEncoderFactory::Create(const
         return webrtc::CreateH264Encoder(environment, webrtc::H264EncoderSettings::Parse(format));
 #else
         GST_INFO("Using H264 GStreamer encoder.");
-        return makeUnique<GStreamerH264Encoder>();
+        return makeUnique<LibWebRTCGStreamerVideoEncoderH264>();
 #endif
     }
 
@@ -422,7 +422,7 @@ std::vector<webrtc::SdpVideoFormat> GStreamerVideoEncoderFactory::GetSupportedFo
     auto formats = supportedH264Formats();
     supportedCodecs.insert(supportedCodecs.end(), formats.begin(), formats.end());
 #else
-    GStreamerH264Encoder().AddCodecIfSupported(supportedCodecs);
+    LibWebRTCGStreamerVideoEncoderH264().AddCodecIfSupported(supportedCodecs);
 #endif
 
     return supportedCodecs;


### PR DESCRIPTION
#### e4c053af4f741f8a14d96f60a665c884ce3250f9
<pre>
[GStreamer][LibWebRTC] Rename video encoder classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=287856">https://bugs.webkit.org/show_bug.cgi?id=287856</a>

Reviewed by Xabier Rodriguez-Calvar.

When building with gcc and the -Os option our libwebrtc GStreamerVideoEncoder class was clashing
with the gstreamer WebCodecs GStreamerVideoEncoder class.

* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/GStreamerVideoEncoderFactory.cpp:
(WebCore::LibWebRTCGStreamerVideoEncoder::LibWebRTCGStreamerVideoEncoder):
(WebCore::LibWebRTCGStreamerVideoEncoderH264::LibWebRTCGStreamerVideoEncoderH264):
(WebCore::GStreamerVideoEncoderFactory::Create):
(WebCore::GStreamerVideoEncoderFactory::GetSupportedFormats const):
(WebCore::GStreamerVideoEncoder::GStreamerVideoEncoder): Deleted.
(WebCore::GStreamerVideoEncoder::pipeline): Deleted.
(WebCore::GStreamerVideoEncoder::makeElement): Deleted.
(WebCore::GStreamerVideoEncoder::returnFromFlowReturn): Deleted.
(WebCore::GStreamerVideoEncoder::createEncoder): Deleted.
(WebCore::GStreamerVideoEncoder::AddCodecIfSupported): Deleted.
(WebCore::GStreamerVideoEncoder::Caps): Deleted.
(WebCore::GStreamerVideoEncoder::ConfigureSupportedCodec): Deleted.
(WebCore::GStreamerVideoEncoder::SetRestrictionCaps): Deleted.
(WebCore::GStreamerH264Encoder::GStreamerH264Encoder): Deleted.

Canonical link: <a href="https://commits.webkit.org/290599@main">https://commits.webkit.org/290599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e09a8c3136edfa420689a96fc3e4871fd770ddc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41126 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10267 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69546 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27128 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/81961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49907 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36324 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40257 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97181 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78540 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77760 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19241 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20823 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10801 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17548 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22875 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17289 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->