### PR TITLE
[UnifiedPDF] [iOS] REGRESSION(290293@main): Main frame PDF content is not sharp on pinch zoom

### DIFF
--- a/Source/WebCore/platform/graphics/IntPoint.h
+++ b/Source/WebCore/platform/graphics/IntPoint.h
@@ -85,6 +85,16 @@ public:
     {
         this->scale(scale, scale);
     }
+
+    constexpr IntPoint scaled(float scale) const
+    {
+        return { static_cast<int>(std::lround(m_x * scale)), static_cast<int>(std::lround(m_y * scale)) };
+    }
+
+    constexpr IntPoint scaled(float scaleX, float scaleY) const
+    {
+        return { static_cast<int>(std::lround(m_x * scaleX)), static_cast<int>(std::lround(m_y * scaleY)) };
+    }
     
     constexpr IntPoint expandedTo(const IntPoint& other) const
     {


### PR DESCRIPTION
#### 2689d158dbf1cd53cb306f6732a9f1fc1de90de7
<pre>
[UnifiedPDF] [iOS] REGRESSION(290293@main): Main frame PDF content is not sharp on pinch zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=287511">https://bugs.webkit.org/show_bug.cgi?id=287511</a>
<a href="https://rdar.apple.com/144640298">rdar://144640298</a>

Reviewed by Wenson Hsieh.

In 290293@main, we opted out of applying page scale factor updates on
main frame plugins in the iOS family. However, we did not adequately
replace this with scale factor application on the core page instead,
which resulted in entirely dropping page scale factor updates when a
main frame plugin is displayed. The most notable symptom of this root
cause is PDF content that is not sharp.

We address the issue in this patch as such:

1. During visible content rect updates, if the page has a main frame
   plugin that does not handle page scale factors, actually apply this
   factor on the core page instead.
2. ... with the caveat that we want to gate this application behind a
   stable state, i.e. not intermediate pinch zoom updates.
3. Ignore the root view to plugin transformation for full main frame
   plugins that do not handle scale factor updates. Without this, text
   selections (and likely annotations had we supported them fully) look
   out of place during pinch gestures, almost as if they were double
   zoomed. This approach likely papers over the real transformation
   issue at hand and would probably not fly if we supported text
   selections on embedded PDFs in iOS, but that is a bridge to cross for
   later.

* Source/WebCore/platform/graphics/IntPoint.h:
(WebCore::IntPoint::scaled const):

Introduce a constexpr const method of receiving a scaled IntPoint
instance, then adopt said methods in PluginView::viewGeometryDidChange.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::viewGeometryDidChange):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didScalePage):

Drive-by fix: Make sure to call into platformDidScalePage() whenever
scale factor is changed, so as to not mess up layer tree transaction
bookkeeping.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/290563@main">https://commits.webkit.org/290563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6890834715c311e54033fcb3701e7d294c41089

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18296 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93446 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/7938 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82051 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49980 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40357 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97285 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17637 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19217 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22283 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17647 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17386 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->