### PR TITLE
[iOS] The selection highlight boxes mess up when the content switch between inflow and out-of-flow

### DIFF
--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-001-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-001-expected.txt
@@ -1,0 +1,12 @@
+When selecting content from different flows, i.e absolute or static, the highlight rects should not be combined if they are not adjacent.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 2
+PASS absoluteLineTop is > staticLineBottom
+PASS successfullyParsed is true
+
+TEST COMPLETE
+static
+absolute

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-001.html
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-001.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #absolute {
+        width: 100vw;
+        height: 50px;
+        position: absolute;
+        left: 0;
+        top: 100px;
+    }
+
+    #container {
+        position: relative;
+    }
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("When selecting content from different flows, i.e absolute or static, the highlight rects should not be combined if they are not adjacent.");
+
+    var container = document.getElementById("container");
+    await UIHelper.longPressElement(container);
+    await UIHelper.waitForSelectionToAppear();
+    getSelection().selectAllChildren(container);
+    await UIHelper.waitForSelectionToAppear();
+    selectionRects = await UIHelper.getUISelectionViewRects();
+
+    shouldBe("selectionRects.length", "2");
+    staticLineBottom = selectionRects[0].top + selectionRects[0].height;
+    absoluteLineTop = selectionRects[1].top;
+    shouldBeGreaterThan("absoluteLineTop", "staticLineBottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="container">
+        <div id="content">static</div>
+        <div id="absolute">absolute</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-002-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-002-expected.txt
@@ -1,0 +1,12 @@
+When selecting content from different flows, i.e absolute or static, the highlight rects should not be combined if they are not adjacent.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 2
+PASS staticLineTop is > absoluteLineBottom
+PASS successfullyParsed is true
+
+TEST COMPLETE
+static
+absolute

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-002.html
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-002.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #absolute {
+        width: 100vw;
+        height: 50px;
+        position: absolute;
+        left: 0;
+        top: -100px;
+    }
+
+    #container {
+        position: relative;
+        margin-top: 150px;
+    }
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("When selecting content from different flows, i.e absolute or static, the highlight rects should not be combined if they are not adjacent.");
+
+    var container = document.getElementById("container");
+    await UIHelper.longPressElement(container);
+    await UIHelper.waitForSelectionToAppear();
+    getSelection().selectAllChildren(container);
+    await UIHelper.waitForSelectionToAppear();
+    selectionRects = await UIHelper.getUISelectionViewRects();
+
+    shouldBe("selectionRects.length", "2");
+    staticLineTop = selectionRects[0].top;
+    absoluteLineBottom = selectionRects[1].top + selectionRects[0].height;
+    shouldBeGreaterThan("staticLineTop", "absoluteLineBottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="container">
+        <div id="content">static</div>
+        <div id="absolute">absolute</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-003-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-003-expected.txt
@@ -1,0 +1,12 @@
+The highlight rects should not be combined if the content is from different flow. Distinguish flows properly, positioned content + static content.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 2
+PASS staticLineTop is > absoluteLineBottom
+PASS successfullyParsed is true
+
+TEST COMPLETE
+absolute
+static

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-003.html
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-003.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #absolute {
+        width: 100vw;
+        height: 50px;
+        position: absolute;
+        left: 0;
+        top: -100px;
+    }
+
+    #container {
+        position: relative;
+        margin-top: 150px;
+    }
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("The highlight rects should not be combined if the content is from different flow. Distinguish flows properly, positioned content + static content.");
+
+    var container = document.getElementById("container");
+    await UIHelper.longPressElement(container);
+    await UIHelper.waitForSelectionToAppear();
+    getSelection().selectAllChildren(container);
+    await UIHelper.waitForSelectionToAppear();
+    selectionRects = await UIHelper.getUISelectionViewRects();
+
+    shouldBe("selectionRects.length", "2");
+    absoluteLineBottom = selectionRects[0].top + selectionRects[0].height;
+    staticLineTop = selectionRects[1].top;
+    shouldBeGreaterThan("staticLineTop", "absoluteLineBottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="container">
+        <div id="absolute">absolute</div>
+        <div id="content">static</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-004-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-004-expected.txt
@@ -1,0 +1,12 @@
+The highlight rects should not be combined if the content is from different flow. Distinguish flows properly, positioned content descendant + static content.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 2
+PASS staticLineTop is > absoluteLineBottom
+PASS successfullyParsed is true
+
+TEST COMPLETE
+absolute
+static

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-004.html
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-004.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #absolute {
+        width: 100vw;
+        height: 50px;
+        position: absolute;
+        left: 0;
+        top: -100px;
+    }
+
+    #container {
+        position: relative;
+        margin-top: 150px;
+    }
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("The highlight rects should not be combined if the content is from different flow. Distinguish flows properly, positioned content descendant + static content.");
+
+    var container = document.getElementById("container");
+    await UIHelper.longPressElement(container);
+    await UIHelper.waitForSelectionToAppear();
+    getSelection().selectAllChildren(container);
+    await UIHelper.waitForSelectionToAppear();
+    selectionRects = await UIHelper.getUISelectionViewRects();
+
+    shouldBe("selectionRects.length", "2");
+    absoluteLineBottom = selectionRects[0].top + selectionRects[0].height;
+    staticLineTop = selectionRects[1].top;
+    shouldBeGreaterThan("staticLineTop", "absoluteLineBottom");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="container">
+        <div><div id="absolute">absolute</div></div>
+        <div id="content">static</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-005-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-005-expected.txt
@@ -1,0 +1,13 @@
+The highlight rects should be combined if the content is from same out of flow. Distinguish flows properly, positioned container + inline and block descendants.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 2
+PASS firstLineBottom is secondLineTop
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Line 1
+Line 2
+

--- a/LayoutTests/editing/selection/ios/select-content-from-different-flow-005.html
+++ b/LayoutTests/editing/selection/ios/select-content-from-different-flow-005.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #absolute {
+        width: 100vw;
+        height: 50px;
+        position: absolute;
+        left: 0;
+        top: -100px;
+    }
+
+    #container {
+        position: relative;
+        margin-top: 150px;
+    }
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("The highlight rects should be combined if the content is from same out of flow. Distinguish flows properly, positioned container + inline and block descendants.");
+
+    var container = document.getElementById("container");
+    await UIHelper.longPressElement(container);
+    await UIHelper.waitForSelectionToAppear();
+    getSelection().selectAllChildren(container);
+    await UIHelper.waitForSelectionToAppear();
+    selectionRects = await UIHelper.getUISelectionViewRects();
+
+    shouldBe("selectionRects.length", "2");
+    firstLineBottom = selectionRects[0].top + selectionRects[0].height;
+    secondLineTop = selectionRects[1].top;
+    shouldBe("firstLineBottom", "secondLineTop");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div id="container">
+        <div id="absolute">
+            <span>Line 1</span>
+            <div>Line 2<div>
+        </div>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/platform/ios/SelectionGeometry.h
+++ b/Source/WebCore/platform/ios/SelectionGeometry.h
@@ -72,6 +72,7 @@ public:
     bool isInFixedPosition() const { return m_isInFixedPosition; }
     int pageNumber() const { return m_pageNumber; }
     SelectionRenderingBehavior behavior() const { return m_behavior; }
+    bool separateFromPreviousLine() const { return m_separateFromPreviousLine; }
 
     void setLogicalLeft(int);
     void setLogicalWidth(int);
@@ -90,6 +91,7 @@ public:
     void setContainsEnd(bool containsEnd) { m_containsEnd = containsEnd; }
     void setIsHorizontal(bool isHorizontal) { m_isHorizontal = isHorizontal; }
     void setBehavior(SelectionRenderingBehavior behavior) { m_behavior = behavior; }
+    void setSeparateFromPreviousLine(bool separate) { m_separateFromPreviousLine = separate; }
 
     WEBCORE_EXPORT void move(float x, float y);
 
@@ -108,6 +110,7 @@ private:
     bool m_containsEnd { false };
     bool m_isHorizontal { true };
     bool m_isInFixedPosition { false };
+    bool m_separateFromPreviousLine { false };
     int m_pageNumber { 0 };
 
     mutable std::optional<IntRect> m_cachedEnclosingRect;


### PR DESCRIPTION
#### 834e9831da4db3819ec6547aaba1f98b5bd89a32
<pre>
[iOS] The selection highlight boxes mess up when the content switch between inflow and out-of-flow
<a href="https://bugs.webkit.org/show_bug.cgi?id=269723">https://bugs.webkit.org/show_bug.cgi?id=269723</a>

Reviewed by Wenson Hsieh.

In iOS, the selection highlight boxes are coalesced. But if the selected content switch between inflow and
out-of-flow, for instance, the content contains text with positioned ancestor and text from inflow,
the combined box could include unexpected area.
To fix this issue, we stop coalescing the highlight boxes of out-of-flow positioned content to others.

* LayoutTests/editing/selection/ios/select-content-from-different-flow-001-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-001.html: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-002-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-002.html: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-003-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-003.html: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-004-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-004.html: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-005-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-from-different-flow-005.html: Added.
* Source/WebCore/platform/ios/SelectionGeometry.h:
(WebCore::SelectionGeometry::separateFromPreviousLine const): Return true if geometry requires to separate lines.
(WebCore::SelectionGeometry::setSeparateFromPreviousLine):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::currentNodeRequiresToSeparateLines): Return true if current node is out-of-flow positioned.
(WebCore::hasAncestorRequiresToSeparateLines): Check if the node has an out-of-flow ancestor within the stayWithin subtree.
(WebCore::previousNodeRequiresToSeparateLines):
(WebCore::RenderObject::collectSelectionGeometriesInternal): Distinguish if current renderer and previous renderer
have switched between inflow and out-of-flow. If current renderer is positioned, or if the previous renderer
has a positioned ancestor, then they are in different flows. Do not coalesce lines that are not in same flow.

Canonical link: <a href="https://commits.webkit.org/291696@main">https://commits.webkit.org/291696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24b4c68566b6877ded5f01759ca5b486d9de1b55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3036 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98731 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71551 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28922 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2336 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80073 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100765 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20777 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15159 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79904 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19876 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24453 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1807 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13933 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25939 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20448 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->