### PR TITLE
AX: Stop calling updateBackingStore() in AXIsolatedObject::children() for performance reasons

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -271,9 +271,6 @@ AXCoreObject* AXCoreObject::firstUnignoredChild()
 
 AXCoreObject* AXCoreObject::nextInPreOrder(bool updateChildrenIfNeeded, AXCoreObject* stayWithin)
 {
-    if (updateChildrenIfNeeded)
-        updateChildrenIfNecessary();
-
     const auto& children = childrenIncludingIgnored(updateChildrenIfNeeded);
     if (!children.isEmpty()) {
         auto role = roleValue();
@@ -299,9 +296,6 @@ AXCoreObject* AXCoreObject::nextInPreOrder(bool updateChildrenIfNeeded, AXCoreOb
 
 AXCoreObject* AXCoreObject::previousInPreOrder(bool updateChildrenIfNeeded, AXCoreObject* stayWithin)
 {
-    if (updateChildrenIfNeeded)
-        updateChildrenIfNecessary();
-
     if (stayWithin == this)
         return nullptr;
 
@@ -337,7 +331,9 @@ AXCoreObject* AXCoreObject::nextSiblingIncludingIgnored(bool updateChildrenIfNee
         return nullptr;
 
     const auto& siblings = parent->childrenIncludingIgnored(updateChildrenIfNeeded);
-    size_t indexOfThis = siblings.find(Ref { *this });
+    size_t indexOfThis = siblings.findIf([this] (const Ref<AXCoreObject>& object) {
+        return object.ptr() == this;
+    });
     if (indexOfThis == notFound)
         return nullptr;
 
@@ -351,7 +347,9 @@ AXCoreObject* AXCoreObject::previousSiblingIncludingIgnored(bool updateChildrenI
         return nullptr;
 
     const auto& siblings = parent->childrenIncludingIgnored(updateChildrenIfNeeded);
-    size_t indexOfThis = siblings.find(Ref { *this });
+    size_t indexOfThis = siblings.findIf([this] (const Ref<AXCoreObject>& object) {
+        return object.ptr() == this;
+    });
     if (indexOfThis == notFound)
         return nullptr;
 
@@ -368,7 +366,9 @@ AXCoreObject* AXCoreObject::nextUnignoredSibling(bool updateChildrenIfNeeded, AX
     if (!parent)
         return nullptr;
     const auto& siblings = parent->unignoredChildren(updateChildrenIfNeeded);
-    size_t indexOfThis = siblings.find(Ref { *this });
+    size_t indexOfThis = siblings.findIf([this] (const Ref<AXCoreObject>& object) {
+        return object.ptr() == this;
+    });
     if (indexOfThis == notFound)
         return nullptr;
 

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1282,7 +1282,6 @@ public:
     // is the default, we should rename this function to childrenIDsIncludingIgnored, as that is what all
     // callers will expect at the time this comment was written.
     Vector<AXID> childrenIDs(bool updateChildrenIfNeeded = true);
-    virtual void updateChildrenIfNecessary() = 0;
     AXCoreObject* nextInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
     AXCoreObject* nextSiblingIncludingIgnored(bool updateChildrenIfNeeded) const;
     AXCoreObject* nextUnignoredSibling(bool updateChildrenIfNeeded, AXCoreObject* unignoredParent = nullptr) const;

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -198,7 +198,7 @@ bool AXSearchManager::matchWithResultsLimit(Ref<AXCoreObject> object, const Acce
 static void appendAccessibilityObject(Ref<AXCoreObject> object, AccessibilityObject::AccessibilityChildrenVector& results)
 {
     if (LIKELY(!object->isAttachment()))
-        results.append(object);
+        results.append(WTFMove(object));
     else {
         // Find the next descendant of this attachment object so search can continue through frames.
         Widget* widget = object->widgetForAttachmentView();
@@ -250,7 +250,12 @@ static void appendChildrenToArray(Ref<AXCoreObject> object, bool isForward, RefP
         startObject = newStartObject;
     }
 
-    size_t searchPosition = startObject ? searchChildren.find(Ref { *startObject }) : notFound;
+    size_t searchPosition = notFound;
+    if (startObject) {
+        searchPosition = searchChildren.findIf([&] (const Ref<AXCoreObject>& object) {
+            return startObject == object.ptr();
+        });
+    }
 
     if (searchPosition != notFound) {
         if (isForward)

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -542,7 +542,7 @@ public:
             addChild(*object, descend);
     }
     virtual bool canHaveChildren() const { return true; }
-    void updateChildrenIfNecessary() override;
+    virtual void updateChildrenIfNecessary();
     virtual void setNeedsToUpdateChildren() { }
     virtual void setNeedsToUpdateSubtree() { }
     virtual void clearChildren();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2450,8 +2450,12 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
                     childObject = nullptr;
             }
 
-            if (childObject)
-                insertionIndex = m_children.find(Ref { *childObject }) + 1;
+            if (childObject) {
+                insertionIndex = m_children.findIf([&childObject] (const Ref<AXCoreObject>& child) {
+                    return child.ptr() == childObject;
+                });
+                ++insertionIndex;
+            }
             continue;
         }
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -177,7 +177,9 @@ void AccessibilityScrollView::removeChildScrollbar(AccessibilityObject* scrollba
     if (!scrollbar)
         return;
 
-    size_t position = m_children.find(Ref { *scrollbar });
+    size_t position = m_children.findIf([&scrollbar] (const Ref<AXCoreObject>& child) {
+        return child.ptr() == scrollbar;
+    });
     if (position != notFound) {
         m_children[position]->detachFromParent();
         m_children.remove(position);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectComponentAtspi.cpp
@@ -112,7 +112,8 @@ AccessibilityObjectAtspi* AccessibilityObjectAtspi::hitTest(const IntPoint& poin
         }
     }
 
-    m_coreObject->updateChildrenIfNecessary();
+    if (auto* axObject = dynamicDowncast<AccessibilityObject>(m_coreObject.get()))
+        axObject->updateChildrenIfNecessary();
     if (auto* coreObject = m_coreObject->accessibilityHitTest(convertedPoint))
         return coreObject->wrapper();
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -686,30 +686,16 @@ const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool
 #elif USE(ATSPI)
     ASSERT(!isMainThread());
 #endif
-    RefPtr<AXIsolatedObject> protectedThis;
-    if (updateChildrenIfNeeded) {
-        // updateBackingStore can delete `this`, so protect it until the end of this function.
-        protectedThis = this;
-        updateBackingStore();
-
-        if (m_childrenDirty) {
-            m_children = WTF::compactMap(m_childrenIDs, [&](auto& childID) -> std::optional<Ref<AXCoreObject>> {
-                if (RefPtr child = tree()->objectForID(childID))
-                    return child.releaseNonNull();
-                return std::nullopt;
-            });
-            m_childrenDirty = false;
-        }
+    if (updateChildrenIfNeeded && m_childrenDirty) {
+        m_children = WTF::compactMap(m_childrenIDs, [&](auto& childID) -> std::optional<Ref<AXCoreObject>> {
+            if (RefPtr child = tree()->objectForID(childID))
+                return child.releaseNonNull();
+            return std::nullopt;
+        });
+        m_childrenDirty = false;
         ASSERT(m_children.size() == m_childrenIDs.size());
     }
     return m_children;
-}
-
-void AXIsolatedObject::updateChildrenIfNecessary()
-{
-    // FIXME: this is a no-op for isolated objects and should be removed from
-    // the public interface. It is used in the mac implementation of
-    // [WebAccessibilityObjectWrapper accessibilityHitTest].
 }
 
 void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& selectedChildren)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -348,7 +348,6 @@ private:
     void setSelectedChildren(const AccessibilityChildrenVector&) final;
     AccessibilityChildrenVector visibleChildren() final { return tree()->objectsForIDs(vectorAttributeValue<AXID>(AXProperty::VisibleChildren)); }
     void setChildrenIDs(Vector<AXID>&&);
-    void updateChildrenIfNecessary() final;
     bool isDetachedFromParent() final;
     AXIsolatedObject* liveRegionAncestor(bool excludeIfOff = true) const final { return Accessibility::liveRegionAncestor(*this, excludeIfOff); }
     const String liveRegionStatus() const final { return stringAttributeValue(AXProperty::LiveRegionStatus); }

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2055,7 +2055,8 @@ id parameterizedAttributeValueForTesting(const RefPtr<AXCoreObject>& backingObje
     if (!backingObject)
         return nil;
 
-    backingObject->updateChildrenIfNecessary();
+    if (auto* axObject = dynamicDowncast<AccessibilityObject>(backingObject.get()))
+        axObject->updateChildrenIfNecessary();
     auto* axObject = backingObject->accessibilityHitTest(IntPoint(point));
 
     id hit = nil;


### PR DESCRIPTION
#### 56d65459b823771b022695053f05ce1bfb7b286d
<pre>
AX: Stop calling updateBackingStore() in AXIsolatedObject::children() for performance reasons
<a href="https://bugs.webkit.org/show_bug.cgi?id=287862">https://bugs.webkit.org/show_bug.cgi?id=287862</a>
<a href="https://rdar.apple.com/145062082">rdar://145062082</a>

Reviewed by Chris Fleizach.

AXIsolatedObject::updateBackingStore() calls AXIsolatedTree::applyPendingChanges(), which takes a lock. This is not
ideal to use in a function that is as hot as AXIsolatedObject::children(). Calling updateBackingStore() also requires
a strong-ref and strong-deref to |this| in the function, since updateBackingStore() can delete |this|. These refs
and derefs, and updateBackingStore show up in samples taken on a popular video website.

With this commit, we remove the call to updateBackingStore in AXIsolatedObject::children. We really should only need
to call updateBackingStore once for every attribute request, and should do so right at the beginning of the attribute
request in the wrapper. This may also be a bit more logical, ensuring each attribute request is served from the same
snapshot of the tree.

This patch also features several unrelated performance improvements:
  - Remove updateChildrenIfNecessary from AXIsolatedObject. It&apos;s a
    no-op, but we still incur the cost of a virtual function call in our
    hottest codepaths (e.g. nextInPreOrder).
  - Remove unnecessary ref-churn, e.g. creating a Ref just to call Vector::find.
  - Inline isValid() and isInTextRun() in AXTextMarker::findMarker, our
    hottest text marker function.
  - Reduce unnecessary calls to AXTextMarker::runs().

All of these things showed up significantly in samples.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::nextInPreOrder):
(WebCore::AXCoreObject::previousInPreOrder):
(WebCore::AXCoreObject::nextSiblingIncludingIgnored const):
(WebCore::AXCoreObject::previousSiblingIncludingIgnored):
(WebCore::AXCoreObject::nextUnignoredSibling const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendAccessibilityObject):
(WebCore::appendChildrenToArray):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::findMarker const):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::removeChildScrollbar):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::children):
(WebCore::AXIsolatedObject::updateChildrenIfNecessary): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper _accessibilityHitTest:returnPlatformElements:]):

Canonical link: <a href="https://commits.webkit.org/290904@main">https://commits.webkit.org/290904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22fabb0941056627027145f818da174ba061ad07

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70057 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27581 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8470 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50383 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41058 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98149 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13467 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79066 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78269 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19397 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11553 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18367 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23681 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21551 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19866 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->