### PR TITLE
[GStreamer][MSE] Optional encoders for AppendPIpeline streams

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -212,7 +212,7 @@ void TrackPrivateBaseGStreamer::tagsChanged()
     if (!tags)
         tags = adoptGRef(gst_tag_list_new_empty());
 
-    GST_DEBUG("Inspecting track at index %d with tags: %" GST_PTR_FORMAT, m_index, tags.get());
+    GST_DEBUG("Inspecting track %" PRIu64 " with tags: %" GST_PTR_FORMAT, m_id, tags.get());
     {
         Locker locker { m_tagMutex };
         m_tags.swap(tags);
@@ -228,7 +228,7 @@ bool TrackPrivateBaseGStreamer::getLanguageCode(GstTagList* tags, AtomString& va
     String language;
     if (getTag(tags, GST_TAG_LANGUAGE_CODE, language)) {
         AtomString convertedLanguage = AtomString(unsafeSpan8(gst_tag_get_language_code_iso_639_1(language.utf8().data())));
-        GST_DEBUG("Converted track %d's language code to %s.", m_index, convertedLanguage.string().utf8().data());
+        GST_DEBUG("Converted track %" PRIu64 "'s language code to %s.", m_id, convertedLanguage.string().utf8().data());
         if (convertedLanguage != value) {
             value = WTFMove(convertedLanguage);
             return true;
@@ -242,7 +242,7 @@ bool TrackPrivateBaseGStreamer::getTag(GstTagList* tags, const gchar* tagName, S
 {
     GUniqueOutPtr<gchar> tagValue;
     if (gst_tag_list_get_string(tags, tagName, &tagValue.outPtr())) {
-        GST_DEBUG("Track %d got %s %s.", m_index, tagName, tagValue.get());
+        GST_DEBUG("Track %" PRIu64 " got %s %s.", m_id, tagName, tagValue.get());
         value = StringType { String::fromLatin1(tagValue.get()) };
         return true;
     }
@@ -293,9 +293,9 @@ void TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged()
         return;
 
     ASSERT(isMainThread()); // because this code writes to AtomString members.
-    GST_INFO("Track %d got stream start for stream %" PRIu64 ". GStreamer stream-id: %s", m_index, streamId.value(), gstStreamId.string().utf8().data());
     m_gstStreamId = gstStreamId;
     m_id = streamId.value();
+    GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_id, m_gstStreamId.string().utf8().data());
 }
 
 void TrackPrivateBaseGStreamer::streamChanged()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h
@@ -62,6 +62,7 @@ private:
     enum StreamType { Audio, Video, Text, Unknown, Invalid };
 #ifndef GST_DISABLE_GST_DEBUG
     static const char * streamTypeToString(StreamType);
+    static const char * streamTypeToStringLower(StreamType);
 #endif
 
     struct Track {
@@ -81,12 +82,15 @@ private:
         TrackID trackId;
         StreamType streamType;
         GRefPtr<GstCaps> caps;
+        GRefPtr<GstCaps> finalCaps;
         FloatSize presentationSize;
 
-        // Needed by some formats. To simplify the code, parser can be a GstIdentity when not needed.
+        // Needed by some formats. To simplify the code, parser/encoder can be a GstIdentity when not needed.
         GRefPtr<GstElement> parser;
+        GRefPtr<GstElement> encoder;
         GRefPtr<GstElement> appsink;
         GRefPtr<GstPad> entryPad; // Sink pad of the parser/GstIdentity.
+        GRefPtr<GstPad> encoderPad; // Sink pad of the encoder/GstIdentity.
         GRefPtr<GstPad> appsinkPad;
 
         RefPtr<WebCore::TrackPrivateBase> webKitTrack;
@@ -98,6 +102,7 @@ private:
         struct PadProbeInformation appsinkPadEventProbeInformation;
 #endif
 
+        void emplaceOptionalEncoderForFormat(GstBin*, const GRefPtr<GstCaps>&);
         void emplaceOptionalParserForFormat(GstBin*, const GRefPtr<GstCaps>&);
         void initializeElements(AppendPipeline*, GstBin*);
         bool isLinked() const { return gst_pad_is_linked(entryPad.get()); }


### PR DESCRIPTION
#### 7926de4222132a135d84b4d4cc05d8f6738f9c6a
<pre>
[GStreamer][MSE] Optional encoders for AppendPIpeline streams
<a href="https://bugs.webkit.org/show_bug.cgi?id=287860">https://bugs.webkit.org/show_bug.cgi?id=287860</a>

Reviewed by Philippe Normand.

Adds optional encoder elements, analogous to the optional parsers streams can have.
This is necessary for TextTrack support in MSE, where we need to re-encode any
subtitle or caption tracks to WebVTT, which is the format WebKit expects.

A stream in AppendPipeline now looks like this:
               __________    ___________    ___________
___________    |        |    |         |    |         |
|         | -&gt; | parser | -&gt; | encoder | -&gt; | appsink |
| demuxer |    |________|    |_________|    |_________|
|_________| -&gt; ...

Additionally, I&apos;ve renamed parser elements, which previously tended to break pipeline dumps.
See: <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7979">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/7979</a>
While this was backported to 1.24.10, the change also makes element names more descriptive.
(Take for example 0_parser, which might now be called parser_0_video.)

Finally, I&apos;ve changed some logging in TrackPrivateBaseGStreamer, which didn&apos;t yet use track IDs.

* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::tagsChanged):
(WebCore::TrackPrivateBaseGStreamer::getLanguageCode):
(WebCore::TrackPrivateBaseGStreamer::getTag):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkCapsChanged):
(WebCore::AppendPipeline::didReceiveInitializationSegment):
(WebCore::createOptionalParserForFormat):
  Just takes the new element&apos;s name as argument now.
(WebCore::createOptionalEncoderForFormat):
  Creates an encoder, analogous to its parser counterpart.
(WebCore::AppendPipeline::recycleTrackForPad):
(WebCore::AppendPipeline::makeWebKitTrack):
(WebCore::AppendPipeline::Track::emplaceOptionalParserForFormat):
  Creates parserName, and links the parser to the encoder, instead of the appsink.
(WebCore::AppendPipeline::Track::emplaceOptionalEncoderForFormat):
  Create an encoder and link it to the appsink, also set finalCaps here.
(WebCore::AppendPipeline::Track::initializeElements):
(WebCore::AppendPipeline::streamTypeToStringLower):
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.h:
  Add fields to AppendPipeline::Track: finalCaps, encoder, and encoderPad.

Canonical link: <a href="https://commits.webkit.org/290605@main">https://commits.webkit.org/290605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f1a41c9d5829cd48b23265410ff66f5b3ca4683

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41214 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69617 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27186 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36386 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40344 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77990 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78606 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77826 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19243 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20886 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17634 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22966 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->