### PR TITLE
[WebGPU] Retain Device for lifetime of its associated MTLCommandBuffer instances

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287868-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287868-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287868.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287868.html
@@ -1,0 +1,17264 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+async function gc() {
+  await 0;
+  if (globalThis.GCController) {
+    globalThis.GCController.collect();
+  } else if (globalThis.$vm) {
+    globalThis.$vm.gc();
+  } else {
+    log('no GC available');
+  }
+}
+
+/**
+ * @param {GPUDevice} device
+ * @param {GPUComputePassEncoder} computePassEncoder
+ */
+function clearResourceUsages(device, computePassEncoder) {
+  let code = `@compute @workgroup_size(1) fn c() {}`;
+  let module = device.createShaderModule({code});
+  computePassEncoder.setPipeline(device.createComputePipeline(
+    {
+      layout: 'auto',
+      compute: {module},
+    }));
+  computePassEncoder.dispatchWorkgroups(1);
+}
+
+/**
+ * @template {any} T
+ * @param {GPUDevice} device
+ * @param {string} label
+ * @param {()=>T} payload
+ * @returns {Promise<T>}
+ */
+async function validationWrapper(device, label, payload)  {
+  device.pushErrorScope('internal');
+  device.pushErrorScope('out-of-memory');
+  device.pushErrorScope('validation');
+  let result = payload();
+  let validationError = await device.popErrorScope();
+  let outOfMemoryError = await device.popErrorScope();
+  let internalError = await device.popErrorScope();
+  let error = validationError ?? outOfMemoryError ?? internalError;
+  if (error) {
+    log('*'.repeat(25));
+    log(error[Symbol.toStringTag]);
+    log(error.message);
+    log(label);
+    if (error.stack != `_`) {
+      log(error.stack);
+    }
+    log(location);
+    log('*'.repeat(25));
+    throw error;
+  }
+  return result;
+}
+
+const videoUrls = [
+
+];
+
+/**
+ * @param {number} index
+ * @returns {Promise<HTMLVideoElement>}
+ */
+function videoWithData(index) {
+  let video = document.createElement('video');
+  video.src = videoUrls[index % videoUrls.length];
+  return new Promise(resolve => {
+    video.onloadeddata = () => {
+      resolve(video);
+    };
+  });
+}
+
+/**
+* @returns {Promise<string>}
+*/
+async function makeDataUrl(width, height, color0, color1) {
+  let offscreenCanvas = new OffscreenCanvas(width, height);
+  let ctx = offscreenCanvas.getContext('2d');
+  let gradient = ctx.createLinearGradient(0, 0, width, height);
+  gradient.addColorStop(0, color0);
+  gradient.addColorStop(0.1, color1);
+  gradient.addColorStop(0.3, color0);
+  gradient.addColorStop(0.7, color1);
+  gradient.addColorStop(0.9, color0);
+  gradient.addColorStop(1, color1);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, width, height);
+  let blob = await offscreenCanvas.convertToBlob();
+  let fileReader = new FileReader();
+  fileReader.readAsDataURL(blob);
+  return new Promise(resolve => {
+    fileReader.onload = () => {
+      resolve(fileReader.result);
+    };
+  });
+}
+
+async function imageWithData(width, height, color0, color1) {
+  let dataUrl = await makeDataUrl(width, height, color0, color1);
+  let img = document.createElement('img');
+  img.src = dataUrl;
+  await img.decode();
+  return img;
+}
+
+/**
+ * @param {string} payload
+ * @returns {string}
+ */
+function toBlobUrl(payload) {
+  let blob = new Blob([payload], {type: 'text/javascript'});
+  return URL.createObjectURL(blob);
+}
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let promise0 = navigator.gpu.requestAdapter({});
+let adapter0 = await promise0;
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'bgra8unorm-storage',
+    'float32-blendable',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxVertexBufferArrayStride: 2048,
+    maxUniformBufferBindingSize: 16486917,
+    maxStorageBufferBindingSize: 158762234,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let imageData0 = new ImageData(8, 8);
+let buffer0 = device0.createBuffer({size: 44, usage: GPUBufferUsage.INDEX});
+let sampler0 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat'});
+let buffer1 = device0.createBuffer({size: 232, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let texture0 = device0.createTexture({
+  size: [142, 16, 66],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 28, y: 5, z: 3},
+  aspect: 'all',
+}, new Uint8Array(6_509).fill(137), /* required buffer size: 6_509 */
+{offset: 47, bytesPerRow: 218, rowsPerImage: 26}, {width: 35, height: 4, depthOrArrayLayers: 2});
+} catch {}
+let sampler1 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'clamp-to-edge', lodMaxClamp: 99.85});
+let textureView0 = texture0.createView({dimension: '2d', baseArrayLayer: 13});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+let renderBundle0 = renderBundleEncoder0.finish({});
+let promise1 = device0.queue.onSubmittedWorkDone();
+let img0 = await imageWithData(34, 17, '#10101010', '#20202020');
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'bt470bg', transfer: 'hlg'} });
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let textureView1 = texture0.createView({dimension: '2d', baseArrayLayer: 17});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let bindGroup0 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let texture1 = device0.createTexture({
+  size: {width: 1360, height: 12, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'astc-8x6-unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'r32uint', access: 'read-write', viewDimension: '3d' },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rg32uint', access: 'write-only', viewDimension: '2d' },
+    },
+    {binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 6,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {binding: 17, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 33,
+      visibility: GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 47,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 54,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '1d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {
+      binding: 55,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: true },
+    },
+    {
+      binding: 65,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'bgra8unorm', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 140,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 189,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '2d', sampleType: 'unfilterable-float', multisampled: false },
+    },
+    {binding: 211, visibility: GPUShaderStage.COMPUTE, externalTexture: {}},
+    {
+      binding: 244,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 247,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 277,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {binding: 286, visibility: GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 394,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 426,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba16float', access: 'write-only', viewDimension: '2d' },
+    },
+  ],
+});
+let bindGroup1 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let texture2 = device0.createTexture({
+  size: {width: 1020, height: 428, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture3 = device0.createTexture({
+  size: [280, 1, 71],
+  mipLevelCount: 5,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView2 = texture0.createView({dimension: '2d', aspect: 'all', baseArrayLayer: 14});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+await gc();
+let imageData1 = new ImageData(28, 72);
+let texture4 = device0.createTexture({
+  size: [71],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\u718d\u0e9f\u2881\u4a3e\u01df\u0ec5\u005b\u{1ff2b}',
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let texture5 = device0.createTexture({
+  size: [2240, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let querySet0 = device0.createQuerySet({type: 'timestamp', count: 298});
+let textureView3 = texture1.createView({format: 'astc-8x6-unorm', mipLevelCount: 1});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: false,
+  stencilReadOnly: true,
+});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+computePassEncoder0.setBindGroup(1, bindGroup1);
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer2 = device0.createBuffer({size: 36, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 522});
+let textureView4 = texture2.createView({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthStencilFormat: 'depth32float', sampleCount: 4});
+let sampler2 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  lodMaxClamp: 90.89,
+  compare: 'never',
+});
+try {
+computePassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(892), 126, 0);
+} catch {}
+try {
+renderBundleEncoder2.setIndexBuffer(buffer0, 'uint16', 6, 2);
+} catch {}
+try {
+renderBundleEncoder2.setVertexBuffer(3, buffer2, 0, 4);
+} catch {}
+let bindGroup2 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let buffer3 = device0.createBuffer({size: 444, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView5 = texture4.createView({baseArrayLayer: 0});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+  await promise1;
+} catch {}
+try {
+adapter0.label = '\u48c5\u9656\u0497\u022d\u0ede\u{1f905}\u5552\ubf32\u{1f6a5}';
+} catch {}
+let buffer4 = device0.createBuffer({
+  label: '\uce00\u3cf3\u0fe9\ud5e1\u3f75',
+  size: 8,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE,
+});
+let commandEncoder1 = device0.createCommandEncoder({});
+let texture6 = device0.createTexture({
+  size: [1020, 428, 24],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView6 = texture2.createView({});
+let computePassEncoder1 = commandEncoder1.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1);
+} catch {}
+let texture7 = device0.createTexture({
+  size: [2240],
+  dimension: '1d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView7 = texture5.createView({});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup2, new Uint32Array(170), 10, 0);
+} catch {}
+let commandEncoder2 = device0.createCommandEncoder();
+let textureView8 = texture6.createView({arrayLayerCount: 1});
+let computePassEncoder2 = commandEncoder2.beginComputePass({timestampWrites: {querySet: querySet0}});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout1]});
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture8 = device0.createTexture({
+  size: {width: 127},
+  dimension: '1d',
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler3 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat'});
+try {
+globalThis.someLabel = texture7.label;
+} catch {}
+let texture9 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture10 = device0.createTexture({size: [35, 4, 10], dimension: '2d', format: 'depth32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView9 = texture6.createView({mipLevelCount: 1});
+let sampler4 = device0.createSampler({magFilter: 'linear', minFilter: 'linear', lodMinClamp: 69.13, lodMaxClamp: 86.52});
+try {
+device0.label = '\u4ba3\ucb39\u09ef\u0d53\u0342';
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let buffer5 = device0.createBuffer({size: 280, usage: GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let textureView10 = texture8.createView({});
+let texture11 = device0.createTexture({
+  size: [510, 214, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder3.insertDebugMarker('\u9edd');
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+let querySet2 = device0.createQuerySet({type: 'timestamp', count: 644});
+let textureView11 = texture7.createView({baseMipLevel: 0});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+let buffer6 = device0.createBuffer({size: 470, usage: GPUBufferUsage.COPY_SRC});
+let texture12 = device0.createTexture({
+  size: {width: 71},
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture13 = device0.createTexture({
+  size: {width: 560, height: 1, depthOrArrayLayers: 53},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView12 = texture13.createView({dimension: '2d', aspect: 'depth-only', baseArrayLayer: 11});
+await gc();
+let texture14 = device0.createTexture({
+  size: [2240],
+  dimension: '1d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView13 = texture0.createView({baseArrayLayer: 8, arrayLayerCount: 16});
+document.body.append(img0);
+try {
+globalThis.someLabel = computePassEncoder0.label;
+} catch {}
+let bindGroup3 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture0}]});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView14 = texture12.createView({mipLevelCount: 1});
+let texture15 = device0.createTexture({
+  size: [560, 1, 488],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(9904), 771, 0);
+} catch {}
+let promise3 = device0.queue.onSubmittedWorkDone();
+try {
+adapter0.label = '\u6133\ufd8d\u{1fb31}\u{1ff68}\u83e2\u4e5e\ua0fc\u9969\ub712';
+} catch {}
+let bindGroup4 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let commandEncoder5 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  size: [280, 1, 1],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup0, new Uint32Array(360), 26, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 19},
+  aspect: 'all',
+}, new Uint8Array(15_350).fill(99), /* required buffer size: 15_350 */
+{offset: 102, bytesPerRow: 953, rowsPerImage: 4}, {width: 56, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({});
+let textureView15 = texture7.createView({});
+let sampler5 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat'});
+let imageData2 = new ImageData(64, 64);
+let commandEncoder7 = device0.createCommandEncoder({});
+try {
+buffer1.unmap();
+} catch {}
+try {
+  await promise2;
+} catch {}
+let textureView16 = texture4.createView({});
+let textureView17 = texture16.createView({dimension: '2d-array', mipLevelCount: 1});
+let computePassEncoder3 = commandEncoder3.beginComputePass({timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 110, endOfPassWriteIndex: 80}});
+let querySet3 = device0.createQuerySet({type: 'timestamp', count: 1089});
+let texture17 = device0.createTexture({
+  size: {width: 71},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture18 = device0.createTexture({
+  size: [2240, 1, 17],
+  mipLevelCount: 5,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder4 = commandEncoder5.beginComputePass();
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder8 = device0.createCommandEncoder({});
+let texture19 = device0.createTexture({
+  size: {width: 127},
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+let bindGroup5 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let textureView18 = texture5.createView({});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+  await promise3;
+} catch {}
+let buffer7 = device0.createBuffer({size: 529, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandBuffer0 = commandEncoder8.finish({});
+let texture20 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder5 = commandEncoder4.beginComputePass();
+try {
+commandEncoder6.resolveQuerySet(querySet2, 128, 0, buffer7, 0);
+} catch {}
+let promise4 = device0.queue.onSubmittedWorkDone();
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'unspecified', transfer: 'smpte240m'} });
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let bindGroup6 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture21 = device0.createTexture({
+  size: {width: 17},
+  dimension: '1d',
+  format: 'rg16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder6 = commandEncoder6.beginComputePass();
+try {
+computePassEncoder2.setBindGroup(2, bindGroup5, new Uint32Array(626), 174, 0);
+} catch {}
+let promise5 = device0.queue.onSubmittedWorkDone();
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let bindGroup7 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture0}]});
+let commandEncoder10 = device0.createCommandEncoder({label: '\u9d1d\u{1ff55}\u9372\ua726\uc3f1\u55a5\u4db3'});
+let textureView19 = texture0.createView({aspect: 'all', baseArrayLayer: 5, arrayLayerCount: 1});
+let textureView20 = texture2.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup1, new Uint32Array(3687), 385, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 161, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(35).fill(248), /* required buffer size: 35 */
+{offset: 35}, {width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture22 = device0.createTexture({
+  size: {width: 2240},
+  dimension: '1d',
+  format: 'r8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder7 = commandEncoder9.beginComputePass();
+try {
+computePassEncoder6.setBindGroup(1, bindGroup1, new Uint32Array(1210), 451, 0);
+} catch {}
+let buffer8 = device0.createBuffer({size: 785, usage: GPUBufferUsage.COPY_SRC});
+let textureView21 = texture10.createView({dimension: '2d'});
+let texture23 = device0.createTexture({
+  size: [280, 1, 5],
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let sampler6 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 94.44});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup3, new Uint32Array(200), 46, 0);
+} catch {}
+let buffer9 = device0.createBuffer({label: '\u08e4\u4245', size: 15456, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView22 = texture10.createView({dimension: '2d'});
+let texture24 = device0.createTexture({
+  size: [2240, 1, 96],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView23 = texture16.createView({mipLevelCount: 1});
+let computePassEncoder8 = commandEncoder7.beginComputePass();
+let sampler7 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 93.67,
+});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup4, []);
+} catch {}
+try {
+  await promise4;
+} catch {}
+let textureView24 = texture22.createView({});
+let computePassEncoder9 = commandEncoder10.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(2, bindGroup6, new Uint32Array(1050), 272, 0);
+} catch {}
+try {
+buffer9.unmap();
+} catch {}
+let buffer10 = device0.createBuffer({size: 156, usage: GPUBufferUsage.COPY_DST});
+let textureView25 = texture0.createView({aspect: 'all', baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData1,
+  origin: { x: 10, y: 2 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  label: '\u5822\u{1fd04}',
+  layout: veryExplicitBindGroupLayout3,
+  entries: [{binding: 0, resource: textureView16}],
+});
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView26 = texture3.createView({baseMipLevel: 0, mipLevelCount: 1, arrayLayerCount: 28});
+let computePassEncoder10 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(3, bindGroup2, new Uint32Array(329), 8, 0);
+} catch {}
+document.body.append(img0);
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 370,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let bindGroup9 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 0, resource: textureView16}]});
+let texture25 = device0.createTexture({
+  size: [255, 107, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView27 = texture21.createView({});
+let externalTexture1 = device0.importExternalTexture({label: '\u7e69\u2bcb\u{1fa66}\u0db7\u40d8\u0a82', source: videoFrame1});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(2, bindGroup9, new Uint32Array(1115), 831, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let texture26 = device0.createTexture({
+  size: {width: 142, height: 16, depthOrArrayLayers: 12},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST,
+  viewFormats: [],
+});
+let sampler8 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMinClamp: 92.01, lodMaxClamp: 93.44});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(1, bindGroup9, new Uint32Array(699), 85, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: imageData2,
+  origin: { x: 2, y: 4 },
+  flipY: false,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 16, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer11 = device0.createBuffer({size: 44, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let texture27 = device0.createTexture({
+  size: {width: 35, height: 4, depthOrArrayLayers: 36},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+commandEncoder2.copyTextureToTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup10 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture1}]});
+let computePassEncoder11 = commandEncoder2.beginComputePass();
+try {
+computePassEncoder6.setBindGroup(2, bindGroup2, new Uint32Array(1714), 1_171, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+document.body.append(img0);
+let buffer12 = device0.createBuffer({size: 73, usage: GPUBufferUsage.INDEX});
+let textureView28 = texture18.createView({aspect: 'all', baseMipLevel: 1, mipLevelCount: 1, arrayLayerCount: 5});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await promise5;
+} catch {}
+let querySet4 = device0.createQuerySet({type: 'timestamp', count: 922});
+let bindGroup11 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 370, resource: textureView24}]});
+let buffer13 = device0.createBuffer({size: 172, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder12 = device0.createCommandEncoder({});
+let texture28 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder12 = commandEncoder12.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, []);
+} catch {}
+document.body.prepend(img0);
+let bindGroup12 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture0}]});
+let commandEncoder13 = device0.createCommandEncoder({});
+let texture29 = device0.createTexture({
+  size: {width: 71, height: 8, depthOrArrayLayers: 18},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView29 = texture29.createView({mipLevelCount: 1, arrayLayerCount: 5});
+let computePassEncoder13 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(2, bindGroup11, new Uint32Array(264), 78, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'smpteRp431', transfer: 'bt1361ExtendedColourGamut'} });
+let bindGroup13 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture1}]});
+let commandEncoder14 = device0.createCommandEncoder();
+let sampler9 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', minFilter: 'linear', lodMaxClamp: 94.59});
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 44, new Uint32Array(10785), 2837, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup14 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture1}]});
+let commandEncoder15 = device0.createCommandEncoder();
+let computePassEncoder14 = commandEncoder15.beginComputePass({timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 680, endOfPassWriteIndex: 530}});
+try {
+computePassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+await gc();
+try {
+computePassEncoder10.setBindGroup(3, bindGroup8, new Uint32Array(1268), 140, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+commandEncoder14.copyBufferToBuffer(buffer13, 8, buffer10, 24, 56);
+} catch {}
+let textureView30 = texture14.createView({dimension: '1d'});
+let computePassEncoder15 = commandEncoder14.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(3, bindGroup6, new Uint32Array(1294), 78, 0);
+} catch {}
+document.body.prepend(img0);
+let texture30 = device0.createTexture({
+  size: {width: 255, height: 107, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView31 = texture3.createView({mipLevelCount: 1, baseArrayLayer: 3, arrayLayerCount: 2});
+let sampler10 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.07,
+  compare: 'greater-equal',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup11, new Uint32Array(6022), 712, 0);
+} catch {}
+try {
+computePassEncoder13.end();
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder();
+let computePassEncoder16 = commandEncoder16.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(3, bindGroup9);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let computePassEncoder17 = commandEncoder13.beginComputePass();
+try {
+device0.queue.writeTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 283, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(31).fill(212), /* required buffer size: 31 */
+{offset: 31, rowsPerImage: 92}, {width: 91, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter0.label = '\u9d60\uba8d\uc626\u{1f9bc}\u0c31';
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE,
+      storageTexture: { format: 'rgba32uint', access: 'write-only', viewDimension: '1d' },
+    },
+  ],
+});
+let commandEncoder18 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder17.beginComputePass();
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 54, y: 0, z: 23},
+  aspect: 'all',
+}, new Uint8Array(38_617).fill(224), /* required buffer size: 38_617 */
+{offset: 97, bytesPerRow: 642, rowsPerImage: 12}, {width: 38, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer14 = device0.createBuffer({size: 224, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder19 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1640});
+let textureView32 = texture17.createView({});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup9, new Uint32Array(1068), 61, 0);
+} catch {}
+let commandBuffer1 = commandEncoder19.finish();
+let computePassEncoder19 = commandEncoder18.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(0, bindGroup1, new Uint32Array(43), 3, 0);
+} catch {}
+let bindGroup15 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 370, resource: textureView27}]});
+let texture31 = device0.createTexture({
+  size: {width: 1020, height: 428, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView33 = texture19.createView({baseArrayLayer: 0});
+await gc();
+let offscreenCanvas0 = new OffscreenCanvas(372, 89);
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let imageData3 = new ImageData(24, 24);
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'bt709', transfer: 'bt709'} });
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder();
+let computePassEncoder20 = commandEncoder20.beginComputePass();
+let sampler11 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge', lodMaxClamp: 58.43});
+let externalTexture2 = device0.importExternalTexture({label: '\u1ed5\u{1f6d9}\ue86f\ud079\u078d', source: videoFrame2});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup1);
+} catch {}
+document.body.prepend(img0);
+let buffer15 = device0.createBuffer({size: 224, usage: GPUBufferUsage.COPY_DST, mappedAtCreation: true});
+let sampler12 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 94.94,
+  compare: 'greater-equal',
+  maxAnisotropy: 12,
+});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: {width: 17},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture33 = device0.createTexture({
+  size: [127, 53, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder21 = commandEncoder21.beginComputePass({timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 4294967295}});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup15, new Uint32Array(1082), 351, 0);
+} catch {}
+try {
+computePassEncoder5.pushDebugGroup('\u5cc8');
+} catch {}
+document.body.append(img0);
+let buffer16 = device0.createBuffer({size: 267, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder22 = device0.createCommandEncoder({});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame0});
+let bindGroup16 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture3}]});
+let commandEncoder23 = device0.createCommandEncoder();
+let sampler13 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 92.65,
+  lodMaxClamp: 93.69,
+});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup16, new Uint32Array(4640), 1_270, 0);
+} catch {}
+let promise6 = device0.queue.onSubmittedWorkDone();
+let buffer17 = device0.createBuffer({size: 4, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let commandEncoder24 = device0.createCommandEncoder({});
+try {
+commandEncoder24.clearBuffer(buffer10);
+} catch {}
+document.body.append(img0);
+let texture34 = device0.createTexture({
+  size: [1020, 428, 1],
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+renderBundleEncoder3.setBindGroup(0, bindGroup1, new Uint32Array(2003), 240, 0);
+} catch {}
+try {
+renderBundleEncoder3.setIndexBuffer(buffer4, 'uint32', 0, 3);
+} catch {}
+let buffer18 = device0.createBuffer({size: 276, usage: GPUBufferUsage.INDIRECT});
+let texture35 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 1},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder22 = commandEncoder22.beginComputePass({timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 94}});
+try {
+computePassEncoder12.setBindGroup(3, bindGroup10);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer14, 0, 10);
+} catch {}
+try {
+commandEncoder23.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 13, y: 1, z: 8},
+  aspect: 'all',
+},
+{
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder24.resolveQuerySet(querySet3, 266, 1, buffer7, 0);
+} catch {}
+try {
+  await promise6;
+} catch {}
+try {
+computePassEncoder7.setBindGroup(2, bindGroup13, new Uint32Array(864), 92, 0);
+} catch {}
+try {
+renderBundleEncoder3.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(0, buffer3, 0);
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 296 */
+  offset: 296,
+  buffer: buffer6,
+}, {
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'smpte170m', transfer: 'smpte240m'} });
+let textureView34 = texture2.createView({});
+let sampler14 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.31,
+  maxAnisotropy: 20,
+});
+try {
+renderBundleEncoder3.setIndexBuffer(buffer0, 'uint32', 0, 0);
+} catch {}
+try {
+renderBundleEncoder3.setVertexBuffer(7, buffer3, 0, 39);
+} catch {}
+try {
+commandEncoder24.copyBufferToBuffer(buffer8, 248, buffer10, 0, 12);
+} catch {}
+let buffer19 = device0.createBuffer({size: 368, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture36 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 12},
+  format: 'depth32float-stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder23 = commandEncoder24.beginComputePass();
+let renderBundle3 = renderBundleEncoder3.finish({});
+let imageData4 = new ImageData(4, 24);
+let commandEncoder25 = device0.createCommandEncoder({});
+let computePassEncoder24 = commandEncoder25.beginComputePass({timestampWrites: {querySet: querySet4}});
+let computePassEncoder25 = commandEncoder23.beginComputePass({timestampWrites: {querySet: querySet0, endOfPassWriteIndex: 7}});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup3);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+try {
+computePassEncoder25.setBindGroup(1, bindGroup12, new Uint32Array(1153), 19, 0);
+} catch {}
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let commandEncoder26 = device0.createCommandEncoder({});
+let textureView35 = texture15.createView({mipLevelCount: 1});
+try {
+buffer2.unmap();
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 236 */
+  offset: 236,
+  bytesPerRow: 8704,
+  buffer: buffer6,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: img0,
+  origin: { x: 1, y: 3 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup17 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture1}]});
+let texture37 = gpuCanvasContext0.getCurrentTexture();
+let textureView36 = texture36.createView({aspect: 'depth-only', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder26 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder23.setBindGroup(0, bindGroup15, new Uint32Array(308), 13, 0);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 5, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(104), /* required buffer size: 6 */
+{offset: 6}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 4, y: 2, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+offscreenCanvas0.height = 165;
+let imageData5 = new ImageData(16, 40);
+let buffer20 = device0.createBuffer({size: 196, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView37 = texture14.createView({});
+let promise7 = device0.queue.onSubmittedWorkDone();
+let bindGroup18 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 0, resource: textureView16}]});
+let commandEncoder27 = device0.createCommandEncoder({});
+let texture38 = device0.createTexture({
+  size: [142, 16, 1],
+  sampleCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+commandEncoder27.resolveQuerySet(querySet2, 150, 21, buffer19, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 12, new Uint32Array(19533), 5498, 4);
+} catch {}
+let bindGroup19 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture0}]});
+let computePassEncoder27 = commandEncoder27.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(0, bindGroup18, []);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let textureView38 = texture2.createView({label: '\u64b7\u{1fb99}\u5564\u0ca7', dimension: '2d-array'});
+let textureView39 = texture8.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let computePassEncoder28 = commandEncoder28.beginComputePass();
+let externalTexture4 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup12, new Uint32Array(707), 68, 0);
+} catch {}
+try {
+computePassEncoder20.pushDebugGroup('\u{1fdf8}');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'smpte170m'} });
+let buffer21 = device0.createBuffer({size: 0, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let commandEncoder29 = device0.createCommandEncoder({});
+let textureView40 = texture38.createView({dimension: '2d-array', aspect: 'all'});
+let computePassEncoder29 = commandEncoder29.beginComputePass();
+try {
+computePassEncoder20.popDebugGroup();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 40, new Uint32Array(3467), 1389, 4);
+} catch {}
+let imageData6 = new ImageData(76, 32);
+let bindGroup20 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 0, resource: textureView16}]});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 116});
+try {
+device0.queue.writeBuffer(buffer21, 0, new DataView(new ArrayBuffer(9045)), 1203, 0);
+} catch {}
+let buffer22 = device0.createBuffer({size: 44, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE, mappedAtCreation: false});
+let texture39 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView41 = texture21.createView({aspect: 'all'});
+let buffer23 = device0.createBuffer({size: 88, usage: GPUBufferUsage.INDEX});
+let bindGroup21 = device0.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 0, resource: textureView16}]});
+let buffer24 = device0.createBuffer({size: 48, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let texture40 = device0.createTexture({size: [560, 1, 144], dimension: '3d', format: 'rgba32float', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup22 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture2}]});
+let buffer25 = device0.createBuffer({size: 101, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let commandEncoder30 = device0.createCommandEncoder({});
+let textureView42 = texture12.createView({});
+let computePassEncoder30 = commandEncoder30.beginComputePass();
+try {
+computePassEncoder3.setBindGroup(2, bindGroup13, new Uint32Array(85), 15, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 96, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(0).fill(74), /* required buffer size: 0 */
+{offset: 0}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer26 = device0.createBuffer({size: 7163, usage: GPUBufferUsage.UNIFORM});
+let texture41 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 12},
+  mipLevelCount: 1,
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler15 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 59.82, compare: 'greater-equal'});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 5},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView43 = texture24.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 47, arrayLayerCount: 1});
+try {
+buffer15.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 19},
+  aspect: 'all',
+}, new Uint8Array(44_693).fill(183), /* required buffer size: 44_693 */
+{offset: 229, bytesPerRow: 226, rowsPerImage: 14}, {width: 42, height: 1, depthOrArrayLayers: 15});
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let textureView44 = texture27.createView({});
+let computePassEncoder31 = commandEncoder31.beginComputePass();
+let sampler16 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge'});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup8, new Uint32Array(3176), 780, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 23, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(8).fill(160), /* required buffer size: 8 */
+{offset: 8}, {width: 249, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame6 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'jedecP22Phosphors', transfer: 'gamma28curve'} });
+let buffer27 = device0.createBuffer({size: 188, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder32 = device0.createCommandEncoder({});
+let computePassEncoder32 = commandEncoder32.beginComputePass({timestampWrites: {querySet: querySet3, beginningOfPassWriteIndex: 1033}});
+let sampler17 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'linear', lodMaxClamp: 80.83});
+let bindGroup23 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 370, resource: textureView24}]});
+let texture42 = gpuCanvasContext0.getCurrentTexture();
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 17,
+});
+try {
+device0.queue.writeBuffer(buffer10, 104, new DataView(new ArrayBuffer(161)), 79, 4);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture24,
+  mipLevel: 0,
+  origin: {x: 468, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(178).fill(185), /* required buffer size: 178 */
+{offset: 178, rowsPerImage: 132}, {width: 405, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup24 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 370, resource: textureView27}]});
+let buffer28 = device0.createBuffer({
+  size: 120,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM,
+});
+let texture43 = device0.createTexture({
+  size: [255, 107, 110],
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture44 = device0.createTexture({
+  size: {width: 71},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler19 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', magFilter: 'nearest'});
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'yCgCo', primaries: 'film', transfer: 'log'} });
+let buffer29 = device0.createBuffer({size: 344, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder33 = device0.createCommandEncoder({});
+try {
+computePassEncoder5.popDebugGroup();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+let shaderModule0 = device0.createShaderModule({
+  code: `
+requires packed_4x8_integer_dot_product;
+
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+var<workgroup> vw2: f16;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw1: array<atomic<u32>, 1>;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* zero global variables used */
+fn fn0() -> vec2h {
+  var out: vec2h;
+  var vf0: vec3f = fma(vec3f(unconst_f32(0.3933e0), unconst_f32(0.3557), unconst_f32(-0.01195e-1)), vec3f(unconst_f32(-0.1249), unconst_f32(0.1440e33), unconst_f32(0.3241)), vec3f(unconst_f32(0.1029), unconst_f32(0.2344), unconst_f32(0.02369e-20)));
+  vf0 = smoothstep(vec3f(unconst_f32(0.3887e-35), unconst_f32(0.04641), unconst_f32(0.04452e20)), vec3f(unconst_f32(0.09017e29), unconst_f32(0.06401e-16), unconst_f32(0.6510e-10)), vec3f(unconst_f32(0.07824e-23), unconst_f32(0.1386e-28), unconst_f32(-0.1760e10)));
+  let vf1: vec3h = radians(vec3h(unconst_f16(5440.3), unconst_f16(22124.2), unconst_f16(8283.2)));
+  if bool(pack4xU8Clamp((vec4u(unconst_u32(162813452), unconst_u32(839659684), unconst_u32(24605060), unconst_u32(179293361)) ^ vec4u(unconst_u32(454378602), unconst_u32(513376072), unconst_u32(69271498), unconst_u32(678403749))))) {
+  var vf2: vec4u = unpack4xU8(unconst_u32(587528971));
+  while any(select(vec2<bool>(unconst_bool(true), unconst_bool(true)), vec2<bool>(unconst_bool(true), unconst_bool(false)), unconst_bool(true))) {
+  vp0 += vec2i(i32(override0));
+  out += exp(vec3h(unconst_f16(440.9), unconst_f16(12.22), unconst_f16(17276.2))).gb;
+  _ = override0;
+}
+  out = bitcast<vec2h>(vf2[unconst_u32(1111737671)]);
+  out *= transpose(mat2x2h(unconst_f16(31633.8), unconst_f16(15323.9), unconst_f16(7020.4), unconst_f16(689.3)))[unconst_i32(1)];
+  out += bitcast<vec2h>(asinh(unconst_f32(0.08950e15)));
+  vf2 = vec4u(select(vec2<bool>(unconst_bool(false), unconst_bool(true)), vec2<bool>(unconst_bool(true), unconst_bool(true)), unconst_bool(false)).ggrr.zxxx.xwyz);
+  _ = override0;
+}
+  return out;
+  _ = override0;
+}
+
+@group(0) @binding(0) var st0: texture_storage_1d<rgba32uint, write>;
+
+struct FragmentOutput0 {
+  @location(3) f0: i32,
+  @location(0) f1: vec4f,
+  @location(4) @interpolate(flat) f2: vec4i,
+  @builtin(frag_depth) f3: f32,
+}
+
+override override0: f16 = 8896.3;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T0 {
+  @align(32) @size(32) f0: array<u32>,
+}
+
+struct T4 {
+  @align(8) @size(1408) f0: array<vec2h>,
+}
+
+var<private> vp0: vec2i = vec2i(337004226, 285289072);
+
+struct T2 {
+  @size(48) f0: array<array<i32, 1>, 1>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct T1 {
+  @size(76) f0: array<u32>,
+}
+
+struct T3 {
+  @align(8) @size(544) f0: array<u32>,
+}
+
+var<workgroup> vw0: atomic<i32>;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+/* zero global variables used */
+@vertex
+fn vertex0() -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf3: vec2f = saturate(vec2f(unconst_f32(-0.2415), unconst_f32(0.04436)));
+  let vf4: vec2<bool> =  !vec2<bool>(unconst_bool(true), unconst_bool(true));
+  var vf5: vec3f = atan(vec3f(unconst_f32(-0.05508e20), unconst_f32(0.1050), unconst_f32(0.07418)));
+  out -= vf5.yzyy;
+  vp0 &= vec2i(i32(any(vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(true)))));
+  vf3 = log2(vec4f(unconst_f32(0.2229), unconst_f32(0.1952e13), unconst_f32(0.05096e-22), unconst_f32(0.1002e35))).wz;
+  vp0 *= vec2i(i32(any(vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)))));
+  vf5 = sqrt(vec2f(unconst_f32(-0.2553), unconst_f32(0.1371e-4))).yyy;
+  var vf6: vec4f = max(vec4f(unconst_f32(0.03227), unconst_f32(0.08470e-12), unconst_f32(0.2954), unconst_f32(0.03766)), vec4f(unconst_f32(0.05218e33), unconst_f32(0.1489e27), unconst_f32(0.4615), unconst_f32(0.2792e17)));
+  vp0 ^= vec2i(atanh(vec2f(unconst_f32(0.00159e-13), unconst_f32(0.00881e-35))).rr);
+  vp0 += vec2i(i32(atanh(unconst_f32(0.00707))));
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment0(@invariant @builtin(position) a0: vec4f) -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  let vf7: i32 = vp0[unconst_u32(2257604007)];
+  let vf8: vec4f = a0;
+  out.f3 = bitcast<vec2f>((vec2i(unconst_i32(-235760948), unconst_i32(949503783)) | vec2i(bitcast<i32>(vf8[unconst_u32(1211654864)])))).r;
+  var vf9: i32 = vf7;
+  var vf10 = fn0();
+  let ptr0: ptr<function, i32> = &vf9;
+  _ = fn0();
+  vf10 -= vec2h(f16((unconst_bool(true) && unconst_bool(false))));
+  var vf11 = fn0();
+  out.f0 |= i32(vf8.x);
+  out.f1 += vec4f(bitcast<f32>((*ptr0)));
+  out.f1 *= vec4f(f32(vf9));
+  return out;
+  _ = override0;
+}
+
+/* used global variables: st0 */
+@compute @workgroup_size(2, 1, 1)
+fn compute0() {
+  atomicXor(&vw1[unconst_u32(349767354)], unconst_u32(1526373867));
+  textureStore(st0, unconst_i32(106217254), vec4u(vec4u(unconst_u32(717704398), unconst_u32(740619250), unconst_u32(225646399), unconst_u32(87498129))));
+  var vf12: vec4h = atan(vec4h(unconst_f16(-1076.2), unconst_f16(4121.5), unconst_f16(1333.0), unconst_f16(629.6)));
+  vw2 = f16(firstLeadingBit(unconst_i32(576319628)));
+  let vf13: vec2h = (vec2h(unconst_f16(-11176.8), unconst_f16(-51003.6)) - unconst_f16(22229.9));
+  textureStore(st0, unconst_i32(122071010), vec4u(vec4u(unconst_u32(574442821), unconst_u32(423919562), unconst_u32(649006010), unconst_u32(665704144))));
+  let vf14: u32 = atomicExchange(&(*&vw1)[unconst_u32(412871466)], unconst_u32(1363918790));
+  return;
+  _ = st0;
+}`,
+});
+let bindGroup25 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture2}]});
+let commandEncoder34 = device0.createCommandEncoder({});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\u{1fefe}');
+} catch {}
+document.body.prepend(img0);
+let commandBuffer2 = commandEncoder33.finish();
+let texture45 = device0.createTexture({
+  size: [35, 4, 36],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder33 = commandEncoder34.beginComputePass({timestampWrites: {querySet: querySet3}});
+let querySet7 = device0.createQuerySet({type: 'timestamp', count: 1064});
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 3,
+});
+try {
+buffer24.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let texture46 = device0.createTexture({
+  size: {width: 17, height: 2, depthOrArrayLayers: 71},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder20.setBindGroup(1, bindGroup4, new Uint32Array(703), 76, 0);
+} catch {}
+let buffer30 = device0.createBuffer({size: 624, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder35 = device0.createCommandEncoder({});
+let sampler21 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.40,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup22, new Uint32Array(303), 65, 0);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let pipeline0 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {count: 4, mask: 0xffffffff, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  constants: {},
+  targets: [{format: 'rgba32float', writeMask: GPUColorWrite.GREEN}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: true,
+    depthCompare: 'greater',
+    stencilWriteMask: 183032109,
+    depthBiasSlopeScale: 432.98051454189067,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'line-list', cullMode: 'front'},
+});
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'smpteSt4281'} });
+let bindGroup26 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 370, resource: textureView41}]});
+let commandEncoder36 = device0.createCommandEncoder({});
+let textureView45 = texture6.createView({});
+let renderPassEncoder0 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{
+  view: textureView40,
+  clearValue: { r: 887.9, g: -133.3, b: 624.7, a: -972.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({colorFormats: ['rg16float']});
+try {
+computePassEncoder5.setBindGroup(1, bindGroup23);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup19, new Uint32Array(61), 11, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup16, []);
+} catch {}
+try {
+commandEncoder35.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 3, z: 20},
+  aspect: 'all',
+},
+{
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 67, y: 11, z: 0},
+  aspect: 'all',
+},
+{width: 30, height: 3, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder35.resolveQuerySet(querySet0, 12, 8, buffer7, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let buffer31 = device0.createBuffer({size: 264, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let computePassEncoder34 = commandEncoder35.beginComputePass({timestampWrites: {querySet: querySet2, beginningOfPassWriteIndex: 163, endOfPassWriteIndex: 388}});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder12.setBindGroup(1, bindGroup14);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(3, bindGroup10, new Uint32Array(395), 15, 0);
+} catch {}
+try {
+computePassEncoder17.end();
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup18, new Uint32Array(1684), 40, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 88, new DataView(new ArrayBuffer(1610)), 211, 20);
+} catch {}
+let buffer32 = device0.createBuffer({size: 23, usage: GPUBufferUsage.INDEX});
+let commandEncoder37 = device0.createCommandEncoder({});
+let texture47 = device0.createTexture({
+  size: [1020, 428, 41],
+  mipLevelCount: 4,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let renderBundle4 = renderBundleEncoder4.finish({});
+let sampler22 = device0.createSampler({addressModeU: 'repeat', lodMaxClamp: 75.45});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup16, new Uint32Array(1851), 165, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup12, new Uint32Array(589), 29, 0);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let computePassEncoder35 = commandEncoder13.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(2, bindGroup10, new Uint32Array(3483), 107, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+document.body.append(img0);
+let bindGroup27 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 370, resource: textureView24}]});
+let computePassEncoder36 = commandEncoder37.beginComputePass();
+let sampler23 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.33,
+});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup25);
+} catch {}
+let texture48 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let textureView46 = texture21.createView({aspect: 'all'});
+try {
+computePassEncoder11.setBindGroup(0, bindGroup3);
+} catch {}
+let textureView47 = texture13.createView({dimension: '2d', aspect: 'depth-only', format: 'depth32float', baseArrayLayer: 28});
+try {
+computePassEncoder24.setBindGroup(1, bindGroup22);
+} catch {}
+let texture49 = device0.createTexture({
+  size: {width: 280, height: 1, depthOrArrayLayers: 2},
+  mipLevelCount: 5,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture50 = gpuCanvasContext0.getCurrentTexture();
+let sampler24 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.44,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(823);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer32, 'uint32', 0, 6);
+} catch {}
+let pipeline1 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  targets: [{
+  format: 'rgba32float',
+  blend: {
+    color: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'less-equal',
+    stencilReadMask: 768138133,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {topology: 'line-list', frontFace: 'cw', cullMode: 'none'},
+});
+let sampler25 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 64.39,
+  compare: 'equal',
+  maxAnisotropy: 15,
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup6, new Uint32Array(781), 8, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer28, 'uint16', 0, 15);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(3, buffer30, 0, 8);
+} catch {}
+document.body.prepend(img0);
+let textureView48 = texture48.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(32, 4, 3, 2);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 343, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(39).fill(94), /* required buffer size: 39 */
+{offset: 39, bytesPerRow: 1391}, {width: 171, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let textureView49 = texture25.createView({dimension: '2d-array'});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup24, new Uint32Array(719), 57, 0);
+} catch {}
+let canvas0 = document.createElement('canvas');
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let buffer33 = device0.createBuffer({size: 13084, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup12);
+} catch {}
+try {
+renderPassEncoder0.setViewport(71.85716688586815, 8.744998956995945, 35.078451557926705, 5.0613136797166325, 0.6659190240781362, 0.9084386249586769);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer33, 'uint32', 7_556, 350);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer19, 0, 36);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let gpuCanvasContext1 = canvas0.getContext('webgpu');
+try {
+computePassEncoder12.setBindGroup(1, bindGroup1, new Uint32Array(365), 315, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: 360.7, g: -892.7, b: -739.1, a: 709.7, });
+} catch {}
+let pipeline2 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0}});
+let offscreenCanvas1 = new OffscreenCanvas(112, 40);
+let textureView50 = texture43.createView({aspect: 'all'});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup25, new Uint32Array(1840), 391, 0);
+} catch {}
+try {
+computePassEncoder20.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer11, 'uint16', 2, 3);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(1, buffer19, 368);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0}});
+let texture51 = gpuCanvasContext0.getCurrentTexture();
+let textureView51 = texture9.createView({baseMipLevel: 0, arrayLayerCount: 1});
+let sampler26 = device0.createSampler({addressModeU: 'mirror-repeat', lodMaxClamp: 82.32});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup23, new Uint32Array(150), 13, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 12, new Uint32Array(9930), 967, 0);
+} catch {}
+let pipeline4 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0}});
+let computePassEncoder37 = commandEncoder36.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(0, bindGroup15, new Uint32Array(1054), 78, 0);
+} catch {}
+let buffer34 = device0.createBuffer({
+  label: '\u8486\u9b59',
+  size: 40,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+  mappedAtCreation: false,
+});
+let commandEncoder38 = device0.createCommandEncoder({});
+let textureView52 = texture1.createView({mipLevelCount: 2});
+let computePassEncoder38 = commandEncoder38.beginComputePass({timestampWrites: {querySet: querySet4}});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 91.89,
+  lodMaxClamp: 97.14,
+  maxAnisotropy: 1,
+});
+let commandEncoder39 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 3133});
+let texture52 = device0.createTexture({
+  size: [2240, 1, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder39 = commandEncoder39.beginComputePass();
+let sampler28 = device0.createSampler({addressModeW: 'repeat', mipmapFilter: 'linear', lodMinClamp: 31.66});
+try {
+computePassEncoder25.insertDebugMarker('\uc183');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 1, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder();
+let textureView53 = texture52.createView({arrayLayerCount: 1});
+try {
+buffer14.unmap();
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout6, veryExplicitBindGroupLayout0]});
+let commandEncoder41 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'timestamp', count: 1768});
+let textureView54 = texture52.createView({});
+let computePassEncoder40 = commandEncoder41.beginComputePass();
+try {
+computePassEncoder20.setBindGroup(0, bindGroup18, new Uint32Array(179), 3, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT, alphaMode: 'opaque'});
+} catch {}
+let computePassEncoder41 = commandEncoder40.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 635, endOfPassWriteIndex: 245}});
+let sampler29 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.60,
+});
+try {
+computePassEncoder37.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer24, 4, new Uint32Array(2868), 405, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer35 = device0.createBuffer({size: 220, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let texture53 = device0.createTexture({
+  size: {width: 1120, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView55 = texture23.createView({});
+let promise9 = device0.queue.onSubmittedWorkDone();
+let pipeline5 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule0, constants: {}}});
+let commandEncoder42 = device0.createCommandEncoder();
+let textureView56 = texture13.createView({dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder42 = commandEncoder42.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(2, bindGroup12, new Uint32Array(770), 54, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(2, 1); };
+} catch {}
+try {
+computePassEncoder3.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture8,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(234).fill(101), /* required buffer size: 234 */
+{offset: 234}, {width: 12, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline4.getBindGroupLayout(0);
+let textureView57 = texture8.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer29, 60); };
+} catch {}
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 280 */
+  offset: 280,
+  buffer: buffer6,
+}, {
+  texture: texture49,
+  mipLevel: 1,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer15, 8, new Int16Array(14206), 7480, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture28,
+  mipLevel: 0,
+  origin: {x: 26, y: 36, z: 0},
+  aspect: 'all',
+}, new Uint8Array(6).fill(28), /* required buffer size: 6 */
+{offset: 6, bytesPerRow: 462}, {width: 111, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let texture54 = device0.createTexture({
+  size: [35, 4, 36],
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView58 = texture40.createView({});
+let computePassEncoder43 = commandEncoder20.beginComputePass();
+try {
+computePassEncoder31.setBindGroup(0, bindGroup6, new Uint32Array(424), 16, 0);
+} catch {}
+try {
+buffer31.unmap();
+} catch {}
+let buffer36 = device0.createBuffer({size: 116, usage: GPUBufferUsage.INDEX});
+let sampler30 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 85.62});
+try {
+computePassEncoder4.setBindGroup(3, bindGroup16, new Uint32Array(5916), 1_092, 0);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let querySet10 = device0.createQuerySet({type: 'timestamp', count: 1177});
+try {
+computePassEncoder6.setPipeline(pipeline5);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let commandEncoder43 = device0.createCommandEncoder();
+let textureView59 = texture10.createView({dimension: '2d-array', aspect: 'depth-only', baseArrayLayer: 6, arrayLayerCount: 1});
+try {
+buffer19.unmap();
+} catch {}
+try {
+commandEncoder43.copyTextureToTexture({
+  texture: texture49,
+  mipLevel: 2,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture49,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let imageData7 = new ImageData(48, 16);
+let buffer37 = device0.createBuffer({
+  size: 424,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE,
+  mappedAtCreation: false,
+});
+let computePassEncoder44 = commandEncoder43.beginComputePass();
+let sampler31 = device0.createSampler({
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder43.setPipeline(pipeline4);
+} catch {}
+let textureView60 = texture45.createView({baseArrayLayer: 0});
+try {
+computePassEncoder26.setPipeline(pipeline2);
+} catch {}
+let gpuCanvasContext2 = offscreenCanvas1.getContext('webgpu');
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let videoFrame9 = new VideoFrame(videoFrame1, {timestamp: 0});
+let textureView61 = texture54.createView({mipLevelCount: 1});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame8});
+try {
+computePassEncoder44.setPipeline(pipeline3);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 0, y: 1, z: 2},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture55 = device0.createTexture({
+  size: {width: 280, height: 1, depthOrArrayLayers: 30},
+  mipLevelCount: 6,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder9.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder27.setPipeline(pipeline4);
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  label: '\u0980\u{1f75f}\u6b77\u3ce2\u04cd\u017e',
+  layout: veryExplicitBindGroupLayout6,
+  entries: [{binding: 30, resource: textureView53}],
+});
+let textureView62 = texture38.createView({dimension: '2d-array', baseArrayLayer: 0});
+try {
+computePassEncoder8.setPipeline(pipeline5);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 900, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(87).fill(120), /* required buffer size: 87 */
+{offset: 87}, {width: 13, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: canvas0,
+  origin: { x: 118, y: 15 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+try {
+computePassEncoder35.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline4);
+} catch {}
+let buffer38 = device0.createBuffer({size: 72, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM});
+let textureView63 = texture17.createView({baseMipLevel: 0});
+let texture56 = device0.createTexture({
+  size: {width: 255, height: 107, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+buffer1.destroy();
+} catch {}
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 360});
+let texture57 = device0.createTexture({
+  size: {width: 35, height: 4, depthOrArrayLayers: 18},
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture58 = device0.createTexture({
+  label: '\u{1fd45}\u{1fdf5}\u1ef3\u{1faff}\u61ae\u4c4c\u0361\u5fdc\u029a',
+  size: {width: 71, height: 8, depthOrArrayLayers: 1},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder35.setBindGroup(0, bindGroup13);
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+enable f16;
+
+enable f16;
+
+requires pointer_composite_access;
+
+struct T0 {
+  @size(256) f0: array<array<atomic<u32>, 1>, 2>,
+  @size(512) f1: u32,
+  @align(16) @size(1536) f2: array<array<atomic<u32>, 1>>,
+}
+
+alias vec3b = vec3<bool>;
+
+struct VertexOutput1 {
+  @builtin(position) f1: vec4f,
+}
+
+var<workgroup> vw4: FragmentOutput1;
+
+@group(0) @binding(0) var st1: texture_storage_1d<rgba32uint, write>;
+
+/* zero global variables used */
+fn fn0(a0: ptr<workgroup, VertexOutput0>) -> VertexOutput0 {
+  var out: VertexOutput0;
+  var vf15: vec4h = select(vec4h(unconst_f16(-14902.8), unconst_f16(-6810.7), unconst_f16(32992.3), unconst_f16(13419.5)), vec4h(unconst_f16(8281.5), unconst_f16(5166.8), unconst_f16(5243.7), unconst_f16(12180.8)), vec4<bool>(firstLeadingBit(vec4u(unconst_u32(362180120), unconst_u32(663273468), unconst_u32(114929309), unconst_u32(1680586527)))));
+  out.f0 *= bitcast<vec4f>((vec2i(unconst_i32(198529082), unconst_i32(415810335)) | vec2i(unconst_i32(32887626), unconst_i32(7232036))).yxxx);
+  let vf16: mat3x2h = transpose(mat2x3h());
+  (*a0) = VertexOutput0(vec4f(vf16[unconst_i32(0)].ggrr));
+  {
+  (*a0).f0 = cos(vec2f(unconst_f32(0.05396e35), unconst_f32(0.3683e23))).xyyy;
+  out.f0 = unpack4x8snorm(unconst_u32(957290625));
+  var vf17: u32 = (pack2x16float(vec2f(unconst_f32(-0.2883e15), unconst_f32(0.2904))) >> unconst_u32(513924394));
+  out.f0 = (*a0).f0;
+  let vf18: f32 = log2(unconst_f32(0.00620e19));
+  var vf19: bool = all(bool(radians(vec3f(unconst_f32(0.4630), unconst_f32(-0.3349), unconst_f32(0.2480e12)))[1]));
+}
+  var vf20: mat3x2h = vf16;
+  out.f0 -= vec4f(f32(dot(vec4u(unconst_u32(1988437916), unconst_u32(60858296), unconst_u32(774990443), unconst_u32(611081186)), vec4u((*a0).f0.rrab.xzxz))));
+  if bool((*a0).f0[2]) {
+  out = VertexOutput0(vec4f((*a0).f0[unconst_u32(873829147)]));
+  let ptr1: ptr<workgroup, VertexOutput0> = &(*a0);
+}
+  let ptr2: ptr<function, mat3x2h> = &vf20;
+  var vf21: vec2h = vf16[unconst_u32(2025097724)];
+  return out;
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct VertexOutput0 {
+  @builtin(position) f0: vec4f,
+}
+
+var<workgroup> vw7: atomic<i32>;
+
+var<workgroup> vw3: VertexOutput1;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<workgroup> vw6: VertexOutput0;
+
+struct T1 {
+  @size(76) f0: array<array<i32, 9>, 1>,
+  @size(8) f1: array<u32, 1>,
+}
+
+struct FragmentOutput1 {
+  @location(0) @interpolate(flat, sample) f0: vec2f,
+  @builtin(sample_mask) f1: u32,
+}
+
+struct T3 {
+  @align(64) @size(1728) f0: array<atomic<i32>>,
+}
+
+struct T2 {
+  @size(16) f0: array<u32>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<workgroup> vw5: VertexOutput0;
+
+/* zero global variables used */
+@vertex
+fn vertex1(@location(5) @interpolate(perspective) a0: f32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  out.f0 += bitcast<vec4f>(insertBits(vec2u(unconst_u32(59853415), unconst_u32(526142743)), vec2u(unconst_u32(49522241), unconst_u32(186957958)), unconst_u32(5505668), unconst_u32(1693499432)).rgrg);
+  var vf22: vec2u = insertBits(vec2u(unconst_u32(78540915), unconst_u32(261881515)), vec2u(unconst_u32(717060533), unconst_u32(711355256)), unconst_u32(308757040), unconst_u32(527334596));
+  vf22 = vec2u(pack4x8unorm(vec4f(unconst_f32(0.03381e-43), unconst_f32(0.8129e-26), unconst_f32(0.01589e28), unconst_f32(0.03593e7))));
+  out.f0 = atan2(vec2f(unconst_f32(0.4866e25), unconst_f32(0.04192)), vec2f(unconst_f32(0.2562e-13), unconst_f32(0.2841))).yxxx;
+  vf22 = vec2u(bitcast<u32>(a0));
+  var vf23: f32 = a0;
+  loop {
+  var vf24: vec4f = (vec4f(unconst_f32(0.3018), unconst_f32(0.1658), unconst_f32(-0.00838e29), unconst_f32(0.5063e-42)) % f32(determinant(mat2x2h(unconst_f16(20923.7), unconst_f16(1554.5), unconst_f16(3254.6), unconst_f16(4423.5)))));
+  var vf25: f32 = a0;
+  vf25 = pow(vec3f(unconst_f32(0.03454e16), unconst_f32(0.3305e28), unconst_f32(0.09657e-37)), unpack2x16snorm(unconst_u32(165489718)).xyx).r;
+  var vf26: vec3u = extractBits(vec3u(unconst_u32(78002419), unconst_u32(1449491266), unconst_u32(52532018)), unconst_u32(262042851), pack4xU8(bitcast<vec4u>(step(vec4f(unconst_f32(0.06675e22), unconst_f32(0.06160), unconst_f32(0.2746), unconst_f32(0.3081)), vec4f(unconst_f32(0.08480e-13), unconst_f32(0.1314e-16), unconst_f32(0.00637e-25), unconst_f32(0.05386e-38))).argg)));
+  var vf27: f32 = a0;
+  let vf28: vec3h = saturate(vec3h(unconst_f16(35241.9), unconst_f16(3004.8), unconst_f16(11709.1)));
+  break;
+}
+  var vf29: vec2h = sin(vec2h(unconst_f16(451.2), unconst_f16(2215.7)));
+  let ptr3: ptr<function, f32> = &vf23;
+  var vf30: mat2x4f = transpose(mat4x2f(vf23, vf23, vf23, vf23, vf23, vf23, vf23, vf23));
+  return out;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex2(@location(12) a0: vec4f) -> VertexOutput1 {
+  var out: VertexOutput1;
+  let vf31: vec4f = atanh(vec4f(unconst_f32(0.1699), unconst_f32(0.03867), unconst_f32(0.07032e-30), unconst_f32(0.09812e-9)));
+  out.f1 = vec4f(vf31[bitcast<u32>(countOneBits(vec3i(unconst_i32(84587265), unconst_i32(356744281), unconst_i32(377063476)))[0])]);
+  let vf32: vec4h = acosh(vec4h(unconst_f16(11923.9), unconst_f16(8605.9), unconst_f16(5814.1), unconst_f16(11672.5)));
+  let vf33: f32 = determinant(mat2x2f(f32((unconst_f32(0.1197e2) >= sinh(unconst_f32(0.1563)))), f32((unconst_f32(0.1197e2) >= sinh(unconst_f32(0.1563)))), f32((unconst_f32(0.1197e2) >= sinh(unconst_f32(0.1563)))), f32((unconst_f32(0.1197e2) >= sinh(unconst_f32(0.1563))))));
+  var vf34: bool = (atanh(vec4f(unconst_f32(0.2442e-7), unconst_f32(0.07287e21), unconst_f32(-0.4401), unconst_f32(0.01524e28))).y < vec4f(vf32)[0]);
+  let vf35: f32 = length(vec4f(unconst_f32(0.3269e37), unconst_f32(-0.1123), unconst_f32(0.05829), unconst_f32(0.02102)));
+  var vf36: bool = (unconst_bool(true) != unconst_bool(true));
+  return out;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex3(@location(1) a0: vec2h, @location(11) @interpolate(flat, first) a1: vec4u, @location(0) a2: vec2f) -> @builtin(position) vec4f {
+  var out: vec4f;
+  var vf37: vec2f = a2;
+  {
+  out = asin(vec4f(unconst_f32(0.02525e35), unconst_f32(0.07450e-35), unconst_f32(0.1643e-8), unconst_f32(0.1169e-4)));
+  var vf38: vec2f = reflect(vec2f(unconst_f32(0.06213e7), unconst_f32(0.07997)), vec2f(unconst_f32(0.9417), unconst_f32(0.1925)));
+  var vf39: vec4h = step(vec4h(unconst_f16(17456.8), unconst_f16(46483.4), unconst_f16(6658.6), unconst_f16(15635.9)), vec4h(unconst_f16(3921.5), unconst_f16(649.5), unconst_f16(6931.9), unconst_f16(-2423.5)));
+}
+  vf37 = vec2f(vf37[unconst_u32(629380845)]);
+  let vf40: f32 = a2[unconst_u32(386210005)];
+  vf37 = vec2f(bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.3565e-36), unconst_f32(-0.01730e-9)))));
+  out *= vec4f(vf37[unconst_u32(1019812934)]);
+  let vf41: vec4u = a1;
+  var vf42: vec2h = fract(vec2h(unconst_f16(1264.2), unconst_f16(2041.1)));
+  vf37 -= vec2f(fract(vec2h(unconst_f16(7059.1), unconst_f16(10938.6))));
+  vf37 *= vec2f(f32(vf42[unconst_u32(257995315)]));
+  let vf43: vec2h = a0;
+  vf42 = bitcast<vec2h>(vf40);
+  return out;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  discard;
+  out.f0 *= select(vec4f(unconst_f32(0.7790), unconst_f32(0.09221e-40), unconst_f32(0.3966e-13), unconst_f32(0.2437e3)), vec4f(unconst_f32(0.1395), unconst_f32(-0.1697e-40), unconst_f32(0.1997e-21), unconst_f32(0.06578)), vec4<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(false), unconst_bool(false))).bb;
+  var vf44: u32 = pack4x8snorm(vec4f(unpack4xI8(unconst_u32(2015119378))));
+  out.f1 = pack4xI8Clamp(unpack4xI8(unconst_u32(638134469)));
+  let vf45: u32 = dot4U8Packed(unconst_u32(428118278), unconst_u32(673522134));
+  out.f0 = vec2f(bitcast<f32>(dot4I8Packed( ~unconst_u32(303350582), unconst_u32(443546687))));
+  return out;
+}
+
+/* used global variables: st1 */
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  var vf46: vec3i = reverseBits(vec3i(unconst_i32(378312666), unconst_i32(-36666233), unconst_i32(680804855)));
+  let vf47: f32 = vw4.f0[unconst_u32(1227582279)];
+  if bool((*&vw4).f0[1]) {
+  for (var it0=u32((*&vw3).f1[2]); it0<(bitcast<u32>(atomicLoad(&(*&vw7))) & 0xfff); it0++) {
+  vw5 = VertexOutput0(vec4f(bitcast<f32>(pack4x8snorm(vec4f(unconst_f32(0.1700e38), unconst_f32(0.2037e-7), unconst_f32(0.8683), unconst_f32(0.7161))))));
+  textureStore(st1, unconst_i32(94058562), vec4u(vec4u(unconst_u32(12989257), unconst_u32(268179117), unconst_u32(356228276), unconst_u32(896616405))));
+  vw3.f1 = workgroupUniformLoad(&vw5).f0;
+  break;
+  _ = st1;
+}
+  var vf48 = fn0(&vw6);
+  let ptr4: ptr<workgroup, u32> = &vw4.f1;
+  _ = st1;
+}
+  fn0(&vw6);
+  var vf49 = fn0(&vw5);
+  while bool(pack4xU8Clamp(vec4u(unconst_u32(322740874), unconst_u32(1703412073), unconst_u32(61316136), unconst_u32(517653131)))) {
+  vw4.f1 |= pack2x16snorm((*&vw4).f0);
+  loop {
+  atomicAnd(&vw7, unconst_i32(176121078));
+  let vf50: i32 = atomicLoad(&(*&vw7));
+  vw4.f1 = vec2u(log2(vec2f(unconst_f32(-0.04886e-24), unconst_f32(-0.2430e8))))[0];
+  break;
+}
+}
+  _ = fn0(&vw5);
+  _ = st1;
+}`,
+});
+let texture59 = device0.createTexture({
+  size: [1020, 428, 1],
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup24, new Uint32Array(557), 49, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+let textureView64 = texture59.createView({dimension: '2d-array', baseMipLevel: 0, arrayLayerCount: 1});
+let textureView65 = texture52.createView({arrayLayerCount: 1});
+let sampler32 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 98.15,
+});
+try {
+computePassEncoder4.setPipeline(pipeline2);
+} catch {}
+let buffer39 = device0.createBuffer({size: 40, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let textureView66 = texture22.createView({});
+try {
+computePassEncoder10.setPipeline(pipeline5);
+} catch {}
+canvas0.height = 88;
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: [560, 1, 119],
+  dimension: '2d',
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView67 = texture26.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder45 = commandEncoder44.beginComputePass();
+try {
+computePassEncoder40.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture36,
+  mipLevel: 0,
+  origin: {x: 0, y: 47, z: 2},
+  aspect: 'stencil-only',
+}, new Uint8Array(35).fill(20), /* required buffer size: 35 */
+{offset: 35}, {width: 256, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: imageData3,
+  origin: { x: 1, y: 5 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 2},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise7;
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(24).fill(63), /* required buffer size: 24 */
+{offset: 24, bytesPerRow: 81, rowsPerImage: 23}, {width: 27, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture61 = device0.createTexture({
+  size: {width: 71, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder45.setPipeline(pipeline2);
+} catch {}
+try {
+  await buffer24.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 8, height: 1, depthOrArrayLayers: 9}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 1, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture3.label = '\ubf20\ue58b\u{1fb23}\u0d72';
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: veryExplicitBindGroupLayout8, entries: [{binding: 5, resource: externalTexture5}]});
+let commandEncoder45 = device0.createCommandEncoder({});
+let texture62 = device0.createTexture({
+  size: {width: 255, height: 107, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView68 = texture56.createView({baseMipLevel: 0, baseArrayLayer: 0});
+let renderPassEncoder1 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView40,
+  clearValue: { r: -159.2, g: -468.6, b: -533.8, a: 872.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 86406486,
+});
+let sampler33 = device0.createSampler({addressModeU: 'clamp-to-edge', addressModeW: 'repeat', lodMaxClamp: 77.39, compare: 'greater'});
+let externalTexture8 = device0.importExternalTexture({source: videoFrame6, colorSpace: 'display-p3'});
+try {
+computePassEncoder8.setBindGroup(1, bindGroup23);
+} catch {}
+let promise10 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise8;
+} catch {}
+let bindGroup30 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 5, resource: externalTexture1}]});
+let buffer40 = device0.createBuffer({size: 28, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let texture63 = device0.createTexture({
+  size: [2240, 1, 10],
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder31.setBindGroup(1, bindGroup6, []);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer14);
+} catch {}
+let buffer41 = device0.createBuffer({size: 40, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ, mappedAtCreation: false});
+let commandEncoder46 = device0.createCommandEncoder({});
+let textureView69 = texture24.createView({mipLevelCount: 1, baseArrayLayer: 20, arrayLayerCount: 5});
+let renderPassEncoder2 = commandEncoder46.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  depthSlice: 18,
+  clearValue: { r: 990.4, g: -812.9, b: 148.3, a: -0.5458, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder36.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(5, buffer19);
+} catch {}
+let imageData8 = new ImageData(20, 60);
+let textureView70 = texture46.createView({mipLevelCount: 1, arrayLayerCount: 5});
+try {
+computePassEncoder44.setBindGroup(3, bindGroup29, new Uint32Array(1256), 41, 0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup10, new Uint32Array(6619), 1_206, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+let texture64 = device0.createTexture({
+  size: {width: 2240, height: 1, depthOrArrayLayers: 3},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder15.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer11, 'uint32', 4, 2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 8, new BigUint64Array(5198), 1253, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'bt709', transfer: 'gamma22curve'} });
+let bindGroup31 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 5, resource: externalTexture0}]});
+let commandEncoder47 = device0.createCommandEncoder({});
+let texture65 = device0.createTexture({
+  size: {width: 71, height: 8, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder46 = commandEncoder47.beginComputePass();
+try {
+computePassEncoder11.setPipeline(pipeline4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u0fbe');
+} catch {}
+document.body.prepend(canvas0);
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'uint', multisampled: false },
+    },
+    {
+      binding: 75,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture66 = device0.createTexture({
+  size: {width: 1120, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler34 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 18,
+});
+try {
+computePassEncoder31.setBindGroup(2, bindGroup31, []);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup25, new Uint32Array(68), 5, 0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle4, renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer22, 'uint16', 4, 11);
+} catch {}
+try {
+buffer38.unmap();
+} catch {}
+document.body.append(canvas0);
+try {
+adapter0.label = '\u1c84\u0b5f\u091c\uceae\u7c94\u541c\u6b2c\u8982\u{1fabe}';
+} catch {}
+let buffer42 = device0.createBuffer({size: 152, usage: GPUBufferUsage.COPY_DST});
+let sampler35 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 73.49,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder31.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup31);
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(80);
+} catch {}
+try {
+renderPassEncoder2.setStencilReference(164);
+} catch {}
+try {
+  await promise10;
+} catch {}
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'bt2020', transfer: 'pq'} });
+let sampler36 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'clamp-to-edge'});
+try {
+computePassEncoder43.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(1, bindGroup25, new Uint32Array(1623), 27, 0);
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup17, new Uint32Array(1287), 357, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(1.2417213994863676, 9.092396083844642, 113.28562828159092, 6.269517667610869, 0.038261499280905165, 0.48022047521238176);
+} catch {}
+let bindGroup32 = device0.createBindGroup({layout: veryExplicitBindGroupLayout8, entries: [{binding: 5, resource: externalTexture7}]});
+let texture67 = device0.createTexture({
+  size: {width: 142, height: 16, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler37 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder12.setBindGroup(2, bindGroup24, new Uint32Array(2336), 859, 0);
+} catch {}
+try {
+computePassEncoder22.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup23, new Uint32Array(1754), 717, 0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(462);
+} catch {}
+let arrayBuffer0 = buffer24.getMappedRange(0, 0);
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 241, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(449).fill(124), /* required buffer size: 449 */
+{offset: 449}, {width: 118, height: 0, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img0);
+let textureView71 = texture16.createView({aspect: 'depth-only', mipLevelCount: 1});
+let sampler38 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 70.90, maxAnisotropy: 1});
+try {
+computePassEncoder29.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer4, 'uint16', 0, 0);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+try {
+  await promise9;
+} catch {}
+let bindGroup33 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture1}]});
+let textureView72 = texture5.createView({dimension: '2d'});
+try {
+computePassEncoder16.setBindGroup(2, bindGroup19);
+} catch {}
+try {
+computePassEncoder8.setBindGroup(1, bindGroup11, new Uint32Array(744), 129, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setViewport(28.725550445425508, 15.723502471588906, 106.9584636436541, 0.07463789944731085, 0.8128656770041587, 0.9526950605607098);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 0, new Uint32Array(6241), 951, 0);
+} catch {}
+let imageData9 = new ImageData(16, 168);
+try {
+globalThis.someLabel = externalTexture0.label;
+} catch {}
+let textureView73 = texture52.createView({});
+let sampler39 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', mipmapFilter: 'linear', lodMaxClamp: 85.56});
+try {
+computePassEncoder21.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder1.setViewport(105.08915072357978, 13.565919960213996, 27.7682686648473, 0.9416546279281438, 0.5680744232234055, 0.6238921677187753);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer2, 0);
+} catch {}
+let commandEncoder48 = device0.createCommandEncoder({});
+let textureView74 = texture45.createView({dimension: '3d', baseArrayLayer: 0});
+let computePassEncoder47 = commandEncoder48.beginComputePass();
+try {
+computePassEncoder19.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer14, 0, 105);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline6 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule1}});
+let commandEncoder49 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 483});
+let textureView75 = texture1.createView({mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer18, 12); };
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer0, 'uint32', 32, 1);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer19, 0, 9);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder50 = device0.createCommandEncoder({});
+try {
+computePassEncoder46.setPipeline(pipeline4);
+} catch {}
+let buffer43 = device0.createBuffer({size: 768, usage: GPUBufferUsage.UNIFORM});
+let textureView76 = texture63.createView({baseArrayLayer: 1, arrayLayerCount: 3});
+try {
+renderPassEncoder2.executeBundles([renderBundle4]);
+} catch {}
+try {
+commandEncoder49.resolveQuerySet(querySet11, 143, 0, buffer19, 256);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 8, new DataView(new ArrayBuffer(5855)), 1086, 32);
+} catch {}
+let img1 = await imageWithData(64, 80, '#10101010', '#20202020');
+let texture68 = device0.createTexture({
+  size: {width: 71, height: 8, depthOrArrayLayers: 50},
+  mipLevelCount: 2,
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder48 = commandEncoder49.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer11, 'uint32', 4, 2);
+} catch {}
+try {
+commandEncoder50.copyBufferToBuffer(buffer19, 48, buffer21, 0, 0);
+} catch {}
+let commandEncoder51 = device0.createCommandEncoder();
+let renderPassEncoder3 = commandEncoder51.beginRenderPass({
+  colorAttachments: [{
+  view: textureView40,
+  clearValue: { r: 78.84, g: -987.9, b: -946.0, a: -96.51, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 791661775,
+});
+let sampler40 = device0.createSampler({
+  label: '\uae39\u4f58\u3f3a\u{1f882}\u8a43\u4122\u{1f819}\u1493\u8554',
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 91.63,
+  compare: 'less',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder3.setBindGroup(3, bindGroup27, new Uint32Array(206), 12, 0);
+} catch {}
+try {
+computePassEncoder25.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer14, 0, 81);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+document.body.append(img1);
+let recycledExplicitBindGroupLayout2 = pipeline6.getBindGroupLayout(0);
+let bindGroup34 = device0.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 0, resource: textureView16}]});
+let commandEncoder52 = device0.createCommandEncoder({});
+let textureView77 = texture4.createView({baseArrayLayer: 0});
+let texture69 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 409},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup13, new Uint32Array(2407), 465, 0);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer35, 'uint16', 12, 33);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(3, buffer31);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(6); };
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt709', transfer: 'smpte240m'} });
+let textureView78 = texture53.createView({});
+let computePassEncoder49 = commandEncoder50.beginComputePass();
+try {
+renderPassEncoder2.beginOcclusionQuery(231);
+} catch {}
+try {
+renderPassEncoder1.setBlendConstant({ r: -460.3, g: 726.8, b: -399.5, a: -732.5, });
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 768 widthInBlocks: 192 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 600 */
+  offset: 600,
+  buffer: buffer8,
+}, {
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 192, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let commandEncoder53 = device0.createCommandEncoder({});
+let querySet13 = device0.createQuerySet({type: 'timestamp', count: 62});
+let textureView79 = texture32.createView({});
+let renderPassEncoder4 = commandEncoder53.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  depthSlice: 1,
+  clearValue: { r: 659.7, g: 629.2, b: 361.5, a: 787.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet11,
+});
+try {
+computePassEncoder26.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer31);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, colorSpace: 'srgb'});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 45, y: 9, z: 0},
+  aspect: 'all',
+}, new Uint8Array(224).fill(7), /* required buffer size: 224 */
+{offset: 224}, {width: 105, height: 1, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder50 = commandEncoder52.beginComputePass({timestampWrites: {querySet: querySet0}});
+try {
+computePassEncoder37.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer40, 'uint16', 0, 7);
+} catch {}
+try {
+  await buffer13.mapAsync(GPUMapMode.WRITE);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 4, height: 1, depthOrArrayLayers: 4}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture54,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 245,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder54 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder54.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer33, 16); };
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup7);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(0, bindGroup25, new Uint32Array(5699), 40, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer32, 'uint32', 0, 0);
+} catch {}
+document.body.prepend(img0);
+let commandEncoder55 = device0.createCommandEncoder({});
+let computePassEncoder52 = commandEncoder55.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder43); computePassEncoder43.dispatchWorkgroupsIndirect(buffer34, 0); };
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 11},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule1, constants: {}}});
+let buffer44 = device0.createBuffer({size: 228, usage: GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX});
+let commandEncoder56 = device0.createCommandEncoder({});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+computePassEncoder43.end();
+} catch {}
+try {
+renderPassEncoder3.setViewport(36.25628177005631, 14.372583149862164, 84.42834586665565, 0.3600692224829185, 0.5650583171751278, 0.7647802592253812);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer40, 'uint32', 8, 0);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer6, 168, buffer24, 8, 0);
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 7772 */
+  offset: 7772,
+  buffer: buffer33,
+}, {
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer45 = device0.createBuffer({size: 160, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let textureView80 = texture65.createView({dimension: '2d-array', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder53 = commandEncoder20.beginComputePass();
+let externalTexture9 = device0.importExternalTexture({source: videoFrame12});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup4, new Uint32Array(705), 158, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder12); computePassEncoder12.dispatchWorkgroupsIndirect(buffer30, 164); };
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer11, 'uint32', 0, 10);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer3, 0, 12);
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2532 */
+  offset: 2532,
+  bytesPerRow: 40448,
+  buffer: buffer33,
+}, {
+  texture: texture54,
+  mipLevel: 2,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({});
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+let sampler41 = device0.createSampler({addressModeV: 'mirror-repeat', lodMaxClamp: 67.71});
+try {
+computePassEncoder12.end();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer45);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup34);
+} catch {}
+try {
+querySet7.destroy();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: offscreenCanvas1,
+  origin: { x: 50, y: 30 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView81 = texture69.createView({mipLevelCount: 1});
+let renderPassEncoder5 = commandEncoder56.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 7,
+  clearValue: { r: -244.6, g: -583.0, b: -66.96, a: 439.4, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+let renderBundle5 = renderBundleEncoder5.finish();
+try {
+renderPassEncoder2.setIndexBuffer(buffer0, 'uint32', 4, 2);
+} catch {}
+try {
+commandEncoder12.resolveQuerySet(querySet2, 4, 0, buffer40, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 0, new Uint32Array(4246), 157, 8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(53).fill(215), /* required buffer size: 53 */
+{offset: 53}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: img1,
+  origin: { x: 5, y: 2 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder54 = commandEncoder57.beginComputePass();
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup8, new Uint32Array(1958), 144, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(1, buffer14);
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let texture70 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 1},
+  format: 'rg16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder55 = commandEncoder12.beginComputePass({timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 20, endOfPassWriteIndex: 3}});
+let sampler42 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 87.72});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(2, bindGroup23, new Uint32Array(321), 149, 0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer22, 'uint32', 32, 0);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: imageData2,
+  origin: { x: 1, y: 2 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-ncl', primaries: 'bt470m', transfer: 'bt2020_12bit'} });
+let commandEncoder58 = device0.createCommandEncoder({});
+let computePassEncoder56 = commandEncoder58.beginComputePass({timestampWrites: {querySet: querySet4}});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], sampleCount: 1, depthReadOnly: true});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup10);
+} catch {}
+try {
+computePassEncoder32.setBindGroup(2, bindGroup28, new Uint32Array(128), 25, 0);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: imageData9,
+  origin: { x: 9, y: 16 },
+  flipY: false,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer46 = device0.createBuffer({size: 280, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+computePassEncoder23.setBindGroup(2, bindGroup14, new Uint32Array(631), 7, 0);
+} catch {}
+try {
+computePassEncoder55.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup33, new Uint32Array(1311), 90, 0);
+} catch {}
+try {
+renderPassEncoder2.setViewport(33.573591822376116, 3.7536291100357553, 0.8773292349322321, 0.06304179722912229, 0.7266013956113662, 0.9553898003119934);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup22, new Uint32Array(2500), 4, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(3, buffer45);
+} catch {}
+try {
+buffer2.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(5, buffer3, 152, 10);
+} catch {}
+let textureView82 = texture69.createView({aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba32float'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  stencilReadOnly: true,
+});
+let renderBundle7 = renderBundleEncoder7.finish({});
+let sampler43 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', compare: 'greater-equal'});
+try {
+computePassEncoder46.setBindGroup(2, bindGroup26, new Uint32Array(2240), 292, 0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+renderBundleEncoder8.setPipeline(pipeline1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 71, y: 0, z: 12},
+  aspect: 'all',
+}, new Uint8Array(335_041).fill(85), /* required buffer size: 335_041 */
+{offset: 497, bytesPerRow: 181, rowsPerImage: 307}, {width: 14, height: 7, depthOrArrayLayers: 7});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+document.body.prepend(canvas0);
+try {
+computePassEncoder25.setBindGroup(3, bindGroup30);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer40, 'uint16', 2, 12);
+} catch {}
+try {
+renderBundleEncoder8.setBindGroup(0, bindGroup3, new Uint32Array(1201), 52, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame8,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 3},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer9, 1_712); };
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer3, 0, 17);
+} catch {}
+let buffer47 = device0.createBuffer({size: 1016, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView83 = texture65.createView({format: 'rg32sint'});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder8.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(2, bindGroup25, new Uint32Array(11), 1, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer18, 0); };
+} catch {}
+try {
+computePassEncoder51.setPipeline(pipeline6);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let pipeline8 = await device0.createRenderPipelineAsync({
+  layout: 'auto',
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {module: shaderModule0, targets: [{format: 'rgba32float', writeMask: GPUColorWrite.BLUE}]},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    depthCompare: 'less',
+    stencilReadMask: 39555956,
+    stencilWriteMask: 828249429,
+    depthBias: -2109240652,
+    depthBiasSlopeScale: 46.24789564334364,
+  },
+  vertex: {module: shaderModule0, constants: {}, buffers: []},
+  primitive: {cullMode: 'none'},
+});
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let texture71 = device0.createTexture({
+  size: {width: 255},
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture72 = device0.createTexture({
+  size: [127, 53, 1],
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(1446);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4, renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer21, 0, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout3 = pipeline5.getBindGroupLayout(0);
+let commandEncoder59 = device0.createCommandEncoder();
+let textureView84 = texture71.createView({});
+let computePassEncoder57 = commandEncoder59.beginComputePass({timestampWrites: {querySet: querySet7, endOfPassWriteIndex: 556}});
+try {
+computePassEncoder22.setBindGroup(3, bindGroup32, new Uint32Array(1695), 128, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+externalTexture2.label = '\u{1f95f}\ub741\u0801\u{1fd2e}\udbd6\u{1ff0a}\u0b84';
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 370,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let texture73 = device0.createTexture({
+  size: [2240, 1, 1],
+  mipLevelCount: 3,
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler44 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', lodMaxClamp: 79.63});
+try {
+computePassEncoder6.setBindGroup(2, bindGroup7);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(0, bindGroup18, new Uint32Array(284), 67, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(0, undefined, 0, 1_483_517_027);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline9 = await device0.createComputePipelineAsync({layout: pipelineLayout3, compute: {module: shaderModule0}});
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup35 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 3, resource: {buffer: buffer5}},
+    {binding: 245, resource: textureView54},
+    {binding: 0, resource: textureView64},
+  ],
+});
+let textureView85 = texture61.createView({dimension: '2d', mipLevelCount: 1});
+try {
+computePassEncoder49.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer12, 'uint16', 2, 2);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(268).fill(150), /* required buffer size: 268 */
+{offset: 268, rowsPerImage: 42}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer48 = device0.createBuffer({size: 173, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder60 = device0.createCommandEncoder({});
+let texture74 = device0.createTexture({
+  size: [17, 2, 18],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderPassEncoder6 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{
+  view: textureView81,
+  depthSlice: 183,
+  clearValue: { r: 158.0, g: 632.7, b: 25.11, a: 174.3, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 22521169,
+});
+let externalTexture10 = device0.importExternalTexture({label: '\ua1bc\u0e9f\udccc\u8e9e\u2157\u0a27\uaa9c\u4154\u0562\u{1f907}', source: videoFrame3});
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer30, 0, 39);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer38, 8, new BigUint64Array(452), 24, 0);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup23, new Uint32Array(991), 30, 0);
+} catch {}
+try {
+computePassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder4.beginOcclusionQuery(54);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle6]);
+} catch {}
+try {
+renderPassEncoder4.setViewport(20.740917324478566, 3.436339084120287, 1.6958546323582098, 0.03876851591953628, 0.01106283799664276, 0.6429437467487747);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer19);
+} catch {}
+try {
+commandEncoder27.clearBuffer(buffer10);
+} catch {}
+let pipeline10 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule1}});
+let textureView86 = texture71.createView({});
+let texture75 = device0.createTexture({size: [510, 214, 40], dimension: '3d', format: 'r32sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView87 = texture24.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 24});
+let computePassEncoder58 = commandEncoder27.beginComputePass();
+try {
+renderPassEncoder6.setIndexBuffer(buffer28, 'uint32', 0, 28);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(29).fill(123), /* required buffer size: 29 */
+{offset: 29}, {width: 92, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let commandEncoder61 = device0.createCommandEncoder({});
+let texture76 = device0.createTexture({
+  size: {width: 142, height: 16, depthOrArrayLayers: 30},
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture77 = device0.createTexture({
+  size: {width: 71, height: 8, depthOrArrayLayers: 28},
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler45 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.88,
+});
+try {
+computePassEncoder49.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup12, new Uint32Array(1187), 446, 0);
+} catch {}
+try {
+renderPassEncoder4.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 276 */
+  offset: 276,
+  rowsPerImage: 180,
+  buffer: buffer33,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let commandEncoder62 = device0.createCommandEncoder({});
+let texture78 = device0.createTexture({
+  size: [510, 214, 1],
+  mipLevelCount: 1,
+  format: 'rg32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture79 = device0.createTexture({
+  size: [1120],
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder59 = commandEncoder61.beginComputePass();
+let renderPassEncoder7 = commandEncoder62.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 168,
+  clearValue: { r: 640.8, g: 580.7, b: -917.2, a: 25.80, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 133265712,
+});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline5);
+} catch {}
+try {
+commandEncoder22.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 30 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1512 */
+  offset: 1512,
+  bytesPerRow: 13312,
+  buffer: buffer33,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 18, y: 41, z: 0},
+  aspect: 'all',
+}, {width: 30, height: 12, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup36 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture5}]});
+let textureView88 = texture69.createView({dimension: '3d', mipLevelCount: 1});
+let renderPassEncoder8 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  depthSlice: 8,
+  clearValue: { r: 509.5, g: 370.3, b: -320.5, a: 392.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder36.setBindGroup(1, bindGroup32, new Uint32Array(52), 2, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1, 2); };
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup27);
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let bindGroup37 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture6}]});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder55.setBindGroup(0, bindGroup28, new Uint32Array(2424), 497, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer45, 'uint32', 36, 1);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(7); };
+} catch {}
+let bindGroup38 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout2, entries: [{binding: 0, resource: textureView77}]});
+let buffer49 = device0.createBuffer({
+  size: 20,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let textureView89 = texture30.createView({mipLevelCount: 1});
+try {
+computePassEncoder26.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder42.setBindGroup(3, bindGroup23, new Uint32Array(440), 10, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1, 4); };
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup29, new Uint32Array(1221), 112, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer44, 'uint32', 60, 2);
+} catch {}
+let texture80 = device0.createTexture({
+  size: [1020, 428, 1],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['r32sint'],
+});
+let textureView90 = texture14.createView({});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['rg16float'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle9 = renderBundleEncoder9.finish({});
+let sampler46 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', mipmapFilter: 'nearest'});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup35);
+} catch {}
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+computePassEncoder30.setPipeline(pipeline7);
+} catch {}
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 370,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let commandEncoder63 = device0.createCommandEncoder();
+let texture81 = device0.createTexture({
+  size: {width: 1120, height: 1, depthOrArrayLayers: 300},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder60 = commandEncoder10.beginComputePass();
+let renderPassEncoder9 = commandEncoder63.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 38,
+  clearValue: { r: -472.9, g: -496.2, b: -565.6, a: 492.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 106263432,
+});
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthStencilFormat: 'depth32float', sampleCount: 4, depthReadOnly: true});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 94.89,
+});
+try {
+computePassEncoder59.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle5]);
+} catch {}
+try {
+renderBundleEncoder10.setBindGroup(0, bindGroup8, new Uint32Array(1654), 378, 0);
+} catch {}
+try {
+renderBundleEncoder10.setVertexBuffer(5, buffer19, 60, 91);
+} catch {}
+try {
+computePassEncoder11.insertDebugMarker('\u0681');
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder({});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 1243});
+let renderPassEncoder10 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 1,
+  clearValue: { r: -32.97, g: 401.8, b: 675.3, a: -570.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundle10 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder53.setBindGroup(3, bindGroup27);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer45, 0, 32);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+let buffer50 = device0.createBuffer({size: 56, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let texture82 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder52.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer44, 'uint32', 4, 16);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle5, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer11, 'uint32', 0, 13);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer14, 56, 56);
+} catch {}
+document.body.prepend(img1);
+let textureView91 = texture36.createView({aspect: 'stencil-only', arrayLayerCount: 4});
+try {
+computePassEncoder39.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup10, new Uint32Array(174), 39, 0);
+} catch {}
+let commandEncoder65 = device0.createCommandEncoder({});
+let texture83 = device0.createTexture({
+  size: {width: 1120, height: 1, depthOrArrayLayers: 129},
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder61 = commandEncoder65.beginComputePass();
+try {
+computePassEncoder48.setBindGroup(2, bindGroup5, new Uint32Array(355), 46, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(1720);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 280, height: 1, depthOrArrayLayers: 5}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 1},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline11 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule1}});
+let commandEncoder66 = device0.createCommandEncoder({});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup2, new Uint32Array(2843), 2_630, 0);
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup6, new Uint32Array(10), 1, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer23, 'uint32', 12, 1);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer14);
+} catch {}
+try {
+commandEncoder66.copyBufferToTexture({
+  /* bytesInLastRow: 992 widthInBlocks: 62 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 1008 */
+  offset: 1008,
+  bytesPerRow: 13056,
+  buffer: buffer47,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 9, y: 6, z: 0},
+  aspect: 'all',
+}, {width: 62, height: 47, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder({});
+let textureView92 = texture27.createView({});
+let sampler48 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.46,
+  compare: 'less-equal',
+  maxAnisotropy: 13,
+});
+try {
+commandEncoder67.copyBufferToBuffer(buffer2, 4, buffer10, 20, 0);
+} catch {}
+try {
+commandEncoder66.insertDebugMarker('\u00d4');
+} catch {}
+try {
+  await promise11;
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({});
+let texture84 = device0.createTexture({
+  size: {width: 35},
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder62 = commandEncoder68.beginComputePass({timestampWrites: {querySet: querySet2, endOfPassWriteIndex: 141}});
+let renderPassEncoder11 = commandEncoder67.beginRenderPass({
+  colorAttachments: [{
+  view: textureView40,
+  clearValue: { r: 749.2, g: 169.2, b: 616.9, a: -912.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet12,
+  timestampWrites: {querySet: querySet9, endOfPassWriteIndex: 953},
+});
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(3, bindGroup2, new Uint32Array(123), 9, 0);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(5, buffer14);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+document.body.prepend(img1);
+let bindGroup39 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 3, resource: {buffer: buffer46}},
+    {binding: 245, resource: textureView54},
+    {binding: 0, resource: textureView80},
+  ],
+});
+let commandEncoder69 = device0.createCommandEncoder({});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(3, bindGroup27, new Uint32Array(821), 118, 0);
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder5.setViewport(7.1651741619451546, 1.7254223468099434, 21.438338851703516, 1.791644689088507, 0.019649235376193674, 0.29223509858340263);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer45, 0, 48);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 392 widthInBlocks: 98 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1784 */
+  offset: 1784,
+  bytesPerRow: 18176,
+  buffer: buffer33,
+}, {
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 98, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 0, new Uint32Array(7671), 66, 0);
+} catch {}
+let textureView93 = texture16.createView({mipLevelCount: 1});
+let computePassEncoder63 = commandEncoder66.beginComputePass({timestampWrites: {querySet: querySet4, endOfPassWriteIndex: 680}});
+try {
+computePassEncoder62.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+let bindGroup40 = device0.createBindGroup({layout: veryExplicitBindGroupLayout11, entries: [{binding: 370, resource: textureView41}]});
+let texture85 = device0.createTexture({
+  size: {width: 2240, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup16);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(4, buffer3);
+} catch {}
+let img2 = await imageWithData(138, 9, '#10101010', '#20202020');
+let buffer51 = device0.createBuffer({size: 412, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let textureView94 = texture65.createView({});
+let textureView95 = texture55.createView({aspect: 'depth-only', mipLevelCount: 1, baseArrayLayer: 7, arrayLayerCount: 5});
+let computePassEncoder64 = commandEncoder69.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(1, bindGroup11, new Uint32Array(1334), 32, 0);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline10);
+} catch {}
+document.body.prepend(canvas0);
+let commandEncoder70 = device0.createCommandEncoder({});
+let querySet15 = device0.createQuerySet({type: 'timestamp', count: 687});
+let textureView96 = texture76.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+let computePassEncoder65 = commandEncoder70.beginComputePass();
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup38);
+} catch {}
+try {
+renderPassEncoder7.setViewport(127.29276737495815, 178.74336149899398, 31.920942371315757, 44.678508375310805, 0.6878346324256708, 0.8346516373687596);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame1,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  label: '\u0d0a\uaf40',
+  entries: [
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      externalTexture: {},
+    },
+  ],
+});
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 221});
+let textureView97 = texture43.createView({aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({
+  colorFormats: ['rgba16uint'],
+  depthStencilFormat: 'stencil8',
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder53.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder11.setIndexBuffer(buffer23, 'uint32', 4, 4);
+} catch {}
+try {
+renderBundleEncoder11.setVertexBuffer(4, buffer2, 0, 14);
+} catch {}
+try {
+gpuCanvasContext1.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.TEXTURE_BINDING, viewFormats: []});
+} catch {}
+let pipeline12 = device0.createRenderPipeline({
+  layout: pipelineLayout1,
+  fragment: {
+  module: shaderModule1,
+  entryPoint: 'fragment1',
+  constants: {},
+  targets: [{
+  format: 'rg16float',
+  blend: {
+    color: {operation: 'min', srcFactor: 'one', dstFactor: 'one'},
+    alpha: {operation: 'max', srcFactor: 'one', dstFactor: 'one'},
+  },
+  writeMask: GPUColorWrite.GREEN,
+}],
+},
+  vertex: {module: shaderModule0, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16', frontFace: 'cw', cullMode: 'front'},
+});
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'unspecified', primaries: 'jedecP22Phosphors', transfer: 'linear'} });
+let bindGroup41 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 245, resource: textureView73},
+    {binding: 0, resource: textureView64},
+    {binding: 3, resource: {buffer: buffer30, size: 316}},
+  ],
+});
+let commandEncoder71 = device0.createCommandEncoder();
+let computePassEncoder66 = commandEncoder71.beginComputePass();
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+renderPassEncoder6.setVertexBuffer(5, buffer44, 0);
+} catch {}
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 245,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+try {
+computePassEncoder66.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer34, 0); };
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup37, new Uint32Array(385), 123, 0);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({
+  bindGroupLayouts: [veryExplicitBindGroupLayout10, recycledExplicitBindGroupLayout3, veryExplicitBindGroupLayout7],
+});
+let buffer52 = device0.createBuffer({size: 1, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let textureView98 = texture84.createView({});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup3, []);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(2, bindGroup36, new Uint32Array(559), 13, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroupsIndirect(buffer29, 24); };
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline2);
+} catch {}
+let buffer53 = device0.createBuffer({size: 92, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder72 = device0.createCommandEncoder({});
+let computePassEncoder67 = commandEncoder72.beginComputePass({timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 526}});
+try {
+computePassEncoder61.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup37, new Uint32Array(352), 18, 0);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer31);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: ['rgba8unorm'],
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let sampler49 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder14.setBindGroup(0, bindGroup38);
+} catch {}
+try {
+computePassEncoder56.setBindGroup(1, bindGroup33, new Uint32Array(983), 102, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder14); computePassEncoder14.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(0, bindGroup4, new Uint32Array(3252), 229, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer23, 'uint16', 14, 20);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline12);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(16); };
+} catch {}
+let imageBitmap0 = await createImageBitmap(videoFrame8);
+let videoFrame15 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'smpte240m', primaries: 'jedecP22Phosphors', transfer: 'gamma22curve'} });
+let buffer54 = device0.createBuffer({size: 36, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: false});
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(3, bindGroup19, new Uint32Array(1312), 136, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer2);
+} catch {}
+let commandEncoder73 = device0.createCommandEncoder({});
+try {
+computePassEncoder54.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder67.setBindGroup(0, bindGroup33, new Uint32Array(1564), 78, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(2, bindGroup26, new Uint32Array(1367), 67, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer3, 0);
+} catch {}
+try {
+buffer25.unmap();
+} catch {}
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 908});
+let textureView99 = texture61.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder64.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup14, []);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(1, buffer50, 8, 7);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer21, 0, new DataView(new ArrayBuffer(3934)), 439, 0);
+} catch {}
+let commandEncoder74 = device0.createCommandEncoder();
+let textureView100 = texture69.createView({dimension: '3d', format: 'r32sint', mipLevelCount: 1});
+try {
+{ clearResourceUsages(device0, computePassEncoder54); computePassEncoder54.dispatchWorkgroupsIndirect(buffer30, 20); };
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup28, new Uint32Array(1301), 28, 0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 14},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture86 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'depth32float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView101 = texture2.createView({label: '\ue385\ua723\u4675\u{1feaa}\u4e3c\u00de\ufde6', dimension: '2d-array', format: 'rgba16float'});
+let computePassEncoder68 = commandEncoder73.beginComputePass();
+let sampler50 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 77.51,
+  lodMaxClamp: 91.84,
+  maxAnisotropy: 5,
+});
+try {
+computePassEncoder14.end();
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer12, 'uint32', 4, 3);
+} catch {}
+try {
+commandEncoder74.clearBuffer(buffer24);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer42, 28, new Uint32Array(4453), 1209, 0);
+} catch {}
+document.body.prepend(canvas0);
+let buffer55 = device0.createBuffer({size: 236, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder75 = device0.createCommandEncoder({});
+let computePassEncoder69 = commandEncoder74.beginComputePass();
+let renderPassEncoder12 = commandEncoder15.beginRenderPass({
+  colorAttachments: [{
+  view: textureView100,
+  depthSlice: 341,
+  clearValue: { r: 543.4, g: 743.5, b: -372.3, a: 146.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup26, new Uint32Array(5532), 800, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, undefined, 0, 1_966_069_328);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+document.body.prepend(img2);
+let canvas1 = document.createElement('canvas');
+let commandEncoder76 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: [35, 4, 36],
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder70 = commandEncoder75.beginComputePass();
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthStencilFormat: 'depth32float', sampleCount: 4});
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder7.setViewport(233.97920080957016, 229.69353238679204, 9.47510389340198, 18.664358626248745, 0.3632475471721157, 0.49490145018219733);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer45, 'uint32', 48, 96);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup9, new Uint32Array(412), 65, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer36, 'uint32', 0, 22);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({});
+let computePassEncoder71 = commandEncoder77.beginComputePass({timestampWrites: {querySet: querySet3}});
+let renderBundle12 = renderBundleEncoder12.finish();
+try {
+computePassEncoder54.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup30);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer28, 'uint16', 10, 7);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline12);
+} catch {}
+let gpuCanvasContext3 = canvas1.getContext('webgpu');
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 380});
+let texture88 = device0.createTexture({
+  size: [1020],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture89 = device0.createTexture({
+  size: {width: 1020, height: 428, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView102 = texture25.createView({});
+try {
+computePassEncoder65.setPipeline(pipeline7);
+} catch {}
+try {
+gpuCanvasContext0.unconfigure();
+} catch {}
+let bindGroup42 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 0, resource: textureView5}]});
+let commandBuffer3 = commandEncoder57.finish();
+let sampler51 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.07,
+  compare: 'always',
+  maxAnisotropy: 20,
+});
+try {
+computePassEncoder4.setBindGroup(1, bindGroup40);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder58.setPipeline(pipeline11);
+} catch {}
+try {
+commandEncoder76.copyBufferToTexture({
+  /* bytesInLastRow: 448 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 464 */
+  offset: 464,
+  bytesPerRow: 17408,
+  buffer: buffer6,
+}, {
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 13, y: 2, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 6, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet18, 42, 0, buffer52, 0);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let buffer56 = device0.createBuffer({size: 216, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder78 = device0.createCommandEncoder();
+let renderPassEncoder13 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{
+  view: textureView60,
+  depthSlice: 19,
+  clearValue: { r: 891.7, g: 613.5, b: 222.5, a: 667.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 508538057,
+});
+try {
+computePassEncoder36.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup19, new Uint32Array(5214), 499, 0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer44, 'uint32', 60, 34);
+} catch {}
+let bindGroup43 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 30, resource: textureView65}]});
+let computePassEncoder72 = commandEncoder78.beginComputePass({
+  timestampWrites: {querySet: querySet13, beginningOfPassWriteIndex: 4294967295, endOfPassWriteIndex: 17},
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup21);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(0, bindGroup3, new Uint32Array(293), 22, 0);
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline9);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder7.setViewport(178.2365829240564, 230.6650753021921, 48.44000740735466, 18.962584511258694, 0.8150084926266413, 0.8411268316361201);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(3, buffer44);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(695).fill(221), /* required buffer size: 695 */
+{offset: 695}, {width: 23, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer57 = device0.createBuffer({size: 136, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder79 = device0.createCommandEncoder({});
+let textureView103 = texture84.createView({mipLevelCount: 1});
+try {
+computePassEncoder19.setBindGroup(1, bindGroup16);
+} catch {}
+try {
+computePassEncoder50.setBindGroup(2, bindGroup35, new Uint32Array(1535), 54, 0);
+} catch {}
+try {
+buffer34.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer41, 0, new BigUint64Array(18298), 9808, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let computePassEncoder73 = commandEncoder79.beginComputePass({timestampWrites: {querySet: querySet3, endOfPassWriteIndex: 600}});
+try {
+computePassEncoder56.setBindGroup(2, bindGroup37, []);
+} catch {}
+try {
+computePassEncoder15.setPipeline(pipeline10);
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer45, 'uint16', 10, 7);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32sint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 245,
+      visibility: GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let buffer58 = device0.createBuffer({
+  size: 24,
+  usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder80 = device0.createCommandEncoder();
+let texture90 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 12},
+  mipLevelCount: 1,
+  sampleCount: 1,
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder74 = commandEncoder80.beginComputePass();
+try {
+computePassEncoder52.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder49); computePassEncoder49.dispatchWorkgroupsIndirect(buffer18, 16); };
+} catch {}
+try {
+computePassEncoder73.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup31);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(3, bindGroup38, new Uint32Array(121), 12, 0);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer45);
+} catch {}
+try {
+computePassEncoder39.pushDebugGroup('\u512e');
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let texture91 = device0.createTexture({size: [255], dimension: '1d', format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let textureView104 = texture40.createView({});
+try {
+{ clearResourceUsages(device0, computePassEncoder49); computePassEncoder49.dispatchWorkgroupsIndirect(buffer9, 9_440); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup25, new Uint32Array(780), 189, 0);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer25, 'uint32', 12, 31);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+try {
+adapter0.label = '\u07e6\u{1fbac}\u3a2c\u3112\u{1fb76}\u{1fbd0}';
+} catch {}
+let commandEncoder81 = device0.createCommandEncoder({});
+let computePassEncoder75 = commandEncoder81.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup3, new Uint32Array(1071), 489, 0);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(27); };
+} catch {}
+document.body.prepend(img1);
+let texture92 = device0.createTexture({
+  size: [8, 6, 1],
+  format: 'astc-8x6-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+  viewFormats: ['astc-8x6-unorm'],
+});
+let sampler52 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder49.end();
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+renderPassEncoder6.insertDebugMarker('\ud53d');
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let bindGroup44 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout10,
+  entries: [
+    {binding: 245, resource: textureView53},
+    {binding: 0, resource: textureView80},
+    {binding: 3, resource: {buffer: buffer3}},
+  ],
+});
+let texture93 = device0.createTexture({
+  size: [280, 1, 1],
+  sampleCount: 4,
+  format: 'depth32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder76 = commandEncoder50.beginComputePass({timestampWrites: {querySet: querySet15, beginningOfPassWriteIndex: 160}});
+try {
+renderPassEncoder12.executeBundles([renderBundle6, renderBundle5, renderBundle6]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 510, height: 214, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame14,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 39, y: 165, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let textureView105 = texture65.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer48, 'uint32', 20, 12);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline12);
+} catch {}
+let texture94 = device0.createTexture({size: [17], dimension: '1d', format: 'rgba32float', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let texture95 = gpuCanvasContext2.getCurrentTexture();
+try {
+computePassEncoder50.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer14, 0, 42);
+} catch {}
+await gc();
+let commandEncoder82 = device0.createCommandEncoder({});
+let computePassEncoder77 = commandEncoder82.beginComputePass({timestampWrites: {querySet: querySet13}});
+try {
+computePassEncoder72.setBindGroup(0, bindGroup8);
+} catch {}
+try {
+computePassEncoder76.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(3, bindGroup28, new Uint32Array(1985), 69, 0);
+} catch {}
+try {
+computePassEncoder39.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture49,
+  mipLevel: 3,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder83 = device0.createCommandEncoder({});
+let renderPassEncoder14 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{
+  view: textureView40,
+  clearValue: { r: -206.8, g: -735.9, b: 875.6, a: -695.5, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet4, beginningOfPassWriteIndex: 806},
+});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup17);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder9.executeBundles([renderBundle6, renderBundle5, renderBundle5]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(426).fill(179), /* required buffer size: 426 */
+{offset: 426}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 140, height: 1, depthOrArrayLayers: 2}
+*/
+{
+  source: imageData5,
+  origin: { x: 4, y: 2 },
+  flipY: true,
+}, {
+  texture: texture49,
+  mipLevel: 1,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer59 = device0.createBuffer({size: 190, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder84 = device0.createCommandEncoder({});
+let texture96 = device0.createTexture({
+  size: [256],
+  dimension: '1d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder78 = commandEncoder84.beginComputePass();
+let sampler53 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder70.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer11, 'uint16', 8, 1);
+} catch {}
+let pipeline13 = device0.createComputePipeline({layout: pipelineLayout3, compute: {module: shaderModule1}});
+document.body.append(img1);
+let externalTexture11 = device0.importExternalTexture({source: videoFrame13});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup44);
+} catch {}
+try {
+computePassEncoder36.setBindGroup(0, bindGroup6, new Uint32Array(1199), 304, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle9]);
+} catch {}
+document.body.prepend(img2);
+await gc();
+let textureView106 = texture74.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder72.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 0,
+  origin: {x: 28, y: 46, z: 0},
+  aspect: 'all',
+}, new Uint8Array(73).fill(172), /* required buffer size: 73 */
+{offset: 73, bytesPerRow: 984}, {width: 122, height: 6, depthOrArrayLayers: 0});
+} catch {}
+document.body.append(img1);
+let bindGroup45 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture10}]});
+let texture97 = device0.createTexture({
+  size: [256, 256, 25],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder5.setBindGroup(0, bindGroup10, new Uint32Array(1003), 122, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup41, new Uint32Array(3222), 1_145, 0);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer11, 'uint32', 0, 0);
+} catch {}
+try {
+renderPassEncoder3.setPipeline(pipeline12);
+} catch {}
+let bindGroup46 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 5, resource: externalTexture2}]});
+let sampler54 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 78.59,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder72); computePassEncoder72.dispatchWorkgroupsIndirect(buffer34, 0); };
+} catch {}
+try {
+computePassEncoder72.end();
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup15, new Uint32Array(181), 5, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle9, renderBundle9, renderBundle9, renderBundle9, renderBundle4, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer58, 0, 0);
+} catch {}
+try {
+commandEncoder78.copyBufferToTexture({
+  /* bytesInLastRow: 16 widthInBlocks: 4 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1612 */
+  offset: 1612,
+  bytesPerRow: 10240,
+  rowsPerImage: 1476,
+  buffer: buffer33,
+}, {
+  texture: texture49,
+  mipLevel: 4,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: imageData7,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(73); };
+} catch {}
+document.body.append(img1);
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder79 = commandEncoder78.beginComputePass({timestampWrites: {querySet: querySet9, endOfPassWriteIndex: 206}});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup28, new Uint32Array(198), 11, 0);
+} catch {}
+try {
+computePassEncoder78.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup42, new Uint32Array(1067), 753, 0);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 556 widthInBlocks: 139 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 8976 */
+  offset: 8976,
+  buffer: buffer33,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 39, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 139, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+offscreenCanvas0.width = 288;
+let veryExplicitBindGroupLayout16 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 370,
+      visibility: GPUShaderStage.COMPUTE,
+      texture: { viewDimension: '1d', sampleType: 'sint', multisampled: false },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout4 = pipeline2.getBindGroupLayout(0);
+let bindGroup47 = device0.createBindGroup({layout: veryExplicitBindGroupLayout13, entries: [{binding: 4, resource: externalTexture11}]});
+let commandEncoder86 = device0.createCommandEncoder({});
+let computePassEncoder80 = commandEncoder86.beginComputePass();
+let sampler55 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+});
+try {
+computePassEncoder38.setBindGroup(1, bindGroup32, new Uint32Array(26), 0, 0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder3.setViewport(112.85301175844243, 9.00457797067079, 5.650068983865833, 2.2284904691968292, 0.06060185824021502, 0.3715010029096456);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(7, buffer30, 0, 160);
+} catch {}
+try {
+commandEncoder85.copyBufferToTexture({
+  /* bytesInLastRow: 1984 widthInBlocks: 124 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4560 */
+  offset: 4560,
+  bytesPerRow: 15104,
+  buffer: buffer33,
+}, {
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 15, y: 12, z: 10},
+  aspect: 'all',
+}, {width: 124, height: 299, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(16); };
+} catch {}
+let buffer60 = device0.createBuffer({
+  size: 360,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture98 = device0.createTexture({
+  size: {width: 1120, height: 1, depthOrArrayLayers: 54},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'stencil8',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView107 = texture61.createView({format: 'r16uint', mipLevelCount: 1});
+let computePassEncoder81 = commandEncoder85.beginComputePass();
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  colorSpace: 'srgb',
+});
+} catch {}
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture99 = device0.createTexture({
+  size: [216, 1420, 1],
+  mipLevelCount: 11,
+  dimension: '2d',
+  format: 'astc-12x10-unorm-srgb',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView108 = texture79.createView({});
+let renderPassEncoder15 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 136,
+  clearValue: { r: -818.4, g: -809.7, b: 658.7, a: -864.0, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet14,
+  timestampWrites: {querySet: querySet13, endOfPassWriteIndex: 26},
+  maxDrawCount: 484601033,
+});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup31);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(6, buffer50, 0, 18);
+} catch {}
+let commandEncoder88 = device0.createCommandEncoder();
+let computePassEncoder82 = commandEncoder88.beginComputePass();
+try {
+computePassEncoder66.setBindGroup(3, bindGroup32, new Uint32Array(105), 18, 0);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer45, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 188, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(138).fill(122), /* required buffer size: 138 */
+{offset: 138}, {width: 161, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let commandEncoder89 = device0.createCommandEncoder({});
+let computePassEncoder83 = commandEncoder89.beginComputePass();
+try {
+computePassEncoder55.setBindGroup(0, bindGroup25, new Uint32Array(713), 66, 0);
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let videoFrame16 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'film', transfer: 'iec6196624'} });
+let autogeneratedBindGroupLayout0 = pipeline7.getBindGroupLayout(0);
+let bindGroup48 = device0.createBindGroup({layout: autogeneratedBindGroupLayout0, entries: [{binding: 0, resource: textureView77}]});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 439});
+let texture100 = device0.createTexture({size: [142, 16, 146], dimension: '3d', format: 'rgba32float', usage: GPUTextureUsage.COPY_DST});
+let sampler56 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'nearest',
+});
+try {
+computePassEncoder52.setBindGroup(0, bindGroup18, new Uint32Array(3370), 808, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer57, 'uint16', 4, 3);
+} catch {}
+try {
+  await promise14;
+} catch {}
+let buffer61 = device0.createBuffer({
+  size: 392,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder90 = device0.createCommandEncoder();
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['r32sint'], depthReadOnly: true, stencilReadOnly: true});
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder81.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+await gc();
+let bindGroup49 = device0.createBindGroup({layout: veryExplicitBindGroupLayout3, entries: [{binding: 0, resource: textureView16}]});
+let textureView109 = texture72.createView({});
+try {
+computePassEncoder77.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup45);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer36, 'uint32', 28, 4);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer19, 4, 117);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture30,
+  mipLevel: 1,
+  origin: {x: 2, y: 4, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 3,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture69,
+  mipLevel: 0,
+  origin: {x: 6, y: 2, z: 18},
+  aspect: 'all',
+}, new Uint8Array(6_759_513).fill(55), /* required buffer size: 6_759_513 */
+{offset: 67, bytesPerRow: 546, rowsPerImage: 121}, {width: 128, height: 38, depthOrArrayLayers: 103});
+} catch {}
+let bindGroup50 = device0.createBindGroup({layout: autogeneratedBindGroupLayout0, entries: [{binding: 0, resource: textureView5}]});
+let commandEncoder91 = device0.createCommandEncoder();
+let textureView110 = texture68.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 19, arrayLayerCount: 1});
+let sampler57 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 76.83,
+  compare: 'not-equal',
+  maxAnisotropy: 2,
+});
+try {
+computePassEncoder83.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup48, new Uint32Array(2277), 422, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(7, buffer61, 60);
+} catch {}
+try {
+commandEncoder91.copyTextureToTexture({
+  texture: texture58,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 37, y: 13, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 1, depthOrArrayLayers: 0});
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+canvas1.height = 76;
+let textureView111 = texture61.createView({mipLevelCount: 2});
+try {
+computePassEncoder81.setBindGroup(0, bindGroup19, new Uint32Array(1542), 157, 0);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup33);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup36, new Uint32Array(262), 14, 0);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder91.copyBufferToTexture({
+  /* bytesInLastRow: 896 widthInBlocks: 112 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2688 */
+  offset: 2688,
+  buffer: buffer33,
+}, {
+  texture: texture79,
+  mipLevel: 0,
+  origin: {x: 193, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 112, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+document.body.append(canvas1);
+let buffer62 = device0.createBuffer({size: 68, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder92 = device0.createCommandEncoder({});
+let computePassEncoder84 = commandEncoder92.beginComputePass();
+try {
+computePassEncoder71.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+computePassEncoder66.setBindGroup(2, bindGroup28, new Uint32Array(3879), 287, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder52); computePassEncoder52.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(1, buffer61, 12, 65);
+} catch {}
+try {
+commandEncoder90.copyBufferToBuffer(buffer47, 244, buffer38, 0, 20);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let texture101 = device0.createTexture({
+  size: [510, 214, 1],
+  format: 'rg8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let computePassEncoder85 = commandEncoder91.beginComputePass();
+try {
+computePassEncoder82.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer40, 'uint32', 0, 11);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(1, buffer60, 0, 26);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+buffer45.unmap();
+} catch {}
+try {
+commandEncoder90.clearBuffer(buffer41);
+} catch {}
+let img3 = await imageWithData(3, 5, '#10101010', '#20202020');
+let buffer63 = device0.createBuffer({size: 104, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let querySet20 = device0.createQuerySet({type: 'timestamp', count: 2461});
+try {
+renderPassEncoder15.setScissorRect(47, 27, 63, 60);
+} catch {}
+try {
+commandEncoder90.copyTextureToTexture({
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 0, y: 110, z: 0},
+  aspect: 'stencil-only',
+},
+{
+  texture: texture89,
+  mipLevel: 1,
+  origin: {x: 0, y: 91, z: 0},
+  aspect: 'all',
+},
+{width: 510, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder93 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: {width: 127, height: 53, depthOrArrayLayers: 67},
+  mipLevelCount: 4,
+  dimension: '3d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder16 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{view: textureView40, loadOp: 'clear', storeOp: 'store'}],
+  timestampWrites: {querySet: querySet10, beginningOfPassWriteIndex: 1141},
+});
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rgba32float'], depthStencilFormat: 'depth32float', sampleCount: 4});
+try {
+computePassEncoder5.setBindGroup(2, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup12);
+} catch {}
+try {
+renderPassEncoder14.setViewport(121.83690530761783, 5.09786370720135, 1.9903361465339395, 3.043027400776144, 0.4782781375941172, 0.976961417926523);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer22, 'uint32', 4, 2);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup30);
+} catch {}
+try {
+commandEncoder90.resolveQuerySet(querySet10, 791, 0, buffer34, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: imageBitmap0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 6},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup51 = device0.createBindGroup({layout: veryExplicitBindGroupLayout12, entries: [{binding: 370, resource: textureView86}]});
+let buffer64 = device0.createBuffer({size: 32, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let computePassEncoder86 = commandEncoder90.beginComputePass({timestampWrites: {querySet: querySet15, endOfPassWriteIndex: 299}});
+let sampler58 = device0.createSampler({addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 45.37});
+try {
+computePassEncoder52.end();
+} catch {}
+try {
+computePassEncoder38.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer11, 'uint16', 6, 2);
+} catch {}
+try {
+renderPassEncoder11.setVertexBuffer(6, buffer19, 0, 69);
+} catch {}
+try {
+renderBundleEncoder14.setPipeline(pipeline1);
+} catch {}
+let pipeline14 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule0}});
+let textureView112 = texture15.createView({baseMipLevel: 0, mipLevelCount: 1});
+let renderPassEncoder17 = commandEncoder55.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 243,
+  clearValue: { r: 350.3, g: 116.5, b: 37.85, a: 620.0, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  timestampWrites: {querySet: querySet10},
+  maxDrawCount: 12051896,
+});
+let sampler59 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.94});
+let externalTexture12 = device0.importExternalTexture({source: videoFrame9, colorSpace: 'srgb'});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup11, new Uint32Array(1638), 236, 0);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline7);
+} catch {}
+let bindGroup52 = device0.createBindGroup({layout: autogeneratedBindGroupLayout0, entries: [{binding: 0, resource: textureView16}]});
+let buffer65 = device0.createBuffer({size: 17808, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder94 = device0.createCommandEncoder({});
+let textureView113 = texture96.createView({});
+let externalTexture13 = device0.importExternalTexture({source: videoFrame7});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup36);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup52);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle6, renderBundle13, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder7.setStencilReference(1439);
+} catch {}
+try {
+renderPassEncoder7.setViewport(125.70462450714803, 145.28534244179224, 82.8505947113362, 73.94516875136536, 0.21016157198175678, 0.698869899968984);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer0, 'uint16', 10, 4);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup27);
+} catch {}
+try {
+renderBundleEncoder14.setIndexBuffer(buffer44, 'uint16', 6, 1);
+} catch {}
+try {
+buffer30.unmap();
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline2.getBindGroupLayout(0);
+let commandEncoder95 = device0.createCommandEncoder({});
+let texture103 = device0.createTexture({
+  size: {width: 256, height: 256, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'rg16uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder66.setBindGroup(2, bindGroup32);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle4, renderBundle4]);
+} catch {}
+try {
+buffer44.unmap();
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture29,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 160 widthInBlocks: 10 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 4064 */
+  offset: 3904,
+  bytesPerRow: 2048,
+  buffer: buffer65,
+}, {width: 10, height: 1, depthOrArrayLayers: 1});
+} catch {}
+try {
+commandEncoder95.clearBuffer(buffer65, 244);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let bindGroup53 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout2, entries: [{binding: 0, resource: textureView77}]});
+let externalTexture14 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder85.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder6.setBlendConstant({ r: 850.4, g: -679.3, b: 467.8, a: 888.6, });
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer28, 'uint16', 30, 3);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(0, buffer45);
+} catch {}
+try {
+commandEncoder94.copyBufferToBuffer(buffer48, 0, buffer21, 0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture71,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(217).fill(145), /* required buffer size: 217 */
+{offset: 217}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let canvas2 = document.createElement('canvas');
+let offscreenCanvas2 = new OffscreenCanvas(107, 1024);
+let buffer66 = device0.createBuffer({size: 112, usage: GPUBufferUsage.INDEX});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup33, new Uint32Array(2607), 365, 0);
+} catch {}
+try {
+renderPassEncoder2.setPipeline(pipeline12);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture({
+  /* bytesInLastRow: 256 widthInBlocks: 64 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1636 */
+  offset: 1636,
+  bytesPerRow: 28672,
+  buffer: buffer33,
+}, {
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 114, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 64, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder94.copyTextureToBuffer({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 0, y: 32, z: 0},
+  aspect: 'depth-only',
+}, {
+  /* bytesInLastRow: 2040 widthInBlocks: 510 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 3572 */
+  offset: 3572,
+  bytesPerRow: 83712,
+  buffer: buffer65,
+}, {width: 510, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 35, height: 4, depthOrArrayLayers: 36}
+*/
+{
+  source: videoFrame11,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 4},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup54 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout1, entries: [{binding: 0, resource: textureView5}]});
+let commandEncoder96 = device0.createCommandEncoder();
+let textureView114 = texture79.createView({});
+let computePassEncoder87 = commandEncoder95.beginComputePass({timestampWrites: {querySet: querySet4}});
+try {
+computePassEncoder53.setBindGroup(0, bindGroup17, new Uint32Array(53), 21, 0);
+} catch {}
+try {
+externalTexture6.label = '\ued64\u3673\u02cc\u{1fdef}\u{1f77f}';
+} catch {}
+let buffer67 = device0.createBuffer({size: 104, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder88 = commandEncoder96.beginComputePass();
+let renderPassEncoder18 = commandEncoder94.beginRenderPass({
+  colorAttachments: [{
+  view: textureView61,
+  depthSlice: 26,
+  clearValue: { r: -461.7, g: -748.9, b: 813.4, a: 312.9, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet20},
+});
+try {
+computePassEncoder81.setBindGroup(2, bindGroup43);
+} catch {}
+try {
+computePassEncoder31.setBindGroup(0, bindGroup29, new Uint32Array(382), 34, 0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup11);
+} catch {}
+try {
+renderPassEncoder7.setScissorRect(33, 48, 21, 24);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer19, 24, 129);
+} catch {}
+let gpuCanvasContext4 = canvas2.getContext('webgpu');
+await gc();
+let commandEncoder97 = device0.createCommandEncoder({});
+let texture104 = device0.createTexture({
+  size: {width: 65, height: 40, depthOrArrayLayers: 57},
+  format: 'astc-5x5-unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView115 = texture57.createView({baseArrayLayer: 2, arrayLayerCount: 2});
+let computePassEncoder89 = commandEncoder97.beginComputePass();
+let sampler60 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.40,
+});
+let promise15 = shaderModule1.getCompilationInfo();
+try {
+buffer41.unmap();
+} catch {}
+let commandEncoder98 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder98.beginComputePass();
+try {
+computePassEncoder21.setBindGroup(0, bindGroup38, new Uint32Array(794), 18, 0);
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup15);
+} catch {}
+try {
+renderPassEncoder17.beginOcclusionQuery(18);
+} catch {}
+try {
+renderPassEncoder17.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle13, renderBundle7]);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer23, 'uint32', 0, 5);
+} catch {}
+try {
+renderPassEncoder13.setPipeline(pipeline12);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let buffer68 = device0.createBuffer({size: 284, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder99 = device0.createCommandEncoder({});
+let computePassEncoder91 = commandEncoder99.beginComputePass();
+try {
+computePassEncoder39.setBindGroup(1, bindGroup33, new Uint32Array(2214), 53, 0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup40, new Uint32Array(2311), 190, 0);
+} catch {}
+try {
+renderPassEncoder5.setViewport(17.378712299591843, 1.6696549268152627, 16.933595227437834, 0.024851702589397673, 0.4679843239596071, 0.8798851935438554);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer17, 'uint16', 0, 0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+await gc();
+let texture105 = device0.createTexture({
+  size: [142, 16, 1],
+  dimension: '2d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let texture106 = gpuCanvasContext2.getCurrentTexture();
+let textureView116 = texture91.createView({});
+try {
+computePassEncoder75.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder89.setBindGroup(1, bindGroup43, new Uint32Array(2683), 592, 0);
+} catch {}
+try {
+computePassEncoder16.end();
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup2, new Uint32Array(452), 59, 0);
+} catch {}
+try {
+renderPassEncoder8.setPipeline(pipeline12);
+} catch {}
+let bindGroup55 = device0.createBindGroup({layout: veryExplicitBindGroupLayout0, entries: [{binding: 5, resource: externalTexture11}]});
+let commandEncoder100 = device0.createCommandEncoder({});
+let computePassEncoder92 = commandEncoder16.beginComputePass();
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['rg16float']});
+try {
+{ clearResourceUsages(device0, computePassEncoder21); computePassEncoder21.dispatchWorkgroups(2, 1, 1); };
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder14.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder9.setScissorRect(99, 13, 8, 37);
+} catch {}
+try {
+renderPassEncoder5.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer31, 0);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup34);
+} catch {}
+let gpuCanvasContext5 = offscreenCanvas2.getContext('webgpu');
+let commandEncoder101 = device0.createCommandEncoder({});
+let texture107 = device0.createTexture({size: [1020, 428, 1], sampleCount: 1, format: 'rgba16uint', usage: GPUTextureUsage.COPY_SRC});
+let textureView117 = texture15.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder70.setBindGroup(2, bindGroup47, new Uint32Array(2061), 242, 0);
+} catch {}
+try {
+computePassEncoder50.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setViewport(4.727387487818003, 2.526488492320639, 14.146545773236259, 1.2070517966967904, 0.3257979647659003, 0.7289297496867972);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer28, 'uint32', 36, 37);
+} catch {}
+try {
+renderPassEncoder16.setVertexBuffer(2, buffer44, 24);
+} catch {}
+try {
+commandEncoder100.copyBufferToBuffer(buffer13, 72, buffer42, 20, 0);
+} catch {}
+try {
+computePassEncoder34.pushDebugGroup('\u0a40');
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(168, 194);
+let commandEncoder102 = device0.createCommandEncoder();
+try {
+computePassEncoder81.setBindGroup(3, bindGroup51, new Uint32Array(3438), 109, 0);
+} catch {}
+try {
+renderPassEncoder5.beginOcclusionQuery(1514);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer17, 'uint32', 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 28, new BigUint64Array(7954), 2086, 0);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let bindGroup56 = device0.createBindGroup({layout: veryExplicitBindGroupLayout16, entries: [{binding: 370, resource: textureView84}]});
+let commandEncoder103 = device0.createCommandEncoder({});
+let texture108 = device0.createTexture({
+  size: {width: 127},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder93 = commandEncoder100.beginComputePass();
+let renderPassEncoder19 = commandEncoder102.beginRenderPass({
+  colorAttachments: [{
+  view: textureView82,
+  depthSlice: 218,
+  clearValue: { r: 462.0, g: 744.0, b: -25.30, a: -779.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet13, beginningOfPassWriteIndex: 24},
+});
+let externalTexture15 = device0.importExternalTexture({source: videoFrame12, colorSpace: 'display-p3'});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup13, new Uint32Array(2198), 140, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup21);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup49, new Uint32Array(1573), 260, 0);
+} catch {}
+try {
+renderPassEncoder5.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder101.copyTextureToTexture({
+  texture: texture76,
+  mipLevel: 0,
+  origin: {x: 2, y: 4, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture24,
+  mipLevel: 1,
+  origin: {x: 206, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 64, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'opaque',
+});
+} catch {}
+let pipeline15 = await device0.createRenderPipelineAsync({
+  layout: pipelineLayout2,
+  multisample: {count: 4, alphaToCoverageEnabled: true},
+  fragment: {
+  module: shaderModule0,
+  entryPoint: 'fragment0',
+  targets: [{
+  format: 'rgba32float',
+  blend: {
+    color: {operation: 'add', srcFactor: 'dst', dstFactor: 'dst-alpha'},
+    alpha: {operation: 'reverse-subtract', srcFactor: 'one-minus-src', dstFactor: 'zero'},
+  },
+  writeMask: GPUColorWrite.ALPHA,
+}],
+},
+  depthStencil: {
+    format: 'depth32float',
+    depthWriteEnabled: false,
+    stencilWriteMask: 680676572,
+    depthBias: -1802379881,
+    depthBiasClamp: 0.0,
+  },
+  vertex: {
+    module: shaderModule1,
+    entryPoint: 'vertex2',
+    constants: {},
+    buffers: [{arrayStride: 592, attributes: [{format: 'float32x3', offset: 96, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'line-list', cullMode: 'none'},
+});
+let gpuCanvasContext6 = offscreenCanvas3.getContext('webgpu');
+try {
+navigator.gpu.getPreferredCanvasFormat();
+} catch {}
+let querySet21 = device0.createQuerySet({type: 'occlusion', count: 568});
+let texture109 = device0.createTexture({
+  size: {width: 510, height: 214, depthOrArrayLayers: 56},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'rg16float',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView118 = texture60.createView({dimension: '2d', aspect: 'depth-only'});
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({
+  label: '\ub3a8\uab4d\u0bfc\u{1fd3a}\u778f\u{1fb9b}\u0f3b',
+  colorFormats: ['rgba32float'],
+  depthStencilFormat: 'depth32float',
+  sampleCount: 4,
+  depthReadOnly: true,
+});
+let sampler61 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 66.54});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup27);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle4, renderBundle9, renderBundle4, renderBundle4, renderBundle4, renderBundle4, renderBundle9, renderBundle4]);
+} catch {}
+try {
+commandEncoder103.copyTextureToBuffer({
+  texture: texture45,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 180 */
+  offset: 180,
+  bytesPerRow: 14336,
+  buffer: buffer60,
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext3.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 510, height: 214, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame10,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture70,
+  mipLevel: 0,
+  origin: {x: 96, y: 26, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+videoFrame0.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame6.close();
+videoFrame8.close();
+videoFrame9.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame12.close();
+videoFrame13.close();
+videoFrame14.close();
+videoFrame15.close();
+videoFrame16.close();
+}
+async function worker0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  requiredFeatures: [
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'float32-blendable',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxVertexBuffers: 8,
+    maxUniformBufferBindingSize: 1013787,
+    maxStorageBufferBindingSize: 145970020,
+    maxUniformBuffersPerShaderStage: 12,
+    maxSampledTexturesPerShaderStage: 16,
+  },
+});
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture0 = device0.createTexture({
+  size: [1, 180, 1],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let commandEncoder1 = device0.createCommandEncoder();
+let texture1 = device0.createTexture({
+  size: {width: 1, height: 90, depthOrArrayLayers: 51},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture2 = device0.createTexture({
+  size: {width: 1, height: 45, depthOrArrayLayers: 48},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let commandEncoder2 = device0.createCommandEncoder();
+let sampler0 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'greater-equal',
+  maxAnisotropy: 18,
+});
+let texture3 = device0.createTexture({
+  size: {width: 128, height: 128, depthOrArrayLayers: 14},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView0 = texture3.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1});
+let computePassEncoder1 = commandEncoder2.beginComputePass();
+try {
+device0.queue.submit([]);
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder({});
+let texture4 = device0.createTexture({
+  size: [9, 241, 1],
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder0 = commandEncoder3.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: 732.5, g: 860.4, b: 410.0, a: -317.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+let imageData0 = new ImageData(48, 36);
+let textureView1 = texture1.createView({baseMipLevel: 0, mipLevelCount: 1});
+let texture5 = device0.createTexture({
+  size: {width: 9, height: 241, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView2 = texture2.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder2 = commandEncoder1.beginComputePass();
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true});
+let renderBundle0 = renderBundleEncoder0.finish();
+let textureView3 = texture4.createView({aspect: 'all'});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true, stencilReadOnly: true});
+try {
+renderPassEncoder0.setVertexBuffer(7, undefined);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 7, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 310,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 420,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 522,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder4 = device0.createCommandEncoder({});
+let textureView4 = texture4.createView({dimension: '2d-array'});
+let computePassEncoder3 = commandEncoder4.beginComputePass();
+let sampler1 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', compare: 'less-equal'});
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder5 = device0.createCommandEncoder({});
+let sampler2 = device0.createSampler({addressModeU: 'mirror-repeat', magFilter: 'linear', minFilter: 'linear', lodMaxClamp: 67.42});
+let textureView5 = texture0.createView({});
+let renderPassEncoder1 = commandEncoder5.beginRenderPass({colorAttachments: [{view: textureView0, loadOp: 'clear', storeOp: 'discard'}]});
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 62, z: 0},
+  aspect: 'all',
+}, new Uint8Array(297).fill(82), /* required buffer size: 297 */
+{offset: 297, bytesPerRow: 36}, {width: 1, height: 8, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 7, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 310,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 420,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 522,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder6 = device0.createCommandEncoder({});
+let texture6 = device0.createTexture({
+  size: [1, 90, 276],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder2 = commandEncoder6.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: 122.2, g: -433.6, b: 52.48, a: -865.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let renderBundle1 = renderBundleEncoder1.finish({});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder7 = device0.createCommandEncoder({});
+let sampler3 = device0.createSampler({addressModeV: 'repeat', maxAnisotropy: 1});
+let renderPassEncoder3 = commandEncoder7.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: 983.8, g: 65.99, b: -532.5, a: -150.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 159410385,
+});
+let sampler4 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 27.20,
+  lodMaxClamp: 42.86,
+});
+try {
+renderPassEncoder1.setBlendConstant({ r: 942.4, g: -28.33, b: -966.7, a: -713.1, });
+} catch {}
+let commandEncoder8 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  size: {width: 9, height: 241, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder4 = commandEncoder8.beginComputePass();
+let textureView6 = texture7.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 1});
+let sampler5 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'mirror-repeat', lodMinClamp: 74.08, lodMaxClamp: 93.02});
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpte432', transfer: 'log'} });
+let pipelineLayout2 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let texture8 = device0.createTexture({
+  size: [78, 1931, 1],
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder3.setViewport(33.63051633472102, 109.69503229564374, 77.04773265080469, 14.386383882236572, 0.7604788384487001, 0.9733871825857803);
+} catch {}
+await gc();
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  label: '\ue287\ud1ed',
+  entries: [
+    {
+      binding: 331,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let buffer0 = device0.createBuffer({size: 160, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+let textureView7 = texture6.createView({baseArrayLayer: 0});
+let texture9 = device0.createTexture({size: [128], dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.COPY_SRC});
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer0, 0, 15);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let texture10 = device0.createTexture({
+  size: {width: 1, height: 45, depthOrArrayLayers: 1},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture11 = device0.createTexture({size: [128], dimension: '1d', format: 'rg8sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+let computePassEncoder5 = commandEncoder9.beginComputePass();
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer0, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+let commandEncoder10 = device0.createCommandEncoder({});
+let texture12 = device0.createTexture({
+  size: [9, 241, 1],
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder4 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: -248.2, g: 828.4, b: -903.1, a: 987.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle0]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder11 = device0.createCommandEncoder({});
+let textureView8 = texture8.createView({});
+let sampler6 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  compare: 'less',
+});
+let commandEncoder12 = device0.createCommandEncoder({});
+let textureView9 = texture4.createView({});
+let texture13 = device0.createTexture({
+  size: [19, 482, 1],
+  mipLevelCount: 3,
+  dimension: '2d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder5 = commandEncoder12.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: -571.1, g: 572.0, b: 798.1, a: -301.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 227627894,
+});
+try {
+renderPassEncoder2.setBlendConstant({ r: -54.26, g: 529.8, b: 324.1, a: -769.9, });
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder11.clearBuffer(buffer0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 13, z: 0},
+  aspect: 'all',
+}, new Uint8Array(19).fill(97), /* required buffer size: 19 */
+{offset: 19, bytesPerRow: 84}, {width: 0, height: 70, depthOrArrayLayers: 0});
+} catch {}
+let texture14 = device0.createTexture({
+  size: {width: 1, height: 180, depthOrArrayLayers: 1},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+await gc();
+let buffer1 = device0.createBuffer({size: 96, usage: GPUBufferUsage.UNIFORM});
+let textureView10 = texture6.createView({baseArrayLayer: 0});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 99.97,
+});
+let buffer2 = device0.createBuffer({size: 100, usage: GPUBufferUsage.STORAGE});
+let texture15 = device0.createTexture({
+  size: [1, 360, 114],
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView11 = texture12.createView({format: 'rgba32uint', mipLevelCount: 1});
+try {
+renderPassEncoder5.setViewport(111.44092781863355, 104.33452165734415, 2.247837929669597, 19.949295952653717, 0.30547228711852226, 0.6321445449889092);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer0, 16, 26);
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 7, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 310,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 420,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 522,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 1,
+});
+let textureView12 = texture2.createView({baseMipLevel: 1, mipLevelCount: 1});
+let renderPassEncoder6 = commandEncoder11.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: -482.8, g: -737.6, b: -695.1, a: -993.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler9 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 50.65, compare: 'always'});
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle1, renderBundle0]);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let imageData1 = new ImageData(84, 48);
+let commandEncoder13 = device0.createCommandEncoder();
+let buffer3 = device0.createBuffer({size: 112, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let texture16 = device0.createTexture({size: [1, 45, 1], format: 'rgba32uint', usage: GPUTextureUsage.STORAGE_BINDING, viewFormats: []});
+let computePassEncoder6 = commandEncoder13.beginComputePass();
+try {
+buffer0.unmap();
+} catch {}
+try {
+computePassEncoder0.insertDebugMarker('\u0fce');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let imageData2 = new ImageData(48, 20);
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt470bg', primaries: 'smpteSt4281', transfer: 'bt2020_12bit'} });
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+try {
+buffer3.unmap();
+} catch {}
+let textureView13 = texture16.createView({dimension: '2d-array'});
+let sampler10 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 79.63});
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle1, renderBundle0, renderBundle1, renderBundle0, renderBundle0, renderBundle0, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+let commandEncoder14 = device0.createCommandEncoder({label: '\ubaa6\udb50\u0e08\u0937\u1ff5\u05e4\uece8\u64f9\u8d8c\u5375'});
+let texture17 = device0.createTexture({
+  size: {width: 39, height: 965, depthOrArrayLayers: 155},
+  dimension: '3d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture18 = device0.createTexture({
+  size: [1, 180, 443],
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView14 = texture8.createView({});
+let computePassEncoder7 = commandEncoder14.beginComputePass();
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(7, buffer0, 4, 3);
+} catch {}
+let textureView15 = texture8.createView({});
+let computePassEncoder8 = commandEncoder11.beginComputePass();
+try {
+renderPassEncoder4.setScissorRect(4, 1, 40, 8);
+} catch {}
+let textureView16 = texture11.createView({aspect: 'all'});
+let sampler11 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 59.20,
+  maxAnisotropy: 14,
+});
+try {
+renderPassEncoder0.setBlendConstant({ r: 369.0, g: 129.4, b: -438.5, a: -144.7, });
+} catch {}
+try {
+renderPassEncoder4.setScissorRect(32, 4, 5, 1);
+} catch {}
+let imageData3 = new ImageData(20, 76);
+let textureView17 = texture12.createView({dimension: '2d-array', mipLevelCount: 1});
+let texture19 = device0.createTexture({
+  size: {width: 78, height: 1931, depthOrArrayLayers: 875},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView18 = texture11.createView({dimension: '1d'});
+let texture20 = device0.createTexture({size: [78, 1931, 1], format: 'depth24plus', usage: GPUTextureUsage.COPY_DST});
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 0, new Uint32Array(17416), 4705, 20);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+adapter0.label = '\u6b7d\u{1f85f}\u5bca\u096b\ue1c6\u{1fe80}\u684a';
+} catch {}
+let buffer4 = device0.createBuffer({size: 96, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.VERTEX});
+try {
+renderPassEncoder4.setVertexBuffer(3, buffer3);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 28, new BigUint64Array(1423), 252, 0);
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'fcc', primaries: 'smpte240m', transfer: 'iec61966-2-1'} });
+let commandEncoder15 = device0.createCommandEncoder({});
+let textureView19 = texture19.createView({mipLevelCount: 1});
+let sampler12 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'always',
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setViewport(88.2286665799596, 112.8096192912897, 34.32643375647666, 13.009618270048987, 0.14661742653143306, 0.4848604329401805);
+} catch {}
+let texture21 = device0.createTexture({
+  size: [9, 241, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let commandEncoder16 = device0.createCommandEncoder({});
+let texture22 = device0.createTexture({
+  size: {width: 19, height: 482, depthOrArrayLayers: 35},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let bindGroup0 = device0.createBindGroup({layout: veryExplicitBindGroupLayout4, entries: [{binding: 0, resource: {buffer: buffer2}}]});
+let querySet0 = device0.createQuerySet({type: 'timestamp', count: 724});
+let textureView20 = texture22.createView({mipLevelCount: 1});
+let computePassEncoder9 = commandEncoder15.beginComputePass();
+let sampler13 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'mirror-repeat'});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0, new Uint32Array(1718), 265, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer5 = device0.createBuffer({size: 44, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 123});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer4, 0, 32);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 12, new DataView(new ArrayBuffer(30670)), 4747, 8);
+} catch {}
+let texture23 = device0.createTexture({
+  size: {width: 19, height: 482, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView21 = texture9.createView({baseMipLevel: 0, mipLevelCount: 1});
+try {
+renderPassEncoder0.setScissorRect(19, 15, 2, 7);
+} catch {}
+try {
+computePassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(5619), 326, 0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle0, renderBundle1, renderBundle1]);
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture17,
+  mipLevel: 0,
+  origin: {x: 7, y: 13, z: 35},
+  aspect: 'all',
+}, new Uint8Array(1_376_452).fill(124), /* required buffer size: 1_376_452 */
+{offset: 26, bytesPerRow: 213, rowsPerImage: 154}, {width: 5, height: 149, depthOrArrayLayers: 42});
+} catch {}
+let textureView22 = texture19.createView({mipLevelCount: 1});
+let computePassEncoder10 = commandEncoder16.beginComputePass();
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.27,
+});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(650), 36, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer3, 0, 4);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let texture24 = device0.createTexture({size: [78, 1931, 1], mipLevelCount: 2, format: 'depth24plus', usage: GPUTextureUsage.COPY_SRC});
+let renderPassEncoder7 = commandEncoder17.beginRenderPass({
+  colorAttachments: [{
+  view: textureView19,
+  depthSlice: 612,
+  clearValue: { r: 248.9, g: -179.5, b: 984.8, a: 900.9, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle0, renderBundle1]);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let textureView23 = texture7.createView({dimension: '2d-array'});
+try {
+computePassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle1, renderBundle0, renderBundle1, renderBundle1, renderBundle0, renderBundle1, renderBundle1]);
+} catch {}
+let buffer6 = device0.createBuffer({size: 120, usage: GPUBufferUsage.INDIRECT});
+let renderPassEncoder8 = commandEncoder18.beginRenderPass({
+  colorAttachments: [{view: textureView19, depthSlice: 695, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 296775157,
+});
+let sampler15 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 82.15, compare: 'equal', maxAnisotropy: 1});
+try {
+computePassEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(121), 11, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(2, buffer0, 0);
+} catch {}
+let textureView24 = texture13.createView({dimension: '2d-array', mipLevelCount: 1});
+let sampler16 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 95.14});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 0,
+  origin: {x: 2, y: 47, z: 0},
+  aspect: 'all',
+}, new Uint8Array(139).fill(149), /* required buffer size: 139 */
+{offset: 139, bytesPerRow: 96}, {width: 0, height: 132, depthOrArrayLayers: 0});
+} catch {}
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 1648});
+let sampler17 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 40.46,
+  lodMaxClamp: 96.56,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup0, new Uint32Array(1088), 100, 0);
+} catch {}
+let textureView25 = texture3.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 6});
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(708), 12, 0);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(0, buffer3, 0, 7);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 0, y: 47, z: 0},
+  aspect: 'all',
+}, new Uint8Array(92).fill(29), /* required buffer size: 92 */
+{offset: 92, bytesPerRow: 9}, {width: 4, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let buffer7 = device0.createBuffer({size: 200, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let textureView26 = texture6.createView({aspect: 'all'});
+try {
+renderPassEncoder5.executeBundles([renderBundle0, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer4, 12);
+} catch {}
+let buffer8 = device0.createBuffer({
+  size: 153,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture25 = device0.createTexture({
+  size: [39],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(189), 46, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup0);
+} catch {}
+let imageData4 = new ImageData(4, 92);
+try {
+device0.queue.label = '\ufbd6\ub472\u{1f6b6}\ub5e3\u41f0\u8a19\u0d6d\u073a\u{1fcc9}\u{1f8fb}';
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '3d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 5,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '3d' },
+    },
+    {binding: 7, visibility: GPUShaderStage.VERTEX, sampler: { type: 'non-filtering' }},
+    {
+      binding: 9,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'uint', multisampled: false },
+    },
+    {binding: 18, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 21,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      sampler: { type: 'comparison' },
+    },
+    {
+      binding: 22,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 40,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 66,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 133,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+    {
+      binding: 310,
+      visibility: GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 420,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+    {
+      binding: 522,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4, veryExplicitBindGroupLayout5]});
+let commandEncoder19 = device0.createCommandEncoder();
+let renderPassEncoder9 = commandEncoder19.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: 399.3, g: -893.4, b: -614.4, a: -984.1, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  timestampWrites: {querySet: querySet0, endOfPassWriteIndex: 584},
+});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0, new Uint32Array(1242), 126, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(701), 11, 0);
+} catch {}
+let texture26 = device0.createTexture({
+  size: [1, 180, 1],
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView27 = texture3.createView({dimension: '2d', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 9, arrayLayerCount: 1});
+let sampler18 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 93.64,
+});
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(352).fill(62), /* required buffer size: 352 */
+{offset: 352, bytesPerRow: 35}, {width: 1, height: 5, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let computePassEncoder11 = commandEncoder20.beginComputePass();
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup0, new Uint32Array(1388), 184, 0);
+} catch {}
+try {
+buffer7.unmap();
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let textureView28 = texture4.createView({});
+let computePassEncoder12 = commandEncoder21.beginComputePass();
+try {
+renderPassEncoder4.setVertexBuffer(6, buffer4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 24, new Uint32Array(5757), 489, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 1, y: 5, z: 0},
+  aspect: 'all',
+}, new Uint8Array(425).fill(15), /* required buffer size: 425 */
+{offset: 425, bytesPerRow: 51}, {width: 0, height: 10, depthOrArrayLayers: 0});
+} catch {}
+let textureView29 = texture16.createView({});
+let texture27 = device0.createTexture({
+  size: {width: 19, height: 482, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup0);
+} catch {}
+let commandEncoder22 = device0.createCommandEncoder({});
+let renderPassEncoder10 = commandEncoder22.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  depthSlice: 236,
+  clearValue: { r: 982.1, g: -202.3, b: 761.4, a: -530.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+device0.queue.writeBuffer(buffer4, 4, new Uint32Array(1071), 112, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 2, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(832).fill(219), /* required buffer size: 832 */
+{offset: 832, bytesPerRow: 58}, {width: 1, height: 18, depthOrArrayLayers: 0});
+} catch {}
+let texture28 = device0.createTexture({
+  label: '\u0b28\u0901\u7776\u0785\ucc96\u2eb6',
+  size: {width: 1, height: 90, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup0, new Uint32Array(253), 130, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(4, buffer4);
+} catch {}
+let commandEncoder23 = device0.createCommandEncoder();
+let textureView30 = texture18.createView({label: '\u0a2c\u{1fcd1}\u0a99', aspect: 'all', baseArrayLayer: 0, arrayLayerCount: 1});
+let computePassEncoder13 = commandEncoder23.beginComputePass();
+try {
+computePassEncoder4.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.lost.then(r => { console.log('device0 lost!'); console.log(r.message, r.reason); });
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0, new Uint32Array(788), 32, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer7);
+} catch {}
+try {
+computePassEncoder4.insertDebugMarker('\u042d');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 12, new BigUint64Array(8489), 230, 0);
+} catch {}
+let computePassEncoder14 = commandEncoder24.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(0, bindGroup0, new Uint32Array(2426), 300, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup0, new Uint32Array(2095), 173, 0);
+} catch {}
+let commandEncoder25 = device0.createCommandEncoder({});
+let textureView31 = texture2.createView({mipLevelCount: 1});
+let computePassEncoder15 = commandEncoder25.beginComputePass();
+try {
+computePassEncoder7.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder10.setBindGroup(0, bindGroup0, new Uint32Array(472), 141, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup0, new Uint32Array(5060), 25, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(2, buffer4);
+} catch {}
+let imageData5 = new ImageData(84, 92);
+let texture29 = device0.createTexture({
+  size: {width: 78, height: 1931, depthOrArrayLayers: 1},
+  mipLevelCount: 5,
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView32 = texture0.createView({});
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint']});
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(1733), 133, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle0, renderBundle0, renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setStencilReference(11);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(3, bindGroup0, new Uint32Array(1218), 124, 0);
+} catch {}
+let promise0 = device0.queue.onSubmittedWorkDone();
+await gc();
+let texture30 = device0.createTexture({
+  size: {width: 9, height: 241, depthOrArrayLayers: 1},
+  mipLevelCount: 4,
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let sampler19 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMinClamp: 91.64,
+  lodMaxClamp: 95.13,
+});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(59).fill(162), /* required buffer size: 59 */
+{offset: 59, bytesPerRow: 75}, {width: 1, height: 34, depthOrArrayLayers: 0});
+} catch {}
+let buffer9 = device0.createBuffer({size: 244, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+try {
+renderBundleEncoder2.setVertexBuffer(2, undefined);
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData5);
+let commandEncoder26 = device0.createCommandEncoder({});
+let textureView33 = texture30.createView({aspect: 'depth-only', mipLevelCount: 1});
+let sampler20 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.38,
+  maxAnisotropy: 11,
+});
+try {
+computePassEncoder3.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(1666), 90, 0);
+} catch {}
+try {
+renderBundleEncoder2.setBindGroup(2, bindGroup0, new Uint32Array(1350), 111, 0);
+} catch {}
+try {
+  await buffer5.mapAsync(GPUMapMode.READ, 0, 8);
+} catch {}
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let commandEncoder27 = device0.createCommandEncoder({});
+let computePassEncoder16 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder0.setBindGroup(2, bindGroup0, new Uint32Array(540), 144, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(2, bindGroup0, new Uint32Array(1423), 1_160, 0);
+} catch {}
+let commandEncoder28 = device0.createCommandEncoder({});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle1, renderBundle0, renderBundle0, renderBundle2, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder0.setViewport(110.46625076587817, 71.24797686593972, 17.49572602752398, 42.70225457523071, 0.7884755728288326, 0.8718610190126719);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer0, 0, 37);
+} catch {}
+try {
+commandEncoder27.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 176 */
+  offset: 176,
+  bytesPerRow: 45312,
+  buffer: buffer7,
+}, {
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 0, y: 53, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 16, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder28.resolveQuerySet(querySet1, 17, 5, buffer8, 0);
+} catch {}
+try {
+commandEncoder27.insertDebugMarker('\u01d2');
+} catch {}
+let imageData6 = new ImageData(36, 8);
+let textureView34 = texture4.createView({dimension: '2d-array', format: 'rgba8snorm'});
+let computePassEncoder17 = commandEncoder28.beginComputePass({timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 380}});
+let externalTexture3 = device0.importExternalTexture({source: videoFrame2});
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup0, new Uint32Array(245), 81, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(0, buffer4);
+} catch {}
+let buffer10 = device0.createBuffer({size: 236, usage: GPUBufferUsage.INDEX});
+let commandEncoder29 = device0.createCommandEncoder({});
+let renderPassEncoder11 = commandEncoder29.beginRenderPass({
+  colorAttachments: [{
+  view: textureView0,
+  clearValue: { r: 852.8, g: -513.6, b: -146.2, a: 250.7, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+let sampler21 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 54.42,
+});
+try {
+renderPassEncoder8.executeBundles([renderBundle0, renderBundle0, renderBundle0]);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+await gc();
+let textureView35 = texture18.createView({});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup0, new Uint32Array(1099), 275, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer10, 'uint16', 10, 55);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let promise1 = device0.queue.onSubmittedWorkDone();
+let buffer11 = device0.createBuffer({size: 72, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder30 = device0.createCommandEncoder({label: '\u788d\uab58\u8910\u935e\u0d41'});
+let sampler22 = device0.createSampler({addressModeV: 'mirror-repeat'});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+computePassEncoder7.setBindGroup(2, bindGroup0, new Uint32Array(4062), 687, 0);
+} catch {}
+try {
+renderPassEncoder8.executeBundles([renderBundle2]);
+} catch {}
+try {
+buffer11.unmap();
+} catch {}
+let buffer12 = device0.createBuffer({size: 88, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.VERTEX});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 90});
+let textureView36 = texture1.createView({mipLevelCount: 1});
+try {
+renderPassEncoder1.executeBundles([renderBundle2, renderBundle2, renderBundle1, renderBundle2, renderBundle2]);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(2, buffer3, 0, 12);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let computePassEncoder18 = commandEncoder30.beginComputePass({timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 16}});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(533), 109, 0);
+} catch {}
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(5, buffer4, 24, 1);
+} catch {}
+try {
+commandEncoder27.copyBufferToBuffer(buffer8, 12, buffer5, 8, 8);
+} catch {}
+let buffer13 = device0.createBuffer({size: 156, usage: GPUBufferUsage.COPY_DST});
+let commandEncoder32 = device0.createCommandEncoder({});
+let textureView37 = texture12.createView({mipLevelCount: 1, baseArrayLayer: 0});
+try {
+computePassEncoder2.setBindGroup(1, bindGroup0, new Uint32Array(820), 240, 0);
+} catch {}
+try {
+renderPassEncoder5.executeBundles([renderBundle2, renderBundle0, renderBundle2, renderBundle0, renderBundle2]);
+} catch {}
+try {
+  await promise0;
+} catch {}
+let buffer14 = device0.createBuffer({size: 88, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let sampler23 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 58.51,
+});
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer0);
+} catch {}
+let commandBuffer0 = commandEncoder4.finish({});
+let texture31 = device0.createTexture({
+  size: {width: 19, height: 482, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView38 = texture5.createView({});
+let computePassEncoder19 = commandEncoder27.beginComputePass();
+try {
+computePassEncoder15.setBindGroup(1, bindGroup0, new Uint32Array(1638), 171, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup0, new Uint32Array(968), 406, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle0, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder5.setVertexBuffer(5, undefined);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder32.clearBuffer(buffer13);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(44, 46);
+let computePassEncoder20 = commandEncoder32.beginComputePass();
+let renderPassEncoder12 = commandEncoder31.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 680.1, g: 422.4, b: -47.65, a: 0.6614, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup0, new Uint32Array(2944), 336, 0);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -385.1, g: -984.9, b: 787.5, a: -270.3, });
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer9, 0);
+} catch {}
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder33.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(2, bindGroup0);
+} catch {}
+let arrayBuffer0 = buffer5.getMappedRange(0, 0);
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(0); };
+} catch {}
+try {
+  await promise1;
+} catch {}
+let videoFrame3 = videoFrame0.clone();
+let commandEncoder34 = device0.createCommandEncoder({});
+let renderPassEncoder13 = commandEncoder34.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: -747.3, g: -558.4, b: -596.3, a: -368.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  timestampWrites: {querySet: querySet0, beginningOfPassWriteIndex: 400},
+  maxDrawCount: 28140651,
+});
+try {
+renderPassEncoder3.executeBundles([renderBundle0]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer10, 'uint16', 42, 105);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let buffer15 = device0.createBuffer({size: 68, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder35 = device0.createCommandEncoder({});
+let texture32 = device0.createTexture({
+  size: {width: 128, height: 128, depthOrArrayLayers: 14},
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView39 = texture5.createView({dimension: '2d-array', baseMipLevel: 0, baseArrayLayer: 0});
+let computePassEncoder22 = commandEncoder35.beginComputePass({timestampWrites: {querySet: querySet0}});
+try {
+computePassEncoder18.setBindGroup(2, bindGroup0, new Uint32Array(1063), 110, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 4, new BigUint64Array(25344), 3103, 0);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let commandEncoder36 = device0.createCommandEncoder();
+let textureView40 = texture17.createView({baseMipLevel: 0});
+let renderPassEncoder14 = commandEncoder36.beginRenderPass({
+  colorAttachments: [{
+  view: textureView27,
+  clearValue: { r: 280.7, g: -509.7, b: -280.5, a: 565.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler24 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 71.46,
+});
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup0, new Uint32Array(3715), 2_236, 0);
+} catch {}
+let externalTexture4 = device0.importExternalTexture({source: videoFrame2});
+let texture33 = device0.createTexture({size: [128, 128, 14], format: 'depth24plus', usage: GPUTextureUsage.COPY_DST});
+let textureView41 = texture0.createView({dimension: '2d-array', aspect: 'all', baseArrayLayer: 0});
+try {
+computePassEncoder0.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(0, bindGroup0);
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout4]});
+let commandEncoder37 = device0.createCommandEncoder({});
+let computePassEncoder23 = commandEncoder37.beginComputePass({timestampWrites: {querySet: querySet0, endOfPassWriteIndex: 645}});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(2, bindGroup0, new Uint32Array(1257), 157, 0);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer0, 8, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture4,
+  mipLevel: 0,
+  origin: {x: 3, y: 31, z: 0},
+  aspect: 'all',
+}, new Uint8Array(23).fill(177), /* required buffer size: 23 */
+{offset: 23, bytesPerRow: 4}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder38 = device0.createCommandEncoder();
+let computePassEncoder24 = commandEncoder38.beginComputePass();
+try {
+renderPassEncoder5.setVertexBuffer(4, undefined, 0, 606_853_149);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle0, renderBundle0]);
+} catch {}
+try {
+renderPassEncoder13.setViewport(5.608885031085407, 4.242449512538215, 95.66840162213128, 80.8327978470468, 0.6583827197928024, 0.6892505384312457);
+} catch {}
+let commandEncoder39 = device0.createCommandEncoder({});
+let texture34 = device0.createTexture({
+  size: [1, 90, 1],
+  format: 'depth24plus',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder15 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{view: textureView0, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet3,
+});
+try {
+computePassEncoder22.setBindGroup(2, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder18.setBindGroup(1, bindGroup0, new Uint32Array(246), 24, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup0, new Uint32Array(761), 125, 0);
+} catch {}
+try {
+renderPassEncoder12.setScissorRect(14, 58, 7, 25);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer10, 'uint16', 2, 2);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(0, buffer3, 28);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 44, new BigUint64Array(3829), 714, 0);
+} catch {}
+try {
+computePassEncoder14.setBindGroup(2, bindGroup0, new Uint32Array(878), 33, 0);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(4, buffer3, 0, 5);
+} catch {}
+try {
+buffer1.unmap();
+} catch {}
+let buffer16 = device0.createBuffer({size: 144, usage: GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+try {
+computePassEncoder19.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer10, 'uint16', 16, 2);
+} catch {}
+try {
+renderPassEncoder2.setVertexBuffer(1, buffer7, 68, 23);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u09fc');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 1, y: 1, z: 0},
+  aspect: 'all',
+}, new Uint8Array(63).fill(114), /* required buffer size: 63 */
+{offset: 63, bytesPerRow: 16}, {width: 0, height: 106, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({label: '\ue95b\u{1fb70}\u0caf\u{1fd86}\u86f1\uaf4e\u{1fafa}\u64dc\u{1fcb7}'});
+let computePassEncoder25 = commandEncoder40.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup0, new Uint32Array(5788), 163, 0);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer10, 'uint32', 20, 2);
+} catch {}
+try {
+computePassEncoder16.pushDebugGroup('\u36e4');
+} catch {}
+let videoFrame4 = videoFrame2.clone();
+let textureView42 = texture34.createView({aspect: 'depth-only', format: 'depth24plus'});
+let sampler25 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.26,
+  maxAnisotropy: 17,
+});
+let sampler26 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.65,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder14.setBindGroup(1, bindGroup0, new Uint32Array(795), 109, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint32', 4, 24);
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(19); };
+} catch {}
+let buffer17 = device0.createBuffer({size: 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView43 = texture16.createView({});
+let texture35 = device0.createTexture({
+  size: {width: 9, height: 241, depthOrArrayLayers: 77},
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView44 = texture12.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup0, new Uint32Array(2014), 409, 0);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setBlendConstant({ r: -306.6, g: 233.1, b: 478.6, a: -600.0, });
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(7, buffer0, 8);
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let commandEncoder41 = device0.createCommandEncoder({});
+let textureView45 = texture3.createView({dimension: 'cube', format: 'rg8sint', mipLevelCount: 1, baseArrayLayer: 1});
+let sampler27 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 15,
+});
+try {
+computePassEncoder11.setBindGroup(1, bindGroup0, new Uint32Array(2368), 563, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint32', 36, 0);
+} catch {}
+let buffer18 = device0.createBuffer({label: '\ubeea\u908c\u2f1e\uf394\u09be', size: 172, usage: GPUBufferUsage.STORAGE});
+let commandEncoder42 = device0.createCommandEncoder({});
+let sampler28 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 58.39});
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer14, 8, 2);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer8, 0, new Uint32Array(37324), 5260, 0);
+} catch {}
+let texture36 = device0.createTexture({
+  size: [78],
+  dimension: '1d',
+  format: 'rgba32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+try {
+computePassEncoder9.setBindGroup(2, bindGroup0);
+} catch {}
+let buffer19 = device0.createBuffer({size: 47, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture37 = device0.createTexture({
+  size: [78, 1931, 506],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder26 = commandEncoder43.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(3, bindGroup0, new Uint32Array(1175), 44, 0);
+} catch {}
+try {
+renderPassEncoder3.setIndexBuffer(buffer10, 'uint16', 20, 11);
+} catch {}
+let promise2 = device0.queue.onSubmittedWorkDone();
+try {
+computePassEncoder19.setBindGroup(1, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder23.setBindGroup(2, bindGroup0, new Uint32Array(256), 18, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer10, 'uint16', 212, 12);
+} catch {}
+try {
+commandEncoder41.copyBufferToBuffer(buffer9, 24, buffer5, 0, 4);
+} catch {}
+try {
+commandEncoder41.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 16 */
+  /* end: 80 */
+  offset: 80,
+  bytesPerRow: 4352,
+  buffer: buffer8,
+}, {
+  texture: texture12,
+  mipLevel: 1,
+  origin: {x: 0, y: 8, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 2, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer4, 8, new Uint32Array(41268), 5919, 0);
+} catch {}
+videoFrame0.close();
+videoFrame1.close();
+videoFrame2.close();
+videoFrame4.close();
+}
+async function worker1() {
+let promise0 = navigator.gpu.requestAdapter({});
+let promise1 = navigator.gpu.requestAdapter({});
+let adapter0 = await navigator.gpu.requestAdapter({});
+let promise2 = adapter0.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {
+    maxBindGroups: 4,
+    maxVertexBuffers: 8,
+    minUniformBufferOffsetAlignment: 256,
+    maxUniformBufferBindingSize: 78996430,
+    maxStorageBufferBindingSize: 144694078,
+  },
+});
+let adapter1 = await promise0;
+let promise3 = adapter1.requestDevice({
+  defaultQueue: {label: '\ufed9\u69aa\u{1f6f0}\u0e99'},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'float32-blendable',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxDynamicStorageBuffersPerPipelineLayout: 4,
+    maxUniformBufferBindingSize: 7703639,
+    maxStorageBufferBindingSize: 135823854,
+  },
+});
+let adapter2 = await navigator.gpu.requestAdapter({});
+let promise4 = adapter2.requestDevice({
+  defaultQueue: {},
+  requiredLimits: {
+    maxDynamicUniformBuffersPerPipelineLayout: 8,
+    maxBindingsPerBindGroup: 1000,
+    maxTextureDimension1D: 8192,
+    maxVertexBuffers: 8,
+    maxUniformBufferBindingSize: 10984026,
+    maxStorageBufferBindingSize: 138748896,
+    maxInterStageShaderVariables: 16,
+  },
+});
+let promise5 = navigator.gpu.requestAdapter({});
+let adapter3 = await promise5;
+let promise6 = adapter3.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxColorAttachmentBytesPerSample: 32,
+    maxUniformBufferBindingSize: 15253821,
+    maxStorageBufferBindingSize: 169004002,
+    maxUniformBuffersPerShaderStage: 12,
+  },
+});
+let adapter4 = await navigator.gpu.requestAdapter({});
+let device0 = await promise4;
+let commandEncoder0 = device0.createCommandEncoder({});
+let texture0 = device0.createTexture({
+  size: [127, 1, 23],
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderBundleEncoder0 = device0.createRenderBundleEncoder({colorFormats: [undefined]});
+let textureView0 = texture0.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 3});
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(13_490).fill(56), /* required buffer size: 13_490 */
+{offset: 130, bytesPerRow: 167, rowsPerImage: 20}, {width: 12, height: 0, depthOrArrayLayers: 5});
+} catch {}
+let textureView1 = texture0.createView({baseArrayLayer: 2, arrayLayerCount: 1});
+let sampler0 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 88.73,
+  lodMaxClamp: 92.92,
+});
+try {
+commandEncoder0.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 1},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder1 = device0.createCommandEncoder({});
+try {
+globalThis.someLabel = textureView0.label;
+} catch {}
+let sampler1 = device0.createSampler({
+  addressModeU: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 81.91,
+  maxAnisotropy: 11,
+});
+let texture1 = device0.createTexture({
+  size: {width: 510},
+  dimension: '1d',
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView2 = texture0.createView({dimension: '2d', aspect: 'all', baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 12});
+let computePassEncoder0 = commandEncoder0.beginComputePass();
+let buffer0 = device0.createBuffer({size: 24, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let computePassEncoder1 = commandEncoder1.beginComputePass();
+let veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 1, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 197,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let buffer1 = device0.createBuffer({size: 412, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE});
+let commandEncoder2 = device0.createCommandEncoder({});
+let textureView3 = texture0.createView({format: 'r32sint', baseArrayLayer: 8, arrayLayerCount: 4});
+let computePassEncoder2 = commandEncoder2.beginComputePass();
+try {
+renderBundleEncoder0.setVertexBuffer(1, undefined, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 0, new Uint32Array(19393), 19393);
+} catch {}
+requestAnimationFrame(startTime => globalThis.startTime=startTime);
+let veryExplicitBindGroupLayout1 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 1, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 197,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture2 = device0.createTexture({size: [64, 64, 35], dimension: '3d', format: 'rgba8sint', usage: GPUTextureUsage.COPY_DST});
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(62).fill(96), /* required buffer size: 62 */
+{offset: 62, rowsPerImage: 1}, {width: 48, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder3 = device0.createCommandEncoder({});
+let computePassEncoder3 = commandEncoder3.beginComputePass();
+let sampler2 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 95.96});
+try {
+renderBundleEncoder0.setVertexBuffer(6, undefined, 0, 830_890_115);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+let veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let textureView4 = texture0.createView({dimension: '2d'});
+let textureView5 = texture2.createView({});
+let renderBundle0 = renderBundleEncoder0.finish({});
+try {
+device0.queue.writeBuffer(buffer0, 4, new Int16Array(4232), 88, 0);
+} catch {}
+let buffer2 = device0.createBuffer({size: 88, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder4 = device0.createCommandEncoder({});
+let sampler3 = device0.createSampler({addressModeW: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 53.38});
+try {
+computePassEncoder2.pushDebugGroup('\u07fd');
+} catch {}
+let textureView6 = texture0.createView({baseArrayLayer: 3, arrayLayerCount: 1});
+let videoFrame0 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'fcc', primaries: 'bt470bg', transfer: 'pq'} });
+let sampler4 = device0.createSampler({label: '\u{1fccd}\ub0bf\u0bfb\ue6d6', addressModeW: 'mirror-repeat', lodMaxClamp: 85.42});
+try {
+computePassEncoder2.popDebugGroup();
+} catch {}
+let pipelineLayout0 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let textureView7 = texture1.createView({});
+let computePassEncoder4 = commandEncoder4.beginComputePass();
+let sampler5 = device0.createSampler({addressModeV: 'mirror-repeat', mipmapFilter: 'linear'});
+try {
+computePassEncoder3.end();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 2},
+  aspect: 'all',
+}, new Uint8Array(206_406).fill(128), /* required buffer size: 206_406 */
+{offset: 6, bytesPerRow: 480, rowsPerImage: 86}, {width: 88, height: 0, depthOrArrayLayers: 6});
+} catch {}
+try {
+veryExplicitBindGroupLayout1.label = '\u{1f6b0}\u8591\u0480\uc594';
+} catch {}
+let texture3 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder5 = commandEncoder3.beginComputePass();
+let sampler6 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 74.36,
+  compare: 'greater',
+  maxAnisotropy: 5,
+});
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup0 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView1}]});
+let pipelineLayout1 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2, veryExplicitBindGroupLayout0]});
+let buffer3 = device0.createBuffer({size: 141, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder5 = device0.createCommandEncoder({});
+let textureView8 = texture2.createView({label: '\u07cf\u{1f6f9}\u669b\u074d\u82b5\u{1fc1e}'});
+let computePassEncoder6 = commandEncoder5.beginComputePass();
+let textureView9 = texture2.createView({dimension: '3d', baseMipLevel: 0, mipLevelCount: 1});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup0, new Uint32Array(70), 1, 0);
+} catch {}
+let pipelineLayout2 = device0.createPipelineLayout({
+  label: '\u{1fd6b}\uaa28\u00ee\u7d87\u4457\u224e\u7e6b\u0ae7',
+  bindGroupLayouts: [veryExplicitBindGroupLayout1],
+});
+let buffer4 = device0.createBuffer({size: 96, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let textureView10 = texture0.createView({dimension: '2d', format: 'r32sint', baseArrayLayer: 1});
+try {
+computePassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(2381), 257, 0);
+} catch {}
+await gc();
+try {
+computePassEncoder6.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(2726), 479, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 4, new Uint32Array(11765), 892, 0);
+} catch {}
+let commandEncoder6 = device0.createCommandEncoder({});
+let sampler7 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.80,
+  maxAnisotropy: 4,
+});
+let computePassEncoder7 = commandEncoder6.beginComputePass();
+let sampler8 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.06,
+  maxAnisotropy: 14,
+});
+let texture4 = device0.createTexture({
+  size: [255, 1, 44],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rg32sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+adapter3.label = '\u0e19\u0852\u{1f8f1}\u8e23\u0e6e\ub529\u08a1\u03d1\ue15b';
+} catch {}
+let commandEncoder7 = device0.createCommandEncoder();
+let texture5 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 35},
+  dimension: '3d',
+  format: 'rgb9e5ufloat',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView11 = texture3.createView({dimension: '2d-array'});
+let pipelineLayout3 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout2, veryExplicitBindGroupLayout2]});
+let textureView12 = texture0.createView({dimension: '2d', baseArrayLayer: 11});
+let computePassEncoder8 = commandEncoder7.beginComputePass();
+try {
+computePassEncoder5.setBindGroup(1, bindGroup0);
+} catch {}
+let buffer5 = device0.createBuffer({
+  size: 44,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let commandEncoder8 = device0.createCommandEncoder({});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup0, new Uint32Array(1511), 168, 0);
+} catch {}
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let texture6 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 58},
+  format: 'rgba8unorm-srgb',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler9 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 78.93});
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder8.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 39, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder9 = device0.createCommandEncoder({});
+let textureView13 = texture6.createView({baseArrayLayer: 1, arrayLayerCount: 17});
+let computePassEncoder9 = commandEncoder9.beginComputePass();
+try {
+computePassEncoder6.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let buffer6 = device0.createBuffer({
+  size: 40,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX,
+});
+let commandEncoder10 = device0.createCommandEncoder({});
+let computePassEncoder10 = commandEncoder8.beginComputePass();
+let buffer7 = device0.createBuffer({size: 76, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder11 = device0.createCommandEncoder({});
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder11.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 69, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+await gc();
+let bindGroup1 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView1}]});
+let commandEncoder12 = device0.createCommandEncoder({});
+try {
+device0.queue.writeBuffer(buffer0, 4, new BigUint64Array(3798), 638, 0);
+} catch {}
+let commandEncoder13 = device0.createCommandEncoder();
+let sampler10 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 85.07,
+  lodMaxClamp: 93.18,
+  compare: 'not-equal',
+  maxAnisotropy: 7,
+});
+let computePassEncoder11 = commandEncoder11.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(0, bindGroup1, new Uint32Array(1456), 295, 0);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(174).fill(163), /* required buffer size: 174 */
+{offset: 174, bytesPerRow: 12, rowsPerImage: 58}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder0.setBindGroup(0, bindGroup1);
+} catch {}
+let buffer8 = device0.createBuffer({size: 48, usage: GPUBufferUsage.STORAGE});
+let commandEncoder14 = device0.createCommandEncoder({});
+let externalTexture0 = device0.importExternalTexture({source: videoFrame0});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup2 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 1, resource: externalTexture0}, {binding: 197, resource: sampler8}],
+});
+let commandEncoder15 = device0.createCommandEncoder({});
+let texture7 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 881},
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture8 = device0.createTexture({size: [255], dimension: '1d', format: 'r32sint', usage: GPUTextureUsage.COPY_SRC});
+let textureView14 = texture5.createView({mipLevelCount: 1});
+let sampler11 = device0.createSampler({addressModeV: 'clamp-to-edge', addressModeW: 'repeat'});
+let promise7 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise7;
+} catch {}
+let commandEncoder16 = device0.createCommandEncoder();
+let texture9 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 18},
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let texture10 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 14},
+  sampleCount: 1,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup2, new Uint32Array(3217), 136, 0);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 44, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 33, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup3 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 197, resource: sampler7}, {binding: 1, resource: externalTexture0}],
+});
+let texture11 = device0.createTexture({
+  size: [510, 1, 312],
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder12 = commandEncoder15.beginComputePass();
+try {
+device0.queue.writeBuffer(buffer0, 0, new Uint32Array(5194), 2686, 0);
+} catch {}
+let veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 15,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'storage', minBindingSize: 0, hasDynamicOffset: true },
+    },
+    {
+      binding: 223,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+  ],
+});
+let querySet0 = device0.createQuerySet({type: 'occlusion', count: 301});
+let texture12 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 16},
+  dimension: '3d',
+  format: 'rgba8snorm',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder13 = commandEncoder10.beginComputePass();
+try {
+commandEncoder16.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer9 = device0.createBuffer({size: 96, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let textureView15 = texture7.createView({});
+let sampler12 = device0.createSampler({
+  label: '\u{1fb59}\u{1fc85}\ub2b6\u0be9\uc023\u{1f98f}\ue8b5\u0a99\uf33b\u8421',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  lodMaxClamp: 94.93,
+});
+try {
+computePassEncoder11.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+commandEncoder16.copyBufferToBuffer(buffer5, 0, buffer0, 0, 0);
+} catch {}
+await gc();
+try {
+commandEncoder14.clearBuffer(buffer0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 0, new Uint32Array(720), 474, 0);
+} catch {}
+let commandEncoder17 = device0.createCommandEncoder({});
+let computePassEncoder14 = commandEncoder12.beginComputePass();
+let computePassEncoder15 = commandEncoder14.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(2, bindGroup3);
+} catch {}
+let commandEncoder18 = device0.createCommandEncoder({});
+let bindGroup4 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 197, resource: sampler4}, {binding: 1, resource: externalTexture0}],
+});
+let commandEncoder19 = device0.createCommandEncoder({});
+let texture13 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 32},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder16 = commandEncoder18.beginComputePass();
+let sampler13 = device0.createSampler({
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 85.75,
+});
+try {
+computePassEncoder7.setBindGroup(1, bindGroup2, new Uint32Array(2400), 725, 0);
+} catch {}
+try {
+commandEncoder13.copyBufferToBuffer(buffer4, 8, buffer2, 40, 32);
+} catch {}
+let promise8 = device0.queue.onSubmittedWorkDone();
+let bindGroup5 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView0}]});
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise8;
+} catch {}
+let textureView16 = texture7.createView({});
+let computePassEncoder17 = commandEncoder17.beginComputePass();
+let sampler14 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 16,
+});
+try {
+computePassEncoder12.setBindGroup(0, bindGroup2, new Uint32Array(840), 111, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer10 = device0.createBuffer({size: 368, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let textureView17 = texture2.createView({aspect: 'all', format: 'rgba8sint', mipLevelCount: 1});
+try {
+computePassEncoder2.setBindGroup(3, bindGroup3);
+} catch {}
+let texture14 = device0.createTexture({
+  size: [63],
+  dimension: '1d',
+  format: 'r32sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+buffer3.unmap();
+} catch {}
+try {
+commandEncoder19.copyBufferToBuffer(buffer6, 8, buffer10, 40, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 87, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder20 = device0.createCommandEncoder({});
+let texture15 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  sampleCount: 1,
+  format: 'rgb10a2unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder18 = commandEncoder19.beginComputePass();
+try {
+commandEncoder20.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 32, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 0, new Uint32Array(5364), 262, 0);
+} catch {}
+let querySet1 = device0.createQuerySet({type: 'occlusion', count: 49});
+let computePassEncoder19 = commandEncoder16.beginComputePass();
+try {
+computePassEncoder8.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+commandEncoder20.copyBufferToBuffer(buffer4, 0, buffer2, 0, 24);
+} catch {}
+try {
+commandEncoder13.copyTextureToTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 45, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\u{1fb59}');
+} catch {}
+let commandEncoder21 = device0.createCommandEncoder({});
+let texture16 = device0.createTexture({
+  size: [255, 1, 1],
+  format: 'rg8uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder20 = commandEncoder13.beginComputePass();
+let sampler15 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 99.98,
+  compare: 'never',
+});
+try {
+globalThis.someLabel = device0.queue.label;
+} catch {}
+let buffer11 = device0.createBuffer({size: 260, usage: GPUBufferUsage.UNIFORM});
+try {
+computePassEncoder10.setBindGroup(2, bindGroup0, new Uint32Array(988), 258, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame1 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte170m', primaries: 'smpte170m', transfer: 'bt2020_10bit'} });
+let commandEncoder22 = device0.createCommandEncoder({});
+let computePassEncoder21 = commandEncoder22.beginComputePass();
+try {
+device0.queue.writeTexture({
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 49, y: 0, z: 23},
+  aspect: 'all',
+}, new Uint8Array(154).fill(132), /* required buffer size: 154 */
+{offset: 154, rowsPerImage: 119}, {width: 88, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame2 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'yCgCo', primaries: 'smpteRp431', transfer: 'smpte170m'} });
+let buffer12 = device0.createBuffer({size: 428, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let textureView18 = texture9.createView({});
+let computePassEncoder22 = commandEncoder20.beginComputePass();
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let textureView19 = texture15.createView({dimension: 'cube-array', baseArrayLayer: 1, arrayLayerCount: 6});
+let computePassEncoder23 = commandEncoder21.beginComputePass();
+try {
+computePassEncoder2.setBindGroup(1, bindGroup4);
+} catch {}
+try {
+buffer4.unmap();
+} catch {}
+try {
+computePassEncoder5.setBindGroup(2, bindGroup3);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 45, y: 0, z: 14},
+  aspect: 'all',
+}, new Uint8Array(15_212).fill(225), /* required buffer size: 15_212 */
+{offset: 44, bytesPerRow: 158, rowsPerImage: 16}, {width: 36, height: 0, depthOrArrayLayers: 7});
+} catch {}
+await gc();
+let commandEncoder23 = device0.createCommandEncoder({});
+let renderBundleEncoder1 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+try {
+renderBundleEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer6, 'uint32', 8, 10);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(4, buffer2, 8, 6);
+} catch {}
+try {
+commandEncoder23.copyBufferToBuffer(buffer5, 8, buffer2, 4, 4);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 408 widthInBlocks: 102 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 64 */
+  offset: 64,
+  bytesPerRow: 11520,
+  buffer: buffer7,
+}, {
+  texture: texture5,
+  mipLevel: 0,
+  origin: {x: 83, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 102, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let imageData0 = new ImageData(8, 48);
+let texture17 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView20 = texture14.createView({});
+let computePassEncoder24 = commandEncoder23.beginComputePass();
+let sampler16 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 92.15,
+  maxAnisotropy: 9,
+});
+try {
+computePassEncoder1.setBindGroup(1, bindGroup4, []);
+} catch {}
+try {
+computePassEncoder11.setBindGroup(2, bindGroup0, new Uint32Array(1416), 231, 0);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(5, buffer6, 0, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame2,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(1, buffer2);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(7, buffer6, 4, 1);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 73, y: 0, z: 4},
+  aspect: 'all',
+}, new Uint8Array(636_481).fill(40), /* required buffer size: 636_481 */
+{offset: 1, bytesPerRow: 117, rowsPerImage: 20}, {width: 21, height: 0, depthOrArrayLayers: 273});
+} catch {}
+let commandEncoder24 = device0.createCommandEncoder();
+let querySet2 = device0.createQuerySet({type: 'occlusion', count: 267});
+let sampler17 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 96.20});
+try {
+renderBundleEncoder1.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder1.setIndexBuffer(buffer9, 'uint32', 4, 15);
+} catch {}
+try {
+renderBundleEncoder1.setVertexBuffer(6, buffer5, 0, 0);
+} catch {}
+await gc();
+let shaderModule0 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+alias vec3b = vec3<bool>;
+
+/* zero global variables used */
+@must_use 
+fn fn1(a0: array<vec4f, 1>) -> vec2u {
+  var out: vec2u;
+  var vf0: vec2f = unpack2x16snorm(vec4u(log2(vec4f(unconst_f32(-0.05418e19), unconst_f32(0.2225e14), unconst_f32(0.1862), unconst_f32(0.04695e-27))).xxzx)[2]);
+  vf0 = vec2f(f32((unconst_bool(false) || unconst_bool(true))));
+  out = vec2u(refract(vec2h(unconst_f16(-8719.9), unconst_f16(2696.7)), vec2h(unconst_f16(22901.1), unconst_f16(13444.7)), unconst_f16(10592.5)).rr);
+  vf0 = atanh(vec3f(unconst_f32(-0.1189e-43), unconst_f32(0.2269), unconst_f32(0.07602))).br;
+  var vf1: vec4f = a0[0];
+  out ^= bitcast<vec2u>(vf0.yx);
+  out -= vec2u(sqrt(vec3h(unconst_f16(22014.2), unconst_f16(5696.5), unconst_f16(10403.1))).xz.rr.gr.gg.xy);
+  var vf2 = fn0(VertexOutput0(vec4u(vf0.grrr.xwzy), vf0.yyxx, vec2i(vf0)[1], vec2h(vf0.rr.xy)));
+  let vf3: vec2f = vf2[unconst_u32(228099195)];
+  vf1 = vec4f(sqrt(vec3h(unconst_f16(13831.9), unconst_f16(69.16), unconst_f16(20008.7))).gbbr.agag);
+  var vf4: vec4f = a0[0];
+  return out;
+}
+
+override override0: bool;
+
+struct FragmentOutput0 {
+  @location(3) @interpolate(flat, first) f0: u32,
+}
+
+struct VertexOutput0 {
+  @location(10) f0: vec4u,
+  @builtin(position) f1: vec4f,
+  @location(2) f2: i32,
+  @location(5) @interpolate(linear, either) f3: vec2h,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @align(32) @size(960) f0: array<array<vec2h, 16>>,
+}
+
+override override1: i32;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn0(a0: VertexOutput0) -> mat2x2f {
+  var out: mat2x2f;
+  out = mat2x2f(vec2f(a0.f3), vec2f(a0.f3.yx));
+  return out;
+}
+
+@group(0) @binding(1) var et0: texture_external;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+/* used global variables: et0 */
+@vertex
+fn vertex0(@location(6) @interpolate(flat, center) a0: u32) -> VertexOutput0 {
+  var out: VertexOutput0;
+  if bool(pack4xU8(vec4u(unconst_u32(802957496), unconst_u32(2721299685), unconst_u32(795006177), unconst_u32(649808328)))) {
+  out.f3 = bitcast<vec2h>(a0);
+  let vf5: f32 = asinh(unconst_f32(0.3236e9));
+  out.f0 -= vec4u(round(vec3h(unconst_f16(12543.4), unconst_f16(45363.2), unconst_f16(125.6))).bgrb);
+  if bool(textureDimensions(et0).x) {
+  var vf6: bool = all(unconst_bool(true));
+}
+  var vf7: bool = (unconst_bool(false) || unconst_bool(false));
+  out.f2 = vec4i(insertBits(unpack4xU8(bitcast<u32>(asinh(unconst_f32(0.4328e-30)))), insertBits(vec4u(unconst_u32(936943097), unconst_u32(285206327), unconst_u32(468347805), unconst_u32(53835892)), vec4u(unconst_u32(908430191), unconst_u32(2154247078), unconst_u32(64315484), unconst_u32(913655835)), unconst_u32(123167315), unconst_u32(303870278)), pack4x8snorm(unpack4x8snorm(unconst_u32(965171095))), unconst_u32(35002324)).barr)[1];
+  _ = et0;
+}
+  out.f3 = bitcast<vec2h>(override1);
+  while bool(pack4x8unorm(vec4f(unconst_f32(0.04267), unconst_f32(0.2817), unconst_f32(0.1349), unconst_f32(0.08566)))) {
+  out.f2 = i32((unconst_i32(108156079) >= unconst_i32(841321846)));
+  var vf8: vec2h = reflect(vec2h(unconst_f16(24260.7), unconst_f16(1343.2)), vec2h(unconst_f16(20753.9), unconst_f16(7912.5)));
+  let vf9: u32 = pack4xI8Clamp(vec4i(unconst_i32(22323471), unconst_i32(-257089044), unconst_i32(62622671), unconst_i32(218094842)));
+  var vf10: u32 = pack4xU8(vec4u(unconst_u32(830959834), unconst_u32(236402911), unconst_u32(235076004), unconst_u32(158121058)));
+  loop {
+  var vf11: vec2h = acosh(vec2h(smoothstep(unconst_f16(4912.3), unconst_f16(23280.6), f16(override0))));
+  var vf12: vec3f = max(vec3f(unconst_f32(0.05585), unconst_f32(0.1769), unconst_f32(0.1347)), vec3f(unconst_f32(0.05404), unconst_f32(0.02095), unconst_f32(0.1118e-22)));
+  var vf13: vec4f = tanh(vec4f(unconst_f32(0.7674e22), unconst_f32(0.3221), unconst_f32(-0.1509e-24), unconst_f32(0.04942)));
+  break;
+  _ = override0;
+}
+  break;
+  _ = override0;
+}
+  out.f2 &= i32(override0);
+  while bool(a0) {
+  out.f0 = vec4u((vec4i(unconst_i32(365488373), unconst_i32(-75455782), unconst_i32(453628917), unconst_i32(77324090)) <= vec4i(unconst_i32(189705686), unconst_i32(915828560), unconst_i32(497665524), unconst_i32(67694691))).baar);
+  out.f2 = vec3i((vec3h(unconst_f16(1847.3), unconst_f16(4121.5), unconst_f16(7576.0)) != vec3h(unconst_f16(16520.8), unconst_f16(9813.7), unconst_f16(2629.8)))).z;
+}
+  out.f3 *= bitcast<vec2h>(override1);
+  return out;
+  _ = override1;
+  _ = override0;
+  _ = et0;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment0() -> FragmentOutput0 {
+  var out: FragmentOutput0;
+  out.f0 &= u32(saturate(vec3h(unconst_f16(8731.1), unconst_f16(26444.6), unconst_f16(9678.0)))[2]);
+  return out;
+}
+
+/* used global variables: et0 */
+@compute @workgroup_size(3, 1, 1)
+fn compute0() {
+  var vf14: vec3h = atan(vec3h(unconst_f16(2601.7), unconst_f16(8443.6), unconst_f16(30450.9)));
+  vf14 += ldexp(vf14.zxxz, vec4i(unconst_i32(-10351057), unconst_i32(628693765), unconst_i32(6940664), unconst_i32(516487715))).wzw;
+  var vf15: u32 = pack2x16unorm(vec2f(unconst_f32(0.03995e31), unconst_f32(0.1111e-3)));
+  _ = et0;
+  _ = fn0(VertexOutput0(vec4u(vf14.yyzz.rabg), vec4f(vf14.xyxy.bbab), vec3i(vf14.xyz.rgg)[0], vf14.xy));
+  loop {
+  fn0(VertexOutput0(unpack4xU8(u32((unconst_bool(false) && unconst_bool(true)))), vec4f(f32((unconst_bool(false) && unconst_bool(true)))), i32((unconst_bool(false) && unconst_bool(true))), vec2h(f16((unconst_bool(false) && unconst_bool(true))))));
+  var vf16: vec3<bool> = (vec3h(unconst_f16(22799.1), unconst_f16(6098.1), unconst_f16(2015.8)) > vec3h(unconst_f16(-3353.9), unconst_f16(19047.5), unconst_f16(1247.0)));
+  var vf17 = fn0(VertexOutput0(insertBits(vec2u(unconst_u32(599533033), unconst_u32(1663705230)), vec2u(vf16.bg.rg.rg.gg), unconst_u32(82069348), unconst_u32(844559651)).yxyy, bitcast<vec4f>(insertBits(vec2u(unconst_u32(599533033), unconst_u32(1663705230)), vec2u(vf16.bg.rg.rg.gg), unconst_u32(82069348), unconst_u32(844559651)).ggrg), bitcast<vec2i>(insertBits(vec2u(unconst_u32(599533033), unconst_u32(1663705230)), vec2u(vf16.bg.rg.rg.gg), unconst_u32(82069348), unconst_u32(844559651)).yy.xx.yy)[0], vec2h(insertBits(vec2u(unconst_u32(599533033), unconst_u32(1663705230)), vec2u(vf16.bg.rg.rg.gg), unconst_u32(82069348), unconst_u32(844559651)).gr.rr.gr)));
+  return;
+  break;
+}
+  _ = et0;
+}`,
+});
+let commandEncoder25 = device0.createCommandEncoder({});
+let querySet3 = device0.createQuerySet({type: 'occlusion', count: 477});
+let textureView21 = texture15.createView({
+  label: '\u3646\uc47e\u07f4\u187b\u{1ff57}\u360d\u587f\uffa8\u{1fee0}',
+  dimension: 'cube-array',
+  arrayLayerCount: 6,
+});
+let textureView22 = texture17.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 1});
+let renderPassEncoder0 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: -642.5, g: 717.0, b: 62.78, a: -455.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+});
+let renderBundle1 = renderBundleEncoder1.finish({});
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+try {
+commandEncoder25.clearBuffer(buffer0);
+} catch {}
+let buffer13 = device0.createBuffer({
+  size: 588,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let commandEncoder26 = device0.createCommandEncoder();
+let querySet4 = device0.createQuerySet({type: 'occlusion', count: 720});
+let texture18 = device0.createTexture({
+  size: [63, 1, 56],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView23 = texture15.createView({dimension: '2d'});
+let computePassEncoder25 = commandEncoder25.beginComputePass();
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let texture19 = device0.createTexture({
+  size: {width: 127},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder15.setBindGroup(3, bindGroup5);
+} catch {}
+try {
+commandEncoder26.copyBufferToBuffer(buffer6, 4, buffer0, 0, 4);
+} catch {}
+try {
+computePassEncoder16.insertDebugMarker('\u937a');
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture20 = device0.createTexture({
+  size: [510, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView24 = texture9.createView({});
+let computePassEncoder26 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder1.setBindGroup(3, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1, new Uint32Array(580), 285, 0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1]);
+} catch {}
+let commandEncoder27 = device0.createCommandEncoder({});
+let querySet5 = device0.createQuerySet({type: 'occlusion', count: 1265});
+let texture21 = device0.createTexture({
+  size: [510, 1, 1],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView25 = texture21.createView({baseArrayLayer: 0});
+try {
+computePassEncoder24.setBindGroup(2, bindGroup2, new Uint32Array(1317), 216, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 10, 4);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer3, 32);
+} catch {}
+let buffer14 = device0.createBuffer({size: 88, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder28 = device0.createCommandEncoder({});
+let texture22 = device0.createTexture({
+  size: [255, 1, 18],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder1 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{view: textureView22, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet4,
+  maxDrawCount: 320596042,
+});
+let sampler18 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 41.81,
+  lodMaxClamp: 87.07,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder9.setBindGroup(3, bindGroup2, new Uint32Array(3105), 243, 0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 28, new Int16Array(4283), 200, 48);
+} catch {}
+let texture23 = device0.createTexture({
+  size: {width: 63},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView26 = texture4.createView({});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup5);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup2, []);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 4, new Uint32Array(13101), 944, 0);
+} catch {}
+try {
+globalThis.someLabel = commandEncoder2.label;
+} catch {}
+let texture24 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'rg32uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture25 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView27 = texture12.createView({baseMipLevel: 0});
+let computePassEncoder27 = commandEncoder27.beginComputePass();
+try {
+computePassEncoder11.setBindGroup(2, bindGroup1, new Uint32Array(3468), 499, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 16, 6);
+} catch {}
+let texture26 = device0.createTexture({
+  size: [63, 1, 26],
+  format: 'rg32uint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+let texture27 = device0.createTexture({
+  size: {width: 255},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView28 = texture23.createView({});
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setViewport(8.542862513766714, 6.676362539804238, 52.76318257981568, 36.41750803871167, 0.46174105210019134, 0.7538383723490258);
+} catch {}
+let commandEncoder29 = device0.createCommandEncoder();
+let commandBuffer0 = commandEncoder29.finish();
+let textureView29 = texture24.createView({baseArrayLayer: 1, arrayLayerCount: 1});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup5, new Uint32Array(4921), 100, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup0);
+} catch {}
+let imageData1 = new ImageData(80, 56);
+try {
+computePassEncoder25.setBindGroup(2, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder0.setViewport(49.788346974797975, 7.5737427637755275, 11.506043738859926, 0.572621241406843, 0.8240601287071182, 0.967632883258446);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer5, 0);
+} catch {}
+let texture28 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 128},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer3, 0);
+} catch {}
+let buffer15 = device0.createBuffer({size: 127, usage: GPUBufferUsage.STORAGE});
+let textureView30 = texture1.createView({aspect: 'all'});
+let externalTexture1 = device0.importExternalTexture({source: videoFrame2, colorSpace: 'srgb'});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u{1f8bc}');
+} catch {}
+await gc();
+try {
+device0.queue.label = '\u3872\uead7\u11ee\u0eca\u0c5c\u{1facf}\u0d49\uaa3a\u0070\u{1f742}\u{1f970}';
+} catch {}
+let sampler19 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', magFilter: 'linear'});
+try {
+computePassEncoder6.setBindGroup(1, bindGroup0, new Uint32Array(2308), 355, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(443);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer3);
+} catch {}
+let commandEncoder30 = device0.createCommandEncoder({});
+let computePassEncoder28 = commandEncoder30.beginComputePass();
+let renderBundleEncoder2 = device0.createRenderBundleEncoder({colorFormats: [undefined], sampleCount: 1, stencilReadOnly: true});
+let renderBundle2 = renderBundleEncoder2.finish({});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle1, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer5, 0, 0);
+} catch {}
+try {
+externalTexture0.label = '\u{1f75e}\u5b1e\u1802\u347f\u3674\u0217\u9b32';
+} catch {}
+let commandEncoder31 = device0.createCommandEncoder({});
+let computePassEncoder29 = commandEncoder31.beginComputePass();
+try {
+computePassEncoder9.setBindGroup(1, bindGroup1);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer9, 'uint32', 0, 10);
+} catch {}
+let texture29 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView31 = texture8.createView({});
+try {
+computePassEncoder1.setBindGroup(0, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 46},
+  aspect: 'all',
+}, new Uint8Array(196).fill(108), /* required buffer size: 196 */
+{offset: 196}, {width: 290, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule1 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires unrestricted_pointer_parameters;
+
+diagnostic(info, xyz);
+
+struct T4 {
+  @size(192) f0: T3,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+override override2: i32;
+
+@id(19839) override override6: bool;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+override override9: f16;
+
+var<workgroup> vw0: array<array<atomic<u32>, 5>, 1>;
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput1 {
+  @location(0) f4: u32,
+  @location(14) f5: vec2f,
+  @location(10) f6: i32,
+  @builtin(position) f7: vec4f,
+  @location(9) @interpolate(linear, centroid) f8: vec4h,
+}
+
+override override3: bool;
+
+struct T5 {
+  @align(16) @size(16) f0: array<array<array<vec2i, 1>, 1>, 1>,
+  @align(16) @size(80) f1: vec2i,
+  @size(96) f2: vec4f,
+  @align(8) @size(160) f3: vec2h,
+  @align(16) @size(528) f4: array<vec2h, 8>,
+}
+
+@id(19284) override override8: i32;
+
+struct FragmentOutput1 {
+  @location(0) f0: i32,
+  @builtin(sample_mask) f1: u32,
+}
+
+var<workgroup> vw1: f32;
+
+struct T2 {
+  @size(136) f0: array<array<vec2f, 3>>,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@id(21683) override override5: f16 = 1624.7;
+
+override override7: i32;
+
+struct T1 {
+  @align(16) @size(1568) f0: array<u32>,
+}
+
+struct T0 {
+  @size(456) f0: array<atomic<i32>>,
+}
+
+struct T6 {
+  @size(38) f0: vec2<bool>,
+  @align(2) f1: array<array<bool, 1>, 13>,
+}
+
+var<workgroup> vw2: atomic<u32>;
+
+@id(64049) override override4: i32;
+
+struct T3 {
+  @size(144) f0: array<array<array<vec4h, 1>, 1>>,
+}
+
+var<workgroup> vw3: array<array<vec2<bool>, 1>, 1>;
+
+/* zero global variables used */
+@vertex
+fn vertex1(@location(8) @interpolate(flat, sample) a0: vec2i) -> VertexOutput1 {
+  var out: VertexOutput1;
+  out.f8 -= vec4h(f16(override6));
+  out.f8 += vec4h(f16(sin(unconst_f32(0.01359e11))));
+  out.f7 += vec4f(f32(tan(unconst_f16(746.0))));
+  out.f6 = i32(override5);
+  out.f8 -= vec4h(f16(override4));
+  var vf18: i32 = override7;
+  let vf19: i32 = override4;
+  return out;
+  _ = override7;
+  _ = override6;
+  _ = override4;
+  _ = override5;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment1() -> FragmentOutput1 {
+  var out: FragmentOutput1;
+  let vf20: vec2f = exp2(vec2f(unconst_f32(0.00506), unconst_f32(0.1048)));
+  out = FragmentOutput1(bitcast<i32>(unpack2x16unorm(unconst_u32(2606860836)).g), pack2x16snorm(unpack2x16unorm(unconst_u32(2606860836))));
+  out.f1 = vec4u(select(vec4i(unconst_i32(90046139), unconst_i32(16774221), unconst_i32(228522387), unconst_i32(76624675)), vec4i((vec4f(countLeadingZeros(vec4i(unconst_i32(469461169), unconst_i32(579915357), unconst_i32(961409109), unconst_i32(57805523)))) < vec4f(unconst_f32(0.02751e-12), unconst_f32(0.01552), unconst_f32(0.1399), unconst_f32(0.4290)))), unconst_bool(true)))[2];
+  switch bitcast<i32>(pack2x16snorm(vec2f(unconst_f32(0.1170), unconst_f32(0.2821)))) { 
+  default {
+  out.f0 &= override7;
+  return out;
+  _ = override7;
+}
+  }
+  let vf21: f32 = smoothstep(unconst_f32(0.1102e-15), unconst_f32(0.02706), unconst_f32(-0.01646));
+  return out;
+  _ = override7;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 1)
+fn compute1() {
+  vw1 = bitcast<f32>(atomicLoad(&(*&vw0)[unconst_u32(539668599)][unconst_u32(2524080052)]));
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 2, 1)
+fn compute2() {
+  let vf22: u32 = atomicLoad(&vw0[0][unconst_u32(1116354758)]);
+  atomicAnd(&vw2, unconst_u32(188894822));
+  atomicSub(&vw0[0][unconst_u32(194967682)], unconst_u32(475689429));
+  let ptr0: ptr<workgroup, array<vec2<bool>, 1>> = &vw3[0];
+}`,
+});
+let commandEncoder32 = device0.createCommandEncoder();
+let texture30 = device0.createTexture({
+  size: [510, 1, 77],
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder30 = commandEncoder32.beginComputePass();
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+let imageData2 = new ImageData(28, 24);
+let pipelineLayout4 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout0]});
+let textureView32 = texture26.createView({dimension: '2d', baseArrayLayer: 5});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup2, new Uint32Array(605), 24, 0);
+} catch {}
+await gc();
+let commandEncoder33 = device0.createCommandEncoder({});
+let computePassEncoder31 = commandEncoder33.beginComputePass();
+let sampler20 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  compare: 'less-equal',
+});
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer6, 8, 2);
+} catch {}
+try {
+renderPassEncoder0.insertDebugMarker('\ua6eb');
+} catch {}
+let videoFrame3 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt709', primaries: 'smpte240m', transfer: 'iec6196624'} });
+let buffer16 = device0.createBuffer({
+  size: 24340,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.VERTEX,
+});
+let commandEncoder34 = device0.createCommandEncoder({});
+let querySet6 = device0.createQuerySet({type: 'occlusion', count: 222});
+let texture31 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 78},
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture32 = device0.createTexture({
+  size: [255],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView33 = texture23.createView({format: 'rgba8sint', baseArrayLayer: 0});
+let sampler21 = device0.createSampler({addressModeU: 'repeat', minFilter: 'nearest', mipmapFilter: 'linear'});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup1, new Uint32Array(444), 114, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setStencilReference(214);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer13, 24, new Uint32Array(1222).fill(11_533), 140, 0);
+} catch {}
+let buffer17 = device0.createBuffer({size: 256, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let querySet7 = device0.createQuerySet({type: 'occlusion', count: 1283});
+let textureView34 = texture9.createView({});
+try {
+computePassEncoder16.setBindGroup(1, bindGroup2, new Uint32Array(1751), 338, 0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup5, []);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 114 widthInBlocks: 57 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 406 */
+  offset: 406,
+  bytesPerRow: 19200,
+  rowsPerImage: 118,
+  buffer: buffer16,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 57, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup6 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView1}]});
+let texture33 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 59},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(1955), 456, 0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1]);
+} catch {}
+try {
+commandEncoder34.copyBufferToBuffer(buffer14, 0, buffer16, 3852, 8);
+} catch {}
+let computePassEncoder32 = commandEncoder34.beginComputePass();
+let bindGroup7 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 197, resource: sampler4}, {binding: 1, resource: externalTexture1}],
+});
+let texture34 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r8snorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture35 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView35 = texture7.createView({});
+try {
+renderPassEncoder0.setIndexBuffer(buffer16, 'uint32', 2_316, 5_199);
+} catch {}
+try {
+device0.queue.submit([commandBuffer0]);
+} catch {}
+let commandEncoder35 = device0.createCommandEncoder({});
+let texture36 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 14},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView36 = texture23.createView({format: 'rgba8sint'});
+try {
+computePassEncoder22.setBindGroup(1, bindGroup2, new Uint32Array(1890), 1_418, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(5, buffer17, 0, 41);
+} catch {}
+try {
+globalThis.someLabel = textureView28.label;
+} catch {}
+let bindGroup8 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 197, resource: sampler3}, {binding: 1, resource: externalTexture0}],
+});
+let buffer18 = device0.createBuffer({size: 456, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+try {
+externalTexture0.label = '\u{1faa5}\u0996\u027e\u4701';
+} catch {}
+let textureView37 = texture36.createView({mipLevelCount: 1});
+let sampler22 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.58,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint16', 32, 5);
+} catch {}
+try {
+commandEncoder35.insertDebugMarker('\u90c0');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 2, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup9 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 197, resource: sampler13}, {binding: 1, resource: externalTexture0}],
+});
+let textureView38 = texture27.createView({});
+let computePassEncoder33 = commandEncoder35.beginComputePass();
+let sampler23 = device0.createSampler({addressModeU: 'repeat', compare: 'less-equal'});
+let pipeline0 = device0.createComputePipeline({layout: pipelineLayout0, compute: {module: shaderModule0, entryPoint: 'compute0', constants: {}}});
+let externalTexture2 = device0.importExternalTexture({source: videoFrame1});
+try {
+computePassEncoder4.setBindGroup(2, bindGroup5);
+} catch {}
+try {
+computePassEncoder19.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup6, new Uint32Array(2894), 319, 0);
+} catch {}
+let renderBundleEncoder3 = device0.createRenderBundleEncoder({colorFormats: ['r16sint']});
+let renderBundle3 = renderBundleEncoder3.finish({});
+try {
+renderPassEncoder0.setBindGroup(3, bindGroup0, new Uint32Array(5685), 641, 0);
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(178);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(7, buffer6, 0);
+} catch {}
+try {
+computePassEncoder14.insertDebugMarker('\ub6ac');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout0 = pipeline0.getBindGroupLayout(0);
+let sampler24 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 92.94,
+});
+try {
+computePassEncoder20.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder24.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData1,
+  origin: { x: 33, y: 19 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 65, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture37 = device0.createTexture({
+  size: [127, 1, 1],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler25 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder26.setPipeline(pipeline0);
+} catch {}
+let commandEncoder36 = device0.createCommandEncoder({});
+let computePassEncoder34 = commandEncoder36.beginComputePass();
+let sampler26 = device0.createSampler({addressModeV: 'repeat', addressModeW: 'repeat', lodMaxClamp: 88.28, maxAnisotropy: 1});
+try {
+computePassEncoder21.setBindGroup(2, bindGroup2, new Uint32Array(3355), 388, 0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup1, new Uint32Array(246), 64, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(27, 1, 1, 7);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint16', 2, 4);
+} catch {}
+let buffer19 = device0.createBuffer({size: 240, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+try {
+computePassEncoder30.setBindGroup(1, bindGroup6, new Uint32Array(1536), 225, 0);
+} catch {}
+try {
+computePassEncoder32.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle1, renderBundle3, renderBundle1, renderBundle1, renderBundle3, renderBundle3, renderBundle3, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer7, 'uint32', 0, 5);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(4, buffer13, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 11},
+  aspect: 'all',
+}, new Uint8Array(97_527).fill(89), /* required buffer size: 97_527 */
+{offset: 87, bytesPerRow: 174, rowsPerImage: 40}, {width: 34, height: 0, depthOrArrayLayers: 15});
+} catch {}
+let commandEncoder37 = device0.createCommandEncoder({});
+let textureView39 = texture18.createView({});
+try {
+computePassEncoder29.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.executeBundles([renderBundle3, renderBundle3, renderBundle3, renderBundle3]);
+} catch {}
+try {
+buffer3.unmap();
+} catch {}
+let pipelineLayout5 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout0]});
+let commandEncoder38 = device0.createCommandEncoder({});
+let sampler27 = device0.createSampler({addressModeW: 'mirror-repeat', lodMaxClamp: 97.63});
+try {
+computePassEncoder20.setBindGroup(3, bindGroup3);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(592);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+let bindGroup10 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView0}]});
+let commandEncoder39 = device0.createCommandEncoder({});
+let textureView40 = texture24.createView({arrayLayerCount: 4});
+let renderPassEncoder2 = commandEncoder38.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: -862.0, g: 527.9, b: -210.4, a: 952.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet7,
+});
+let sampler28 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.71,
+});
+try {
+computePassEncoder30.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer16, 'uint32', 3_060, 1_233);
+} catch {}
+try {
+commandEncoder37.copyTextureToTexture({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 31, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 30, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 32, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise9 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise9;
+} catch {}
+let imageData3 = new ImageData(84, 16);
+let buffer20 = device0.createBuffer({size: 332, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let texture38 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 64},
+  mipLevelCount: 7,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder35 = commandEncoder37.beginComputePass();
+try {
+computePassEncoder12.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder8.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6, new Uint32Array(486), 140, 0);
+} catch {}
+let imageData4 = new ImageData(4, 8);
+try {
+computePassEncoder12.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+computePassEncoder34.setPipeline(pipeline0);
+} catch {}
+try {
+commandEncoder39.copyBufferToTexture({
+  /* bytesInLastRow: 20 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 720 */
+  offset: 720,
+  bytesPerRow: 7936,
+  buffer: buffer16,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 50, y: 0, z: 4},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder39.copyTextureToTexture({
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 3},
+  aspect: 'all',
+},
+{
+  texture: texture2,
+  mipLevel: 0,
+  origin: {x: 1, y: 3, z: 4},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 13});
+} catch {}
+let commandEncoder40 = device0.createCommandEncoder({});
+let textureView41 = texture31.createView({baseArrayLayer: 7, arrayLayerCount: 3});
+let sampler29 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 99.37});
+try {
+computePassEncoder24.setBindGroup(0, bindGroup2, new Uint32Array(1003), 243, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer7, 0); };
+} catch {}
+try {
+renderPassEncoder2.beginOcclusionQuery(721);
+} catch {}
+let buffer21 = device0.createBuffer({
+  size: 156,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+  mappedAtCreation: false,
+});
+let commandEncoder41 = device0.createCommandEncoder({});
+let querySet8 = device0.createQuerySet({type: 'occlusion', count: 1065});
+let texture39 = device0.createTexture({
+  size: {width: 127},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView42 = texture29.createView({dimension: 'cube'});
+let computePassEncoder36 = commandEncoder40.beginComputePass();
+let renderPassEncoder3 = commandEncoder39.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: -193.2, g: 361.3, b: 733.9, a: 107.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet5,
+  maxDrawCount: 10591715,
+});
+try {
+computePassEncoder33.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+computePassEncoder29.setBindGroup(1, bindGroup1, new Uint32Array(1967), 565, 0);
+} catch {}
+try {
+computePassEncoder18.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder2.setBlendConstant({ r: 75.59, g: -280.1, b: 384.9, a: 361.7, });
+} catch {}
+let buffer22 = device0.createBuffer({size: 36, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX});
+let texture40 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 72},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView43 = texture40.createView({});
+let computePassEncoder37 = commandEncoder41.beginComputePass();
+try {
+computePassEncoder0.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup4, new Uint32Array(1425), 111, 0);
+} catch {}
+try {
+renderPassEncoder3.executeBundles([renderBundle3, renderBundle1]);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let bindGroup11 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 197, resource: sampler7}, {binding: 1, resource: externalTexture0}],
+});
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 47, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(61).fill(235), /* required buffer size: 61 */
+{offset: 61}, {width: 61, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup12 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture0}, {binding: 197, resource: sampler17}],
+});
+let commandEncoder42 = device0.createCommandEncoder();
+let computePassEncoder38 = commandEncoder42.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroups(2, 1, 2); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder24); computePassEncoder24.dispatchWorkgroupsIndirect(buffer6, 0); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup11, new Uint32Array(1178), 162, 0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint16', 44, 7);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+try {
+buffer8.unmap();
+} catch {}
+let bindGroup13 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView1}]});
+let commandEncoder43 = device0.createCommandEncoder({});
+let texture41 = device0.createTexture({
+  size: [510],
+  dimension: '1d',
+  format: 'rgba16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder32.setBindGroup(0, bindGroup4);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(0, bindGroup8, new Uint32Array(126), 5, 0);
+} catch {}
+let commandEncoder44 = device0.createCommandEncoder({});
+let texture42 = device0.createTexture({
+  size: [510],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder39 = commandEncoder44.beginComputePass();
+let renderPassEncoder4 = commandEncoder43.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 896.7, g: -987.6, b: 236.9, a: -1.403, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 34596177,
+});
+let sampler30 = device0.createSampler({addressModeU: 'repeat', addressModeW: 'repeat', lodMaxClamp: 94.89, compare: 'never'});
+try {
+computePassEncoder33.setBindGroup(2, bindGroup7, new Uint32Array(1228), 0, 0);
+} catch {}
+try {
+computePassEncoder24.end();
+} catch {}
+try {
+computePassEncoder2.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder2.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder2.setIndexBuffer(buffer7, 'uint16', 18, 14);
+} catch {}
+try {
+commandEncoder23.copyTextureToBuffer({
+  texture: texture1,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 624 widthInBlocks: 156 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1436 */
+  offset: 1436,
+  bytesPerRow: 18688,
+  buffer: buffer16,
+}, {width: 156, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout4 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 1, visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX, externalTexture: {}},
+    {
+      binding: 197,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      sampler: { type: 'filtering' },
+    },
+  ],
+});
+let texture43 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 33},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder32); computePassEncoder32.dispatchWorkgroupsIndirect(buffer10, 4); };
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup6, []);
+} catch {}
+try {
+commandEncoder23.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2256 */
+  offset: 2256,
+  buffer: buffer16,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 8, new BigUint64Array(8278), 2839, 0);
+} catch {}
+let computePassEncoder40 = commandEncoder23.beginComputePass();
+let externalTexture3 = device0.importExternalTexture({source: videoFrame3, colorSpace: 'display-p3'});
+try {
+computePassEncoder10.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+computePassEncoder7.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.setBindGroup(1, bindGroup5, new Uint32Array(694), 11, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+let veryExplicitBindGroupLayout5 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 152,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let buffer23 = device0.createBuffer({
+  size: 146,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder45 = device0.createCommandEncoder();
+let computePassEncoder41 = commandEncoder45.beginComputePass();
+let sampler31 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 82.43,
+  compare: 'equal',
+});
+try {
+renderPassEncoder2.end();
+} catch {}
+try {
+renderPassEncoder1.setStencilReference(424);
+} catch {}
+try {
+renderPassEncoder3.setVertexBuffer(5, buffer17, 0, 16);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+globalThis.someLabel = externalTexture3.label;
+} catch {}
+let bindGroup14 = device0.createBindGroup({
+  label: '\u039f\u757c\ue074\u3dda\u098f\u7812\u0634\u{1f71c}\u070b\u6147\ub947',
+  layout: veryExplicitBindGroupLayout5,
+  entries: [{binding: 152, resource: textureView18}],
+});
+let commandEncoder46 = device0.createCommandEncoder({});
+let querySet9 = device0.createQuerySet({type: 'occlusion', count: 1138});
+try {
+computePassEncoder16.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder32.end();
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, new Uint32Array(105), 30, 0);
+} catch {}
+try {
+commandEncoder46.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4412 */
+  offset: 4412,
+  buffer: buffer16,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup15 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 197, resource: sampler0}, {binding: 1, resource: externalTexture2}],
+});
+let commandEncoder47 = device0.createCommandEncoder({});
+try {
+computePassEncoder13.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+commandEncoder38.resolveQuerySet(querySet7, 221, 1, buffer12, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame3,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 46, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup16 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView0}]});
+let commandEncoder48 = device0.createCommandEncoder();
+let texture44 = device0.createTexture({
+  size: [63, 1, 57],
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView44 = texture22.createView({baseArrayLayer: 1, arrayLayerCount: 2});
+try {
+computePassEncoder4.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder3.end();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle1, renderBundle1, renderBundle1]);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(2, buffer6);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 232 widthInBlocks: 58 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1660 */
+  offset: 1660,
+  bytesPerRow: 37376,
+  buffer: buffer16,
+}, {width: 58, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer24 = device0.createBuffer({size: 35, usage: GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let commandEncoder49 = device0.createCommandEncoder({});
+let textureView45 = texture4.createView({aspect: 'all'});
+let texture45 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 147},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView46 = texture43.createView({dimension: '3d', mipLevelCount: 1});
+let computePassEncoder42 = commandEncoder48.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer12, 228); };
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup13, new Uint32Array(4330), 990, 0);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(11, 4, 2, 7);
+} catch {}
+try {
+commandEncoder39.copyTextureToBuffer({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1884 */
+  offset: 1884,
+  bytesPerRow: 57344,
+  buffer: buffer16,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let recycledExplicitBindGroupLayout1 = pipeline0.getBindGroupLayout(0);
+let buffer25 = device0.createBuffer({size: 68, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: false});
+let commandEncoder50 = device0.createCommandEncoder({});
+let textureView47 = texture12.createView({dimension: '3d'});
+try {
+computePassEncoder15.setBindGroup(2, bindGroup15, new Uint32Array(1456), 125, 0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup13, new Uint32Array(1320), 404, 0);
+} catch {}
+try {
+renderPassEncoder1.setViewport(60.13784269369966, 40.248733403005616, 1.6072921362912982, 20.896948176910254, 0.8993339294994944, 0.9073805585646563);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer2, 8, 1);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+commandEncoder47.copyBufferToBuffer(buffer23, 40, buffer2, 8, 0);
+} catch {}
+try {
+commandEncoder34.copyBufferToTexture({
+  /* bytesInLastRow: 72 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 664 */
+  offset: 664,
+  bytesPerRow: 38656,
+  buffer: buffer16,
+}, {
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(113).fill(115), /* required buffer size: 113 */
+{offset: 113, bytesPerRow: 79}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let recycledExplicitBindGroupLayout2 = pipeline0.getBindGroupLayout(0);
+let commandBuffer1 = commandEncoder38.finish({});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1, 1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer23, 0); };
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(280);
+} catch {}
+let computePassEncoder43 = commandEncoder39.beginComputePass();
+try {
+computePassEncoder7.setBindGroup(1, bindGroup14, new Uint32Array(1902), 811, 0);
+} catch {}
+try {
+computePassEncoder11.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup8, []);
+} catch {}
+try {
+commandEncoder47.copyTextureToBuffer({
+  texture: texture39,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 22 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 208 */
+  offset: 208,
+  bytesPerRow: 18688,
+  rowsPerImage: 60,
+  buffer: buffer20,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder34.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 77, y: 0, z: 6},
+  aspect: 'all',
+},
+{
+  texture: texture7,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 213},
+  aspect: 'all',
+},
+{width: 104, height: 0, depthOrArrayLayers: 287});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let buffer26 = device0.createBuffer({size: 304, usage: GPUBufferUsage.COPY_DST});
+let texture46 = device0.createTexture({
+  size: [255],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView48 = texture38.createView({mipLevelCount: 1});
+try {
+computePassEncoder20.setPipeline(pipeline0);
+} catch {}
+try {
+device0.queue.submit([commandBuffer1]);
+} catch {}
+let videoFrame4 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'bt2020-cl', primaries: 'smpte240m', transfer: 'unspecified'} });
+let bindGroup17 = device0.createBindGroup({layout: veryExplicitBindGroupLayout5, entries: [{binding: 152, resource: textureView27}]});
+let commandEncoder51 = device0.createCommandEncoder({});
+let querySet10 = device0.createQuerySet({type: 'occlusion', count: 123});
+let textureView49 = texture1.createView({mipLevelCount: 1});
+let renderPassEncoder5 = commandEncoder49.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: -745.5, g: 221.5, b: -787.7, a: -548.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder15.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer7, 'uint16', 2, 2);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer3, 0);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 856 widthInBlocks: 107 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1512 */
+  offset: 1512,
+  buffer: buffer16,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 107, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let computePassEncoder44 = commandEncoder47.beginComputePass();
+try {
+computePassEncoder38.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder5.setIndexBuffer(buffer9, 'uint16', 22, 34);
+} catch {}
+try {
+commandEncoder50.copyBufferToTexture({
+  /* bytesInLastRow: 28 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2344 */
+  offset: 2344,
+  bytesPerRow: 6912,
+  rowsPerImage: 1167,
+  buffer: buffer16,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup18 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView6}]});
+let commandEncoder52 = device0.createCommandEncoder({});
+let commandBuffer2 = commandEncoder34.finish({});
+let texture47 = device0.createTexture({
+  size: [255],
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  viewFormats: [],
+});
+let textureView50 = texture15.createView({dimension: '2d'});
+try {
+commandEncoder46.resolveQuerySet(querySet0, 27, 0, buffer24, 0);
+} catch {}
+let texture48 = device0.createTexture({size: [64, 64, 12], format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+try {
+computePassEncoder31.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer1, 196); };
+} catch {}
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder5.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder51.copyBufferToBuffer(buffer6, 12, buffer10, 0, 4);
+} catch {}
+let veryExplicitBindGroupLayout6 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 152,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba8snorm', access: 'read-only', viewDimension: '3d' },
+    },
+  ],
+});
+let bindGroup19 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView0}]});
+let buffer27 = device0.createBuffer({size: 106, usage: GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder53 = device0.createCommandEncoder({});
+let textureView51 = texture27.createView({dimension: '1d', format: 'rgba8sint', mipLevelCount: 1});
+try {
+renderPassEncoder5.end();
+} catch {}
+try {
+renderPassEncoder0.beginOcclusionQuery(232);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle1]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 27, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(386).fill(21), /* required buffer size: 386 */
+{offset: 386}, {width: 10, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let commandEncoder54 = device0.createCommandEncoder({});
+let textureView52 = texture28.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let renderPassEncoder6 = commandEncoder53.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 29,
+  clearValue: { r: -756.9, g: -514.5, b: -667.7, a: -643.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 106242585,
+});
+try {
+computePassEncoder21.setBindGroup(3, bindGroup4);
+} catch {}
+try {
+computePassEncoder23.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup3, []);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle3, renderBundle1]);
+} catch {}
+try {
+commandEncoder50.copyTextureToTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture25,
+  mipLevel: 1,
+  origin: {x: 4, y: 26, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData5 = new ImageData(72, 44);
+let renderBundleEncoder4 = device0.createRenderBundleEncoder({
+  label: '\ud353\udad4\uf2b0\u04c3\u0b3f\ub3d7\uf09b',
+  colorFormats: ['r16sint'],
+  depthReadOnly: true,
+  stencilReadOnly: true,
+});
+try {
+computePassEncoder1.setBindGroup(3, bindGroup11);
+} catch {}
+try {
+computePassEncoder20.setBindGroup(0, bindGroup4, new Uint32Array(250), 62, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer17, 8);
+} catch {}
+try {
+  await buffer4.mapAsync(GPUMapMode.WRITE, 0, 12);
+} catch {}
+try {
+commandEncoder54.copyBufferToTexture({
+  /* bytesInLastRow: 80 widthInBlocks: 20 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1232 */
+  offset: 1232,
+  buffer: buffer16,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 20, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+computePassEncoder38.insertDebugMarker('\u5131');
+} catch {}
+let shaderModule2 = device0.createShaderModule({
+  code: `
+enable f16;
+
+requires packed_4x8_integer_dot_product;
+
+requires pointer_composite_access;
+
+diagnostic(info, xyz);
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T2 {
+  @align(4) @size(128) f0: f16,
+  @size(1024) f1: array<atomic<u32>>,
+}
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+struct T0 {
+  @align(16) @size(64) f0: array<vec2u, 1>,
+}
+
+@group(0) @binding(197) var sam2: sampler;
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct FragmentOutput2 {
+  @location(0) f0: vec4i,
+}
+
+var<workgroup> vw5: u32;
+
+struct T1 {
+  @size(16) f0: i32,
+  @size(44) f1: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct S0 {
+  @location(0) f0: u32,
+}
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+@group(0) @binding(1) var et2: texture_external;
+
+var<workgroup> vw4: T0;
+
+/* zero global variables used */
+@fragment
+fn fragment2(a0: S0) -> FragmentOutput2 {
+  var out: FragmentOutput2;
+  let vf23: vec4f = floor(vec4f(unconst_f32(0.3178e29), unconst_f32(0.1016e-13), unconst_f32(0.1058), unconst_f32(0.1054)));
+  out.f0 = vec4i(exp(vec3f(unconst_f32(0.2258), unconst_f32(0.7495), unconst_f32(0.3114))).rbbg.xyzx.aaar);
+  out.f0 = bitcast<vec4i>(vf23.wxxw.yyyw.bbrg.aagg);
+  switch vec2i(exp(vec2f(unconst_f32(0.05750), unconst_f32(0.3625))).gg.gr).g { 
+  default {
+  var vf24: vec4h = faceForward(vec4h(unconst_f16(288.3), unconst_f16(16341.8), unconst_f16(45211.7), unconst_f16(10308.3)), vec4h(unconst_f16(-20955.9), unconst_f16(5415.2), unconst_f16(16232.5), unconst_f16(2051.1)), vec4h(f16(pack2x16float(vec2f(unconst_f32(0.5715), unconst_f32(0.1712))))));
+  var vf25: vec2f = atanh(vec2f(unconst_f32(0.00810e24), unconst_f32(-0.1145)));
+  out.f0 = vec4i(sinh(vec3f(unconst_f32(-0.00921), unconst_f32(0.2768), unconst_f32(0.1755e-29))).rbbb.zxyz);
+  while bool(degrees(vec2f(unconst_f32(0.2523e-21), unconst_f32(0.1817e36)))[1]) {
+  out = FragmentOutput2(vec4i(i32(a0.f0)));
+}
+  break;
+}
+  }
+  out.f0 -= bitcast<vec4i>(atan(vec3f(unconst_f32(-0.1937), unconst_f32(0.2825), unconst_f32(0.2906))).rgbb);
+  out.f0 *= vec4i(exp(vec3f(unconst_f32(0.07073e-14), unconst_f32(0.01996), unconst_f32(0.1660e-33))).zyzx);
+  var vf26: vec4f = ceil(vec4f(unconst_f32(-0.06678e4), unconst_f32(0.1839e-30), unconst_f32(0.03751e-44), unconst_f32(0.1649)));
+  vf26 += vec4f(ldexp(unconst_f32(0.09188e-4), i32(atanh(unconst_f16(45021.8)))));
+  let vf27: vec4i = (vec4i(unconst_i32(20730861), unconst_i32(668875083), unconst_i32(283830593), unconst_i32(-336887882)) ^ vec4i(unconst_i32(245585810), unconst_i32(306767234), unconst_i32(760439873), unconst_i32(265125493)));
+  return out;
+}
+
+/* used global variables: et2, sam2 */
+@compute @workgroup_size(1, 1, 2)
+fn compute3() {
+  switch bitcast<i32>(pack2x16snorm(vec2f(unconst_f32(0.1138e9), unconst_f32(0.4565e-27)))) { 
+  default {
+  let ptr1: ptr<workgroup, array<vec2u, 1>> = &(*&vw4).f0;
+  while bool(workgroupUniformLoad(&vw4).f0[0].r) {
+  switch i32(pack4xI8(bitcast<vec4i>(insertBits(vec4u(unconst_u32(1395002379), unconst_u32(2675370170), unconst_u32(569870877), unconst_u32(1117305830)), vec4u(unconst_u32(79542027), unconst_u32(243688883), unconst_u32(1249725004), unconst_u32(210881543)), unconst_u32(1457458051), unconst_u32(133148072))))) { 
+  default {
+  vw4 = T0(array<vec2u, 1>(vec2u(u32(log(unconst_f16(12632.4))))));
+  vw4 = T0(array<vec2u, 1>(vec2u(textureLoad(et2, vec2u((*&vw4).f0[pack4x8unorm(textureSampleBaseClampToEdge(et2, sam2, vec2f(unconst_f32(0.09549e-14), unconst_f32(0.05286))))][unconst_u32(275921403)])).rb)));
+  let vf28: vec4f = quantizeToF16(vec4f(unconst_f32(0.08322), unconst_f32(0.05958), unconst_f32(0.1051), unconst_f32(0.2660)));
+  _ = et2;
+  _ = sam2;
+}
+  }
+  var vf29: f16 = distance(unconst_f16(19621.0), unconst_f16(3957.3));
+  _ = et2;
+  _ = sam2;
+}
+  let vf30: vec2f = degrees(vec2f(unconst_f32(0.04594), unconst_f32(0.1796e21)));
+  vw5 = bitcast<vec4u>(unpack4xI8(pack4x8snorm(unpack4x8snorm(unconst_u32(562206308)))))[2];
+  while bool((*ptr1)[0][1]) {
+  var vf31: bool = (unconst_bool(false) || unconst_bool(true));
+  var vf32: vec3f = sinh(vec3f(unconst_f32(0.1941e-44), unconst_f32(-0.07968), unconst_f32(0.2561e12)));
+}
+  let vf33: vec2h = acos(vec2h(unconst_f16(2700.0), unconst_f16(5445.5)));
+  _ = sam2;
+  _ = et2;
+}
+  }
+  vw4.f0[unconst_u32(518814170)] += vec2u(textureLoad(et2, vec2u(unconst_u32(954253980), unconst_u32(3660179951))).ag);
+  let vf34: vec3<bool> =  !vec3<bool>(unconst_bool(false), unconst_bool(true), unconst_bool(true));
+  vw5 <<= vw4.f0[0][0];
+  let vf35: vec4f = textureSampleBaseClampToEdge(et2, sam2, vec2f(unconst_f32(0.00796), unconst_f32(0.4375)));
+  vw4 = T0(array<vec2u, 1>(bitcast<vec2u>(firstTrailingBit(vec4i(unconst_i32(44560744), unconst_i32(424598395), unconst_i32(1257179159), unconst_i32(487042518))).bb)));
+  vw5 = (*&vw5);
+  let vf36: u32 = (*&vw4).f0[0][unconst_u32(2483968596)];
+  vw5 >>= vw4.f0[0][0];
+  vw5 = (*&vw4).f0[unconst_u32(447754974)][unconst_u32(1877677741)];
+  _ = sam2;
+  _ = et2;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(1, 1, 2)
+fn compute4() {
+  {
+  let ptr2: ptr<workgroup, array<vec2u, 1>> = &(*&vw4).f0;
+}
+  while bool((*&vw4).f0[unconst_u32(74145772)].g) {
+  vw5 = vec4u(clamp(vec4h(unconst_f16(23225.7), unconst_f16(8980.3), unconst_f16(3640.9), unconst_f16(818.2)), vec4h(unconst_f16(11553.1), unconst_f16(8462.8), unconst_f16(4913.6), unconst_f16(9315.7)), vec4h(unconst_f16(16995.6), unconst_f16(6673.1), unconst_f16(1092.0), unconst_f16(6474.0))).rggb).b;
+  vw4.f0[unconst_u32(73732631)] = unpack4xU8(unconst_u32(27670919)).rr;
+  vw4 = T0(array<vec2u, 1>(vec2u((*&vw5))));
+  break;
+}
+  vw5 = bitcast<vec4u>(unpack4x8unorm(unconst_u32(243821008)).xwzy)[1];
+  var vf37: vec3f = asinh(vec3f(unconst_f32(0.2211), unconst_f32(0.03274e-7), unconst_f32(0.3241e-30)));
+}`,
+});
+let buffer28 = device0.createBuffer({
+  size: 0,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX,
+});
+let texture49 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 32},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let sampler32 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', lodMaxClamp: 76.55});
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup14, new Uint32Array(104), 16, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint16', 0, 4);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer3);
+} catch {}
+try {
+commandEncoder49.copyTextureToTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 175, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture9,
+  mipLevel: 0,
+  origin: {x: 76, y: 0, z: 1},
+  aspect: 'all',
+},
+{width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u9a3d');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(30).fill(245), /* required buffer size: 30 */
+{offset: 30}, {width: 4, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule3 = device0.createShaderModule({
+  code: `
+requires readonly_and_readwrite_storage_textures;
+
+enable f16;
+
+struct T0 {
+  @size(40) f0: array<u32>,
+}
+
+@group(0) @binding(762) var<storage, read_write> buffer31: array<array<array<array<f16, 19>, 1>, 1>>;
+
+override override11: u32 = 698417442;
+
+@id(17003) override override16 = 0.00404;
+
+var<workgroup> vw6: atomic<i32>;
+
+override override17 = 0.04491e-22;
+
+@id(1863) override override12: i32;
+
+override override10: f16;
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+struct VertexOutput2 {
+  @builtin(position) f9: vec4f,
+}
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct FragmentOutput3 {
+  @location(4) f0: vec2i,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+@group(0) @binding(0) var<storage, read_write> buffer29: array<array<array<array<f16, 1>, 14>, 5>>;
+
+override override20: u32;
+
+@id(26739) override override19: f16 = 971.8;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+@group(2) @binding(1) var st1: texture_storage_2d_array<r32sint, write>;
+
+struct VertexOutput3 {
+  @builtin(position) f10: vec4f,
+  @location(0) @interpolate(flat, either) f11: u32,
+  @location(2) f12: vec4i,
+  @location(15) @interpolate(linear, centroid) f13: vec4f,
+  @location(5) f14: vec4h,
+  @location(7) @interpolate(perspective, centroid) f15: vec4h,
+}
+
+@id(45164) override override14 = 0.2129;
+
+override override13: u32 = 857643815;
+
+@group(0) @binding(3) var<uniform> buffer30: array<array<vec4f, 13>, 1>;
+
+override override18: i32 = 112046592;
+
+struct T1 {
+  @align(16) @size(208) f0: vec2i,
+}
+
+@id(409) override override15: i32 = 780802146;
+
+struct T2 {
+  @size(140) f0: array<atomic<i32>>,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex2(@location(10) a0: f16, @location(5) a1: u32, @location(2) a2: vec2h, @location(9) a3: vec4h, @location(8) a4: u32, @location(3) a5: vec2i) -> VertexOutput2 {
+  var out: VertexOutput2;
+  let vf38: bool = (unconst_f16(2058.2) > unconst_f16(8272.6));
+  out.f9 = vec4f(f32(a0));
+  out.f9 = vec4f(f32(saturate(unconst_f16(7440.8))));
+  out.f9 = vec4f(f32(override10));
+  let vf39: i32 = override12;
+  switch i32(all((vec3<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(false)) | vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false))))) { 
+  default {
+  let vf40: f16 = override10;
+  let vf41: f16 = override10;
+  out = VertexOutput2(unpack4x8unorm((unconst_u32(164433439) >> unconst_u32(1456575018))));
+  _ = override10;
+}
+  }
+  var vf42: vec3<bool> = (vec3<bool>(unconst_bool(true), unconst_bool(true), unconst_bool(false)) | vec3<bool>(unconst_bool(true), unconst_bool(false), unconst_bool(true)));
+  out.f9 = vec4f(f32((unconst_f16(19974.7) > unconst_f16(-61488.0))));
+  return out;
+  _ = override10;
+  _ = override12;
+}
+
+/* zero global variables used */
+@vertex
+fn vertex3(@location(12) @interpolate(flat) a0: vec2h) -> VertexOutput3 {
+  var out: VertexOutput3;
+  for (var it0=u32(length(vec3f(unconst_f32(0.04306e7), unconst_f32(0.1052e-13), unconst_f32(0.06300)))); it0<(pack2x16snorm(pow(vec2f(smoothstep(vec2h(unconst_f16(26006.7), unconst_f16(3261.0)), vec2h(unconst_f16(9385.2), unconst_f16(6669.4)), vec2h(unconst_f16(4851.6), unconst_f16(-2733.1))).gg), pow(vec2f(unconst_f32(0.08811), unconst_f32(0.05435)), vec2f(unconst_f32(0.8087), unconst_f32(0.1898e8))))) & 0xfff); it0++) {
+  let vf43: u32 = override11;
+  _ = override11;
+}
+  let vf44: i32 = dot4I8Packed(unconst_u32(229472122), unconst_u32(419392500));
+  let vf45: vec2u =  ~vec2u(unconst_u32(682443571), unconst_u32(84784805));
+  let vf46: i32 = override12;
+  var vf47: vec4i = reverseBits(vec4i(unconst_i32(681230198), unconst_i32(284098930), unconst_i32(267678656), unconst_i32(1367625525)));
+  let vf48: vec2h = log(vec2h(unconst_f16(46860.8), unconst_f16(4396.1)));
+  let vf49: vec4<bool> = (vec4u(unconst_u32(978875652), unconst_u32(415955390), unconst_u32(1987948230), unconst_u32(202268615)) <= vec4u(unconst_u32(1093396780), unconst_u32(24793226), unconst_u32(597001420), unconst_u32(489586365)));
+  return out;
+  _ = override12;
+  _ = override11;
+}
+
+/* used global variables: buffer29, buffer30, st1 */
+@fragment
+fn fragment3() -> FragmentOutput3 {
+  var out: FragmentOutput3;
+  out.f0 *= vec2i(i32(buffer29[unconst_u32(332015359)][unconst_u32(265309132)][13][0]));
+  let ptr3: ptr<storage, f16, read_write> = &buffer29[arrayLength(&buffer29)][4][13][0];
+  out.f0 *= vec2i((*&buffer30)[0][12].wy);
+  let ptr4: ptr<storage, f16, read_write> = &(*&buffer29)[unconst_u32(115381979)][unconst_u32(679953100)][13][unconst_u32(3016767303)];
+  let ptr5: ptr<uniform, vec4f> = &(*&buffer30)[0][12];
+  var vf50: vec4f = unpack4x8unorm(unconst_u32(798385354));
+  let ptr6: ptr<storage, array<array<array<array<f16, 1>, 14>, 5>>, read_write> = &(*&buffer29);
+  out.f0 = vec2i(i32((*&buffer29)[unconst_u32(423321878)][4][unconst_u32(125924959)][0]));
+  out.f0 |= bitcast<vec2i>((*&buffer30)[0][12].rr);
+  let ptr7: ptr<storage, array<f16, 1>, read_write> = &(*&buffer29)[arrayLength(&(*&buffer29))][4][unconst_u32(599879591)];
+  textureStore(st1, vec2i(unconst_i32(245527790), unconst_i32(42600168)), unconst_i32(369563052), vec4i(vec4i(unconst_i32(1495860480), unconst_i32(4817673), unconst_i32(67295183), unconst_i32(565676))));
+  return out;
+  _ = buffer30;
+  _ = buffer29;
+  _ = st1;
+}
+
+/* used global variables: buffer31 */
+@compute @workgroup_size(6, 1, 1)
+fn compute5(@builtin(num_workgroups) a0: vec3u) {
+  let ptr8: ptr<storage, f16, read_write> = &buffer31[unconst_u32(680467853)][0][u32(buffer31[arrayLength(&buffer31)][unconst_u32(2499951772)][unconst_u32(552095460)][18])][unconst_u32(25851139)];
+  return;
+  _ = buffer31;
+}`,
+});
+let renderPassEncoder7 = commandEncoder49.beginRenderPass({colorAttachments: [{view: textureView39, depthSlice: 28, loadOp: 'clear', storeOp: 'discard'}]});
+let sampler33 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  minFilter: 'nearest',
+  mipmapFilter: 'linear',
+  lodMinClamp: 45.44,
+  lodMaxClamp: 57.10,
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder1.beginOcclusionQuery(202);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup10, new Uint32Array(599), 43, 0);
+} catch {}
+let computePassEncoder45 = commandEncoder54.beginComputePass();
+let renderBundleEncoder5 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(2, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder4.insertDebugMarker('\u0606');
+} catch {}
+await gc();
+try {
+bindGroup3.label = '\u1b0a\uc242\udf7b\u5565\u9ceb\u06e0\uff6b';
+} catch {}
+let bindGroup20 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 1, resource: externalTexture0}, {binding: 197, resource: sampler9}],
+});
+let commandEncoder55 = device0.createCommandEncoder({});
+let texture50 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 11},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView53 = texture12.createView({});
+let computePassEncoder46 = commandEncoder46.beginComputePass();
+try {
+computePassEncoder13.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer6, 12); };
+} catch {}
+try {
+computePassEncoder35.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup13);
+} catch {}
+try {
+renderPassEncoder0.setBlendConstant({ r: -20.71, g: -859.5, b: -162.9, a: -888.7, });
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer22, 'uint32', 8, 0);
+} catch {}
+try {
+renderBundleEncoder5.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData5,
+  origin: { x: 0, y: 9 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 34, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder56 = device0.createCommandEncoder({});
+let textureView54 = texture11.createView({});
+let computePassEncoder47 = commandEncoder50.beginComputePass();
+let sampler34 = device0.createSampler({addressModeV: 'mirror-repeat', magFilter: 'nearest', lodMaxClamp: 83.63});
+try {
+computePassEncoder12.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder5.setPipeline(pipeline0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(3, bindGroup4, new Uint32Array(98), 52, 0);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder52.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 840 */
+  offset: 840,
+  rowsPerImage: 100,
+  buffer: buffer16,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let veryExplicitBindGroupLayout7 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let recycledExplicitBindGroupLayout3 = pipeline0.getBindGroupLayout(0);
+let texture51 = device0.createTexture({
+  size: {width: 63},
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView55 = texture42.createView({});
+let computePassEncoder48 = commandEncoder51.beginComputePass();
+let externalTexture4 = device0.importExternalTexture({source: videoFrame3});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+computePassEncoder16.setBindGroup(1, bindGroup13, new Uint32Array(2071), 20, 0);
+} catch {}
+try {
+computePassEncoder33.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder6.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup0);
+} catch {}
+try {
+renderBundleEncoder5.setIndexBuffer(buffer9, 'uint32', 28, 6);
+} catch {}
+let pipeline1 = device0.createComputePipeline({layout: pipelineLayout1, compute: {module: shaderModule1, entryPoint: 'compute1', constants: {}}});
+let videoFrame5 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: true, matrix: 'rgb', primaries: 'bt470bg', transfer: 'smpte170m'} });
+let bindGroup21 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 197, resource: sampler29}, {binding: 1, resource: externalTexture0}],
+});
+let texture52 = device0.createTexture({
+  size: [63],
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView56 = texture10.createView({aspect: 'depth-only', baseMipLevel: 0, baseArrayLayer: 1, arrayLayerCount: 3});
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup20, new Uint32Array(833), 99, 0);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer16, 'uint32', 708, 2_448);
+} catch {}
+try {
+buffer0.unmap();
+} catch {}
+try {
+commandEncoder56.copyTextureToBuffer({
+  texture: texture41,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 880 widthInBlocks: 110 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 3000 */
+  offset: 3000,
+  buffer: buffer16,
+}, {width: 110, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer32 = device0.createBuffer({size: 71, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE});
+let texture53 = device0.createTexture({
+  size: [63, 1, 31],
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView57 = texture31.createView({baseArrayLayer: 23, arrayLayerCount: 4});
+let renderBundle4 = renderBundleEncoder5.finish({});
+try {
+computePassEncoder2.setBindGroup(0, bindGroup2, new Uint32Array(527), 107, 0);
+} catch {}
+try {
+computePassEncoder31.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer22, 'uint32', 0, 6);
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 560 */
+  offset: 560,
+  bytesPerRow: 7424,
+  buffer: buffer16,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture40,
+  mipLevel: 0,
+  origin: {x: 2, y: 15, z: 1},
+  aspect: 'all',
+}, new Uint8Array(42_758).fill(140), /* required buffer size: 42_758 */
+{offset: 81, bytesPerRow: 89, rowsPerImage: 28}, {width: 23, height: 4, depthOrArrayLayers: 18});
+} catch {}
+let commandEncoder57 = device0.createCommandEncoder({});
+let texture54 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView58 = texture10.createView({aspect: 'depth-only', format: 'depth16unorm', baseArrayLayer: 2, arrayLayerCount: 5});
+let renderPassEncoder8 = commandEncoder56.beginRenderPass({colorAttachments: [{view: textureView22, loadOp: 'clear', storeOp: 'store'}]});
+try {
+computePassEncoder15.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+computePassEncoder33.setBindGroup(0, bindGroup20, new Uint32Array(317), 115, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer7, 'uint32', 4, 16);
+} catch {}
+try {
+buffer10.unmap();
+} catch {}
+let commandEncoder58 = device0.createCommandEncoder({});
+let textureView59 = texture17.createView({dimension: 'cube-array', format: 'r16sint', mipLevelCount: 1, baseArrayLayer: 2, arrayLayerCount: 6});
+try {
+computePassEncoder13.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(3, bindGroup5, new Uint32Array(112), 11, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup11);
+} catch {}
+try {
+buffer18.unmap();
+} catch {}
+try {
+device0.queue.submit([commandBuffer2]);
+} catch {}
+let texture55 = device0.createTexture({size: {width: 64}, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView60 = texture15.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder0.beginOcclusionQuery(194);
+} catch {}
+try {
+renderPassEncoder0.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup4, new Uint32Array(206), 30, 0);
+} catch {}
+try {
+buffer22.unmap();
+} catch {}
+try {
+computePassEncoder47.insertDebugMarker('\u{1fabf}');
+} catch {}
+let imageBitmap0 = await createImageBitmap(imageData1);
+let commandEncoder59 = device0.createCommandEncoder({});
+let texture56 = device0.createTexture({size: [63], sampleCount: 1, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder49 = commandEncoder59.beginComputePass();
+try {
+renderPassEncoder7.setIndexBuffer(buffer9, 'uint16', 18, 0);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(2, bindGroup21);
+} catch {}
+try {
+commandEncoder57.copyBufferToTexture({
+  /* bytesInLastRow: 116 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 4688 */
+  offset: 4688,
+  bytesPerRow: 9216,
+  buffer: buffer16,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.insertDebugMarker('\ue88c');
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData0,
+  origin: { x: 1, y: 1 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer33 = device0.createBuffer({size: 95, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder60 = device0.createCommandEncoder({});
+let textureView61 = texture26.createView({dimension: '2d'});
+let texture57 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 116},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder50 = commandEncoder57.beginComputePass();
+let sampler35 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 80.17,
+  maxAnisotropy: 5,
+});
+let externalTexture5 = device0.importExternalTexture({source: videoFrame4});
+try {
+computePassEncoder17.setBindGroup(1, bindGroup19, new Uint32Array(3257), 1_895, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder20); computePassEncoder20.dispatchWorkgroupsIndirect(buffer6, 4); };
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup4, []);
+} catch {}
+try {
+renderBundleEncoder4.setBindGroup(1, bindGroup1, new Uint32Array(1123), 227, 0);
+} catch {}
+let sampler36 = device0.createSampler({
+  label: '\u0ae0\u0fec\u0af2\u{1f87e}\u0016\u0258\ubb56\u04e9\u{1f7fc}\u{1f8be}',
+  addressModeU: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 91.33,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer10, 36); };
+} catch {}
+try {
+computePassEncoder47.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle3]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer22, 'uint32', 0, 1);
+} catch {}
+try {
+commandEncoder52.copyTextureToBuffer({
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 14, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 600 widthInBlocks: 75 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 672 */
+  offset: 672,
+  bytesPerRow: 23296,
+  buffer: buffer16,
+}, {width: 75, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder60.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture44,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 7},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder55.resolveQuerySet(querySet10, 19, 0, buffer27, 0);
+} catch {}
+try {
+globalThis.someLabel = externalTexture4.label;
+} catch {}
+let bindGroup22 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 197, resource: sampler21}, {binding: 1, resource: externalTexture3}],
+});
+let commandEncoder61 = device0.createCommandEncoder({});
+let textureView62 = texture14.createView({});
+let texture58 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 55},
+  mipLevelCount: 6,
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let renderBundle5 = renderBundleEncoder4.finish({});
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle3, renderBundle5, renderBundle3, renderBundle3]);
+} catch {}
+try {
+buffer20.unmap();
+} catch {}
+try {
+commandEncoder61.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 6436 */
+  offset: 6436,
+  bytesPerRow: 40704,
+  buffer: buffer16,
+}, {
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 61, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer26, 92, new DataView(new ArrayBuffer(65536)), 46168, 28);
+} catch {}
+let veryExplicitBindGroupLayout8 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 246,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', hasDynamicOffset: false },
+    },
+  ],
+});
+let texture59 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder34.dispatchWorkgroupsIndirect(buffer9, 12);
+} catch {}
+try {
+computePassEncoder21.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup0);
+} catch {}
+let imageBitmap1 = await createImageBitmap(imageData4);
+let buffer34 = device0.createBuffer({size: 64, usage: GPUBufferUsage.INDEX | GPUBufferUsage.STORAGE | GPUBufferUsage.VERTEX});
+let commandEncoder62 = device0.createCommandEncoder({});
+let computePassEncoder51 = commandEncoder62.beginComputePass();
+try {
+computePassEncoder20.end();
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(4, buffer28, 0, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 48, new Int16Array(1050), 84, 0);
+} catch {}
+let pipeline2 = await device0.createComputePipelineAsync({layout: 'auto', compute: {module: shaderModule3}});
+let recycledExplicitBindGroupLayout4 = pipeline1.getBindGroupLayout(0);
+let commandBuffer3 = commandEncoder52.finish();
+let textureView63 = texture7.createView({});
+let computePassEncoder52 = commandEncoder58.beginComputePass();
+try {
+renderPassEncoder1.setBindGroup(2, bindGroup13, new Uint32Array(488), 69, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(5, undefined, 847_186_719, 2_213_402_865);
+} catch {}
+try {
+commandEncoder61.clearBuffer(buffer20);
+} catch {}
+let bindGroup23 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [{binding: 1, resource: externalTexture2}, {binding: 197, resource: sampler22}],
+});
+let textureView64 = texture49.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 6});
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(3, bindGroup13, new Uint32Array(249), 0, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle4, renderBundle1, renderBundle5, renderBundle4]);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer16, 'uint16', 912, 3_689);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(0, buffer34, 0, 27);
+} catch {}
+try {
+commandEncoder55.copyTextureToTexture({
+  texture: texture14,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder63 = device0.createCommandEncoder({});
+let texture60 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'rgb10a2uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture61 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder9 = commandEncoder13.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -774.8, g: 252.6, b: -872.1, a: -994.8, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  maxDrawCount: 408832764,
+});
+try {
+computePassEncoder37.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer28, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout6 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout7]});
+let textureView65 = texture60.createView({dimension: 'cube', mipLevelCount: 1});
+let renderPassEncoder10 = commandEncoder60.beginRenderPass({
+  colorAttachments: [{view: textureView22, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 411505657,
+});
+try {
+computePassEncoder25.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer20, 'uint32', 64, 42);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+buffer28.unmap();
+} catch {}
+try {
+commandEncoder55.copyBufferToTexture({
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 64 */
+  offset: 64,
+  bytesPerRow: 4352,
+  rowsPerImage: 118,
+  buffer: buffer33,
+}, {
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder64 = device0.createCommandEncoder();
+let texture62 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder53 = commandEncoder55.beginComputePass();
+try {
+computePassEncoder35.setBindGroup(0, bindGroup18);
+} catch {}
+try {
+computePassEncoder0.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup14, new Uint32Array(1311), 384, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(3, buffer16, 868, 19_562);
+} catch {}
+let texture63 = device0.createTexture({
+  size: {width: 127},
+  dimension: '1d',
+  format: 'r32float',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder48.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+computePassEncoder9.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer6, 'uint16', 20, 3);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(5, buffer28, 0, 0);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 46 widthInBlocks: 23 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7456 */
+  offset: 7456,
+  bytesPerRow: 34304,
+  buffer: buffer16,
+}, {
+  texture: texture48,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 23, height: 20, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder64.copyTextureToTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 4},
+  aspect: 'all',
+},
+{
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 42, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder64.resolveQuerySet(querySet10, 0, 0, buffer1, 0);
+} catch {}
+let buffer35 = device0.createBuffer({size: 204, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let textureView66 = texture63.createView({dimension: '1d'});
+try {
+computePassEncoder45.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup1, new Uint32Array(67), 1, 0);
+} catch {}
+try {
+renderPassEncoder8.setVertexBuffer(7, buffer28, 0, 0);
+} catch {}
+let videoFrame6 = new VideoFrame(imageBitmap1, {timestamp: 0});
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+try {
+textureView10.label = '\u035e\u0816\uf91f\u59da\u9d65\u723b\uec6b\u0e42';
+} catch {}
+let pipelineLayout7 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout3]});
+let commandEncoder65 = device0.createCommandEncoder({});
+let textureView67 = texture62.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+let texture64 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 51},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let renderBundleEncoder6 = device0.createRenderBundleEncoder({colorFormats: [undefined], depthReadOnly: true, stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer9, 0); };
+} catch {}
+try {
+computePassEncoder42.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup8);
+} catch {}
+try {
+renderPassEncoder7.setBlendConstant({ r: -75.24, g: 753.6, b: -809.9, a: 917.4, });
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer34, 'uint32', 0, 18);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(2, buffer16, 4_884, 7_356);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(0, buffer17, 0, 16);
+} catch {}
+let texture65 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 1},
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder46.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(1, bindGroup22);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer22, 'uint16', 4, 2);
+} catch {}
+try {
+renderPassEncoder6.setVertexBuffer(4, buffer2, 0, 26);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(1, buffer6, 0);
+} catch {}
+let buffer36 = device0.createBuffer({
+  size: 128,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+  mappedAtCreation: false,
+});
+let texture66 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView68 = texture27.createView({});
+try {
+computePassEncoder13.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup9, new Uint32Array(123), 2, 0);
+} catch {}
+try {
+commandEncoder64.copyBufferToTexture({
+  /* bytesInLastRow: 2 widthInBlocks: 1 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 644 */
+  offset: 644,
+  bytesPerRow: 19712,
+  buffer: buffer16,
+}, {
+  texture: texture54,
+  mipLevel: 1,
+  origin: {x: 1, y: 7, z: 2},
+  aspect: 'all',
+}, {width: 1, height: 9, depthOrArrayLayers: 0});
+} catch {}
+let shaderModule4 = device0.createShaderModule({
+  code: `
+enable f16;
+
+enable f16;
+
+requires pointer_composite_access;
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+var<private> vp17: array<array<vec2<bool>, 1>, 17> = array<array<vec2<bool>, 1>, 17>();
+
+struct T8 {
+  f0: vec2h,
+  @size(36) f1: array<array<atomic<i32>, 1>>,
+}
+
+var<private> vp33 = frexp(vec2f(0.05625, 0.4813e-7));
+
+var<private> vp37 = modf(vec2f(0.06494e-27, 0.07071e-31));
+
+var<private> vp29: vec2i = vec2i(387454798, 283823019);
+
+var<private> vp14: array<vec4f, 1> = array(vec4f(0.2035, 0.1109e35, 0.03554, 0.2245));
+
+var<private> vp21: FragmentOutput4 = FragmentOutput4(vec4i(366860960, 94284271, 700625128, 375562295));
+
+var<private> vp35: T6 = T6();
+
+override override22: u32 = 17553473;
+
+var<private> vp13: vec4f = vec4f(0.02955, 0.03248e-34, 0.01409e-11, -0.7599);
+
+var<private> vp31 = array(modf(f16(-11235.7)));
+
+var<private> vp7: FragmentOutput4 = FragmentOutput4();
+
+var<private> vp0: T6 = T6();
+
+var<private> vp23: vec4u = vec4u(725382958, 181979112, 185197400, 238017781);
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+var<private> vp32: array<vec2f, 1> = array<vec2f, 1>();
+
+struct T5 {
+  @size(140) f0: array<array<atomic<u32>, 1>>,
+}
+
+var<private> vp11 = frexp(vec2h(9058.9, 6249.1));
+
+struct T1 {
+  f0: array<u32, 64>,
+  @size(256) f1: vec2<bool>,
+  @size(256) f2: u32,
+}
+
+struct FragmentOutput4 {
+  @location(0) f0: vec4i,
+}
+
+var<private> vp12: f16 = f16(31323.2);
+
+var<private> vp22: array<FragmentOutput4, 1> = array<FragmentOutput4, 1>();
+
+var<private> vp39 = modf(vec4f(0.07430, 0.5267, -0.1221e-39, 0.07838));
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+var<private> vp24: FragmentOutput4 = FragmentOutput4(vec4i(395165851, 150742731, 35155653, 37874337));
+
+var<private> vp1: array<T6, 1> = array<T6, 1>();
+
+var<private> vp2: mat4x2f = mat4x2f(0.02043, 0.2206, -0.1113, 0.1897e-6, 0.05762e3, 0.2038e4, 0.1290, 0.01949);
+
+var<private> vp36: T6 = T6();
+
+var<private> vp25 = array(frexp(vec2h(52589.0, 24153.2)));
+
+var<private> vp18: FragmentOutput4 = FragmentOutput4();
+
+var<private> vp6: bool = bool(false);
+
+@group(0) @binding(0) var<storage, read_write> buffer37: array<array<array<array<array<array<array<f16, 7>, 1>, 1>, 1>, 1>, 10>>;
+
+@id(65026) override override21: u32 = 34471975;
+
+var<private> vp8 = modf(f16(23692.4));
+
+var<private> vp19 = array(modf(f16(36960.2)));
+
+var<private> vp34: FragmentOutput4 = FragmentOutput4();
+
+var<private> vp16: FragmentOutput4 = FragmentOutput4();
+
+/* used global variables: buffer37, buffer38 */
+fn fn1() -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(vec4u(bitcast<u32>(vp30.f0[0][0])))));
+  while bool((*&buffer37)[unconst_u32(1058845503)][9][0][unconst_u32(410363101)][0][0][6]) {
+  let ptr11: ptr<private, vec4f> = &vp39.whole;
+  let ptr12: ptr<storage, array<f16, 7>, read_write> = &buffer37[unconst_u32(1539024250)][unconst_u32(132688087)][unconst_u32(102920381)][unconst_u32(592390184)][0][unconst_u32(1094255786)];
+  if bool((*&buffer37)[arrayLength(&(*&buffer37))][9][unconst_u32(68874356)][unconst_u32(768398511)][unconst_u32(476377079)][unconst_u32(64253590)][unconst_u32(260941668)]) {
+  var vf51 = fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(unpack4xU8(u32(buffer37[arrayLength(&buffer37)][9][unconst_u32(280970114)][0][unconst_u32(278028231)][unconst_u32(2041376878)][6])))));
+  _ = buffer37;
+}
+  let ptr13: ptr<storage, array<f16, 7>, read_write> = &(*&buffer37)[unconst_u32(509781996)][9][0][0][unconst_u32(40560570)][unconst_u32(1683411979)];
+  var vf52 = fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(unpack4xU8(u32(buffer37[arrayLength(&buffer37)][9][0][unconst_u32(626987204)][0][unconst_u32(1727158392)][unconst_u32(1049223449)])))));
+  vp38.f0[unconst_u32(226450553)][0] |= i32((*&buffer37)[unconst_u32(187303130)][unconst_u32(423513379)][0][unconst_u32(242366975)][unconst_u32(746679904)][0][unconst_u32(2364869497)]);
+  return out;
+  _ = buffer37;
+}
+  while bool((*&buffer37)[arrayLength(&(*&buffer37))][unconst_u32(203196835)][unconst_u32(11485107)][0][unconst_u32(1321431194)][0][unconst_u32(1313828128)]) {
+  let ptr14: ptr<private, array<i32, 1>> = &vp38.f0[unconst_u32(97740031)];
+  fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(vec4u(u32(buffer37[unconst_u32(106065319)][unconst_u32(407121515)][0][u32((*&buffer37)[arrayLength(&(*&buffer37))][unconst_u32(1109482962)][unconst_u32(111474714)][unconst_u32(797260436)][unconst_u32(1126678789)][unconst_u32(304372376)][6])][0][0][6])))));
+  return out;
+  _ = buffer37;
+}
+  var vf53 = fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(unpack4xU8(u32(buffer37[unconst_u32(1577822237)][unconst_u32(29793724)][0][0][unconst_u32(29228221)][unconst_u32(194801819)][6])))));
+  var vf54 = fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(unpack4xU8(bitcast<u32>(vp35.f0[0][0])))));
+  var vf55: f32 = buffer38[unconst_u32(6198300)][u32(buffer37[arrayLength(&buffer37)][unconst_u32(151568324)][0][0][unconst_u32(257172677)][0][6])];
+  return out;
+  _ = buffer37;
+  _ = buffer38;
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+var<private> vp15: T6 = T6();
+
+struct T0 {
+  @align(16) @size(208) f0: array<u32>,
+}
+
+@group(0) @binding(3) var<uniform> buffer38: array<vec4f, 13>;
+
+var<private> vp38: T6 = T6(array(array(i32(714704777))));
+
+var<private> vp28: vec2i = vec2i(572908765, 85461516);
+
+struct T3 {
+  @align(16) @size(208) f0: array<atomic<i32>>,
+}
+
+var<private> vp9: T6 = T6();
+
+struct T6 {
+  @size(40) f0: array<array<i32, 1>, 1>,
+}
+
+var<private> vp10 = frexp(vec2f(0.05183e-2, 0.00174e10));
+
+var<private> vp3: array<array<f32, 1>, 56> = array<array<f32, 1>, 56>();
+
+var<private> vp27: FragmentOutput4 = FragmentOutput4(vec4i(367304837, 398787255, 260417354, 1005668026));
+
+var<private> vp41: array<FragmentOutput4, 1> = array<FragmentOutput4, 1>(FragmentOutput4(vec4i(1589604984, -143146179, 316545880, 81328006)));
+
+var<private> vp5: FragmentOutput4 = FragmentOutput4(vec4i(-33672566, 134771056, 313901912, 86709032));
+
+var<private> vp42: FragmentOutput4 = FragmentOutput4();
+
+var<private> vp4: u32 = u32(281077530);
+
+alias vec3b = vec3<bool>;
+
+var<private> vp30: T6 = T6(array(array<i32, 1>()));
+
+struct T7 {
+  f0: T0,
+}
+
+var<private> vp20: mat4x2h = mat4x2h(20446.7, 11002.1, 1513.6, 14089.6, 1892.0, 5724.9, 23526.7, 7194.7);
+
+var<private> vp26 = array(frexp(vec3h(4831.2, 41697.5, 1769.9)), frexp(vec3h(2966.1, 4042.1, 9404.4)), frexp(vec3h(13764.9, 24823.4, 22728.5)), frexp(vec3h(10160.3, 1170.6, 4496.1)));
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+var<private> vp43: FragmentOutput4 = FragmentOutput4(vec4i(269157061, 4932737, 92205487, 94926427));
+
+/* zero global variables used */
+fn fn0(a0: array<array<vec4u, 1>, 1>) -> vec4u {
+  var out: vec4u;
+  let ptr9: ptr<private, vec4i> = &vp41[unconst_u32(958089923)].f0;
+  let ptr10: ptr<private, i32> = &vp9.f0[bitcast<vec4u>(vp41[unconst_u32(264560157)].f0).a][unconst_u32(1018743464)];
+  return out;
+}
+
+var<private> vp40: vec2f = vec2f(0.1797e28, 0.00965);
+
+struct T4 {
+  @align(16) f0: T2,
+}
+
+struct T2 {
+  @align(8) @size(208) f0: array<array<array<array<array<vec2h, 1>, 1>, 1>, 6>>,
+}
+
+/* zero global variables used */
+@vertex
+fn vertex4() -> @builtin(position) vec4f {
+  var out: vec4f;
+  loop {
+  vp25[unconst_u32(385986205)].fract = bitcast<vec2h>(vp34.f0[unconst_u32(281149007)]);
+  vp22[unconst_u32(1557236818)] = FragmentOutput4(bitcast<vec4i>(vp37.fract.yyxy));
+  vp23 &= unpack4xU8(bitcast<u32>(vp15.f0[bitcast<u32>(vp0.f0[0][0])][unconst_u32(546329207)]));
+  let ptr15: ptr<private, vec2<bool>> = &vp17[16][unconst_u32(991879801)];
+  let ptr16: ptr<private, vec2i> = &vp11.exp;
+  if bool(vp36.f0[0][unconst_u32(772586040)]) {
+  let ptr17: ptr<private, i32> = &vp15.f0[0][unconst_u32(743459536)];
+  var vf56: vec2f = sqrt(vec2f(unconst_f32(0.1177e-35), unconst_f32(0.1168e-44)));
+  vp34.f0 |= vec4i(i32(vp19[0].whole));
+  break;
+}
+  break;
+}
+  let ptr18: ptr<private, i32> = &vp36.f0[0][0];
+  let ptr19: ptr<private, array<vec2<bool>, 1>> = &vp17[16];
+  out -= bitcast<vec4f>(vp27.f0.xzxz);
+  let ptr20: ptr<private, f16> = &vp19[0].fract;
+  return out;
+}
+
+/* used global variables: buffer37 */
+@fragment
+fn fragment4(@location(14) a0: vec2f) -> FragmentOutput4 {
+  var out: FragmentOutput4;
+  vp28 |= vec2i(i32(buffer37[arrayLength(&buffer37)][9][unconst_u32(455620365)][unconst_u32(2457182638)][0][0][6]));
+  loop {
+  vp1[unconst_u32(540065116)].f0[unconst_u32(578411893)][unconst_u32(723521173)] += i32((*&buffer37)[unconst_u32(472338103)][9][unconst_u32(1154973828)][0][u32(vp1[0].f0[unconst_u32(58639196)][unconst_u32(70384808)])][0][6]);
+  break;
+  _ = buffer37;
+}
+  let ptr21: ptr<storage, array<array<array<f16, 7>, 1>, 1>, read_write> = &buffer37[arrayLength(&buffer37)][9][0][unconst_u32(861310050)];
+  vp3[unconst_u32(17048546)][unconst_u32(740450592)] = f32(buffer37[arrayLength(&buffer37)][9][unconst_u32(829550268)][unconst_u32(557548094)][unconst_u32(1316605745)][0][6]);
+  let ptr22: ptr<storage, array<f16, 7>, read_write> = &buffer37[arrayLength(&buffer37)][9][0][unconst_u32(969177015)][0][0];
+  return out;
+  _ = buffer37;
+}
+
+/* zero global variables used */
+@compute @workgroup_size(4, 2, 1)
+fn compute6() {
+  var vf57 = fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(unpack4xU8(u32(vp36.f0[0][0])))));
+  if bool(vp35.f0[0][0]) {
+  vp34.f0 -= vec4i(bitcast<i32>(vp3[55][0]));
+  let ptr23: ptr<private, vec4i> = &vp24.f0;
+  let ptr24: ptr<private, array<array<f32, 1>, 56>> = &vp3;
+  vp1[0].f0[unconst_u32(574368946)][unconst_u32(28212648)] = vp22[vec2u(vp10.exp).r].f0.y;
+  vp22[unconst_u32(1055549839)].f0 |= vec4i(vp9.f0[unconst_u32(247808946)][unconst_u32(1154431076)]);
+  let ptr25: ptr<private, i32> = &vp35.f0[0][0];
+}
+  var vf58 = fn0(array<array<vec4u, 1>, 1>(array<vec4u, 1>(vec4u(bitcast<u32>(vp1[unconst_u32(28782346)].f0[0][0])))));
+  vp13 *= vec4f(bitcast<f32>(pack2x16snorm(vec2f(unconst_f32(0.1543e-12), unconst_f32(0.2512)))));
+  vp26[unconst_u32(317035700)] = frexp(degrees(vec3h(unconst_f16(12420.8), unconst_f16(7342.0), unconst_f16(13884.9))));
+  vp5.f0 *= vec4i(i32(vp31[0].fract));
+}`,
+});
+let commandEncoder66 = device0.createCommandEncoder({});
+let texture67 = device0.createTexture({
+  size: [255, 1, 1],
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView69 = texture14.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let renderPassEncoder11 = commandEncoder64.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 6,
+  clearValue: { r: -752.8, g: 551.3, b: -457.5, a: 958.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder7.setBindGroup(3, bindGroup6);
+} catch {}
+try {
+computePassEncoder48.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder1.setScissorRect(0, 9, 8, 2);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(6, buffer17);
+} catch {}
+let arrayBuffer0 = buffer4.getMappedRange(0, 0);
+try {
+commandEncoder65.copyBufferToTexture({
+  /* bytesInLastRow: 120 widthInBlocks: 60 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 3742 */
+  offset: 3742,
+  buffer: buffer16,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 56, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 60, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.submit([commandBuffer3]);
+} catch {}
+let commandEncoder67 = device0.createCommandEncoder({});
+let querySet11 = device0.createQuerySet({type: 'occlusion', count: 668});
+let texture68 = device0.createTexture({
+  size: [127, 1, 1],
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder54 = commandEncoder61.beginComputePass();
+let sampler37 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 88.76,
+});
+try {
+computePassEncoder9.setBindGroup(0, bindGroup15);
+} catch {}
+try {
+computePassEncoder10.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup15, new Uint32Array(637), 197, 0);
+} catch {}
+let commandEncoder68 = device0.createCommandEncoder({});
+let querySet12 = device0.createQuerySet({type: 'occlusion', count: 82});
+let sampler38 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  lodMaxClamp: 71.07,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+computePassEncoder8.setBindGroup(2, bindGroup6);
+} catch {}
+try {
+computePassEncoder22.setBindGroup(3, bindGroup1, new Uint32Array(3388), 506, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(1, bindGroup21, new Uint32Array(122), 30, 0);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer22, 'uint32', 4, 1);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderBundleEncoder6.setIndexBuffer(buffer23, 'uint16', 0, 41);
+} catch {}
+let commandEncoder69 = device0.createCommandEncoder({});
+let texture69 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView70 = texture42.createView({arrayLayerCount: 1});
+let computePassEncoder55 = commandEncoder66.beginComputePass();
+let renderPassEncoder12 = commandEncoder68.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 34,
+  clearValue: { r: 105.3, g: -921.3, b: 125.3, a: -704.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 189081434,
+});
+let renderBundleEncoder7 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true});
+try {
+renderPassEncoder1.setIndexBuffer(buffer6, 'uint16', 0, 6);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(3, buffer13);
+} catch {}
+try {
+renderBundleEncoder6.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+commandEncoder69.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 7672 */
+  offset: 7672,
+  buffer: buffer16,
+}, {
+  texture: texture68,
+  mipLevel: 2,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder67.resolveQuerySet(querySet11, 189, 0, buffer28, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 12, new Int16Array(8263), 155, 32);
+} catch {}
+let recycledExplicitBindGroupLayout5 = pipeline0.getBindGroupLayout(0);
+let bindGroup24 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 1, resource: textureView0}]});
+let computePassEncoder56 = commandEncoder69.beginComputePass();
+try {
+computePassEncoder52.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(3, bindGroup13, new Uint32Array(220), 34, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(1, bindGroup12, new Uint32Array(926), 214, 0);
+} catch {}
+try {
+renderBundleEncoder6.setVertexBuffer(6, buffer16, 0, 5_540);
+} catch {}
+try {
+commandEncoder67.copyBufferToTexture({
+  /* bytesInLastRow: 0 widthInBlocks: 0 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1004 */
+  offset: 1004,
+  rowsPerImage: 235,
+  buffer: buffer16,
+}, {
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 10, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame0,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup25 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 1, resource: textureView6}]});
+let commandEncoder70 = device0.createCommandEncoder({});
+let textureView71 = texture63.createView({});
+let texture70 = device0.createTexture({size: [64, 64, 12], format: 'r16sint', usage: GPUTextureUsage.COPY_DST});
+let computePassEncoder57 = commandEncoder65.beginComputePass();
+let renderPassEncoder13 = commandEncoder67.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -6.683, g: 776.6, b: 349.5, a: 9.711, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet7,
+});
+let renderBundle6 = renderBundleEncoder6.finish({});
+try {
+renderBundleEncoder7.setBindGroup(0, bindGroup25, new Uint32Array(1392), 821, 0);
+} catch {}
+try {
+commandEncoder63.copyTextureToTexture({
+  texture: texture23,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture69,
+  mipLevel: 1,
+  origin: {x: 1, y: 3, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture71 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView72 = texture2.createView({});
+let computePassEncoder58 = commandEncoder63.beginComputePass();
+try {
+computePassEncoder7.setBindGroup(1, bindGroup17);
+} catch {}
+try {
+computePassEncoder43.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup6, new Uint32Array(292), 0, 0);
+} catch {}
+try {
+renderBundleEncoder7.setBindGroup(3, bindGroup3, new Uint32Array(1112), 148, 0);
+} catch {}
+try {
+renderBundleEncoder7.setVertexBuffer(4, buffer36, 4);
+} catch {}
+let buffer40 = device0.createBuffer({size: 144, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.VERTEX});
+let texture72 = device0.createTexture({
+  size: {width: 63},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder59 = commandEncoder70.beginComputePass();
+let renderBundle7 = renderBundleEncoder7.finish({});
+let sampler39 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'nearest',
+  lodMaxClamp: 95.51,
+});
+try {
+computePassEncoder27.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer20, 'uint32', 4, 76);
+} catch {}
+try {
+buffer16.unmap();
+} catch {}
+let textureView73 = texture65.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer16, 1_900, 1_452);
+} catch {}
+let videoFrame7 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'smpte240m', transfer: 'hlg'} });
+let commandEncoder71 = device0.createCommandEncoder();
+let texture73 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 3},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder60 = commandEncoder71.beginComputePass();
+let sampler40 = device0.createSampler({label: '\u498e\u{1fda8}\u00e9\u{1fcd3}\u219f\u{1ff39}\u0424\ubfa3\uc1fa', addressModeW: 'repeat'});
+try {
+computePassEncoder49.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.executeBundles([renderBundle7]);
+} catch {}
+let buffer41 = device0.createBuffer({size: 36, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder72 = device0.createCommandEncoder({});
+let texture74 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  sampleCount: 1,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView74 = texture7.createView({});
+let computePassEncoder61 = commandEncoder72.beginComputePass();
+try {
+computePassEncoder42.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+computePassEncoder17.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(1, bindGroup21, new Uint32Array(336), 43, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer20, 'uint32', 8, 142);
+} catch {}
+try {
+computePassEncoder46.insertDebugMarker('\u0abb');
+} catch {}
+let pipeline3 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3}});
+let buffer42 = device0.createBuffer({label: '\u{1fe69}\u0e43', size: 512, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let texture75 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 876},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder22.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(0, bindGroup24);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup17, new Uint32Array(2352), 305, 0);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle7]);
+} catch {}
+let arrayBuffer1 = buffer4.getMappedRange(8, 0);
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup26 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 152, resource: textureView34}]});
+let commandEncoder73 = device0.createCommandEncoder({});
+let textureView75 = texture64.createView({dimension: '2d-array', mipLevelCount: 1, baseArrayLayer: 14, arrayLayerCount: 24});
+try {
+computePassEncoder58.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(205);
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder73.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 28 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2474 */
+  offset: 2474,
+  buffer: buffer16,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 7, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder73.resolveQuerySet(querySet10, 2, 2, buffer1, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture37,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(448).fill(35), /* required buffer size: 448 */
+{offset: 448}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(30); };
+} catch {}
+let bindGroup27 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 246, resource: {buffer: buffer21}}, {binding: 0, resource: {buffer: buffer21, size: 64}}],
+});
+let computePassEncoder62 = commandEncoder73.beginComputePass();
+let sampler41 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 51.64,
+  compare: 'always',
+  maxAnisotropy: 14,
+});
+let externalTexture6 = device0.importExternalTexture({source: videoFrame0});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer23, 44); };
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer16, 'uint32', 1_164, 12_070);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 1 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup28 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 0, resource: {buffer: buffer1}}, {binding: 246, resource: {buffer: buffer8}}],
+});
+let buffer43 = device0.createBuffer({size: 36, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder74 = device0.createCommandEncoder();
+let renderPassEncoder14 = commandEncoder74.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 24,
+  clearValue: { r: -921.2, g: 499.0, b: -841.7, a: 11.17, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 135894,
+});
+try {
+computePassEncoder47.setBindGroup(0, bindGroup0, []);
+} catch {}
+try {
+computePassEncoder26.setBindGroup(1, bindGroup16, new Uint32Array(337), 0, 0);
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle7, renderBundle1]);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 16, new Uint32Array(5288).fill(8_600), 407, 0);
+} catch {}
+let pipelineLayout8 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout0]});
+let textureView76 = texture34.createView({dimension: '2d-array', mipLevelCount: 1});
+try {
+computePassEncoder35.setBindGroup(3, bindGroup5, new Uint32Array(833), 132, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup26, new Uint32Array(2516), 513, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture0,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 3},
+  aspect: 'all',
+}, new Uint8Array(9_604).fill(214), /* required buffer size: 9_604 */
+{offset: 100, bytesPerRow: 44, rowsPerImage: 24}, {width: 6, height: 0, depthOrArrayLayers: 10});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture76 = device0.createTexture({
+  size: [64, 64, 12],
+  mipLevelCount: 2,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler42 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'repeat', magFilter: 'nearest'});
+try {
+computePassEncoder39.setBindGroup(0, bindGroup23);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroupsIndirect(buffer1, 20); };
+} catch {}
+try {
+computePassEncoder28.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(1, bindGroup10, new Uint32Array(2369), 51, 0);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(0, buffer6, 4, 0);
+} catch {}
+try {
+globalThis.someLabel = externalTexture2.label;
+} catch {}
+let buffer44 = device0.createBuffer({size: 68, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let textureView77 = texture47.createView({format: 'r16sint'});
+let sampler43 = device0.createSampler({
+  label: '\u{1f6e5}\u{1f612}\u61fd\u0eea\u05aa\u0bbd\u2265\u{1fc67}\u04c1\u09cd',
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMinClamp: 28.21,
+  maxAnisotropy: 4,
+});
+try {
+computePassEncoder50.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup22, new Uint32Array(2522), 351, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(1, buffer2, 0, 20);
+} catch {}
+let offscreenCanvas0 = new OffscreenCanvas(27, 85);
+let buffer45 = device0.createBuffer({size: 64, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let textureView78 = texture60.createView({dimension: 'cube', aspect: 'all', baseMipLevel: 0, mipLevelCount: 1});
+let texture77 = device0.createTexture({
+  size: [510, 1, 11],
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer17, 0, 4);
+} catch {}
+let bindGroup29 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 1, resource: textureView0}]});
+let commandEncoder75 = device0.createCommandEncoder({});
+let computePassEncoder63 = commandEncoder75.beginComputePass();
+let promise10 = device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule2, entryPoint: 'compute4', constants: {}}});
+let commandEncoder76 = device0.createCommandEncoder({});
+let sampler44 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  lodMaxClamp: 84.43,
+  compare: 'greater-equal',
+});
+try {
+computePassEncoder43.setBindGroup(1, bindGroup7);
+} catch {}
+try {
+computePassEncoder54.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup3, new Uint32Array(2056), 1_474, 0);
+} catch {}
+try {
+renderPassEncoder12.setIndexBuffer(buffer22, 'uint32', 4, 24);
+} catch {}
+try {
+commandEncoder76.resolveQuerySet(querySet5, 13, 8, buffer13, 0);
+} catch {}
+offscreenCanvas0.height = 401;
+let texture78 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder15 = commandEncoder76.beginRenderPass({
+  colorAttachments: [{view: textureView22, loadOp: 'clear', storeOp: 'discard'}],
+  occlusionQuerySet: querySet1,
+  maxDrawCount: 303113479,
+});
+let sampler45 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  lodMaxClamp: 81.91,
+});
+try {
+computePassEncoder51.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder6.setIndexBuffer(buffer34, 'uint32', 0, 2);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer22, 0, new Uint32Array(5203), 2, 0);
+} catch {}
+let videoFrame8 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt709', primaries: 'jedecP22Phosphors', transfer: 'gamma28curve'} });
+let bindGroup30 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 197, resource: sampler5}, {binding: 1, resource: externalTexture6}],
+});
+let textureView79 = texture75.createView({arrayLayerCount: 1});
+try {
+renderPassEncoder9.setBindGroup(0, bindGroup2, []);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(1, bindGroup3, new Uint32Array(861), 34, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(47);
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(6, buffer17, 20, 9);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let autogeneratedBindGroupLayout0 = pipeline3.getBindGroupLayout(0);
+let querySet13 = device0.createQuerySet({label: '\u{1f9a1}\u7be1\u080a\ub712\u3a1b', type: 'occlusion', count: 193});
+let renderBundleEncoder8 = device0.createRenderBundleEncoder({colorFormats: [undefined], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder15.setBindGroup(0, bindGroup12, new Uint32Array(1894), 152, 0);
+} catch {}
+try {
+computePassEncoder39.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder52.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(0, bindGroup26);
+} catch {}
+try {
+renderBundleEncoder8.setVertexBuffer(1, buffer36, 0, 5);
+} catch {}
+let bindGroup31 = device0.createBindGroup({layout: veryExplicitBindGroupLayout6, entries: [{binding: 152, resource: textureView24}]});
+let querySet14 = device0.createQuerySet({type: 'occlusion', count: 532});
+let renderBundle8 = renderBundleEncoder8.finish({});
+try {
+computePassEncoder40.setBindGroup(3, bindGroup17, new Uint32Array(45), 19, 0);
+} catch {}
+try {
+computePassEncoder40.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup19, []);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer36, 'uint32', 36, 11);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(4, buffer40, 0, 5);
+} catch {}
+let commandEncoder77 = device0.createCommandEncoder({});
+let texture79 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 72},
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+});
+let renderPassEncoder16 = commandEncoder77.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 754,
+  clearValue: { r: -618.8, g: -116.9, b: -65.68, a: 431.4, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let sampler46 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 65.37,
+});
+try {
+computePassEncoder27.setBindGroup(3, bindGroup14, []);
+} catch {}
+try {
+computePassEncoder53.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(1, bindGroup20, new Uint32Array(616), 48, 0);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+let pipeline4 = device0.createRenderPipeline({
+  layout: pipelineLayout5,
+  fragment: {
+  module: shaderModule1,
+  constants: {override7: 1},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALL | GPUColorWrite.ALPHA}],
+},
+  vertex: {module: shaderModule4, buffers: []},
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint32', frontFace: 'cw', cullMode: 'front'},
+});
+let commandEncoder78 = device0.createCommandEncoder({});
+let computePassEncoder64 = commandEncoder78.beginComputePass();
+try {
+computePassEncoder57.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(3, bindGroup17, new Uint32Array(873), 268, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder13); computePassEncoder13.dispatchWorkgroups(2, 1, 2); };
+} catch {}
+try {
+computePassEncoder14.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup1, []);
+} catch {}
+try {
+renderPassEncoder1.setViewport(50.707982446796265, 34.10509844274955, 2.9452784600811124, 20.024085115501975, 0.21031856915978353, 0.6190529236737831);
+} catch {}
+try {
+renderPassEncoder8.setIndexBuffer(buffer6, 'uint16', 4, 6);
+} catch {}
+try {
+buffer24.unmap();
+} catch {}
+try {
+renderPassEncoder1.insertDebugMarker('\u{1fe05}');
+} catch {}
+let gpuCanvasContext0 = offscreenCanvas0.getContext('webgpu');
+let commandEncoder79 = device0.createCommandEncoder({});
+let computePassEncoder65 = commandEncoder79.beginComputePass();
+try {
+computePassEncoder44.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer23, 20); };
+} catch {}
+try {
+computePassEncoder65.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(2, buffer13);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture20,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(189).fill(59), /* required buffer size: 189 */
+{offset: 189}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView80 = texture65.createView({dimension: '2d-array'});
+try {
+computePassEncoder27.setBindGroup(1, bindGroup28, new Uint32Array(374), 24, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder6.executeBundles([renderBundle7, renderBundle4, renderBundle5]);
+} catch {}
+let bindGroup32 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture6}, {binding: 197, resource: sampler3}],
+});
+try {
+computePassEncoder11.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+computePassEncoder53.setBindGroup(0, bindGroup1, new Uint32Array(3560), 400, 0);
+} catch {}
+try {
+computePassEncoder1.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+let imageData6 = new ImageData(120, 20);
+let texture80 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 24},
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+try {
+computePassEncoder64.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(3, bindGroup18, new Uint32Array(1494), 17, 0);
+} catch {}
+let imageData7 = new ImageData(56, 16);
+let texture81 = device0.createTexture({
+  size: [255, 1, 95],
+  mipLevelCount: 2,
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder55.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder14.beginOcclusionQuery(13);
+} catch {}
+try {
+buffer13.unmap();
+} catch {}
+let bindGroup33 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 1, resource: textureView3}]});
+let commandEncoder80 = device0.createCommandEncoder({});
+let texture82 = device0.createTexture({
+  size: [255, 1, 1],
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: ['rgba8sint'],
+});
+let renderPassEncoder17 = commandEncoder80.beginRenderPass({colorAttachments: [{view: textureView39, depthSlice: 21, loadOp: 'clear', storeOp: 'store'}]});
+let sampler47 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  lodMinClamp: 1.021,
+  compare: 'never',
+});
+try {
+computePassEncoder25.setBindGroup(1, bindGroup18, new Uint32Array(4980), 753, 0);
+} catch {}
+try {
+computePassEncoder36.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(2, bindGroup17, new Uint32Array(3246), 3_003, 0);
+} catch {}
+try {
+renderPassEncoder14.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder1.setViewport(38.1777093885329, 4.239584616383894, 22.489473980267363, 11.095796698381967, 0.29097378588135425, 0.32400257687730105);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(6, buffer36);
+} catch {}
+try {
+adapter0.label = '\u{1f68f}\u06c4\ua088\ud77b\u{1ff12}';
+} catch {}
+let bindGroup34 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView1}]});
+let buffer46 = device0.createBuffer({size: 280, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.VERTEX});
+let commandEncoder81 = device0.createCommandEncoder({});
+let textureView81 = texture75.createView({arrayLayerCount: 1});
+let computePassEncoder66 = commandEncoder81.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer10, 76); };
+} catch {}
+try {
+computePassEncoder62.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup19);
+} catch {}
+let bindGroup35 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout3,
+  entries: [{binding: 1, resource: externalTexture1}, {binding: 197, resource: sampler33}],
+});
+let textureView82 = texture54.createView({mipLevelCount: 1, arrayLayerCount: 4});
+try {
+computePassEncoder41.setPipeline(pipeline0);
+} catch {}
+try {
+computePassEncoder16.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(0, bindGroup16, new Uint32Array(4455), 1_057, 0);
+} catch {}
+try {
+renderPassEncoder15.executeBundles([renderBundle4]);
+} catch {}
+try {
+renderPassEncoder15.setViewport(18.95833949884465, 50.04923306957472, 8.25777835951583, 5.420402162189128, 0.5222300945721311, 0.9259607674759722);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+globalThis.someLabel = bindGroup21.label;
+} catch {}
+let recycledExplicitBindGroupLayout6 = pipeline1.getBindGroupLayout(1);
+let bindGroup36 = device0.createBindGroup({layout: veryExplicitBindGroupLayout2, entries: [{binding: 1, resource: textureView0}]});
+let commandEncoder82 = device0.createCommandEncoder({});
+let textureView83 = texture37.createView({dimension: '2d-array', mipLevelCount: 1, arrayLayerCount: 1});
+let sampler48 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 71.09,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder33); computePassEncoder33.dispatchWorkgroupsIndirect(buffer6, 8); };
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder13.beginOcclusionQuery(860);
+} catch {}
+let buffer47 = device0.createBuffer({size: 580, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder83 = device0.createCommandEncoder();
+let textureView84 = texture63.createView({});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup35, new Uint32Array(1795), 929, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder39); computePassEncoder39.dispatchWorkgroups(1); };
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(2, bindGroup20, new Uint32Array(575), 15, 0);
+} catch {}
+try {
+renderPassEncoder10.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder9.setVertexBuffer(6, buffer13, 0, 118);
+} catch {}
+try {
+buffer46.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+await gc();
+let offscreenCanvas1 = new OffscreenCanvas(24, 63);
+let textureView85 = texture77.createView({arrayLayerCount: 4});
+let computePassEncoder67 = commandEncoder82.beginComputePass();
+let renderPassEncoder18 = commandEncoder83.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 26.50, g: 608.1, b: -958.3, a: 998.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet8,
+});
+try {
+computePassEncoder14.setBindGroup(2, bindGroup20, new Uint32Array(3047), 315, 0);
+} catch {}
+try {
+renderPassEncoder8.setBindGroup(2, bindGroup15, new Uint32Array(251), 9, 0);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle5, renderBundle3]);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(7, buffer46);
+} catch {}
+let offscreenCanvas2 = new OffscreenCanvas(45, 167);
+let commandEncoder84 = device0.createCommandEncoder();
+let querySet15 = device0.createQuerySet({type: 'occlusion', count: 1616});
+let renderPassEncoder19 = commandEncoder84.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 433,
+  clearValue: { r: -205.3, g: -582.4, b: 922.4, a: -557.2, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder34.setBindGroup(0, bindGroup9);
+} catch {}
+try {
+computePassEncoder33.end();
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup14, new Uint32Array(2553), 194, 0);
+} catch {}
+try {
+renderPassEncoder16.setIndexBuffer(buffer9, 'uint16', 14, 0);
+} catch {}
+try {
+renderPassEncoder0.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder57.pushDebugGroup('\u0756');
+} catch {}
+let gpuCanvasContext1 = offscreenCanvas1.getContext('webgpu');
+let buffer48 = device0.createBuffer({size: 84, usage: GPUBufferUsage.COPY_DST});
+try {
+computePassEncoder18.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup18, new Uint32Array(148), 6, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 45, y: 3 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+adapter2.label = '\u{1f86c}\u{1f8d8}';
+} catch {}
+let commandEncoder85 = device0.createCommandEncoder({});
+let computePassEncoder68 = commandEncoder85.beginComputePass();
+try {
+computePassEncoder22.setBindGroup(3, bindGroup5, new Uint32Array(320), 57, 0);
+} catch {}
+try {
+renderPassEncoder8.end();
+} catch {}
+try {
+renderPassEncoder13.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(2, buffer46, 68, 2);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 4, new Uint32Array(18187), 6698, 16);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipelineLayout9 = device0.createPipelineLayout({
+  bindGroupLayouts: [veryExplicitBindGroupLayout7, veryExplicitBindGroupLayout2, veryExplicitBindGroupLayout0],
+});
+let buffer49 = device0.createBuffer({size: 322, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let textureView86 = texture76.createView({dimension: 'cube', format: 'rg8sint', mipLevelCount: 1});
+let texture83 = device0.createTexture({
+  size: [64, 64, 555],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView87 = texture54.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 1});
+try {
+computePassEncoder44.setBindGroup(1, bindGroup19, new Uint32Array(151), 79, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder34); computePassEncoder34.dispatchWorkgroupsIndirect(buffer44, 56); };
+} catch {}
+try {
+computePassEncoder66.setPipeline(pipeline2);
+} catch {}
+try {
+  await shaderModule0.getCompilationInfo();
+} catch {}
+try {
+commandEncoder56.copyBufferToTexture({
+  /* bytesInLastRow: 30 widthInBlocks: 15 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2544 */
+  offset: 2544,
+  bytesPerRow: 9984,
+  buffer: buffer16,
+}, {
+  texture: texture37,
+  mipLevel: 1,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 15, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture60,
+  mipLevel: 1,
+  origin: {x: 5, y: 2, z: 0},
+  aspect: 'all',
+}, new Uint8Array(130).fill(23), /* required buffer size: 130 */
+{offset: 130, bytesPerRow: 40}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData4,
+  origin: { x: 0, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 2, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let videoFrame9 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'unspecified', primaries: 'smpte240m', transfer: 'bt1361ExtendedColourGamut'} });
+let buffer50 = device0.createBuffer({size: 248, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX});
+let texture84 = device0.createTexture({
+  size: [255, 1, 1],
+  format: 'depth16unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let sampler49 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 91.22});
+try {
+computePassEncoder58.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+computePassEncoder39.setBindGroup(0, bindGroup7, new Uint32Array(3343), 665, 0);
+} catch {}
+try {
+computePassEncoder57.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder0.executeBundles([renderBundle3, renderBundle4]);
+} catch {}
+try {
+commandEncoder35.copyBufferToBuffer(buffer21, 20, buffer36, 4, 0);
+} catch {}
+let videoFrame10 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt470bg', primaries: 'film', transfer: 'gamma22curve'} });
+let commandBuffer4 = commandEncoder35.finish();
+let texture85 = device0.createTexture({
+  size: [64, 64, 12],
+  format: 'rgba32sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder69 = commandEncoder56.beginComputePass();
+try {
+computePassEncoder28.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+computePassEncoder38.setBindGroup(1, bindGroup5, new Uint32Array(816), 155, 0);
+} catch {}
+try {
+computePassEncoder68.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer23, 'uint32', 32, 8);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let veryExplicitBindGroupLayout9 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8uint', access: 'read-only', viewDimension: '3d' },
+    },
+    {
+      binding: 6,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'rgba32sint', access: 'write-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let commandEncoder86 = device0.createCommandEncoder({});
+let textureView88 = texture85.createView({baseMipLevel: 0, mipLevelCount: 1, baseArrayLayer: 4, arrayLayerCount: 1});
+let texture86 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 251},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let computePassEncoder70 = commandEncoder86.beginComputePass();
+let sampler50 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 98.11,
+  compare: 'equal',
+  maxAnisotropy: 6,
+});
+try {
+computePassEncoder31.setBindGroup(0, bindGroup17, new Uint32Array(95), 6, 0);
+} catch {}
+try {
+computePassEncoder59.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(708);
+} catch {}
+try {
+renderPassEncoder18.setIndexBuffer(buffer16, 'uint16', 396, 871);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(1, buffer5, 0, 9);
+} catch {}
+try {
+computePassEncoder57.popDebugGroup();
+} catch {}
+try {
+device0.queue.submit([commandBuffer4]);
+} catch {}
+try {
+globalThis.someLabel = device0.label;
+} catch {}
+let buffer51 = device0.createBuffer({size: 24, usage: GPUBufferUsage.COPY_SRC});
+let commandEncoder87 = device0.createCommandEncoder({});
+let texture87 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 46},
+  dimension: '3d',
+  format: 'rgba8uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+renderPassEncoder6.setBindGroup(3, bindGroup34, new Uint32Array(697), 32, 0);
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(2, buffer16, 0, 8_654);
+} catch {}
+try {
+commandEncoder87.copyBufferToTexture({
+  /* bytesInLastRow: 56 widthInBlocks: 14 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 2248 */
+  offset: 2248,
+  rowsPerImage: 1078,
+  buffer: buffer16,
+}, {
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 2, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 14, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder87.copyTextureToBuffer({
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 3, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 10 widthInBlocks: 5 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 2216 */
+  offset: 2216,
+  buffer: buffer16,
+}, {width: 5, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView89 = texture87.createView({mipLevelCount: 1, arrayLayerCount: 1});
+let texture88 = device0.createTexture({
+  size: [510, 1, 15],
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder56.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+computePassEncoder63.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup5, []);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup21, new Uint32Array(1512), 94, 0);
+} catch {}
+try {
+renderPassEncoder18.setViewport(34.531047518891654, 39.33957530412783, 15.693359511227424, 6.6910743702639905, 0.7786316578140439, 0.9362240831525185);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer23, 'uint16', 54, 10);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 15, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(123).fill(207), /* required buffer size: 123 */
+{offset: 123, rowsPerImage: 39}, {width: 28, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let querySet16 = device0.createQuerySet({type: 'occlusion', count: 1056});
+let sampler51 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  maxAnisotropy: 3,
+});
+try {
+computePassEncoder7.setBindGroup(0, bindGroup33, new Uint32Array(4323), 1_135, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder70.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder7.setBindGroup(2, bindGroup25);
+} catch {}
+try {
+renderPassEncoder17.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(0, buffer3, 0);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer50, 32, new Uint32Array(556), 131, 4);
+} catch {}
+let buffer52 = device0.createBuffer({
+  size: 0,
+  usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder88 = device0.createCommandEncoder({});
+let renderPassEncoder20 = commandEncoder87.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 793,
+  clearValue: { r: 147.8, g: 680.1, b: -744.8, a: 925.6, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+});
+let externalTexture7 = device0.importExternalTexture({source: videoFrame10, colorSpace: 'srgb'});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup19);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(0, bindGroup20, new Uint32Array(8359), 4_522, 0);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup10);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder88.copyBufferToTexture({
+  /* bytesInLastRow: 4 widthInBlocks: 2 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1062 */
+  offset: 1062,
+  bytesPerRow: 24064,
+  buffer: buffer16,
+}, {
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 3, y: 2, z: 3},
+  aspect: 'all',
+}, {width: 2, height: 7, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData6,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 81, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup37 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 0, resource: {buffer: buffer17}}, {binding: 246, resource: {buffer: buffer21, offset: 0}}],
+});
+let texture89 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder71 = commandEncoder88.beginComputePass();
+try {
+renderPassEncoder14.setIndexBuffer(buffer20, 'uint32', 52, 23);
+} catch {}
+let imageData8 = new ImageData(12, 76);
+let veryExplicitBindGroupLayout10 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      buffer: { type: 'uniform', minBindingSize: 0, hasDynamicOffset: false },
+    },
+    {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      buffer: { type: 'uniform', hasDynamicOffset: false },
+    },
+    {
+      binding: 2,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: { type: 'non-filtering' },
+    },
+    {
+      binding: 3,
+      visibility: GPUShaderStage.FRAGMENT,
+      storageTexture: { format: 'r32float', access: 'read-write', viewDimension: '1d' },
+    },
+    {
+      binding: 4,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'read-only-storage', hasDynamicOffset: false },
+    },
+    {
+      binding: 16,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'sint', multisampled: false },
+    },
+    {binding: 26, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+    {
+      binding: 30,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'float', multisampled: false },
+    },
+    {
+      binding: 298,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+    {
+      binding: 446,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      texture: { viewDimension: 'cube', sampleType: 'uint', multisampled: false },
+    },
+  ],
+});
+let bindGroup38 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [{binding: 1, resource: externalTexture5}, {binding: 197, resource: sampler0}],
+});
+try {
+computePassEncoder35.setBindGroup(1, bindGroup0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(1); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder15); computePassEncoder15.dispatchWorkgroupsIndirect(buffer23, 48); };
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture78,
+  mipLevel: 1,
+  origin: {x: 17, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(1).fill(199), /* required buffer size: 1 */
+{offset: 1}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData9 = new ImageData(20, 36);
+let bindGroup39 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 6, resource: textureView88}, {binding: 0, resource: textureView89}],
+});
+let buffer53 = device0.createBuffer({size: 184, usage: GPUBufferUsage.INDIRECT});
+let commandEncoder89 = device0.createCommandEncoder();
+let texture90 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 1},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView90 = texture45.createView({label: '\u{1f93a}\u6922\ue805\u5218', format: 'r16sint', mipLevelCount: 1, arrayLayerCount: 1});
+let computePassEncoder72 = commandEncoder89.beginComputePass();
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let promise11 = device0.queue.onSubmittedWorkDone();
+let gpuCanvasContext2 = offscreenCanvas2.getContext('webgpu');
+let bindGroup40 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout8,
+  entries: [{binding: 0, resource: {buffer: buffer34}}, {binding: 246, resource: {buffer: buffer5}}],
+});
+let commandEncoder90 = device0.createCommandEncoder({});
+let renderPassEncoder21 = commandEncoder90.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 629,
+  clearValue: { r: 80.79, g: -506.8, b: 727.8, a: -301.6, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet4,
+});
+let sampler52 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 90.47});
+try {
+computePassEncoder15.end();
+} catch {}
+try {
+computePassEncoder69.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder16.setBlendConstant({ r: 755.1, g: -917.4, b: 461.3, a: -757.3, });
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(4, buffer16);
+} catch {}
+try {
+buffer35.unmap();
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture11,
+  mipLevel: 0,
+  origin: {x: 163, y: 0, z: 1},
+  aspect: 'all',
+}, new Uint8Array(42_602).fill(7), /* required buffer size: 42_602 */
+{offset: 14, bytesPerRow: 26, rowsPerImage: 42}, {width: 6, height: 0, depthOrArrayLayers: 40});
+} catch {}
+let buffer54 = device0.createBuffer({size: 36, usage: GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let renderPassEncoder22 = commandEncoder14.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 62.72, g: 454.0, b: 725.1, a: 433.4, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet9,
+  maxDrawCount: 45946401,
+});
+try {
+renderPassEncoder6.setVertexBuffer(1, buffer17, 40, 3);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let pipeline5 = device0.createRenderPipeline({
+  layout: 'auto',
+  fragment: {
+  module: shaderModule1,
+  constants: {override7: 1},
+  targets: [{format: 'r16sint', writeMask: GPUColorWrite.ALPHA | GPUColorWrite.GREEN | GPUColorWrite.RED}],
+},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex2',
+    constants: {override10: 1, 1_863: 1},
+    buffers: [
+      {
+        arrayStride: 372,
+        stepMode: 'instance',
+        attributes: [
+          {format: 'uint32', offset: 48, shaderLocation: 8},
+          {format: 'unorm16x2', offset: 224, shaderLocation: 2},
+          {format: 'unorm10-10-10-2', offset: 24, shaderLocation: 9},
+          {format: 'uint32', offset: 32, shaderLocation: 5},
+          {format: 'unorm16x2', offset: 32, shaderLocation: 10},
+        ],
+      },
+      {
+        arrayStride: 184,
+        stepMode: 'instance',
+        attributes: [{format: 'sint32x2', offset: 24, shaderLocation: 3}],
+      },
+    ],
+  },
+  primitive: {topology: 'line-strip', stripIndexFormat: 'uint16'},
+});
+let videoFrame11 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'RGBX',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'bt709', transfer: 'bt2020_10bit'} });
+let buffer55 = device0.createBuffer({size: 152, usage: GPUBufferUsage.INDEX, mappedAtCreation: false});
+let textureView91 = texture4.createView({});
+try {
+renderPassEncoder14.setBindGroup(0, bindGroup39, new Uint32Array(364), 91, 0);
+} catch {}
+let texture91 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView92 = texture70.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 4});
+let sampler53 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 95.28,
+});
+try {
+computePassEncoder41.setBindGroup(0, bindGroup2, new Uint32Array(42), 9, 0);
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+} catch {}
+let querySet17 = device0.createQuerySet({type: 'occlusion', count: 462});
+let texture92 = device0.createTexture({
+  size: [64, 64, 248],
+  mipLevelCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView93 = texture49.createView({baseArrayLayer: 5, arrayLayerCount: 9});
+let sampler54 = device0.createSampler({addressModeW: 'repeat', lodMaxClamp: 78.63});
+try {
+computePassEncoder9.setBindGroup(1, bindGroup26);
+} catch {}
+try {
+computePassEncoder27.setBindGroup(1, bindGroup20, new Uint32Array(3632), 2_269, 0);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(3, bindGroup23, new Uint32Array(1173), 676, 0);
+} catch {}
+let imageData10 = new ImageData(60, 4);
+let commandEncoder91 = device0.createCommandEncoder({});
+let textureView94 = texture30.createView({dimension: '2d', baseArrayLayer: 4});
+let texture93 = device0.createTexture({
+  size: [127, 1, 86],
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let textureView95 = texture36.createView({mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder73 = commandEncoder91.beginComputePass();
+try {
+renderPassEncoder15.executeBundles([renderBundle5]);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let buffer56 = device0.createBuffer({
+  size: 244,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX,
+});
+let commandEncoder92 = device0.createCommandEncoder({});
+try {
+computePassEncoder22.setBindGroup(0, bindGroup15, new Uint32Array(4436), 189, 0);
+} catch {}
+try {
+computePassEncoder34.end();
+} catch {}
+try {
+computePassEncoder72.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup16, new Uint32Array(672), 3, 0);
+} catch {}
+try {
+commandEncoder92.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 1},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 64 widthInBlocks: 8 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 2112 */
+  offset: 2112,
+  bytesPerRow: 8960,
+  buffer: buffer16,
+}, {width: 8, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture85,
+  mipLevel: 0,
+  origin: {x: 3, y: 21, z: 1},
+  aspect: 'all',
+}, new Uint8Array(6_935).fill(80), /* required buffer size: 6_935 */
+{offset: 19, bytesPerRow: 75, rowsPerImage: 78}, {width: 1, height: 15, depthOrArrayLayers: 2});
+} catch {}
+let bindGroup41 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 6, resource: textureView88}, {binding: 0, resource: textureView89}],
+});
+try {
+computePassEncoder37.setBindGroup(0, bindGroup13);
+} catch {}
+try {
+computePassEncoder52.setBindGroup(2, bindGroup34, new Uint32Array(806), 277, 0);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(1, bindGroup4, new Uint32Array(121), 1, 0);
+} catch {}
+try {
+renderPassEncoder1.setVertexBuffer(1, buffer36);
+} catch {}
+let bindGroup42 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 197, resource: sampler53}, {binding: 1, resource: externalTexture7}],
+});
+let buffer57 = device0.createBuffer({size: 25, usage: GPUBufferUsage.QUERY_RESOLVE});
+let sampler55 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'mirror-repeat', addressModeW: 'repeat', mipmapFilter: 'linear'});
+try {
+computePassEncoder63.setBindGroup(3, bindGroup17);
+} catch {}
+try {
+computePassEncoder67.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder4.setIndexBuffer(buffer9, 'uint16', 6, 0);
+} catch {}
+let videoFrame12 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'I420A',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'rgb', primaries: 'smpteRp431', transfer: 'iec61966-2-1'} });
+let autogeneratedBindGroupLayout1 = pipeline2.getBindGroupLayout(0);
+let commandEncoder93 = device0.createCommandEncoder({});
+try {
+computePassEncoder54.setBindGroup(3, bindGroup39);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData9,
+  origin: { x: 7, y: 2 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: true,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let buffer58 = device0.createBuffer({size: 536, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ});
+let commandEncoder94 = device0.createCommandEncoder();
+let computePassEncoder74 = commandEncoder94.beginComputePass();
+let renderPassEncoder23 = commandEncoder93.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -590.8, g: 100.5, b: -756.0, a: 761.8, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+let renderBundleEncoder9 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true});
+try {
+computePassEncoder67.setBindGroup(0, bindGroup17, new Uint32Array(3468), 125, 0);
+} catch {}
+try {
+renderPassEncoder10.setIndexBuffer(buffer49, 'uint16', 2, 6);
+} catch {}
+try {
+buffer43.unmap();
+} catch {}
+try {
+commandEncoder92.copyBufferToTexture({
+  /* bytesInLastRow: 24 widthInBlocks: 6 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1156 */
+  offset: 1156,
+  buffer: buffer16,
+}, {
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder95 = device0.createCommandEncoder();
+let texture94 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 557},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder75 = commandEncoder92.beginComputePass();
+let renderBundleEncoder10 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], stencilReadOnly: true});
+let renderBundle9 = renderBundleEncoder10.finish({});
+try {
+computePassEncoder45.setBindGroup(2, bindGroup40, new Uint32Array(5279), 16, 0);
+} catch {}
+try {
+computePassEncoder60.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder15.setViewport(20.122465756977654, 59.23852200952336, 8.764914881442422, 0.005006938590236801, 0.9458222614215074, 0.9495258342078475);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint16', 14, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(5, buffer13, 0, 52);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer23, 'uint16', 72, 17);
+} catch {}
+try {
+commandEncoder95.copyBufferToTexture({
+  /* bytesInLastRow: 280 widthInBlocks: 35 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 360 */
+  offset: 360,
+  bytesPerRow: 6656,
+  buffer: buffer18,
+}, {
+  texture: texture21,
+  mipLevel: 0,
+  origin: {x: 57, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 35, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageBitmap1,
+  origin: { x: 1, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup43 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [{binding: 1, resource: externalTexture0}, {binding: 197, resource: sampler4}],
+});
+let commandEncoder96 = device0.createCommandEncoder();
+let textureView96 = texture38.createView({mipLevelCount: 4});
+try {
+computePassEncoder29.setBindGroup(0, bindGroup22, new Uint32Array(566), 154, 0);
+} catch {}
+try {
+computePassEncoder44.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder22.setIndexBuffer(buffer36, 'uint16', 56, 4);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer13, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer22, 'uint32', 0, 5);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer10, 4, new DataView(new ArrayBuffer(10207)), 1801, 64);
+} catch {}
+let pipeline6 = await promise10;
+let bindGroup44 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 1, resource: textureView0}]});
+let textureView97 = texture19.createView({});
+let sampler56 = device0.createSampler({
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 99.94,
+  maxAnisotropy: 7,
+});
+try {
+renderPassEncoder16.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder19.setViewport(36.602527382097406, 41.766324059370056, 14.200387929418493, 1.7408430560626278, 0.23294224447494993, 0.6513669347699147);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer9, 'uint16', 6, 1);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer28, 0, 0);
+} catch {}
+try {
+buffer17.unmap();
+} catch {}
+let textureView98 = texture53.createView({dimension: '2d', baseMipLevel: 1, mipLevelCount: 1, baseArrayLayer: 4});
+let computePassEncoder76 = commandEncoder96.beginComputePass();
+let externalTexture8 = device0.importExternalTexture({source: videoFrame1});
+try {
+renderPassEncoder14.setBindGroup(2, bindGroup40, new Uint32Array(3844), 583, 0);
+} catch {}
+try {
+renderBundleEncoder9.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder9.setVertexBuffer(2, buffer2, 0, 0);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture35,
+  mipLevel: 0,
+  origin: {x: 1, y: 4, z: 1},
+  aspect: 'all',
+}, new Uint8Array(86).fill(157), /* required buffer size: 86 */
+{offset: 86, bytesPerRow: 38}, {width: 3, height: 21, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise11;
+} catch {}
+let bindGroup45 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture3}, {binding: 197, resource: sampler55}],
+});
+let texture95 = device0.createTexture({size: [63, 1, 1], mipLevelCount: 4, format: 'rgba8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let textureView99 = texture0.createView({dimension: '2d', format: 'r32sint', baseArrayLayer: 2});
+let sampler57 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', addressModeW: 'mirror-repeat', lodMaxClamp: 91.67});
+try {
+computePassEncoder75.setBindGroup(1, bindGroup45, new Uint32Array(218), 71, 0);
+} catch {}
+try {
+computePassEncoder61.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(2, bindGroup2, new Uint32Array(707), 49, 0);
+} catch {}
+try {
+renderBundleEncoder9.setIndexBuffer(buffer22, 'uint16', 0, 11);
+} catch {}
+try {
+commandEncoder36.copyBufferToBuffer(buffer5, 0, buffer10, 88, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture96 = gpuCanvasContext1.getCurrentTexture();
+let textureView100 = texture3.createView({format: 'r32float', baseMipLevel: 0});
+let renderBundle10 = renderBundleEncoder9.finish({});
+try {
+computePassEncoder67.setBindGroup(1, bindGroup9);
+} catch {}
+try {
+renderPassEncoder6.setBindGroup(0, bindGroup20, new Uint32Array(4018), 1_057, 0);
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -809.1, g: -423.8, b: 133.1, a: -861.1, });
+} catch {}
+try {
+renderPassEncoder6.draw(174, 147, 956_701_530, 1_583_581_758);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer40, 56);
+} catch {}
+try {
+renderPassEncoder4.setVertexBuffer(4, buffer2);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'bgra8unorm', usage: GPUTextureUsage.RENDER_ATTACHMENT});
+} catch {}
+let commandEncoder97 = device0.createCommandEncoder({});
+let textureView101 = texture93.createView({dimension: '3d', format: 'r16sint', mipLevelCount: 1, baseArrayLayer: 0});
+let computePassEncoder77 = commandEncoder36.beginComputePass();
+let sampler58 = device0.createSampler({addressModeU: 'repeat', addressModeV: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 77.94});
+try {
+{ clearResourceUsages(device0, computePassEncoder9); computePassEncoder9.dispatchWorkgroupsIndirect(buffer40, 0); };
+} catch {}
+try {
+renderPassEncoder23.setScissorRect(16, 0, 208, 0);
+} catch {}
+try {
+renderPassEncoder6.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder18.setVertexBuffer(4, undefined);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup46 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [{binding: 1, resource: externalTexture0}, {binding: 197, resource: sampler21}],
+});
+let computePassEncoder78 = commandEncoder97.beginComputePass();
+let renderPassEncoder24 = commandEncoder95.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: 444.2, g: -49.21, b: -398.7, a: 812.9, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 71889619,
+});
+try {
+computePassEncoder37.setBindGroup(3, bindGroup40, new Uint32Array(7319), 3_310, 0);
+} catch {}
+try {
+renderPassEncoder6.drawIndexedIndirect(buffer49, 28);
+} catch {}
+let promise12 = device0.queue.onSubmittedWorkDone();
+let buffer59 = device0.createBuffer({size: 116, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.UNIFORM});
+let textureView102 = texture50.createView({});
+try {
+computePassEncoder78.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup5);
+} catch {}
+try {
+renderPassEncoder18.executeBundles([renderBundle5, renderBundle5]);
+} catch {}
+try {
+renderPassEncoder6.draw(314, 315, 1_056_527_320, 385_401_698);
+} catch {}
+try {
+renderPassEncoder6.drawIndirect(buffer7, 8);
+} catch {}
+try {
+buffer12.unmap();
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'premultiplied',
+});
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let pipelineLayout10 = device0.createPipelineLayout({bindGroupLayouts: [recycledExplicitBindGroupLayout5]});
+let commandEncoder98 = device0.createCommandEncoder({});
+let textureView103 = texture22.createView({dimension: '2d'});
+let computePassEncoder79 = commandEncoder98.beginComputePass();
+try {
+renderPassEncoder15.setBindGroup(3, bindGroup46, new Uint32Array(1283), 227, 0);
+} catch {}
+try {
+renderPassEncoder6.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer59, 12, new Uint32Array(16009), 1061, 0);
+} catch {}
+let textureView104 = texture65.createView({dimension: '2d-array'});
+let texture97 = device0.createTexture({
+  size: {width: 255},
+  dimension: '1d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+});
+let computePassEncoder80 = commandEncoder53.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(1, bindGroup29);
+} catch {}
+try {
+computePassEncoder55.insertDebugMarker('\u12a9');
+} catch {}
+let imageData11 = new ImageData(44, 28);
+let buffer60 = device0.createBuffer({size: 172, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let texture98 = device0.createTexture({
+  size: [255, 1, 11],
+  format: 'rgba16uint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture99 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 554},
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let renderBundleEncoder11 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true});
+let renderBundle11 = renderBundleEncoder11.finish({});
+try {
+computePassEncoder9.end();
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder14.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let bindGroup47 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture8}, {binding: 197, resource: sampler27}],
+});
+let buffer61 = device0.createBuffer({size: 365, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE, mappedAtCreation: false});
+let textureView105 = texture98.createView({arrayLayerCount: 2});
+let computePassEncoder81 = commandEncoder9.beginComputePass();
+let sampler59 = device0.createSampler({
+  addressModeU: 'clamp-to-edge',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  lodMaxClamp: 70.12,
+});
+try {
+computePassEncoder25.setBindGroup(3, bindGroup36, []);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup22, new Uint32Array(630), 51, 0);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(30);
+} catch {}
+try {
+renderPassEncoder17.setIndexBuffer(buffer22, 'uint32', 4, 4);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+let veryExplicitBindGroupLayout11 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 205,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+let texture100 = device0.createTexture({
+  label: '\ub69f\u9bd3\u1527\u32a8\u0f46',
+  size: [63, 1, 82],
+  mipLevelCount: 2,
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let textureView106 = texture39.createView({});
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup23);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+gpuCanvasContext2.unconfigure();
+} catch {}
+let imageBitmap2 = await createImageBitmap(imageData8);
+let sampler60 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'nearest',
+  lodMaxClamp: 87.82,
+});
+try {
+computePassEncoder72.setBindGroup(1, bindGroup2);
+} catch {}
+try {
+computePassEncoder75.setPipeline(pipeline2);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+let pipeline7 = await device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule0, constants: {}}});
+let imageBitmap3 = await createImageBitmap(imageData9);
+let bindGroup48 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout6,
+  entries: [{binding: 197, resource: sampler54}, {binding: 1, resource: externalTexture3}],
+});
+let sampler61 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  lodMaxClamp: 94.63,
+  compare: 'not-equal',
+});
+try {
+computePassEncoder53.setBindGroup(1, bindGroup10);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder26); computePassEncoder26.dispatchWorkgroups(3); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer7, 20); };
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup13, new Uint32Array(5918), 1_283, 0);
+} catch {}
+try {
+renderPassEncoder12.setPipeline(pipeline4);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup49 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture4}, {binding: 197, resource: sampler24}],
+});
+let commandEncoder99 = device0.createCommandEncoder({});
+let texture101 = device0.createTexture({
+  size: [127, 1, 103],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView107 = texture82.createView({dimension: '2d-array'});
+let computePassEncoder82 = commandEncoder99.beginComputePass();
+try {
+computePassEncoder26.end();
+} catch {}
+try {
+commandEncoder26.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1322 */
+  offset: 1322,
+  bytesPerRow: 4608,
+  buffer: buffer16,
+}, {
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder26.copyTextureToBuffer({
+  texture: texture32,
+  mipLevel: 0,
+  origin: {x: 12, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 154 widthInBlocks: 77 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1544 */
+  offset: 1544,
+  bytesPerRow: 16896,
+  buffer: buffer16,
+}, {width: 77, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData2,
+  origin: { x: 4, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 21, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let bindGroup50 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 6, resource: textureView88}, {binding: 0, resource: textureView89}],
+});
+let commandEncoder100 = device0.createCommandEncoder({});
+let texture102 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 2,
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView108 = texture12.createView({});
+let computePassEncoder83 = commandEncoder100.beginComputePass();
+try {
+computePassEncoder81.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder21.setIndexBuffer(buffer36, 'uint32', 0, 32);
+} catch {}
+let buffer62 = device0.createBuffer({size: 120, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let commandEncoder101 = device0.createCommandEncoder({});
+let computePassEncoder84 = commandEncoder26.beginComputePass();
+try {
+computePassEncoder29.setBindGroup(0, bindGroup30, new Uint32Array(1806), 1_806, 0);
+} catch {}
+try {
+computePassEncoder71.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder9.setBindGroup(3, bindGroup16);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(2, bindGroup29, new Uint32Array(79), 6, 0);
+} catch {}
+try {
+renderPassEncoder13.executeBundles([renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(6, undefined, 0);
+} catch {}
+let buffer63 = device0.createBuffer({size: 116, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM});
+let commandEncoder102 = device0.createCommandEncoder({});
+let computePassEncoder85 = commandEncoder101.beginComputePass();
+try {
+computePassEncoder76.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup32);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(0, bindGroup21, new Uint32Array(231), 70, 0);
+} catch {}
+try {
+  await buffer43.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+commandEncoder102.insertDebugMarker('\u57e8');
+} catch {}
+let computePassEncoder86 = commandEncoder102.beginComputePass();
+let renderBundleEncoder12 = device0.createRenderBundleEncoder({colorFormats: [undefined], depthReadOnly: true, stencilReadOnly: true});
+let sampler62 = device0.createSampler({
+  label: '\u0a33\u{1f95e}\u0798\u6676\u0859',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 89.36,
+});
+try {
+computePassEncoder85.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder22.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder7.setIndexBuffer(buffer56, 'uint16', 16, 37);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup30, new Uint32Array(2008), 47, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(0, buffer17, 12);
+} catch {}
+try {
+renderPassEncoder11.pushDebugGroup('\u7f99');
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(40).fill(217), /* required buffer size: 40 */
+{offset: 40}, {width: 50, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(14); };
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroups(4, 1); };
+} catch {}
+try {
+computePassEncoder83.setPipeline(pipeline1);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup12, new Uint32Array(2052), 34, 0);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(7, buffer2);
+} catch {}
+await gc();
+try {
+computePassEncoder37.label = '\u3b70\u0a5f';
+} catch {}
+let autogeneratedBindGroupLayout2 = pipeline2.getBindGroupLayout(0);
+let bindGroup51 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 1, resource: textureView6}]});
+let buffer64 = device0.createBuffer({
+  size: 212,
+  usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder103 = device0.createCommandEncoder({});
+let texture103 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder87 = commandEncoder103.beginComputePass();
+let sampler63 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'mirror-repeat',
+  addressModeW: 'clamp-to-edge',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 88.66,
+});
+let externalTexture9 = device0.importExternalTexture({source: videoFrame12});
+try {
+renderPassEncoder18.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder0.setScissorRect(24, 4, 13, 21);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup49, new Uint32Array(169), 1, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer55, 'uint32', 24, 12);
+} catch {}
+try {
+renderBundleEncoder12.setVertexBuffer(6, buffer5);
+} catch {}
+let texture104 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 35},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder87.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder15.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup41);
+} catch {}
+let texture105 = device0.createTexture({size: {width: 255}, dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+try {
+computePassEncoder51.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+computePassEncoder78.setBindGroup(1, bindGroup14, new Uint32Array(4673), 1_586, 0);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(0, bindGroup29, new Uint32Array(3156), 823, 0);
+} catch {}
+try {
+renderBundleEncoder12.setIndexBuffer(buffer23, 'uint16', 16, 130);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let bindGroup52 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout1,
+  entries: [{binding: 1, resource: externalTexture3}, {binding: 197, resource: sampler33}],
+});
+let texture106 = device0.createTexture({
+  size: [510, 1, 1],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder50.setBindGroup(0, bindGroup2);
+} catch {}
+try {
+renderPassEncoder11.executeBundles([renderBundle10, renderBundle10]);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(1, bindGroup38);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+  alphaMode: 'opaque',
+});
+} catch {}
+let commandEncoder104 = device0.createCommandEncoder();
+let renderPassEncoder25 = commandEncoder104.beginRenderPass({
+  colorAttachments: [{view: textureView39, depthSlice: 39, loadOp: 'clear', storeOp: 'store'}],
+  occlusionQuerySet: querySet9,
+});
+let sampler64 = device0.createSampler({addressModeU: 'mirror-repeat', mipmapFilter: 'nearest', lodMaxClamp: 97.77});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup43, []);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(2, bindGroup13, new Uint32Array(645), 179, 0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(2, bindGroup1);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup48);
+} catch {}
+let promise13 = device0.queue.onSubmittedWorkDone();
+let buffer65 = device0.createBuffer({size: 128, usage: GPUBufferUsage.UNIFORM});
+let commandEncoder105 = device0.createCommandEncoder({});
+let textureView109 = texture87.createView({baseMipLevel: 0});
+let renderPassEncoder26 = commandEncoder105.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 373.5, g: -64.15, b: -549.4, a: -646.3, },
+  loadOp: 'clear',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet17,
+});
+let sampler65 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'linear',
+  compare: 'equal',
+});
+try {
+computePassEncoder47.setBindGroup(2, bindGroup27);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup6);
+} catch {}
+try {
+renderPassEncoder22.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer9, 'uint32', 12, 0);
+} catch {}
+try {
+renderPassEncoder11.popDebugGroup();
+} catch {}
+let bindGroup53 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout4,
+  entries: [{binding: 1, resource: externalTexture2}, {binding: 197, resource: sampler9}],
+});
+let textureView110 = texture98.createView({dimension: '2d-array', aspect: 'all', arrayLayerCount: 1});
+let texture107 = device0.createTexture({
+  size: {width: 255, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 3,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup34);
+} catch {}
+try {
+computePassEncoder80.setBindGroup(3, bindGroup15, new Uint32Array(2117), 110, 0);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(2, buffer16, 0, 365);
+} catch {}
+try {
+renderBundleEncoder12.setBindGroup(3, bindGroup8);
+} catch {}
+let offscreenCanvas3 = new OffscreenCanvas(230, 49);
+let textureView111 = texture90.createView({});
+let renderBundle12 = renderBundleEncoder12.finish({});
+let sampler66 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'mirror-repeat',
+  minFilter: 'nearest',
+  lodMaxClamp: 99.51,
+});
+try {
+computePassEncoder13.end();
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup35, new Uint32Array(1666), 10, 0);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+buffer41.unmap();
+} catch {}
+try {
+computePassEncoder17.insertDebugMarker('\u529a');
+} catch {}
+let promise14 = device0.queue.onSubmittedWorkDone();
+let texture108 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 17},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let renderPassEncoder27 = commandEncoder10.beginRenderPass({
+  colorAttachments: [{
+  view: textureView107,
+  clearValue: { r: 930.6, g: -453.7, b: 493.4, a: 638.7, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 313015875,
+});
+let sampler67 = device0.createSampler({addressModeV: 'repeat', minFilter: 'nearest', lodMaxClamp: 62.12, compare: 'less-equal'});
+let externalTexture10 = device0.importExternalTexture({source: videoFrame10});
+try {
+computePassEncoder73.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder27.setIndexBuffer(buffer22, 'uint32', 0, 9);
+} catch {}
+try {
+renderPassEncoder25.setPipeline(pipeline5);
+} catch {}
+let promise15 = device0.queue.onSubmittedWorkDone();
+let commandEncoder106 = device0.createCommandEncoder({});
+let querySet18 = device0.createQuerySet({type: 'occlusion', count: 1644});
+let computePassEncoder88 = commandEncoder106.beginComputePass();
+try {
+computePassEncoder27.setBindGroup(1, bindGroup30, new Uint32Array(2561), 2_561, 0);
+} catch {}
+try {
+computePassEncoder86.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder19.setBindGroup(1, bindGroup9, []);
+} catch {}
+try {
+renderPassEncoder26.setIndexBuffer(buffer50, 'uint16', 4, 107);
+} catch {}
+try {
+renderPassEncoder4.setPipeline(pipeline5);
+} catch {}
+try {
+device0.pushErrorScope('internal');
+} catch {}
+let arrayBuffer2 = buffer43.getMappedRange(0, 0);
+try {
+computePassEncoder80.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup4, new Uint32Array(360), 81, 0);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -328.6, g: -281.6, b: -746.8, a: -833.4, });
+} catch {}
+try {
+renderPassEncoder14.setVertexBuffer(0, buffer28, 0);
+} catch {}
+let pipelineLayout11 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout6]});
+try {
+renderPassEncoder24.setBindGroup(0, bindGroup1);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup11, new Uint32Array(6335), 275, 0);
+} catch {}
+try {
+renderPassEncoder26.setBlendConstant({ r: 865.9, g: 404.4, b: 639.7, a: -505.4, });
+} catch {}
+try {
+renderPassEncoder13.setIndexBuffer(buffer56, 'uint32', 60, 8);
+} catch {}
+let promise16 = device0.queue.onSubmittedWorkDone();
+let buffer66 = device0.createBuffer({size: 626, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder107 = device0.createCommandEncoder({});
+let computePassEncoder89 = commandEncoder107.beginComputePass();
+let sampler68 = device0.createSampler({addressModeV: 'mirror-repeat', compare: 'equal'});
+try {
+computePassEncoder77.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderPassEncoder26.beginOcclusionQuery(369);
+} catch {}
+try {
+renderPassEncoder26.endOcclusionQuery();
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+gpuCanvasContext1.unconfigure();
+} catch {}
+let commandEncoder108 = device0.createCommandEncoder({});
+let computePassEncoder90 = commandEncoder108.beginComputePass();
+try {
+computePassEncoder82.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+try {
+computePassEncoder35.pushDebugGroup('\u799b');
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let recycledExplicitBindGroupLayout7 = pipeline6.getBindGroupLayout(0);
+let bindGroup54 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout5,
+  entries: [{binding: 1, resource: externalTexture0}, {binding: 197, resource: sampler55}],
+});
+let buffer67 = device0.createBuffer({size: 16, usage: GPUBufferUsage.COPY_SRC});
+let texture109 = device0.createTexture({
+  label: '\u91ba\ud5d3',
+  size: {width: 127, height: 1, depthOrArrayLayers: 978},
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let sampler69 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat'});
+try {
+computePassEncoder58.setBindGroup(0, bindGroup10, []);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.queue.writeBuffer(buffer32, 0, new DataView(new ArrayBuffer(4016)), 83, 20);
+} catch {}
+let bindGroup55 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture9}, {binding: 197, resource: sampler12}],
+});
+let sampler70 = device0.createSampler({
+  label: '\uf3f5\u0ee9\u0aa7\u81b3\u{1faee}\ucdf5',
+  addressModeV: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 91.99,
+});
+try {
+computePassEncoder90.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder1.setBindGroup(3, bindGroup10, []);
+} catch {}
+try {
+renderPassEncoder0.setBindGroup(0, bindGroup45, new Uint32Array(1161), 84, 0);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer40, 20);
+} catch {}
+try {
+computePassEncoder35.popDebugGroup();
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(102); };
+} catch {}
+let textureView112 = texture36.createView({mipLevelCount: 1});
+let sampler71 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 97.55,
+  compare: 'always',
+});
+try {
+computePassEncoder88.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder27.end();
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer12, 4);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer23, 16);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(5, buffer16);
+} catch {}
+let buffer68 = device0.createBuffer({
+  label: '\u3733\u0288\ue29f\u3054\u0cbc',
+  size: 56,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT,
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroupsIndirect(buffer56, 136); };
+} catch {}
+try {
+computePassEncoder89.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder25.setBindGroup(0, bindGroup33);
+} catch {}
+try {
+renderPassEncoder10.setBindGroup(2, bindGroup36, new Uint32Array(2975), 32, 0);
+} catch {}
+try {
+renderPassEncoder20.executeBundles([renderBundle9, renderBundle9, renderBundle9, renderBundle9, renderBundle9]);
+} catch {}
+try {
+renderPassEncoder0.draw(186, 35, 531_307_410, 767_671_740);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer7, 16);
+} catch {}
+try {
+renderPassEncoder19.setIndexBuffer(buffer23, 'uint16', 12, 29);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder0.setVertexBuffer(7, buffer13);
+} catch {}
+let commandEncoder109 = device0.createCommandEncoder({});
+let textureView113 = texture55.createView({});
+let renderBundleEncoder13 = device0.createRenderBundleEncoder({colorFormats: ['rgba8sint'], stencilReadOnly: true});
+try {
+{ clearResourceUsages(device0, computePassEncoder59); computePassEncoder59.dispatchWorkgroups(5); };
+} catch {}
+try {
+renderPassEncoder0.draw(146, 157, 88_867_865, 1_558_872_952);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer61, 52);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer6, 4);
+} catch {}
+try {
+renderPassEncoder22.setVertexBuffer(3, buffer28, 0, 0);
+} catch {}
+try {
+commandEncoder10.copyBufferToTexture({
+  /* bytesInLastRow: 14 widthInBlocks: 7 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1598 */
+  offset: 1598,
+  rowsPerImage: 525,
+  buffer: buffer16,
+}, {
+  texture: texture51,
+  mipLevel: 0,
+  origin: {x: 5, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 7, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer2, 4, new Uint32Array(9984), 203, 0);
+} catch {}
+let pipeline8 = device0.createComputePipeline({layout: 'auto', compute: {module: shaderModule3, constants: {}}});
+let gpuCanvasContext3 = offscreenCanvas3.getContext('webgpu');
+await gc();
+let autogeneratedBindGroupLayout3 = pipeline8.getBindGroupLayout(0);
+let texture110 = device0.createTexture({
+  size: {width: 64},
+  mipLevelCount: 1,
+  dimension: '1d',
+  format: 'rg11b10ufloat',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder91 = commandEncoder109.beginComputePass();
+try {
+computePassEncoder74.setBindGroup(1, bindGroup11);
+} catch {}
+try {
+renderPassEncoder17.setBindGroup(3, bindGroup8);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer34, 'uint16', 2, 9);
+} catch {}
+try {
+renderPassEncoder18.setPipeline(pipeline4);
+} catch {}
+let promise17 = device0.queue.onSubmittedWorkDone();
+try {
+  await promise17;
+} catch {}
+await gc();
+let computePassEncoder92 = commandEncoder10.beginComputePass();
+let sampler72 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'mirror-repeat',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 89.31,
+  compare: 'less',
+});
+try {
+computePassEncoder76.setBindGroup(0, bindGroup7);
+} catch {}
+try {
+computePassEncoder79.setPipeline(pipeline8);
+} catch {}
+try {
+renderPassEncoder0.draw(125, 180, 1_382_637_937, 54_472_827);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer23, 4);
+} catch {}
+try {
+renderPassEncoder0.drawIndirect(buffer61, 0);
+} catch {}
+try {
+renderPassEncoder26.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder22.insertDebugMarker('\u8f98');
+} catch {}
+let promise18 = device0.createComputePipelineAsync({layout: pipelineLayout10, compute: {module: shaderModule0}});
+let buffer69 = device0.createBuffer({size: 124, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT});
+let commandEncoder110 = device0.createCommandEncoder({});
+let computePassEncoder93 = commandEncoder110.beginComputePass();
+let renderBundle13 = renderBundleEncoder13.finish({});
+try {
+computePassEncoder17.setBindGroup(0, bindGroup47, []);
+} catch {}
+try {
+computePassEncoder59.setBindGroup(2, bindGroup0, new Uint32Array(1682), 101, 0);
+} catch {}
+try {
+computePassEncoder92.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder12.setStencilReference(25);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 35, 0, 791_797_970, 179_816_991);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline4);
+} catch {}
+try {
+renderPassEncoder24.setVertexBuffer(5, buffer2);
+} catch {}
+try {
+renderPassEncoder15.insertDebugMarker('\u{1ffc6}');
+} catch {}
+let buffer70 = device0.createBuffer({size: 200, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.VERTEX});
+let commandEncoder111 = device0.createCommandEncoder({});
+let texture111 = device0.createTexture({
+  size: [255, 1, 596],
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+});
+try {
+renderPassEncoder25.beginOcclusionQuery(191);
+} catch {}
+try {
+renderPassEncoder7.executeBundles([renderBundle11]);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer7, 0);
+} catch {}
+try {
+renderPassEncoder1.setIndexBuffer(buffer45, 'uint16', 4, 7);
+} catch {}
+try {
+commandEncoder111.copyBufferToBuffer(buffer67, 0, buffer35, 8, 0);
+} catch {}
+try {
+commandEncoder111.copyBufferToTexture({
+  /* bytesInLastRow: 510 widthInBlocks: 255 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4704 */
+  offset: 4704,
+  bytesPerRow: 17664,
+  rowsPerImage: 733,
+  buffer: buffer16,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {width: 255, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer60, 12, new Uint32Array(152), 32, 16);
+} catch {}
+let promise19 = device0.createComputePipelineAsync({layout: pipelineLayout7, compute: {module: shaderModule1, entryPoint: 'compute1', constants: {}}});
+await gc();
+let imageData12 = new ImageData(4, 36);
+let commandEncoder112 = device0.createCommandEncoder({});
+let texture112 = device0.createTexture({
+  size: [510, 1, 47],
+  dimension: '2d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder94 = commandEncoder112.beginComputePass();
+try {
+computePassEncoder74.setBindGroup(3, bindGroup42, new Uint32Array(1958), 521, 0);
+} catch {}
+try {
+computePassEncoder4.setPipeline(pipeline3);
+} catch {}
+try {
+computePassEncoder91.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder0.drawIndexed(0, 76, 0, 392_716_243, 945_264_965);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer9, 8);
+} catch {}
+try {
+commandEncoder111.copyTextureToBuffer({
+  texture: texture22,
+  mipLevel: 0,
+  origin: {x: 98, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 296 widthInBlocks: 37 aspectSpecificFormat.texelBlockSize: 8 */
+  /* end: 1208 */
+  offset: 1208,
+  bytesPerRow: 9984,
+  buffer: buffer16,
+}, {width: 37, height: 0, depthOrArrayLayers: 1});
+} catch {}
+let bindGroup56 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout9,
+  entries: [{binding: 6, resource: textureView88}, {binding: 0, resource: textureView89}],
+});
+let commandEncoder113 = device0.createCommandEncoder({});
+let computePassEncoder95 = commandEncoder111.beginComputePass();
+try {
+computePassEncoder22.setBindGroup(0, bindGroup52, new Uint32Array(295), 19, 0);
+} catch {}
+try {
+computePassEncoder95.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder4.setBindGroup(0, bindGroup35, new Uint32Array(230), 8, 0);
+} catch {}
+try {
+renderPassEncoder18.setScissorRect(6, 3, 26, 4);
+} catch {}
+try {
+renderPassEncoder0.drawIndexedIndirect(buffer62, 20);
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer20, 'uint16', 78, 10);
+} catch {}
+try {
+buffer49.unmap();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer20, 40, new Int16Array(5749), 559, 4);
+} catch {}
+let bindGroup57 = device0.createBindGroup({layout: recycledExplicitBindGroupLayout4, entries: [{binding: 1, resource: textureView6}]});
+let buffer71 = device0.createBuffer({size: 12, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.INDEX | GPUBufferUsage.UNIFORM});
+let commandEncoder114 = device0.createCommandEncoder({});
+let texture113 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 17},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  viewFormats: [],
+});
+let textureView114 = texture42.createView({});
+let renderPassEncoder28 = commandEncoder113.beginRenderPass({
+  colorAttachments: [{
+  view: textureView79,
+  depthSlice: 854,
+  clearValue: { r: 960.2, g: -10.53, b: -218.0, a: -239.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  maxDrawCount: 133452705,
+});
+let sampler73 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', lodMaxClamp: 76.71});
+try {
+computePassEncoder93.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder0.draw(380, 91, 902_842_626, 1_221_530_559);
+} catch {}
+try {
+renderPassEncoder0.setIndexBuffer(buffer50, 'uint16', 22, 16);
+} catch {}
+let pipeline9 = device0.createRenderPipeline({
+  layout: pipelineLayout10,
+  fragment: {module: shaderModule1, constants: {override7: 1}, targets: [{format: 'r16sint', writeMask: 0}]},
+  vertex: {
+    module: shaderModule3,
+    entryPoint: 'vertex3',
+    constants: {1_863: 1},
+    buffers: [{arrayStride: 1376, attributes: [{format: 'unorm8x2', offset: 644, shaderLocation: 12}]}],
+  },
+  primitive: {topology: 'point-list', cullMode: 'back'},
+});
+let texture114 = device0.createTexture({
+  size: {width: 64},
+  dimension: '1d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder96 = commandEncoder114.beginComputePass();
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup18);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup49, new Uint32Array(1560), 123, 0);
+} catch {}
+try {
+renderPassEncoder0.end();
+} catch {}
+try {
+commandEncoder24.copyBufferToTexture({
+  /* bytesInLastRow: 136 widthInBlocks: 34 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 1672 */
+  offset: 1672,
+  bytesPerRow: 15616,
+  buffer: buffer16,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 22, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 34, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageBitmap4 = await createImageBitmap(videoFrame6);
+let commandEncoder115 = device0.createCommandEncoder({});
+let querySet19 = device0.createQuerySet({type: 'occlusion', count: 453});
+let texture115 = device0.createTexture({
+  size: [63, 1, 79],
+  mipLevelCount: 2,
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rgba8sint'],
+});
+let textureView115 = texture109.createView({});
+let renderPassEncoder29 = commandEncoder24.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -954.3, g: 175.3, b: -895.8, a: -427.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder39.end();
+} catch {}
+try {
+renderPassEncoder25.endOcclusionQuery();
+} catch {}
+try {
+commandEncoder115.copyBufferToBuffer(buffer36, 4, buffer16, 6700, 48);
+} catch {}
+let textureView116 = texture106.createView({dimension: '2d-array', format: 'rgba8sint', mipLevelCount: 1});
+let renderPassEncoder30 = commandEncoder115.beginRenderPass({
+  label: '\u1ca6\u3e10\u8df2\u{1fff6}\uf951\u{1f649}\u0ee3\u2020\u{1ffde}\u4c6a\u{1fad6}',
+  colorAttachments: [{
+  view: textureView83,
+  clearValue: { r: -285.3, g: -922.1, b: -63.71, a: -373.5, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder2); computePassEncoder2.dispatchWorkgroupsIndirect(buffer62, 60); };
+} catch {}
+try {
+commandEncoder44.copyBufferToBuffer(buffer41, 0, buffer63, 4, 4);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer19, 28, new Uint32Array(10581), 1189, 0);
+} catch {}
+let commandEncoder116 = device0.createCommandEncoder({});
+let texture116 = device0.createTexture({
+  size: [510, 1, 40],
+  sampleCount: 1,
+  dimension: '2d',
+  format: 'r32float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+try {
+computePassEncoder94.setPipeline(pipeline6);
+} catch {}
+try {
+gpuCanvasContext3.unconfigure();
+} catch {}
+let videoFrame13 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'NV12',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'bt2020-cl', primaries: 'film', transfer: 'smpteSt4281'} });
+let buffer72 = device0.createBuffer({size: 134, usage: GPUBufferUsage.COPY_DST});
+let computePassEncoder97 = commandEncoder116.beginComputePass();
+try {
+computePassEncoder10.setBindGroup(2, bindGroup16, new Uint32Array(5612), 31, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(3, bindGroup38, new Uint32Array(5154), 384, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData10,
+  origin: { x: 4, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 29, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 30, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData13 = new ImageData(32, 76);
+let sampler74 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'mirror-repeat', lodMaxClamp: 76.84});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup43);
+} catch {}
+try {
+renderPassEncoder24.setBindGroup(3, bindGroup49);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup13, new Uint32Array(904), 145, 0);
+} catch {}
+try {
+commandEncoder44.copyBufferToTexture({
+  /* bytesInLastRow: 510 widthInBlocks: 255 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4988 */
+  offset: 4988,
+  bytesPerRow: 46080,
+  buffer: buffer16,
+}, {
+  texture: texture84,
+  mipLevel: 0,
+  origin: {x: 0, y: 0, z: 0},
+  aspect: 'depth-only',
+}, {width: 255, height: 1, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext1.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+globalThis.someLabel = externalTexture5.label;
+} catch {}
+let bindGroup58 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout7,
+  entries: [{binding: 197, resource: sampler63}, {binding: 1, resource: externalTexture4}],
+});
+let commandEncoder117 = device0.createCommandEncoder({});
+let renderPassEncoder31 = commandEncoder44.beginRenderPass({
+  colorAttachments: [{
+  view: textureView64,
+  clearValue: { r: -588.1, g: 65.57, b: -60.37, a: -603.5, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  occlusionQuerySet: querySet9,
+});
+try {
+computePassEncoder91.setBindGroup(0, bindGroup36, new Uint32Array(3268), 2_784, 0);
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+let texture117 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 1020},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder49.setBindGroup(0, bindGroup40);
+} catch {}
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer36);
+} catch {}
+try {
+querySet19.destroy();
+} catch {}
+let pipeline10 = await device0.createComputePipelineAsync({layout: pipelineLayout1, compute: {module: shaderModule2, entryPoint: 'compute4'}});
+let commandEncoder118 = device0.createCommandEncoder({});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup51);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(1, bindGroup41);
+} catch {}
+try {
+renderPassEncoder30.setIndexBuffer(buffer55, 'uint16', 30, 4);
+} catch {}
+try {
+commandEncoder117.copyBufferToBuffer(buffer14, 40, buffer20, 64, 16);
+} catch {}
+try {
+commandEncoder117.copyTextureToBuffer({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 28, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 194 widthInBlocks: 97 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1950 */
+  offset: 1950,
+  bytesPerRow: 17152,
+  buffer: buffer16,
+}, {width: 97, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder70.pushDebugGroup('\uc661');
+} catch {}
+let buffer73 = device0.createBuffer({size: 68, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.UNIFORM});
+let commandEncoder119 = device0.createCommandEncoder({});
+let texture118 = device0.createTexture({size: [63, 1, 6], format: 'rgba8sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder98 = commandEncoder118.beginComputePass();
+let sampler75 = device0.createSampler({addressModeV: 'mirror-repeat', addressModeW: 'repeat', mipmapFilter: 'nearest', lodMaxClamp: 86.91});
+try {
+computePassEncoder70.setBindGroup(1, bindGroup42, new Uint32Array(1010), 82, 0);
+} catch {}
+try {
+computePassEncoder2.end();
+} catch {}
+try {
+computePassEncoder56.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(0, bindGroup11, new Uint32Array(686), 50, 0);
+} catch {}
+try {
+commandEncoder117.resolveQuerySet(querySet9, 43, 2, buffer64, 0);
+} catch {}
+let pipeline11 = await promise19;
+let computePassEncoder99 = commandEncoder2.beginComputePass();
+let renderBundleEncoder14 = device0.createRenderBundleEncoder({colorFormats: ['rg8sint'], depthReadOnly: true});
+try {
+computePassEncoder69.setBindGroup(0, bindGroup20);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder6); computePassEncoder6.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder88.setPipeline(pipeline6);
+} catch {}
+try {
+computePassEncoder74.setPipeline(pipeline1);
+} catch {}
+try {
+renderPassEncoder23.setBindGroup(1, bindGroup6, new Uint32Array(559), 17, 0);
+} catch {}
+try {
+renderPassEncoder1.beginOcclusionQuery(292);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(2, buffer17, 0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup13);
+} catch {}
+try {
+commandEncoder44.label = '\uece1\u083c\u38e3\u3e40\u56e0\u{1fe8c}';
+} catch {}
+let textureView117 = texture109.createView({});
+let computePassEncoder100 = commandEncoder117.beginComputePass();
+try {
+computePassEncoder97.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder13.setBindGroup(3, bindGroup41, new Uint32Array(407), 91, 0);
+} catch {}
+try {
+renderPassEncoder1.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder12.setVertexBuffer(4, buffer28, 0);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(0, bindGroup27, []);
+} catch {}
+try {
+renderBundleEncoder14.setBindGroup(2, bindGroup46, new Uint32Array(2106), 286, 0);
+} catch {}
+try {
+commandEncoder119.copyTextureToTexture({
+  texture: texture46,
+  mipLevel: 0,
+  origin: {x: 13, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture56,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let imageData14 = new ImageData(8, 44);
+let commandEncoder120 = device0.createCommandEncoder({});
+let textureView118 = texture71.createView({dimension: 'cube-array', mipLevelCount: 1, baseArrayLayer: 0, arrayLayerCount: 6});
+let renderBundle14 = renderBundleEncoder14.finish({});
+try {
+computePassEncoder6.setBindGroup(0, bindGroup43, new Uint32Array(1719), 3, 0);
+} catch {}
+try {
+computePassEncoder98.setPipeline(pipeline10);
+} catch {}
+try {
+buffer5.unmap();
+} catch {}
+try {
+  await device0.queue.onSubmittedWorkDone();
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(34); };
+} catch {}
+let buffer74 = device0.createBuffer({size: 168, usage: GPUBufferUsage.VERTEX, mappedAtCreation: false});
+let textureView119 = texture23.createView({});
+let renderPassEncoder32 = commandEncoder120.beginRenderPass({
+  colorAttachments: [{
+  view: textureView98,
+  clearValue: { r: 484.8, g: 178.7, b: 798.4, a: -949.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 44434827,
+});
+try {
+computePassEncoder6.end();
+} catch {}
+try {
+device0.queue.writeBuffer(buffer72, 4, new Uint32Array(2426), 172, 0);
+} catch {}
+let veryExplicitBindGroupLayout12 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'storage', hasDynamicOffset: true }},
+    {binding: 3, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform', hasDynamicOffset: true }},
+    {
+      binding: 762,
+      visibility: GPUShaderStage.COMPUTE,
+      buffer: { type: 'storage', minBindingSize: 39, hasDynamicOffset: false },
+    },
+  ],
+});
+let commandEncoder121 = device0.createCommandEncoder({});
+let texture119 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 14},
+  sampleCount: 1,
+  dimension: '3d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.STORAGE_BINDING,
+});
+let computePassEncoder101 = commandEncoder119.beginComputePass();
+try {
+computePassEncoder59.end();
+} catch {}
+try {
+renderPassEncoder26.setScissorRect(2, 9, 8, 21);
+} catch {}
+try {
+renderPassEncoder9.setIndexBuffer(buffer6, 'uint32', 0, 5);
+} catch {}
+try {
+buffer6.unmap();
+} catch {}
+try {
+commandEncoder70.copyBufferToTexture({
+  /* bytesInLastRow: 76 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 864 */
+  offset: 864,
+  buffer: buffer16,
+}, {
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 66, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder70.popDebugGroup();
+} catch {}
+let recycledExplicitBindGroupLayout8 = pipeline10.getBindGroupLayout(0);
+let pipelineLayout12 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout12]});
+let buffer75 = device0.createBuffer({size: 504, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.UNIFORM});
+let texture120 = device0.createTexture({
+  size: [127, 1, 29],
+  mipLevelCount: 3,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_SRC,
+});
+let textureView120 = texture116.createView({dimension: '2d', baseMipLevel: 0, baseArrayLayer: 19});
+let renderPassEncoder33 = commandEncoder121.beginRenderPass({
+  colorAttachments: [{
+  view: textureView90,
+  depthSlice: 116,
+  clearValue: { r: -726.1, g: -833.0, b: -83.66, a: 292.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder69); computePassEncoder69.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder69.end();
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(7, buffer40, 0, 9);
+} catch {}
+try {
+gpuCanvasContext0.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.COPY_SRC, alphaMode: 'premultiplied'});
+} catch {}
+let autogeneratedBindGroupLayout4 = pipeline3.getBindGroupLayout(0);
+let bindGroup59 = device0.createBindGroup({layout: veryExplicitBindGroupLayout7, entries: [{binding: 1, resource: textureView0}]});
+let commandEncoder122 = device0.createCommandEncoder();
+let texture121 = device0.createTexture({size: [510], dimension: '1d', format: 'r16sint', usage: GPUTextureUsage.TEXTURE_BINDING});
+let computePassEncoder102 = commandEncoder56.beginComputePass();
+let renderPassEncoder34 = commandEncoder122.beginRenderPass({
+  colorAttachments: [{view: textureView115, depthSlice: 25, loadOp: 'load', storeOp: 'discard'}],
+  maxDrawCount: 355484026,
+});
+let sampler76 = device0.createSampler({lodMaxClamp: 69.29});
+try {
+renderPassEncoder10.setVertexBuffer(3, buffer60);
+} catch {}
+try {
+buffer56.unmap();
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'display-p3',
+});
+} catch {}
+let buffer76 = device0.createBuffer({size: 480, usage: GPUBufferUsage.INDEX | GPUBufferUsage.QUERY_RESOLVE});
+let texture122 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder103 = commandEncoder5.beginComputePass();
+let renderPassEncoder35 = commandEncoder70.beginRenderPass({
+  colorAttachments: [{view: textureView83, loadOp: 'load', storeOp: 'discard'}],
+  occlusionQuerySet: querySet12,
+});
+let sampler77 = device0.createSampler({
+  addressModeV: 'clamp-to-edge',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+  lodMaxClamp: 83.85,
+  maxAnisotropy: 13,
+});
+try {
+computePassEncoder101.setPipeline(pipeline0);
+} catch {}
+try {
+renderPassEncoder35.setBindGroup(3, bindGroup59);
+} catch {}
+try {
+renderPassEncoder26.executeBundles([renderBundle11, renderBundle1]);
+} catch {}
+let pipelineLayout13 = device0.createPipelineLayout({bindGroupLayouts: [veryExplicitBindGroupLayout9]});
+let textureView121 = texture50.createView({aspect: 'all'});
+try {
+renderPassEncoder25.end();
+} catch {}
+try {
+renderPassEncoder14.setBlendConstant({ r: -966.4, g: -599.0, b: -135.0, a: -536.5, });
+} catch {}
+try {
+globalThis.someLabel = externalTexture10.label;
+} catch {}
+let buffer77 = device0.createBuffer({
+  label: '\u91cd\u8dcf\u0e29\u{1f628}\u96af\u{1f9fc}\u{1f684}\u{1f6cf}\ud5cf',
+  size: 264,
+  usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+});
+let texture123 = device0.createTexture({
+  size: [127],
+  sampleCount: 1,
+  dimension: '1d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let computePassEncoder104 = commandEncoder104.beginComputePass();
+try {
+computePassEncoder22.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer69, 'uint16', 12, 29);
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture97,
+  mipLevel: 0,
+  origin: {x: 42, y: 0, z: 0},
+  aspect: 'all',
+}, new Uint8Array(308).fill(13), /* required buffer size: 308 */
+{offset: 308}, {width: 44, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(18); };
+} catch {}
+let texture124 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 1},
+  format: 'rg8unorm',
+  usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: [],
+});
+let texture125 = device0.createTexture({size: [255, 1, 1], format: 'rgba8sint', usage: GPUTextureUsage.COPY_SRC, viewFormats: []});
+try {
+computePassEncoder103.setPipeline(pipeline7);
+} catch {}
+let texture126 = device0.createTexture({
+  label: '\u7592\u{1f89c}\u3293\u8a8b\udf05\uaa8c\u8853\u{1ffa7}\u0d06\u0214',
+  size: {width: 255, height: 1, depthOrArrayLayers: 19},
+  mipLevelCount: 1,
+  dimension: '2d',
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let textureView122 = texture101.createView({dimension: '2d', mipLevelCount: 1, baseArrayLayer: 8});
+try {
+computePassEncoder76.setBindGroup(1, bindGroup37, new Uint32Array(1406), 352, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder41); computePassEncoder41.dispatchWorkgroupsIndirect(buffer53, 8); };
+} catch {}
+try {
+computePassEncoder99.setPipeline(pipeline2);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup31);
+} catch {}
+try {
+renderPassEncoder16.setScissorRect(2, 0, 12, 5);
+} catch {}
+try {
+renderPassEncoder24.setIndexBuffer(buffer9, 'uint16', 0, 12);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(0, buffer17, 24, 38);
+} catch {}
+try {
+device0.queue.writeBuffer(buffer0, 0, new DataView(new ArrayBuffer(829)), 109, 0);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(2, bindGroup28);
+} catch {}
+try {
+renderPassEncoder20.setBindGroup(2, bindGroup47, new Uint32Array(509), 83, 0);
+} catch {}
+try {
+renderPassEncoder7.setVertexBuffer(6, buffer17, 96, 17);
+} catch {}
+let veryExplicitBindGroupLayout13 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 23,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rgba8sint', access: 'read-only', viewDimension: '1d' },
+    },
+    {
+      binding: 205,
+      visibility: GPUShaderStage.VERTEX,
+      storageTexture: { format: 'rg32uint', access: 'read-only', viewDimension: '2d-array' },
+    },
+  ],
+});
+try {
+computePassEncoder41.end();
+} catch {}
+try {
+computePassEncoder84.setPipeline(pipeline7);
+} catch {}
+try {
+renderPassEncoder19.setVertexBuffer(0, buffer70, 20, 10);
+} catch {}
+try {
+commandEncoder45.copyTextureToBuffer({
+  texture: texture42,
+  mipLevel: 0,
+  origin: {x: 26, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1798 */
+  offset: 1798,
+  buffer: buffer16,
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+if (!arrayBuffer0.detached) { new Uint8Array(arrayBuffer0).fill(55); };
+} catch {}
+let buffer78 = device0.createBuffer({size: 284, usage: GPUBufferUsage.INDEX | GPUBufferUsage.INDIRECT, mappedAtCreation: false});
+let commandEncoder123 = device0.createCommandEncoder({});
+let textureView123 = texture61.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+computePassEncoder104.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder16.executeBundles([renderBundle13]);
+} catch {}
+try {
+renderPassEncoder10.setBlendConstant({ r: -366.1, g: -338.7, b: 602.1, a: -343.4, });
+} catch {}
+try {
+renderPassEncoder30.setVertexBuffer(5, buffer3);
+} catch {}
+let pipeline12 = await promise18;
+try {
+  await promise14;
+} catch {}
+let buffer79 = device0.createBuffer({size: 40, usage: GPUBufferUsage.UNIFORM});
+let computePassEncoder105 = commandEncoder123.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder29); computePassEncoder29.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder102.setPipeline(pipeline3);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(3, bindGroup53);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer76, 'uint16', 78, 1);
+} catch {}
+try {
+renderPassEncoder1.setPipeline(pipeline5);
+} catch {}
+try {
+renderPassEncoder15.setVertexBuffer(3, buffer13, 0, 58);
+} catch {}
+try {
+commandEncoder45.copyBufferToTexture({
+  /* bytesInLastRow: 226 widthInBlocks: 113 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 4262 */
+  offset: 4262,
+  bytesPerRow: 27648,
+  buffer: buffer16,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 25, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 113, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+commandEncoder45.copyTextureToTexture({
+  texture: texture83,
+  mipLevel: 1,
+  origin: {x: 2, y: 1, z: 18},
+  aspect: 'all',
+},
+{
+  texture: texture27,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba8unorm', usage: GPUTextureUsage.COPY_DST});
+} catch {}
+let shaderModule5 = device0.createShaderModule({
+  code: `
+diagnostic(info, xyz);
+
+requires pointer_composite_access;
+
+enable f16;
+
+struct T0 {
+  @align(8) @size(8) f0: array<u32>,
+}
+
+fn unconst_i32(v: i32) -> i32 { return v; }
+
+/* zero global variables used */
+fn fn4(a0: ptr<function, VertexOutput4>) {
+  if bool((vec4u(unconst_u32(933909282), unconst_u32(2023763554), unconst_u32(222173942), unconst_u32(407273721)) ^ vec4u(unconst_u32(141903103), unconst_u32(2362781381), unconst_u32(208176258), unconst_u32(79349611))).x) {
+  while bool(faceForward(vec2h(unconst_f16(21759.0), unconst_f16(-8716.3)), vec2h(unconst_f16(4584.2), unconst_f16(-6991.3)), vec2h(unconst_f16(9651.6), unconst_f16(-336.6))).y) {
+  var vf60: vec4f = unpack4x8unorm(unconst_u32(213607576));
+  let vf61: vec3f = inverseSqrt(vec3f(unconst_f32(0.3136), unconst_f32(0.02273), unconst_f32(0.1677e-6)));
+}
+  loop {
+  let vf62: vec2f = (vec2f(unconst_f32(0.05871e-2), unconst_f32(0.2831e30)) / unconst_f32(0.06635e-37));
+  break;
+}
+  let vf63: u32 = pack2x16snorm(vec2f(unconst_f32(0.00966e24), unconst_f32(0.03714e-33)));
+  (*a0).f16 = (*a0).f16;
+}
+  vp44 = VertexOutput4(vec4f((*a0).f16[unconst_u32(458281456)]));
+  switch vec4i((vec4u(unconst_u32(373877525), unconst_u32(515834094), unconst_u32(639094613), unconst_u32(52391971)) ^ vec4u(unconst_u32(49149446), unconst_u32(412525549), unconst_u32(1302992795), unconst_u32(57301902))))[2] { 
+  default {
+  (*a0).f16 -= cross(vec3f(unconst_f32(0.1009), unconst_f32(0.5153e-11), unconst_f32(0.7369e-45)), (*a0).f16.bab).yxzy;
+  break;
+}
+  }
+  let ptr29: ptr<function, VertexOutput4> = &(*a0);
+  (*a0).f16 = vec4f(asinh(vec3h(unconst_f16(27285.6), unconst_f16(3802.4), unconst_f16(21007.4))).brgb.wzzx.agab);
+  var vf64: vec3f = ldexp(vec3f(unconst_f32(0.01142), unconst_f32(0.2191), unconst_f32(0.1261e-12)), vec3i(i32((*a0).f16[unconst_u32(210741102)])));
+  let ptr30: ptr<function, vec4f> = &(*a0).f16;
+  vf64 = vp44.f16.bra;
+  return;
+}
+
+struct FragmentOutput5 {
+  @location(0) @interpolate(flat, center) f0: vec4i,
+  @location(1) @interpolate(flat) f1: i32,
+}
+
+struct T6 {
+  f0: T2,
+}
+
+struct T2 {
+  @align(4) f0: bool,
+}
+
+/* zero global variables used */
+fn fn0(a0: sampler) -> T6 {
+  var out: T6;
+  let ptr26: ptr<private, vec4f> = &vp44.f16;
+  vp44 = VertexOutput4(cross(vec3f(unconst_f32(0.05342), unconst_f32(-0.1418e35), unconst_f32(0.04845)), vec3f(unconst_f32(0.2490), unconst_f32(0.05899), unconst_f32(0.2085))).yxxy);
+  vp44.f16 += cos(vec4f(unconst_f32(0.1024), unconst_f32(-0.03223), unconst_f32(0.00710e32), unconst_f32(0.07154e-30)));
+  out = T6(T2(bool(dot(vec2f(unconst_f32(0.01788e9), unconst_f32(0.3567e-4)), vec2f(unconst_f32(0.1506), unconst_f32(0.04124))))));
+  return out;
+}
+
+/* zero global variables used */
+fn fn2() {
+  loop {
+  vp44.f16 = unpack4x8snorm(pack2x16float(vec2f(unconst_f32(0.1306), unconst_f32(0.3325))));
+  break;
+}
+}
+
+struct VertexOutput5 {
+  @location(2) @interpolate(linear) f17: f16,
+  @location(0) @interpolate(flat, center) f18: vec4h,
+  @builtin(position) f19: vec4f,
+  @location(13) f20: f16,
+}
+
+@group(0) @binding(1) var et3: texture_external;
+
+var<private> vp44: VertexOutput4 = VertexOutput4(vec4f(0.1869, 0.06844e-10, -0.3691, 0.4662));
+
+fn unconst_f16(v: f16) -> f16 { return v; }
+
+fn unconst_u32(v: u32) -> u32 { return v; }
+
+/* used global variables: sam3 */
+fn fn5(a0: i32, a1: texture_external) {
+  let vf65: bool = (bool(ldexp(vec2f(unconst_f32(0.4634), unconst_f32(-0.2021e29)), vec2i(unconst_i32(86432995), unconst_i32(326577167)))[1]) || unconst_bool(false));
+  var vf66 = fn0(sam3);
+  vf66 = T6(T2(vf66.f0.f0));
+  vp44.f16 = vec4f(vec4f(unconst_f32(0.1079e-10), unconst_f32(-0.1648e-32), unconst_f32(0.04540e-29), unconst_f32(0.1853e25)));
+  _ = sam3;
+}
+
+/* zero global variables used */
+fn fn1(a0: ptr<function, array<T6, 1>>) {
+  if (*a0)[0].f0.f0 {
+  let ptr27: ptr<private, VertexOutput4> = &vp44;
+  var vf59: vec2h = asin(vec2h(unconst_f16(8375.3), unconst_f16(12729.1)));
+  (*a0)[unconst_u32(299549693)].f0.f0 = (*a0)[0].f0.f0;
+  switch bitcast<vec2i>(tan(vp44.f16.wy).gr).y { 
+  default {
+  (*a0)[u32((unconst_f32(0.2478) >= unconst_f32(0.03748)))].f0.f0 = bool(ceil(vec2h(unconst_f16(1713.8), unconst_f16(384.0))).r);
+  break;
+}
+  }
+  (*a0)[u32((*a0)[0].f0.f0)].f0.f0 = (*a0)[unconst_u32(706382727)].f0.f0;
+  loop {
+  break;
+}
+}
+  (*a0)[unconst_u32(686675033)] = T6(T2((*a0)[vec3u(reflect(vec3h(f16((*a0)[0].f0.f0)), vec3h(unconst_f16(11031.8), unconst_f16(2129.5), unconst_f16(11634.0)))).z].f0.f0));
+  (*a0)[unconst_u32(4498505)].f0.f0 = (*a0)[unconst_u32(123757026)].f0.f0;
+  let ptr28: ptr<private, vec4f> = &vp44.f16;
+  return;
+}
+
+/* zero global variables used */
+@must_use 
+fn fn3() -> VertexOutput5 {
+  var out: VertexOutput5;
+  out.f18 += vec4h(extractBits(vec3i(unconst_i32(298896626), unconst_i32(77477643), unconst_i32(684419685)), unconst_u32(53355795), unconst_u32(142490)).brgg.zxxx);
+  out.f18 = vec4h(f16(pack4xU8(vec4u(unconst_u32(567367896), unconst_u32(416727190), unconst_u32(584561623), unconst_u32(439084716)))));
+  return out;
+}
+
+struct VertexOutput4 {
+  @invariant @builtin(position) f16: vec4f,
+}
+
+struct T3 {
+  @size(1024) f0: T2,
+}
+
+struct T4 {
+  @size(32) f0: T0,
+}
+
+fn unconst_bool(v: bool) -> bool { return v; }
+
+struct T1 {
+  @align(32) @size(224) f0: array<u32>,
+}
+
+@group(0) @binding(197) var sam3: sampler;
+
+fn unconst_f32(v: f32) -> f32 { return v; }
+
+struct T5 {
+  @align(32) @size(480) f0: atomic<u32>,
+  @size(960) f1: array<atomic<u32>>,
+}
+
+/* used global variables: et3, sam3 */
+@vertex
+fn vertex5(@location(10) @interpolate(linear) a0: f32) -> VertexOutput4 {
+  var out: VertexOutput4;
+  _ = et3;
+  out.f16 = bitcast<vec4f>(textureDimensions(et3).xyyx.abrg);
+  out.f16 -= vec4f(floor(unconst_f32(0.1723e-6)));
+  if bool(textureDimensions(et3)[1]) {
+  out.f16 = textureSampleBaseClampToEdge(et3, sam3, vec2f(unconst_f32(0.5929), unconst_f32(0.4741e-9)));
+  _ = sam3;
+  _ = et3;
+}
+  return out;
+  _ = sam3;
+  _ = et3;
+}
+
+/* used global variables: sam3 */
+@vertex
+fn vertex6(@location(6) @interpolate(flat) a0: f32, @location(3) @interpolate(flat, first) a1: i32) -> VertexOutput5 {
+  var out: VertexOutput5;
+  out.f17 = vec4h((vec4h(unconst_f16(5401.4), unconst_f16(-4965.5), unconst_f16(42822.3), unconst_f16(30605.3)) <= vec4h(unconst_f16(47590.3), unconst_f16(9403.1), unconst_f16(32559.7), unconst_f16(12896.6))))[0];
+  out.f18 += vec4h(vp44.f16);
+  loop {
+  fn2();
+  out.f20 -= f16(a1);
+  var vf67: i32 = a1;
+  _ = sam3;
+  vp44.f16 = vec4f(vp44.f16[unconst_u32(610058886)]);
+  while bool(determinant(mat4x4f(unconst_f32(0.1148), unconst_f32(0.1394), unconst_f32(0.5940e25), unconst_f32(0.2874e7), unconst_f32(0.1939), unconst_f32(0.00395e9), unconst_f32(0.01448e20), unconst_f32(0.1458e5), unconst_f32(0.3372), unconst_f32(0.05623e-13), unconst_f32(0.1517), unconst_f32(0.07800), unconst_f32(0.04532e31), unconst_f32(0.06392e-24), unconst_f32(0.1679e-17), unconst_f32(0.05585)))) {
+  out.f20 -= degrees(vec2h(unpack4xI8(unconst_u32(20510265)).gb.gr)).x;
+  let vf68: i32 = a1;
+  var vf69: vec4<bool> = (vec4f(unconst_f32(0.09749e-43), unconst_f32(0.1583e-12), unconst_f32(0.2147), unconst_f32(0.2769e-27)) >= vec4f(unconst_f32(0.1423), unconst_f32(-0.3294), unconst_f32(0.1630), unconst_f32(0.3369e-8)));
+  out.f20 = vec4h(vp44.f16).z;
+  break;
+}
+  break;
+  _ = sam3;
+}
+  vp44.f16 *= vec4f(bitcast<f32>(a1));
+  out.f18 = vec4h(atan(vec4f(unconst_f32(0.00227e-34), unconst_f32(0.1447), unconst_f32(0.5177e-10), unconst_f32(0.1118e-37))));
+  return out;
+  _ = sam3;
+}
+
+/* zero global variables used */
+@fragment
+fn fragment5() -> FragmentOutput5 {
+  var out: FragmentOutput5;
+  vp44.f16 = unpack2x16unorm(unconst_u32(3131257159)).yyyy;
+  out.f0 = vec4i(step(vec4h(unconst_f16(6382.6), unconst_f16(5581.6), unconst_f16(5768.0), unconst_f16(10510.2)), vec4h(unconst_f16(3406.6), unconst_f16(33757.1), unconst_f16(10010.8), unconst_f16(-1546.2))).zxyz.bbbg);
+  return out;
+}
+
+/* used global variables: et3, sam3 */
+@compute @workgroup_size(2, 1, 1)
+fn compute7() {
+  vp44.f16 = textureSampleBaseClampToEdge(et3, sam3, vec2f(unconst_f32(-0.5830e35), unconst_f32(0.05548e17)));
+  var vf70 = fn3();
+  vp44 = VertexOutput4(vec4f(f32(insertBits(vec4i(sin(vec4h(unconst_f16(6176.8), unconst_f16(6724.3), unconst_f16(-32171.1), unconst_f16(14347.3))))[0], unconst_i32(35252492), unconst_u32(141392331), unconst_u32(169012482)))));
+  vp44.f16 += vec4f(vf70.f18.wwyy);
+  _ = fn3();
+  _ = sam3;
+  _ = et3;
+}`,
+});
+let buffer80 = device0.createBuffer({
+  size: 36,
+  usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.STORAGE | GPUBufferUsage.UNIFORM,
+});
+let commandEncoder124 = device0.createCommandEncoder({label: '\u{1fe39}\u{1fe62}\u{1fbc1}\u7ccb\u7ace\u0ba5\u01d1\u2f2c\u954f'});
+let texture127 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 8},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView124 = texture45.createView({mipLevelCount: 1});
+let computePassEncoder106 = commandEncoder124.beginComputePass();
+try {
+computePassEncoder84.setBindGroup(2, bindGroup41, []);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(3, bindGroup16, new Uint32Array(983), 95, 0);
+} catch {}
+try {
+renderPassEncoder12.setBindGroup(2, bindGroup6, new Uint32Array(1497), 113, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 0, 1, -1_771_456_001);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer68, 4);
+} catch {}
+try {
+device0.queue.submit([]);
+} catch {}
+let textureView125 = texture111.createView({format: 'rgba8sint'});
+let renderPassEncoder36 = commandEncoder45.beginRenderPass({
+  colorAttachments: [{
+  view: textureView22,
+  clearValue: { r: 646.7, g: 651.2, b: 138.2, a: -784.0, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet3,
+});
+let sampler78 = device0.createSampler({
+  addressModeU: 'mirror-repeat',
+  addressModeV: 'repeat',
+  addressModeW: 'mirror-repeat',
+  magFilter: 'nearest',
+  minFilter: 'linear',
+  lodMaxClamp: 98.98,
+});
+try {
+computePassEncoder97.setBindGroup(0, bindGroup22);
+} catch {}
+try {
+computePassEncoder88.setBindGroup(1, bindGroup59, new Uint32Array(1433), 227, 0);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder22); computePassEncoder22.dispatchWorkgroups(1); };
+} catch {}
+try {
+computePassEncoder100.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder16.setBindGroup(3, bindGroup42);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle9, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder35.setIndexBuffer(buffer78, 'uint32', 96, 11);
+} catch {}
+let bindGroup60 = device0.createBindGroup({layout: autogeneratedBindGroupLayout3, entries: [{binding: 762, resource: {buffer: buffer63}}]});
+let commandEncoder125 = device0.createCommandEncoder({});
+let texture128 = device0.createTexture({
+  size: {width: 127, height: 1, depthOrArrayLayers: 1},
+  mipLevelCount: 1,
+  format: 'rg8sint',
+  usage: GPUTextureUsage.TEXTURE_BINDING,
+  viewFormats: ['rg8sint'],
+});
+try {
+computePassEncoder66.setBindGroup(1, bindGroup44);
+} catch {}
+try {
+computePassEncoder28.setBindGroup(0, bindGroup46, new Uint32Array(2137), 988, 0);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup60);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 0, 0, -2_038_380_857);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer68, 8);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer53, 16);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame7,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let textureView126 = texture85.createView({arrayLayerCount: 1});
+let texture129 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 57},
+  mipLevelCount: 4,
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder52.setBindGroup(3, bindGroup14);
+} catch {}
+try {
+{ clearResourceUsages(device0, computePassEncoder76); computePassEncoder76.dispatchWorkgroupsIndirect(buffer64, 16); };
+} catch {}
+try {
+computePassEncoder96.setPipeline(pipeline6);
+} catch {}
+try {
+renderPassEncoder36.setStencilReference(472);
+} catch {}
+try {
+renderPassEncoder1.draw(76, 0, 201_513_900, 0);
+} catch {}
+let computePassEncoder107 = commandEncoder125.beginComputePass();
+let sampler79 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeV: 'repeat',
+  mipmapFilter: 'nearest',
+  lodMinClamp: 44.15,
+  lodMaxClamp: 66.33,
+});
+try {
+computePassEncoder68.setBindGroup(1, bindGroup5, new Uint32Array(640), 33, 0);
+} catch {}
+try {
+computePassEncoder22.end();
+} catch {}
+try {
+computePassEncoder106.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder23.executeBundles([renderBundle13, renderBundle13]);
+} catch {}
+try {
+renderPassEncoder36.setViewport(34.1476830094679, 9.61206710620121, 27.840980387358826, 46.14948483074534, 0.5750981141294669, 0.8433552867987159);
+} catch {}
+try {
+renderPassEncoder1.draw(71, 0, 578_409_453);
+} catch {}
+try {
+renderPassEncoder1.drawIndexed(0, 0, 1, 346_233_205);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer53, 8);
+} catch {}
+try {
+device0.addEventListener('uncapturederror', e => { console.log('device0.uncapturederror'); console.log(e); e.label = device0.label; });
+} catch {}
+try {
+commandEncoder20.copyBufferToTexture({
+  /* bytesInLastRow: 58 widthInBlocks: 29 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1312 */
+  offset: 1312,
+  rowsPerImage: 1216,
+  buffer: buffer16,
+}, {
+  texture: texture67,
+  mipLevel: 0,
+  origin: {x: 33, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 29, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+computePassEncoder37.insertDebugMarker('\u0b13');
+} catch {}
+let bindGroup61 = device0.createBindGroup({
+  layout: autogeneratedBindGroupLayout4,
+  entries: [{binding: 762, resource: {buffer: buffer21, size: 40}}],
+});
+let commandEncoder126 = device0.createCommandEncoder({});
+let texture130 = gpuCanvasContext2.getCurrentTexture();
+let textureView127 = texture35.createView({label: '\ucdb4\ua70e', dimension: '2d', baseArrayLayer: 1});
+let computePassEncoder108 = commandEncoder20.beginComputePass();
+let renderPassEncoder37 = commandEncoder126.beginRenderPass({
+  colorAttachments: [{
+  view: textureView81,
+  depthSlice: 130,
+  clearValue: { r: 299.2, g: 249.8, b: 648.3, a: 706.9, },
+  loadOp: 'clear',
+  storeOp: 'discard',
+}],
+});
+try {
+computePassEncoder107.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(1, bindGroup17, new Uint32Array(4253), 977, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndirect(buffer64, 196);
+} catch {}
+try {
+renderPassEncoder11.setIndexBuffer(buffer55, 'uint32', 68, 0);
+} catch {}
+let buffer81 = device0.createBuffer({size: 892, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.MAP_WRITE});
+let commandEncoder127 = device0.createCommandEncoder({});
+let texture131 = device0.createTexture({
+  size: {width: 64, height: 64, depthOrArrayLayers: 209},
+  mipLevelCount: 5,
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+try {
+computePassEncoder40.setBindGroup(0, bindGroup34);
+} catch {}
+try {
+computePassEncoder105.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder11.setBindGroup(2, bindGroup9, new Uint32Array(2845), 763, 0);
+} catch {}
+try {
+renderPassEncoder1.drawIndexedIndirect(buffer1, 20);
+} catch {}
+try {
+renderPassEncoder23.setIndexBuffer(buffer54, 'uint32', 0, 4);
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(3, buffer70, 0, 9);
+} catch {}
+try {
+commandEncoder127.copyTextureToTexture({
+  texture: texture101,
+  mipLevel: 0,
+  origin: {x: 6, y: 0, z: 26},
+  aspect: 'all',
+},
+{
+  texture: texture89,
+  mipLevel: 0,
+  origin: {x: 19, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 17, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let pipeline13 = await device0.createComputePipelineAsync({layout: pipelineLayout0, compute: {module: shaderModule1, entryPoint: 'compute2', constants: {}}});
+let computePassEncoder109 = commandEncoder127.beginComputePass();
+let sampler80 = device0.createSampler({
+  label: '\u8624\u2c6b\u0f37\u94aa\u0faf\u0b19\uad38\u0d39\ue986',
+  addressModeV: 'repeat',
+  minFilter: 'nearest',
+  lodMinClamp: 45.15,
+  lodMaxClamp: 70.00,
+});
+try {
+computePassEncoder74.setBindGroup(0, bindGroup29);
+} catch {}
+try {
+computePassEncoder107.setBindGroup(1, bindGroup58, new Uint32Array(192), 96, 0);
+} catch {}
+try {
+renderPassEncoder14.setBindGroup(3, bindGroup57);
+} catch {}
+try {
+renderPassEncoder1.end();
+} catch {}
+try {
+renderPassEncoder20.setVertexBuffer(6, buffer17, 0, 84);
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST,
+  colorSpace: 'srgb',
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture87,
+  mipLevel: 0,
+  origin: {x: 8, y: 0, z: 8},
+  aspect: 'all',
+}, new Uint8Array(2_832).fill(106), /* required buffer size: 2_832 */
+{offset: 192, bytesPerRow: 132, rowsPerImage: 20}, {width: 19, height: 0, depthOrArrayLayers: 2});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: imageData3,
+  origin: { x: 23, y: 0 },
+  flipY: false,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder128 = device0.createCommandEncoder({});
+let texture132 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 1},
+  format: 'rgba8sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.STORAGE_BINDING,
+  viewFormats: [],
+});
+let renderPassEncoder38 = commandEncoder28.beginRenderPass({
+  colorAttachments: [{
+  view: textureView39,
+  depthSlice: 6,
+  clearValue: { r: -150.8, g: 895.2, b: 477.6, a: 14.34, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+  maxDrawCount: 793518862,
+});
+try {
+computePassEncoder19.setBindGroup(3, bindGroup41);
+} catch {}
+try {
+computePassEncoder63.setBindGroup(3, bindGroup13, new Uint32Array(2355), 346, 0);
+} catch {}
+try {
+computePassEncoder79.end();
+} catch {}
+try {
+computePassEncoder109.setPipeline(pipeline8);
+} catch {}
+try {
+commandEncoder128.copyTextureToBuffer({
+  texture: texture124,
+  mipLevel: 0,
+  origin: {x: 195, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 22 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1676 */
+  offset: 1676,
+  bytesPerRow: 16640,
+  buffer: buffer16,
+}, {width: 22, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise12;
+} catch {}
+let imageData15 = new ImageData(204, 12);
+let veryExplicitBindGroupLayout14 = device0.createBindGroupLayout({
+  entries: [
+    {
+      binding: 0,
+      visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.VERTEX,
+      texture: { viewDimension: '2d', sampleType: 'depth', multisampled: false },
+    },
+  ],
+});
+let commandEncoder129 = device0.createCommandEncoder({});
+try {
+computePassEncoder18.setBindGroup(0, bindGroup35);
+} catch {}
+try {
+computePassEncoder108.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder34.setBindGroup(1, bindGroup12);
+} catch {}
+try {
+renderPassEncoder29.setBindGroup(2, bindGroup44, new Uint32Array(775), 54, 0);
+} catch {}
+try {
+renderPassEncoder21.setVertexBuffer(6, undefined, 2_144_830_642, 77_044_192);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame9,
+  origin: { x: 0, y: 0 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: true,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture133 = device0.createTexture({
+  size: {width: 510, height: 1, depthOrArrayLayers: 379},
+  mipLevelCount: 2,
+  dimension: '3d',
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT,
+});
+let textureView128 = texture25.createView({dimension: '2d', aspect: 'all', mipLevelCount: 1, baseArrayLayer: 8});
+let renderPassEncoder39 = commandEncoder98.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  depthSlice: 216,
+  clearValue: { r: 104.5, g: -112.4, b: 967.8, a: 106.1, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+computePassEncoder14.setBindGroup(1, bindGroup15);
+} catch {}
+try {
+computePassEncoder4.setBindGroup(0, bindGroup24, new Uint32Array(368), 162, 0);
+} catch {}
+try {
+computePassEncoder76.end();
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(44);
+} catch {}
+try {
+renderPassEncoder36.executeBundles([renderBundle1]);
+} catch {}
+try {
+renderPassEncoder33.setPipeline(pipeline9);
+} catch {}
+try {
+gpuCanvasContext0.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC,
+  alphaMode: 'opaque',
+});
+} catch {}
+let promise20 = device0.queue.onSubmittedWorkDone();
+let bindGroup62 = device0.createBindGroup({layout: autogeneratedBindGroupLayout4, entries: [{binding: 762, resource: {buffer: buffer2}}]});
+let sampler81 = device0.createSampler({
+  addressModeV: 'repeat',
+  addressModeW: 'repeat',
+  magFilter: 'linear',
+  minFilter: 'linear',
+  mipmapFilter: 'linear',
+});
+try {
+renderPassEncoder26.setBindGroup(0, bindGroup42);
+} catch {}
+try {
+renderPassEncoder15.endOcclusionQuery();
+} catch {}
+try {
+renderPassEncoder19.setScissorRect(4, 3, 47, 31);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+let bindGroup63 = device0.createBindGroup({
+  layout: veryExplicitBindGroupLayout0,
+  entries: [{binding: 1, resource: externalTexture6}, {binding: 197, resource: sampler58}],
+});
+let sampler82 = device0.createSampler({
+  addressModeU: 'repeat',
+  mipmapFilter: 'linear',
+  lodMinClamp: 20.98,
+  compare: 'greater',
+  maxAnisotropy: 1,
+});
+try {
+renderPassEncoder19.setVertexBuffer(1, buffer74, 0, 10);
+} catch {}
+let videoFrame14 = new VideoFrame(new ArrayBuffer(16), { codedWidth: 2, codedHeight: 2, format: 'BGRA',  timestamp: 0, colorSpace: {fullRange: false, matrix: 'smpte240m', primaries: 'jedecP22Phosphors', transfer: 'pq'} });
+let commandEncoder130 = device0.createCommandEncoder({});
+let computePassEncoder110 = commandEncoder96.beginComputePass();
+try {
+computePassEncoder110.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder20.setIndexBuffer(buffer20, 'uint32', 8, 4);
+} catch {}
+try {
+commandEncoder129.copyBufferToBuffer(buffer73, 4, buffer13, 520, 4);
+} catch {}
+try {
+commandEncoder128.clearBuffer(buffer48);
+} catch {}
+try {
+computePassEncoder74.insertDebugMarker('\u05ef');
+} catch {}
+let computePassEncoder111 = commandEncoder129.beginComputePass();
+let renderBundleEncoder15 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup8, new Uint32Array(857), 67, 0);
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderBundleEncoder15.setIndexBuffer(buffer55, 'uint16', 46, 15);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+  await buffer58.mapAsync(GPUMapMode.READ);
+} catch {}
+try {
+  await promise15;
+} catch {}
+let textureView129 = texture122.createView({dimension: 'cube-array', arrayLayerCount: 6});
+try {
+renderPassEncoder16.setBlendConstant({ r: 115.8, g: 281.9, b: -777.5, a: 807.9, });
+} catch {}
+try {
+  await promise16;
+} catch {}
+let recycledExplicitBindGroupLayout9 = pipeline13.getBindGroupLayout(0);
+let bindGroup64 = device0.createBindGroup({
+  layout: recycledExplicitBindGroupLayout2,
+  entries: [{binding: 1, resource: externalTexture8}, {binding: 197, resource: sampler60}],
+});
+let buffer82 = device0.createBuffer({size: 640, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.STORAGE});
+let renderPassEncoder40 = commandEncoder128.beginRenderPass({
+  colorAttachments: [{
+  view: textureView122,
+  clearValue: { r: 438.6, g: 727.7, b: 772.2, a: 325.2, },
+  loadOp: 'load',
+  storeOp: 'store',
+}],
+});
+try {
+{ clearResourceUsages(device0, computePassEncoder74); computePassEncoder74.dispatchWorkgroupsIndirect(buffer68, 0); };
+} catch {}
+try {
+computePassEncoder111.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder15.beginOcclusionQuery(43);
+} catch {}
+try {
+renderPassEncoder34.setIndexBuffer(buffer76, 'uint16', 4, 45);
+} catch {}
+try {
+commandEncoder130.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 9 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 248 */
+  offset: 248,
+  bytesPerRow: 51712,
+  rowsPerImage: 324,
+  buffer: buffer42,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 5},
+  aspect: 'all',
+}, {width: 9, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+externalTexture5.label = '\ud539\u602a\u0ee0\u{1fbdd}\u0428\u01e7\ua135\u33b4\u{1fa49}';
+} catch {}
+let commandEncoder131 = device0.createCommandEncoder({});
+try {
+renderPassEncoder30.setBindGroup(3, bindGroup57, new Uint32Array(1810), 34, 0);
+} catch {}
+try {
+renderPassEncoder10.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(3, buffer6, 0, 0);
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'rgba16float',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.TEXTURE_BINDING,
+  alphaMode: 'opaque',
+});
+} catch {}
+try {
+device0.queue.writeBuffer(buffer68, 12, new Uint32Array(110), 34, 0);
+} catch {}
+let veryExplicitBindGroupLayout15 = device0.createBindGroupLayout({
+  entries: [
+    {binding: 5, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'storage', hasDynamicOffset: false }},
+  ],
+});
+let buffer83 = device0.createBuffer({size: 280, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE});
+let commandEncoder132 = device0.createCommandEncoder({});
+let textureView130 = texture85.createView({dimension: 'cube', mipLevelCount: 1});
+let renderPassEncoder41 = commandEncoder132.beginRenderPass({
+  colorAttachments: [{view: textureView117, depthSlice: 328, loadOp: 'clear', storeOp: 'store'}],
+  maxDrawCount: 24680718,
+});
+try {
+renderPassEncoder38.setBindGroup(0, bindGroup50);
+} catch {}
+try {
+renderPassEncoder36.setVertexBuffer(7, buffer3, 0, 10);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline5);
+} catch {}
+try {
+gpuCanvasContext2.configure({device: device0, format: 'rgba16float', usage: GPUTextureUsage.RENDER_ATTACHMENT, colorSpace: 'srgb'});
+} catch {}
+try {
+computePassEncoder109.setBindGroup(2, bindGroup36, new Uint32Array(374), 0, 0);
+} catch {}
+try {
+renderPassEncoder37.setBindGroup(3, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(2, bindGroup58, new Uint32Array(1583), 515, 0);
+} catch {}
+try {
+commandEncoder131.copyBufferToBuffer(buffer44, 36, buffer32, 0, 8);
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 36 widthInBlocks: 18 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1066 */
+  offset: 1066,
+  rowsPerImage: 43,
+  buffer: buffer16,
+}, {
+  texture: texture74,
+  mipLevel: 0,
+  origin: {x: 35, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 18, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let commandEncoder133 = device0.createCommandEncoder();
+let renderPassEncoder42 = commandEncoder130.beginRenderPass({
+  colorAttachments: [{
+  view: textureView115,
+  depthSlice: 966,
+  clearValue: { r: 926.8, g: 782.6, b: -299.5, a: -714.2, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+});
+try {
+renderPassEncoder42.setBindGroup(1, bindGroup8, []);
+} catch {}
+try {
+renderPassEncoder15.setIndexBuffer(buffer56, 'uint32', 48, 66);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(1, bindGroup33, new Uint32Array(4879), 288, 0);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline9);
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 160 widthInBlocks: 40 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 380 */
+  offset: 380,
+  bytesPerRow: 54528,
+  buffer: buffer18,
+}, {
+  texture: texture13,
+  mipLevel: 0,
+  origin: {x: 9, y: 0, z: 2},
+  aspect: 'all',
+}, {width: 40, height: 0, depthOrArrayLayers: 1});
+} catch {}
+try {
+device0.queue.writeTexture({
+  texture: texture75,
+  mipLevel: 0,
+  origin: {x: 2, y: 9, z: 33},
+  aspect: 'all',
+}, new Uint8Array(125_191).fill(146), /* required buffer size: 125_191 */
+{offset: 117, bytesPerRow: 110, rowsPerImage: 20}, {width: 1, height: 18, depthOrArrayLayers: 57});
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 1 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 4, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'display-p3',
+  premultipliedAlpha: false,
+}, {width: 1, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise13;
+} catch {}
+let commandEncoder134 = device0.createCommandEncoder({});
+let computePassEncoder112 = commandEncoder134.beginComputePass();
+let renderBundleEncoder16 = device0.createRenderBundleEncoder({colorFormats: ['r16sint'], depthReadOnly: true, stencilReadOnly: false});
+try {
+computePassEncoder18.setBindGroup(1, bindGroup0, new Uint32Array(237), 25, 0);
+} catch {}
+try {
+computePassEncoder112.setPipeline(pipeline10);
+} catch {}
+try {
+renderPassEncoder13.setVertexBuffer(7, buffer6, 4);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup25);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer16, 'uint16', 7_518, 918);
+} catch {}
+try {
+commandEncoder131.copyTextureToTexture({
+  texture: texture72,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+},
+{
+  texture: texture47,
+  mipLevel: 0,
+  origin: {x: 1, y: 0, z: 0},
+  aspect: 'all',
+},
+{width: 6, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let promise21 = device0.queue.onSubmittedWorkDone();
+let buffer84 = device0.createBuffer({size: 432, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder135 = device0.createCommandEncoder({});
+let texture134 = device0.createTexture({
+  label: '\u641e\u7285\u{1f606}\ub0a5\ubc9d',
+  size: {width: 63, height: 1, depthOrArrayLayers: 3},
+  dimension: '3d',
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let textureView131 = texture61.createView({baseArrayLayer: 4, arrayLayerCount: 2});
+let renderPassEncoder43 = commandEncoder135.beginRenderPass({
+  colorAttachments: [{
+  view: textureView124,
+  depthSlice: 138,
+  clearValue: { r: -671.8, g: 924.6, b: -82.22, a: -955.8, },
+  loadOp: 'load',
+  storeOp: 'discard',
+}],
+  occlusionQuerySet: querySet0,
+  maxDrawCount: 41911893,
+});
+let sampler83 = device0.createSampler({addressModeU: 'mirror-repeat', addressModeV: 'repeat', minFilter: 'linear', mipmapFilter: 'linear'});
+let externalTexture11 = device0.importExternalTexture({source: videoFrame12});
+try {
+{ clearResourceUsages(device0, computePassEncoder17); computePassEncoder17.dispatchWorkgroupsIndirect(buffer49, 36); };
+} catch {}
+try {
+computePassEncoder29.end();
+} catch {}
+try {
+renderPassEncoder41.setVertexBuffer(2, buffer36, 36);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer3, 0);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+commandEncoder31.copyBufferToTexture({
+  /* bytesInLastRow: 38 widthInBlocks: 19 aspectSpecificFormat.texelBlockSize: 2 */
+  /* end: 1754 */
+  offset: 1754,
+  bytesPerRow: 6144,
+  buffer: buffer16,
+}, {
+  texture: texture19,
+  mipLevel: 0,
+  origin: {x: 16, y: 0, z: 0},
+  aspect: 'all',
+}, {width: 19, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+gpuCanvasContext2.configure({
+  device: device0,
+  format: 'bgra8unorm',
+  usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+  colorSpace: 'srgb',
+});
+} catch {}
+try {
+if (!arrayBuffer1.detached) { new Uint8Array(arrayBuffer1).fill(150); };
+} catch {}
+let commandEncoder136 = device0.createCommandEncoder({});
+let querySet20 = device0.createQuerySet({type: 'occlusion', count: 1794});
+let computePassEncoder113 = commandEncoder31.beginComputePass();
+try {
+computePassEncoder75.setBindGroup(1, bindGroup48);
+} catch {}
+try {
+computePassEncoder1.setBindGroup(3, bindGroup50, new Uint32Array(638), 133, 0);
+} catch {}
+try {
+renderPassEncoder17.setPipeline(pipeline5);
+} catch {}
+try {
+device0.pushErrorScope('out-of-memory');
+} catch {}
+try {
+device0.lost.then(({reason, message}) => { console.log('device0 lost!'); console.log(message, reason); });
+} catch {}
+try {
+commandEncoder131.copyBufferToTexture({
+  /* bytesInLastRow: 12 widthInBlocks: 3 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 12 */
+  offset: 12,
+  bytesPerRow: 2816,
+  buffer: buffer23,
+}, {
+  texture: texture94,
+  mipLevel: 1,
+  origin: {x: 11, y: 0, z: 112},
+  aspect: 'all',
+}, {width: 3, height: 0, depthOrArrayLayers: 0});
+} catch {}
+let texture135 = device0.createTexture({
+  label: '\u{1fe17}\u68c7',
+  size: {width: 64, height: 64, depthOrArrayLayers: 12},
+  format: 'rg8sint',
+  usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+});
+let computePassEncoder114 = commandEncoder133.beginComputePass();
+let sampler84 = device0.createSampler({
+  addressModeU: 'repeat',
+  addressModeW: 'clamp-to-edge',
+  magFilter: 'nearest',
+  mipmapFilter: 'nearest',
+  lodMaxClamp: 97.13,
+});
+try {
+computePassEncoder113.setPipeline(pipeline12);
+} catch {}
+try {
+renderPassEncoder11.setPipeline(pipeline5);
+} catch {}
+try {
+renderBundleEncoder15.setBindGroup(0, bindGroup54, new Uint32Array(2445), 204, 0);
+} catch {}
+try {
+device0.queue.copyExternalImageToTexture(/*
+{width: 127, height: 1, depthOrArrayLayers: 1}
+*/
+{
+  source: videoFrame6,
+  origin: { x: 0, y: 2 },
+  flipY: true,
+}, {
+  texture: texture3,
+  mipLevel: 0,
+  origin: {x: 18, y: 0, z: 0},
+  aspect: 'all',
+  colorSpace: 'srgb',
+  premultipliedAlpha: false,
+}, {width: 0, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(0, bindGroup45);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer36, 'uint32', 4, 72);
+} catch {}
+try {
+renderBundleEncoder15.setPipeline(pipeline4);
+} catch {}
+try {
+renderBundleEncoder15.setVertexBuffer(5, buffer17, 24);
+} catch {}
+let buffer85 = device0.createBuffer({size: 228, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE});
+let commandEncoder137 = device0.createCommandEncoder({label: '\uaea5\u2674\u3f2a\u{1fcee}\uc4c0'});
+let textureView132 = texture85.createView({dimension: 'cube'});
+let texture136 = device0.createTexture({
+  size: {width: 63, height: 1, depthOrArrayLayers: 1},
+  format: 'r16sint',
+  usage: GPUTextureUsage.COPY_DST,
+});
+let computePassEncoder115 = commandEncoder137.beginComputePass();
+try {
+{ clearResourceUsages(device0, computePassEncoder44); computePassEncoder44.dispatchWorkgroupsIndirect(buffer23, 4); };
+} catch {}
+try {
+renderPassEncoder28.executeBundles([renderBundle9]);
+} catch {}
+try {
+renderBundleEncoder16.setBindGroup(3, bindGroup54, new Uint32Array(431), 23, 0);
+} catch {}
+try {
+renderBundleEncoder15.draw(255, 58, 525_805_478, 21_373_677);
+} catch {}
+try {
+renderBundleEncoder16.setVertexBuffer(1, buffer74);
+} catch {}
+try {
+commandEncoder131.copyTextureToBuffer({
+  texture: texture125,
+  mipLevel: 0,
+  origin: {x: 11, y: 0, z: 0},
+  aspect: 'all',
+}, {
+  /* bytesInLastRow: 44 widthInBlocks: 11 aspectSpecificFormat.texelBlockSize: 4 */
+  /* end: 348 */
+  offset: 348,
+  bytesPerRow: 21248,
+  buffer: buffer10,
+}, {width: 11, height: 0, depthOrArrayLayers: 0});
+} catch {}
+try {
+  await promise20;
+} catch {}
+let textureView133 = texture69.createView({dimension: 'cube-array', mipLevelCount: 1, arrayLayerCount: 6});
+try {
+computePassEncoder114.setPipeline(pipeline11);
+} catch {}
+try {
+renderPassEncoder21.setBindGroup(2, bindGroup21, new Uint32Array(1595), 34, 0);
+} catch {}
+try {
+renderPassEncoder12.setBlendConstant({ r: -875.9, g: -589.4, b: -250.8, a: -376.7, });
+} catch {}
+try {
+renderPassEncoder14.setIndexBuffer(buffer7, 'uint32', 20, 15);
+} catch {}
+try {
+renderBundleEncoder16.setIndexBuffer(buffer23, 'uint16', 14, 24);
+} catch {}
+try {
+device0.pushErrorScope('validation');
+} catch {}
+try {
+  await promise21;
+} catch {}
+videoFrame1.close();
+videoFrame2.close();
+videoFrame3.close();
+videoFrame5.close();
+videoFrame7.close();
+videoFrame10.close();
+videoFrame11.close();
+videoFrame13.close();
+videoFrame14.close();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+new Worker(toBlobUrl(`${sharedScript}; log('hello from worker0'); ${worker0}; worker0().catch(log);`)),
+new Worker(toBlobUrl(`${sharedScript}; log('hello from worker1'); ${worker1}; worker1().catch(log);`))
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -35,6 +35,7 @@
 #import <wtf/Ref.h>
 #import <wtf/TZoneMalloc.h>
 #import <wtf/ThreadSafeRefCounted.h>
+#import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
 struct WGPUInstanceImpl {
@@ -47,6 +48,7 @@ class MachSendRight;
 namespace WebGPU {
 
 class Adapter;
+class Device;
 class PresentationContext;
 
 // https://gpuweb.github.io/gpuweb/#gpu
@@ -66,6 +68,7 @@ public:
     void requestAdapter(const WGPURequestAdapterOptions&, CompletionHandler<void(WGPURequestAdapterStatus, Ref<Adapter>&&, String&&)>&& callback);
 
     bool isValid() const { return m_isValid; }
+    void retainDevice(Device&, id<MTLCommandBuffer>);
 
     // This can be called on a background thread.
     using WorkItem = Function<void()>;
@@ -81,6 +84,8 @@ private:
 
     // This can be used on a background thread.
     Deque<WGPUWorkItem> m_pendingWork WTF_GUARDED_BY_LOCK(m_lock);
+    using CommandBufferContainer = Vector<WeakObjCPtr<id<MTLCommandBuffer>>>;
+    HashMap<RefPtr<Device>, CommandBufferContainer> retainedDeviceInstances WTF_GUARDED_BY_LOCK(m_lock);
     const std::optional<const MachSendRight> m_webProcessID;
     const WGPUScheduleWorkBlock m_scheduleWorkBlock;
     Lock m_lock;

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -146,6 +146,10 @@ id<MTLCommandBuffer> Queue::commandBufferWithDescriptor(MTLCommandBufferDescript
     if (buffer)
         [m_createdNotCommittedBuffers addObject:buffer];
 
+    if (auto instance = m_instance.get()) {
+        if (auto device = m_device.get())
+            instance->retainDevice(*device, buffer);
+    }
     return buffer;
 }
 


### PR DESCRIPTION
#### ff7fa08bda15a39638b55d71ddfb7cbfd2d9a50c
<pre>
[WebGPU] Retain Device for lifetime of its associated MTLCommandBuffer instances
<a href="https://bugs.webkit.org/show_bug.cgi?id=287868">https://bugs.webkit.org/show_bug.cgi?id=287868</a>
<a href="https://rdar.apple.com/145031314">rdar://145031314</a>

Reviewed by Tadeu Zagallo.

To workaround <a href="https://rdar.apple.com/143905417">rdar://143905417</a>, manually retain the Device for the lifetime
of all the MTLCommandBuffers associated with it.

* LayoutTests/fast/webgpu/nocrash/fuzz-287868-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287868.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::Instance::retainDevice):
Store a container which maps a Device to all its pending MTLCommandBuffer instances.

* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::commandBufferWithDescriptor):
Retain on MTLCommandBuffer creation.

Canonical link: <a href="https://commits.webkit.org/290588@main">https://commits.webkit.org/290588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7f2c3739b65b8faddf02590fae14bf74acbdcea1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41189 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69601 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27175 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49950 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36366 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40318 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77973 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97244 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12940 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78592 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19235 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22257 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10863 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22940 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20797 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->