### PR TITLE
[WebGPU] RenderPassEncoder.executeBundles fails to clear state after executing bundle commands

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287866-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287866-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-287866.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-287866.html
@@ -1,0 +1,200 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'shader-f16',
+    'bgra8unorm-storage',
+  ],
+});
+// START
+b = device0.createShaderModule({
+  code : ` 
+              fn c(e: ptr<workgroup, d>, u: u32) -> f32 {
+              var f: f32;
+              return f;
+              _ = g;
+              _ = h;
+            }
+              @id(9193) override h: f16;
+              struct d {
+              i: vec4i   }
+              var<workgroup> j: d;
+              override g: bool;
+              @vertex fn k() -> @builtin(position) vec4f {
+              var f: vec4f;
+              return f;
+            }
+              @compute @workgroup_size(1) fn l() {
+              c(&j, pack4xI8Clamp(j.i));
+            }
+             `
+})
+m = device0.createBuffer({size : 208, usage : GPUBufferUsage.INDIRECT})
+n = device0.createBindGroupLayout({
+  entries : [ {
+    binding : 0,
+    visibility : GPUShaderStage.FRAGMENT,
+    buffer : {type : 'storage', hasDynamicOffset : true}
+  } ]
+})
+o = device0.createPipelineLayout({bindGroupLayouts : [ n ]})
+p = device0.createTexture({
+  size : [ 2, 2, 6 ],
+  dimension : '3d',
+  format : 'rg32float',
+  usage : GPUTextureUsage.RENDER_ATTACHMENT
+})
+q = device0.createShaderModule({
+  code : ` 
+              @fragment fn a() -> @location(200) vec2f {
+              var f: vec2f;
+              return f;
+            }
+             `
+})
+r = device0.createShaderModule({
+  code : ` 
+              struct ab {
+              @location(0) i: vec2f}
+              @group(0) @binding(0) var<storage, read_write> ad: array<array<array<array<array<array<f16, 1>, 1>, 5>, 2>, 19>>;
+              struct s {
+              @builtin(position) e: vec4f}
+              @vertex fn v() -> s {
+              var f: s;
+              return f;
+            }
+              @fragment fn w() -> ab {
+              var f: ab;
+              loop {
+           f.i = vec2f(f32(ad[u32()][8][1][0][0][0]));
+           break;
+         }
+              return f;
+            }
+             `
+})
+t = device0.createPipelineLayout({bindGroupLayouts : []})
+af = device0.createRenderPipeline({
+  layout : t,
+  fragment : {module : q, targets : [ {format : 'rg32float'} ]},
+  vertex : {module : b}
+})
+ag = device0.createRenderBundleEncoder({colorFormats : [ 'rg32float' ]})
+try {
+  ag.setPipeline(af)
+} catch {
+}
+ah = device0.createComputePipeline(
+    {layout : o, compute : {module : b, constants : {g : 1, 9_193 : 1}}})
+try {
+  ag.drawIndirect(m, 4)
+} catch {
+}
+ai = device0.createRenderPipelineAsync({
+  layout : o,
+  fragment : {module : r, targets : [ {format : 'rg32float'} ]},
+  vertex : {module : r},
+  primitive : {topology : 'point-list'}
+})
+aj = ag.finish()
+ak = await ai
+al = p.createView()
+am = device0.createBuffer({size : 4, usage : GPUBufferUsage.INDEX})
+an = device0.createBuffer({size : 1024, usage : GPUBufferUsage.STORAGE})
+ao = device0.createCommandEncoder()
+ap = ao.beginRenderPass({
+  colorAttachments :
+      [ {view : al, depthSlice : 5, loadOp : 'load', storeOp : 'discard'} ]
+})
+try {
+  ap.setIndexBuffer(am, 'uint32')
+} catch {
+}
+ar = ah.getBindGroupLayout(0)
+try {
+  ap.setPipeline(ak)
+} catch {
+}
+as = device0.createBindGroup(
+    {layout : ar, entries : [ {binding : 0, resource : {buffer : an}} ]})
+try {
+  ap.setBindGroup(0, as, new Uint32Array(86), 6, 1)
+  ap.drawIndexed(0)
+  ap.executeBundles([ aj ])
+  ap.drawIndexed(1)
+  ap.end()
+} catch {
+}
+at = ao.finish()
+try {
+  device0.queue.submit([ at ])
+} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1218,6 +1218,18 @@ void RenderPassEncoder::executeBundles(Vector<Ref<RenderBundle>>&& bundles)
 
         bundle->replayCommands(*this);
     }
+
+    m_vertexBuffers.clear();
+    m_bindGroups.clear();
+    m_bindGroupDynamicOffsets.clear();
+    m_pipeline = nullptr;
+    m_vertexDynamicOffsets.clear();
+    m_priorVertexDynamicOffsets.clear();
+    m_fragmentDynamicOffsets.clear();
+    m_priorFragmentDynamicOffsets.clear();
+    m_indexBuffer = nullptr;
+    m_maxVertexBufferSlot = 0;
+    m_maxBindGroupSlot = 0;
 }
 
 bool RenderPassEncoder::colorDepthStencilTargetsMatch(const RenderPipeline& pipeline) const


### PR DESCRIPTION
#### 5279d7db78312442040c4e72732b7187ade75e90
<pre>
[WebGPU] RenderPassEncoder.executeBundles fails to clear state after executing bundle commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=287866">https://bugs.webkit.org/show_bug.cgi?id=287866</a>
<a href="https://rdar.apple.com/145033045">rdar://145033045</a>

Reviewed by Tadeu Zagallo.

The specification for executeBundles, <a href="https://www.w3.org/TR/webgpu/#render-pass-encoder-bundles">https://www.w3.org/TR/webgpu/#render-pass-encoder-bundles</a>, says:

    After a GPURenderBundle has executed, the render pass’s pipeline, bind group, and
    vertex/index buffer state is cleared (to the initial, empty values).

which we were not previously ensuring. This could lead to out of bounds data reads via
stale dynamic offsets.

ComputePassEncoder doesn&apos;t support bundles, so change only applies to RenderPassEncoder.

* LayoutTests/fast/webgpu/nocrash/fuzz-287866-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-287866.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::executeBundles):
Clear state after executeBundles call.

Canonical link: <a href="https://commits.webkit.org/290586@main">https://commits.webkit.org/290586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec407e0a9a0dc0c2e8deafdb5e99e7499549bda7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90407 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41190 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69602 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27173 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82013 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49951 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36371 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/77974 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97245 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/12942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78591 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77837 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77806 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22259 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/10864 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/22941 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19130 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->