### PR TITLE
Re-import close-watcher WPTs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: closewatcher
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
@@ -1,8 +1,8 @@
 
-PASS requestClose() with no user activation
+FAIL requestClose() with no user activation assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 PASS destroy() then requestClose()
 PASS close() then requestClose()
-PASS requestClose() then destroy()
+FAIL requestClose() then destroy() assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 PASS close() then destroy()
 PASS destroy() then close request
 PASS Close request then destroy()

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html
@@ -14,7 +14,7 @@ test(t => {
 
   watcher.requestClose();
 
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 }, "requestClose() with no user activation");
 
 test(t => {
@@ -43,10 +43,10 @@ test(t => {
   let watcher = createRecordingCloseWatcher(t, events);
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 
   watcher.destroy();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 }, "requestClose() then destroy()");
 
 test(t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
@@ -1,8 +1,8 @@
 
 PASS destroy() inside oncancel
-PASS destroy() inside onclose
+FAIL destroy() inside onclose assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 PASS close() inside oncancel
-PASS close() inside onclose
+FAIL close() inside onclose assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 PASS requestClose() inside oncancel
-PASS requestClose() inside onclose
+FAIL requestClose() inside onclose assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html
@@ -30,10 +30,10 @@ test(t => {
   watcher.onclose = () => { watcher.destroy(); }
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"], "since it was inactive, no more events fired");
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "destroy() inside onclose");
 
 promise_test(async t => {
@@ -58,10 +58,10 @@ test(t => {
   watcher.onclose = () => { watcher.close(); }
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"], "since it was inactive, no more events fired");
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "close() inside onclose");
 
 promise_test(async t => {
@@ -86,9 +86,9 @@ test(t => {
   watcher.onclose = () => { watcher.requestClose(); }
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"]);
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 
   watcher.requestClose();
-  assert_array_equals(events, ["cancel[cancelable=false]", "close"], "since it was inactive, no more events fired");
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "requestClose() inside onclose");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/w3c-import.log
@@ -38,6 +38,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyn-dialog.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-CloseWatcher.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/nyyyn-dialog.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn-activate.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/yn.html

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected-expected.txt
@@ -1,0 +1,4 @@
+b0
+
+FAIL Disconnect dialog with close request assert_false: d1 should now be closed. expected false got true
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=author href="mailto:wpt@keithcirkel.co.uk">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>b0</button>
+
+<dialog id=d1>
+  <button id=b1>b1</button>
+
+  <dialog id=d2>d2</dialog>
+</dialog>
+
+<script>
+promise_test(async () => {
+  const d1 = document.getElementById('d1');
+  const d2 = document.getElementById('d2');
+  await test_driver.click(b0);
+  d1.showModal();
+  await test_driver.click(b1);
+  d2.showModal();
+
+  assert_true(d1.matches(':modal'), 'd1 should be open.');
+  assert_true(d2.matches(':modal'), 'd2 should be open.');
+
+  d2.remove()
+
+  assert_false(d2.matches(':modal'), 'd2 should now be closed.');
+  await sendCloseRequest();
+  assert_false(d2.matches(':modal'), 'd2 still now be closed.');
+  assert_false(d1.matches(':modal'), 'd1 should now be closed.');
+
+  await sendCloseRequest();
+  assert_false(d2.matches(':modal'), 'd2 still now be closed.');
+  assert_false(d1.matches(':modal'), 'd1 still now be closed.');
+}, 'Disconnect dialog with close request');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected-expected.txt
@@ -1,0 +1,4 @@
+b0
+
+PASS Disconnect popover with close request
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=author href="mailto:wpt@keithcirkel.co.uk">
+<link rel=help href="https://github.com/whatwg/html/pull/9462">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<button id=b0>b0</button>
+
+<div id=p1 popover=auto>
+  <button id=b1>b1</button>
+
+  <div id=p2 popover=auto>p2</div>
+</div>
+
+<script>
+promise_test(async () => {
+  const p1 = document.getElementById('p1');
+  const p2 = document.getElementById('p2');
+  await test_driver.click(b0);
+  p1.showPopover();
+  await test_driver.click(b1);
+  p2.showPopover();
+
+  assert_true(p1.matches(':popover-open'), 'p1 should be open.');
+  assert_true(p2.matches(':popover-open'), 'p2 should be open.');
+
+  p2.remove()
+
+  assert_false(p2.matches(':popover-open'), 'p2 should now be closed.');
+  await sendCloseRequest();
+  assert_false(p2.matches(':popover-open'), 'p2 still now be closed.');
+  assert_false(p1.matches(':popover-open'), 'p1 should now be closed.');
+
+  await sendCloseRequest();
+  assert_false(p2.matches(':popover-open'), 'p2 still now be closed.');
+  assert_false(p1.matches(':popover-open'), 'p1 still now be closed.');
+}, 'Disconnect popover with close request');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/abortsignal.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html
 /LayoutTests/imported/w3c/web-platform-tests/close-watcher/event-properties.html

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
@@ -1,8 +1,8 @@
 
-PASS requestClose() with no user activation
+FAIL requestClose() with no user activation assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 PASS destroy() then requestClose()
 PASS close() then requestClose()
-PASS requestClose() then destroy()
+FAIL requestClose() then destroy() assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
 PASS close() then destroy()
 PASS destroy() then close request
 FAIL Close request then destroy() assert_array_equals: lengths differ, expected array ["cancel[cancelable=false]", "close"] length 2, got [] length 0


### PR DESCRIPTION
#### 6cba1086fd286e3d1d0ae042ef4114890c08b34f
<pre>
Re-import close-watcher WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=287870">https://bugs.webkit.org/show_bug.cgi?id=287870</a>

Reviewed by Tim Nguyen.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/cd546585e048de3c88ffdaa7f83e23f4a0dba932">https://github.com/web-platform-tests/wpt/commit/cd546585e048de3c88ffdaa7f83e23f4a0dba932</a>

* LayoutTests/imported/w3c/web-platform-tests/close-watcher/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic.html:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-popover-disconnected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/w3c-import.log:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt:

Canonical link: <a href="https://commits.webkit.org/290720@main">https://commits.webkit.org/290720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edd1141e20cf268cb0e605eee07f31ee46dd28b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10176 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41431 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18501 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69766 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27315 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82207 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50109 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7830 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36589 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40560 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78148 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97491 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77988 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19298 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22419 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21045 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21044 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->