### PR TITLE
CloseWatcher requestClose() requires history action activation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL requestClose() with no user activation assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS requestClose() with no user activation
 PASS destroy() then requestClose()
 PASS close() then requestClose()
-FAIL requestClose() then destroy() assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS requestClose() then destroy()
 PASS close() then destroy()
 PASS destroy() then close request
 PASS Close request then destroy()

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
@@ -1,8 +1,8 @@
 
 PASS destroy() inside oncancel
-FAIL destroy() inside onclose assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS destroy() inside onclose
 PASS close() inside oncancel
-FAIL close() inside onclose assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS close() inside onclose
 PASS requestClose() inside oncancel
-FAIL requestClose() inside onclose assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS requestClose() inside onclose
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL requestClose() with no user activation assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS requestClose() with no user activation
 PASS destroy() then requestClose()
 PASS close() then requestClose()
-FAIL requestClose() then destroy() assert_array_equals: expected property 0 to be "cancel[cancelable=true]" but got "cancel[cancelable=false]" (expected array ["cancel[cancelable=true]", "close"] got ["cancel[cancelable=false]", "close"])
+PASS requestClose() then destroy()
 PASS close() then destroy()
 PASS destroy() then close request
 FAIL Close request then destroy() assert_array_equals: lengths differ, expected array ["cancel[cancelable=false]", "close"] length 2, got [] length 0

--- a/Source/WebCore/html/closewatcher/CloseWatcher.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.cpp
@@ -93,17 +93,17 @@ ScriptExecutionContext* CloseWatcher::scriptExecutionContext() const
 
 void CloseWatcher::requestClose()
 {
-    requestToClose();
+    requestToClose(RequireHistoryActionActivation::No);
 }
 
-bool CloseWatcher::requestToClose()
+bool CloseWatcher::requestToClose(RequireHistoryActionActivation requireHistoryActionActivation)
 {
     if (!canBeClosed())
         return true;
 
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     Ref manager = protect(document->window())->closeWatcherManager();
-    bool canPreventClose = manager->canPreventClose() && document->window()->hasHistoryActionActivation();
+    bool canPreventClose = requireHistoryActionActivation == RequireHistoryActionActivation::No || (manager->canPreventClose() && document->window()->hasHistoryActionActivation());
     Ref cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, canPreventClose ? Event::IsCancelable::Yes : Event::IsCancelable::No);
     m_isRunningCancelAction = true;
     dispatchEvent(cancelEvent);

--- a/Source/WebCore/html/closewatcher/CloseWatcher.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.cpp
@@ -83,17 +83,17 @@ CloseWatcher::CloseWatcher(Document& document)
 
 void CloseWatcher::requestClose()
 {
-    requestToClose();
+    requestToClose(RequireHistoryActionActivation::No);
 }
 
-bool CloseWatcher::requestToClose()
+bool CloseWatcher::requestToClose(RequireHistoryActionActivation requireHistoryActionActivation)
 {
     if (!canBeClosed())
         return true;
 
     RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     Ref manager = document->protectedWindow()->closeWatcherManager();
-    bool canPreventClose = manager->canPreventClose() && document->protectedWindow()->hasHistoryActionActivation();
+    bool canPreventClose = requireHistoryActionActivation == RequireHistoryActionActivation::No || (manager->canPreventClose() && document->protectedWindow()->hasHistoryActionActivation());
     Ref cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, canPreventClose ? Event::IsCancelable::Yes : Event::IsCancelable::No);
     m_isRunningCancelAction = true;
     dispatchEvent(cancelEvent);

--- a/Source/WebCore/html/closewatcher/CloseWatcher.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.h
@@ -37,6 +37,8 @@ namespace WebCore {
 
 class KeyboardEvent;
 
+enum class RequireHistoryActionActivation : bool { No, Yes };
+
 class CloseWatcher final : public RefCounted<CloseWatcher>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(CloseWatcher);
 public:
@@ -51,7 +53,7 @@ public:
     bool isActive() const { return m_active; }
 
     void requestClose();
-    bool requestToClose();
+    bool requestToClose(RequireHistoryActionActivation);
     void close();
     void destroy();
 

--- a/Source/WebCore/html/closewatcher/CloseWatcher.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.h
@@ -36,6 +36,8 @@ namespace WebCore {
 
 class KeyboardEvent;
 
+enum class RequireHistoryActionActivation : bool { No, Yes };
+
 class CloseWatcher final : public RefCounted<CloseWatcher>, public EventTarget, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(CloseWatcher);
 public:
@@ -50,7 +52,7 @@ public:
     bool isActive() const { return m_active; }
 
     void requestClose();
-    bool requestToClose();
+    bool requestToClose(RequireHistoryActionActivation = RequireHistoryActionActivation::Yes);
     void close();
     void destroy();
 

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
@@ -80,7 +80,7 @@ void CloseWatcherManager::escapeKeyHandler(KeyboardEvent& event)
         auto& group = m_groups.last();
         Vector<Ref<CloseWatcher>> groupCopy(group);
         for (Ref watcher : groupCopy | std::views::reverse) {
-            if (!watcher->requestToClose())
+            if (!watcher->requestToClose(RequireHistoryActionActivation::Yes))
                 break;
         }
     }


### PR DESCRIPTION
#### e84a0a95fef2b18f8f776653e9288fd67fdde423
<pre>
CloseWatcher requestClose() requires history action activation
<a href="https://bugs.webkit.org/show_bug.cgi?id=287873">https://bugs.webkit.org/show_bug.cgi?id=287873</a>

Reviewed by Anne van Kesteren.

The specification no longer requires history action activation for
close watcher cancel events to be cancelable, when triggered via JS.

This patch removes that restriction for the requestClose() JS function.

* LayoutTests/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/close-watcher/basic-expected.txt:
* Source/WebCore/html/closewatcher/CloseWatcher.cpp:
(WebCore::CloseWatcher::requestClose):
(WebCore::CloseWatcher::requestToClose):
* Source/WebCore/html/closewatcher/CloseWatcher.h:
* Source/WebCore/html/closewatcher/CloseWatcherManager.cpp:
(WebCore::CloseWatcherManager::escapeKeyHandler):

Canonical link: <a href="https://commits.webkit.org/313246@main">https://commits.webkit.org/313246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ab36849c3267368d4fb74ccb8b6947658ffbebc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171484 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126146 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146030 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106724 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19184 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137250 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173988 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21301 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25405 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134455 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35696 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36280 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97999 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28991 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35190 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102941 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34936 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->