### PR TITLE
Unify IPInt memory index masking

### DIFF
--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -867,7 +867,13 @@ instructionLabel(_table_set)
 
 reservedOpcode(0x27)
 
+macro popMemoryIndex(reg, tmp)
+    popInt32(reg, tmp)
+    ori 0, reg
+end
+
 macro ipintCheckMemoryBound(mem, scratch, size)
+    # Memory indices are 32 bit
     leap size - 1[mem], scratch
     bpb scratch, boundsCheckingSize, .continuation
     ipintException(OutOfBoundsMemoryAccess)
@@ -877,8 +883,7 @@ end
 instructionLabel(_i32_load_mem)
     # i32.load
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
@@ -894,8 +899,7 @@ instructionLabel(_i32_load_mem)
 instructionLabel(_i64_load_mem)
     # i32.load
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
@@ -911,8 +915,7 @@ instructionLabel(_i64_load_mem)
 instructionLabel(_f32_load_mem)
     # f32.load
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
@@ -928,8 +931,7 @@ instructionLabel(_f32_load_mem)
 instructionLabel(_f64_load_mem)
     # f64.load
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
@@ -946,8 +948,7 @@ instructionLabel(_f64_load_mem)
 instructionLabel(_i32_load8s_mem)
     # i32.load8_s
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
@@ -964,8 +965,7 @@ instructionLabel(_i32_load8s_mem)
 instructionLabel(_i32_load8u_mem)
     # i32.load8_u
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
@@ -981,8 +981,7 @@ instructionLabel(_i32_load8u_mem)
 instructionLabel(_i32_load16s_mem)
     # i32.load16_s
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
@@ -999,8 +998,7 @@ instructionLabel(_i32_load16s_mem)
 instructionLabel(_i32_load16u_mem)
     # i32.load16_u
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
@@ -1017,8 +1015,7 @@ instructionLabel(_i32_load16u_mem)
 instructionLabel(_i64_load8s_mem)
     # i64.load8_s
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
@@ -1035,8 +1032,7 @@ instructionLabel(_i64_load8s_mem)
 instructionLabel(_i64_load8u_mem)
     # i64.load8_u
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
@@ -1052,8 +1048,7 @@ instructionLabel(_i64_load8u_mem)
 instructionLabel(_i64_load16s_mem)
     # i64.load16_s
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
@@ -1070,8 +1065,7 @@ instructionLabel(_i64_load16s_mem)
 instructionLabel(_i64_load16u_mem)
     # i64.load16_u
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
@@ -1087,8 +1081,7 @@ instructionLabel(_i64_load16u_mem)
 instructionLabel(_i64_load32s_mem)
     # i64.load32_s
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
@@ -1105,8 +1098,7 @@ instructionLabel(_i64_load32s_mem)
 instructionLabel(_i64_load32u_mem)
     # i64.load8_s
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
@@ -1125,8 +1117,7 @@ instructionLabel(_i32_store_mem)
     # pop data
     popInt32(t1, t2)
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
@@ -1143,8 +1134,7 @@ instructionLabel(_i64_store_mem)
     # pop data
     popInt64(t1, t2)
     # pop index
-    popInt64(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
@@ -1161,8 +1151,7 @@ instructionLabel(_f32_store_mem)
     # pop data
     popFloat32(ft0)
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)
@@ -1179,8 +1168,7 @@ instructionLabel(_f64_store_mem)
     # pop data
     popFloat64(ft0)
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 8)
@@ -1197,8 +1185,7 @@ instructionLabel(_i32_store8_mem)
     # pop data
     popInt32(t1, t2)
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
@@ -1215,8 +1202,7 @@ instructionLabel(_i32_store16_mem)
     # pop data
     popInt32(t1, t2)
     # pop index
-    popInt32(t0, t2)
-    ori 0, t0
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
@@ -1233,7 +1219,7 @@ instructionLabel(_i64_store8_mem)
     # pop data
     popInt64(t1, t2)
     # pop index
-    popInt64(t0, t2)
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 1)
@@ -1250,7 +1236,7 @@ instructionLabel(_i64_store16_mem)
     # pop data
     popInt64(t1, t2)
     # pop index
-    popInt64(t0, t2)
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 2)
@@ -1267,7 +1253,7 @@ instructionLabel(_i64_store32_mem)
     # pop data
     popInt64(t1, t2)
     # pop index
-    popInt64(t0, t2)
+    popMemoryIndex(t0, t2)
     loadi IPInt::Const32Metadata::value[MC], t2
     addp t2, t0
     ipintCheckMemoryBound(t0, t2, 4)


### PR DESCRIPTION
#### c3dadf54693bf4f0ba97f9ff8b4f627934c03a2d
<pre>
Unify IPInt memory index masking
<a href="https://bugs.webkit.org/show_bug.cgi?id=287297">https://bugs.webkit.org/show_bug.cgi?id=287297</a>
<a href="https://rdar.apple.com/144890544">rdar://144890544</a>

Reviewed by Yusuke Suzuki.

Some memory operations were not properly masking their memory index, leading
to out of memory accesses. This patch moves the bitmask to shared logic so
that all memory operations will mask the index properly.

* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/290589@main">https://commits.webkit.org/290589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6364276abf888ae65c401968ef09d75f3c23c33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41273 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69644 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27211 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49992 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36432 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40403 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83297 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97331 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89271 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17683 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78632 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77859 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22297 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20924 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14246 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17693 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111760 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17432 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19216 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->