### PR TITLE
Address safer C++ static analysis warnings in SuspendableWorkQueue

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,4 +1,3 @@
 wtf/PrintStream.h
 wtf/RunLoop.h
-wtf/SuspendableWorkQueue.cpp
 wtf/ThreadSafeWeakPtr.h

--- a/Source/WTF/wtf/SuspendableWorkQueue.cpp
+++ b/Source/WTF/wtf/SuspendableWorkQueue.cpp
@@ -74,8 +74,8 @@ void SuspendableWorkQueue::suspend(Function<void()>&& suspendFunction, Completio
 
     m_state = State::WillSuspend;
     // Make sure queue will be suspended when there is no task scheduled on the queue.
-    WorkQueue::dispatch([this] {
-        suspendIfNeeded();
+    WorkQueue::dispatch([protectedThis = Ref { *this }] {
+        protectedThis->suspendIfNeeded();
     });
 }
 
@@ -97,9 +97,8 @@ void SuspendableWorkQueue::resume()
 void SuspendableWorkQueue::dispatch(Function<void()>&& function)
 {
     RELEASE_ASSERT(function);
-    // WorkQueue will protect this in dispatch().
-    WorkQueue::dispatch([this, function = WTFMove(function)] {
-        suspendIfNeeded();
+    WorkQueue::dispatch([protectedThis = Ref { *this }, function = WTFMove(function)] {
+        protectedThis->suspendIfNeeded();
         function();
     });
 }
@@ -107,8 +106,8 @@ void SuspendableWorkQueue::dispatch(Function<void()>&& function)
 void SuspendableWorkQueue::dispatchAfter(Seconds seconds, Function<void()>&& function)
 {
     RELEASE_ASSERT(function);
-    WorkQueue::dispatchAfter(seconds, [this, function = WTFMove(function)] {
-        suspendIfNeeded();
+    WorkQueue::dispatchAfter(seconds, [protectedThis = Ref { *this }, function = WTFMove(function)] {
+        protectedThis->suspendIfNeeded();
         function();
     });
 }

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -35,7 +35,6 @@ namespace {
 
 struct DispatchWorkItem {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    Ref<WorkQueueBase> m_workQueue;
     Function<void()> m_function;
     void operator()() { m_function(); }
 };
@@ -51,7 +50,7 @@ template<typename T> static void dispatchWorkItem(void* dispatchContext)
 
 void WorkQueueBase::dispatch(Function<void()>&& function)
 {
-    dispatch_async_f(m_dispatchQueue.get(), new DispatchWorkItem { Ref { *this }, WTFMove(function) }, dispatchWorkItem<DispatchWorkItem>);
+    dispatch_async_f(m_dispatchQueue.get(), new DispatchWorkItem { WTFMove(function) }, dispatchWorkItem<DispatchWorkItem>);
 }
 
 void WorkQueueBase::dispatchWithQOS(Function<void()>&& function, QOS qos)
@@ -68,7 +67,7 @@ void WorkQueueBase::dispatchWithQOS(Function<void()>&& function, QOS qos)
 
 void WorkQueueBase::dispatchAfter(Seconds duration, Function<void()>&& function)
 {
-    dispatch_after_f(dispatch_time(DISPATCH_TIME_NOW, duration.nanosecondsAs<int64_t>()), m_dispatchQueue.get(), new DispatchWorkItem { Ref { *this },  WTFMove(function) }, dispatchWorkItem<DispatchWorkItem>);
+    dispatch_after_f(dispatch_time(DISPATCH_TIME_NOW, duration.nanosecondsAs<int64_t>()), m_dispatchQueue.get(), new DispatchWorkItem { WTFMove(function) }, dispatchWorkItem<DispatchWorkItem>);
 }
 
 void WorkQueueBase::dispatchSync(Function<void()>&& function)

--- a/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WorkQueue.cpp
@@ -59,7 +59,7 @@ TEST(WTF_WorkQueue, Simple)
     static const char* longTestLabel = "longTest";
     static const char* thirdTestLabel = "thirdTest";
 
-    auto queue = WorkQueue::create("com.apple.WebKit.Test.simple"_s);
+    Ref queue = WorkQueue::create("com.apple.WebKit.Test.simple"_s);
     int initialRefCount = queue->refCount();
     EXPECT_EQ(1, initialRefCount);
 
@@ -86,8 +86,6 @@ TEST(WTF_WorkQueue, Simple)
 
         m_testCompleted.notifyOne();
     });
-
-    EXPECT_GT(queue->refCount(), 1U);
 
     m_testCompleted.wait(m_lock);
 


### PR DESCRIPTION
#### 6506a07acabe61b6bdb9c347b5f4050b0a2dab7a
<pre>
Address safer C++ static analysis warnings in SuspendableWorkQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=287882">https://bugs.webkit.org/show_bug.cgi?id=287882</a>

Reviewed by Ryosuke Niwa.

Update WorkQueue::dispatch() to use keeping `this` alive. There is no need to keep `this`
alive for the task to run as with dispatch_queue the task will keep its queue alive and
run no matter what.

This means that the call site in SuspendableWorkQueue can now explicitly protect
`this` when dispatching, thus making static analysis happy.

* Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::suspend):
(WTF::SuspendableWorkQueue::dispatch):
(WTF::SuspendableWorkQueue::dispatchAfter):
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::dispatch):
(WTF::WorkQueueBase::dispatchAfter):

Canonical link: <a href="https://commits.webkit.org/290609@main">https://commits.webkit.org/290609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ec67a98a67e9d3d55588a554b63e9b30b721e4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69671 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93545 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7983 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50020 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36485 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40456 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83351 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37553 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97384 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89324 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78683 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77892 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22330 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20961 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14257 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23078 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111813 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17485 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->