### PR TITLE
[Cocoa] Adjust page color sampling heuristic to not fall back on extended page background color

### DIFF
--- a/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
+++ b/LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html
@@ -88,7 +88,7 @@ addEventListener("load", async () => {
         top: "rgb(0, 122, 255)",
         left: "rgb(255, 59, 48)",
         right: "rgb(52, 199, 89)",
-        bottom: "rgb(42, 42, 42)"
+        bottom: null
     });
 
     finishJSTest();

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -364,7 +364,7 @@ Color PageColorSampler::predominantColor(Page& page, const LayoutRect& absoluteR
             return WTFMove(*mostFrequentColor);
     }
 
-    return page.pageExtendedBackgroundColor();
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2883,6 +2883,20 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 #endif // PLATFORM(VISION)
 #endif // ENABLE(GAMEPAD)
 
+- (_WKRectEdge)_fixedContainerEdges
+{
+    _WKRectEdge edges = _WKRectEdgeNone;
+    if (_fixedContainerEdges.fixedEdges.bottom())
+        edges |= _WKRectEdgeBottom;
+    if (_fixedContainerEdges.fixedEdges.left())
+        edges |= _WKRectEdgeLeft;
+    if (_fixedContainerEdges.fixedEdges.right())
+        edges |= _WKRectEdgeRight;
+    if (_fixedContainerEdges.fixedEdges.top())
+        edges |= _WKRectEdgeTop;
+    return edges;
+}
+
 - (WebCore::CocoaColor *)_sampledBottomFixedPositionContentColor:(const WebCore::FixedContainerEdges&)edges
 {
     if (!edges.fixedEdges.bottom())
@@ -2940,7 +2954,7 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
     if (_fixedContainerEdges == edges)
         return;
 
-    Vector<SEL, 4> changedSelectors;
+    Vector<SEL, 5> changedSelectors;
 
     using FixedEdgeColors = WebCore::RectEdges<RetainPtr<WebCore::CocoaColor>>;
     FixedEdgeColors oldColors {
@@ -2968,6 +2982,9 @@ static _WKSelectionAttributes selectionAttributes(const WebKit::EditorState& edi
 
     if (oldColors.top() != newColors.top() || ![oldColors.top() isEqual:newColors.top().get()])
         changedSelectors.append(@selector(_sampledTopFixedPositionContentColor));
+
+    if (_fixedContainerEdges.fixedEdges != edges.fixedEdges)
+        changedSelectors.append(@selector(_fixedContainerEdges));
 
     for (auto selector : changedSelectors)
         [self willChangeValueForKey:NSStringFromSelector(selector)];

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -406,6 +406,7 @@ for this property.
 
 @property (nonatomic, readonly) BOOL _isSuspended;
 
+@property (nonatomic, readonly) _WKRectEdge _fixedContainerEdges WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 #if TARGET_OS_IPHONE
 @property (nonatomic, readonly) UIColor *_sampledTopFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 @property (nonatomic, readonly) UIColor *_sampledLeftFixedPositionContentColor WK_API_AVAILABLE(ios(WK_IOS_TBA), visionos(WK_XROS_TBA));


### PR DESCRIPTION
#### 3745ca7490caae96f45a148b838b988134608f91
<pre>
[Cocoa] Adjust page color sampling heuristic to not fall back on extended page background color
<a href="https://bugs.webkit.org/show_bug.cgi?id=287883">https://bugs.webkit.org/show_bug.cgi?id=287883</a>

Reviewed by Abrar Rahman Protyasha.

Make small adjustments to the heuristic added in 290447@main:

-   Remove the &quot;extended page background color&quot; fallback.
-   Instead, add a separate method that returns `_WKRectEdge`, indicating which edges of the
    viewport are adjacent to fixed-position containers.

* LayoutTests/fast/page-color-sampling/basic-fixed-container-edge-sampling.html:

Rebaseline a layout test.

* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _fixedContainerEdges]):
(-[WKWebView _updateFixedContainerEdges:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:

Canonical link: <a href="https://commits.webkit.org/290570@main">https://commits.webkit.org/290570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7973b1b6ae3fabea96d47d109ff5f25192dc3ee0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90450 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/9982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92502 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18301 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/49981 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/77998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37484 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97290 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17642 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/12972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17900 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19223 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20899 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17652 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20846 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19175 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->