### PR TITLE
[cocoa] Explicitly set the minimum TLS version to 1.0 when enabled

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -138,6 +138,11 @@ struct NetworkSessionCreationParameters {
     String resourceMonitorThrottlerDirectory;
     SandboxExtension::Handle resourceMonitorThrottlerDirectoryExtensionHandle;
 #endif
+#if ENABLE(TLS_1_2_DEFAULT_MINIMUM)
+    bool isLegacyTLSAllowed { false };
+#else
+    bool isLegacyTLSAllowed { true };
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -112,6 +112,7 @@ enum class WebKit::AllowsCellularAccess : bool;
     String resourceMonitorThrottlerDirectory;
     WebKit::SandboxExtensionHandle resourceMonitorThrottlerDirectoryExtensionHandle;
 #endif
+    bool isLegacyTLSAllowed;
 };
 
 #if USE(SOUP)

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -167,6 +167,7 @@ public:
 
     void applyProxyConfigurationToSessionConfiguration(NSURLSessionConfiguration *);
 #endif
+    bool isLegacyTLSAllowed() const { return m_isLegacyTLSAllowed; }
 
 private:
     void invalidateAndCancel() override;
@@ -229,6 +230,7 @@ private:
     bool m_fastServerTrustEvaluationEnabled { false };
     String m_dataConnectionServiceType;
     bool m_preventsSystemHTTPProxyAuthentication { false };
+    bool m_isLegacyTLSAllowed { false };
 #if HAVE(AD_ATTRIBUTION_KIT_PRIVATE_BROWSING)
     Markable<WTF::UUID> m_donatedEphemeralImpressionSessionID;
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2204,6 +2204,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
 #if HAVE(NW_PROXY_CONFIG)
     networkSessionParameters.proxyConfigData = m_proxyConfigData;
 #endif
+    networkSessionParameters.isLegacyTLSAllowed = m_configuration->legacyTLSEnabled();
 
     parameters.networkSessionParameters = WTFMove(networkSessionParameters);
     parameters.networkSessionParameters.resourceLoadStatisticsParameters.enabled = trackingPreventionEnabled();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -324,7 +324,11 @@ private:
     bool m_deviceManagementRestrictionsEnabled { false };
     bool m_allLoadsBlockedByDeviceManagementRestrictionsForTesting { false };
     bool m_allowsCellularAccess { true };
+#if ENABLE(TLS_1_2_DEFAULT_MINIMUM)
+    bool m_legacyTLSEnabled { false };
+#else
     bool m_legacyTLSEnabled { true };
+#endif
     bool m_fastServerTrustEvaluationEnabled { false };
     bool m_serviceWorkerProcessTerminationDelayEnabled { true };
     bool m_testingSessionEnabled { false };

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -133,8 +133,12 @@ RetainPtr<nw_parameters_t> HTTPServer::listenerParameters(Protocol protocol, Cer
         auto options = adoptNS(nw_tls_copy_sec_protocol_options(protocolOptions));
         auto identity = adoptNS(sec_identity_create(testIdentity.get()));
         sec_protocol_options_set_local_identity(options.get(), identity.get());
-        if (protocol == Protocol::HttpsWithLegacyTLS)
+        if (protocol == Protocol::HttpsWithLegacyTLS) {
+#if ENABLE(TLS_1_2_DEFAULT_MINIMUM)
+            sec_protocol_options_set_min_tls_protocol_version(options.get(), tls_protocol_version_TLSv10);
+#endif
             sec_protocol_options_set_max_tls_protocol_version(options.get(), tls_protocol_version_TLSv10);
+        }
         if (verifier) {
             sec_protocol_options_set_peer_authentication_required(options.get(), true);
             sec_protocol_options_set_verify_block(options.get(), makeBlockPtr([verifier = WTFMove(verifier)](sec_protocol_metadata_t metadata, sec_trust_t trust, sec_protocol_verify_complete_t completion) {


### PR DESCRIPTION
#### cad628f39ffbd176042a10c5af8e6cf51b9d5026
<pre>
[cocoa] Explicitly set the minimum TLS version to 1.0 when enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=280145">https://bugs.webkit.org/show_bug.cgi?id=280145</a>
<a href="https://rdar.apple.com/136185611">rdar://136185611</a>

Reviewed by Alex Christensen.

The system default minimum TLS version is changing to TLS 1.2. Continue
allowing older protocol versions if the option is enabled.

Original patch by Guoye Zhang

* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::NetworkSessionCocoa):
(WebKit::SessionSet::initializeEphemeralStatelessSessionIfNeeded):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TLSDeprecation.mm:
(TestWebKitAPI::TEST(TLSVersion, DefaultBehavior)):
(TestWebKitAPI::TEST(TLSVersion, NetworkSession)):
(TestWebKitAPI::webViewWithNavigationDelegate):
(TestWebKitAPI::TEST(TLSVersion, LegacySubresources)):
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::HTTPServer::listenerParameters):

Canonical link: <a href="https://commits.webkit.org/291333@main">https://commits.webkit.org/291333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/521f8426c3ef8da860eb7e2d7dc3ee77bf874310

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92516 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28322 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51208 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9060 "Found 2 new test failures: imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1414 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42354 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79380 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99527 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79883 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79161 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12579 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14775 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19551 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24723 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19238 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22698 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->