### PR TITLE
Unreviewed, unskip files that are no longer failing on the safer c++ bot after the compiler update

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -34,7 +34,6 @@
 ./bytecode/StructureStubInfo.cpp
 ./bytecode/UnlinkedCodeBlockGenerator.cpp
 ./bytecode/UnlinkedFunctionExecutable.cpp
-./bytecode/Watchpoint.h
 ./bytecompiler/BytecodeGenerator.cpp
 ./bytecompiler/NodesCodegen.cpp
 ./debugger/Debugger.cpp
@@ -91,7 +90,6 @@
 ./jit/ICStats.cpp
 ./jit/ICStats.h
 ./jit/JIT.cpp
-./jit/JITCode.cpp
 ./jit/JITSafepoint.cpp
 ./jit/JITWorklist.cpp
 ./jit/JITWorklistThread.cpp
@@ -123,10 +121,8 @@
 ./runtime/JSGlobalObject.cpp
 ./runtime/JSLock.cpp
 ./runtime/JSModuleEnvironment.cpp
-./runtime/JSModuleNamespaceObject.cpp
 ./runtime/JSObject.cpp
 ./runtime/JSRunLoopTimer.cpp
-./runtime/JSString.cpp
 ./runtime/JSSymbolTableObject.cpp
 ./runtime/ModuleProgramExecutable.cpp
 ./runtime/NativeExecutable.cpp
@@ -187,10 +183,8 @@ API/tests/CompareAndSwapTest.cpp
 API/tests/testapi.cpp
 bytecode/CodeBlock.h
 bytecode/DirectEvalCodeCache.h
-bytecode/InlineCacheCompiler.h
 bytecode/SharedJITStubSet.h
 bytecode/UnlinkedCodeBlock.h
-bytecode/Watchpoint.h
 bytecompiler/BytecodeGenerator.h
 dfg/DFGAbstractInterpreterInlines.h
 dfg/DFGJITCompiler.h
@@ -203,7 +197,6 @@ inspector/InspectorBackendDispatchers.cpp
 inspector/InspectorFrontendDispatchers.cpp
 inspector/InspectorProtocolObjects.h
 inspector/JavaScriptCallFrame.h
-jit/JITStubRoutine.h
 jit/JITWorklistInlines.h
 jsc.cpp
 parser/Parser.cpp
@@ -216,14 +209,12 @@ runtime/CacheableIdentifierInlines.h
 runtime/InferredValue.h
 runtime/JSGenericTypedArrayViewInlines.h
 runtime/JSObjectInlines.h
-runtime/JSSymbolTableObject.h
 runtime/RegExpKey.h
 runtime/ScriptExecutable.h
 runtime/StructureInlines.h
 runtime/VM.h
 wasm/WasmBBQJIT.cpp
 wasm/WasmBBQJIT64.cpp
-wasm/WasmCallee.h
 wasm/WasmFormat.h
 wasm/WasmIPIntSlowPaths.cpp
 wasm/WasmMemory.h

--- a/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,4 +1,3 @@
-WebKitBuild/Release/usr/local/include/wtf/text/StringImpl.h
 wtf/AutomaticThread.cpp
 wtf/JSONValues.cpp
 wtf/MemoryPressureHandler.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,4 +1,3 @@
-wtf/AutomaticThread.cpp
 wtf/PrintStream.h
 wtf/RunLoop.h
 wtf/SuspendableWorkQueue.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,8 +1,6 @@
 wtf/AutomaticThread.cpp
 wtf/MemoryPressureHandler.cpp
-wtf/MetaAllocator.h
 wtf/RecursiveLockAdapter.h
-wtf/RedBlackTree.h
 wtf/Ref.h
 wtf/ThreadSafeWeakPtr.h
 wtf/text/AtomStringImpl.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -99,7 +99,6 @@ rendering/updating/RenderTreeBuilder.cpp
 style/StyleAdjuster.cpp
 style/StyleResolveForDocument.cpp
 style/StyleScope.cpp
-svg/properties/SVGPropertyOwnerRegistry.h
 testing/Internals.cpp
 testing/Internals.mm
 workers/DedicatedWorkerGlobalScope.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -226,7 +226,6 @@ Modules/webaudio/RealtimeAnalyser.cpp
 Modules/webaudio/ScriptProcessorNode.cpp
 Modules/webaudio/StereoPannerNode.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
-Modules/webauthn/PublicKeyCredential.cpp
 Modules/webauthn/fido/Pin.cpp
 Modules/webcodecs/WebCodecsAudioData.cpp
 Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -259,12 +258,10 @@ accessibility/AXObjectCache.cpp
 accessibility/AXObjectCache.h
 accessibility/AXSearchManager.cpp
 accessibility/AXTextMarker.cpp
-accessibility/AccessibilityARIAGridRow.cpp
 accessibility/AccessibilityImageMapLink.cpp
 accessibility/AccessibilityList.cpp
 accessibility/AccessibilityListBox.cpp
 accessibility/AccessibilityListBoxOption.cpp
-accessibility/AccessibilityMathMLElement.cpp
 accessibility/AccessibilityMenuList.cpp
 accessibility/AccessibilityMenuListOption.cpp
 accessibility/AccessibilityMenuListPopup.cpp
@@ -281,7 +278,6 @@ accessibility/AccessibilityTable.cpp
 accessibility/AccessibilityTableCell.cpp
 accessibility/AccessibilityTableColumn.cpp
 accessibility/AccessibilityTableHeaderContainer.cpp
-accessibility/AccessibilityTableRow.cpp
 accessibility/isolatedtree/AXIsolatedObject.cpp
 accessibility/isolatedtree/AXIsolatedObject.h
 accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -303,7 +299,6 @@ animation/KeyframeEffect.cpp
 animation/ScrollTimeline.cpp
 animation/StyleOriginatedAnimation.cpp
 animation/StyleOriginatedAnimationEvent.cpp
-animation/TimelineRange.cpp
 animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
 animation/WebAnimationUtilities.cpp
@@ -428,7 +423,6 @@ css/CSSComputedStyleDeclaration.cpp
 css/CSSCounterStyle.cpp
 css/CSSCounterStyleDescriptors.cpp
 css/CSSCounterStyleRegistry.cpp
-css/CSSCounterStyleRule.cpp
 css/CSSCounterStyleRule.h
 css/CSSCounterValue.cpp
 css/CSSCounterValue.h
@@ -543,7 +537,6 @@ dom/BoundaryPoint.cpp
 dom/BroadcastChannel.cpp
 dom/ChildListMutationScope.h
 dom/ComposedTreeIterator.cpp
-dom/ComposedTreeIterator.h
 dom/ContainerNode.cpp
 dom/ContainerNodeAlgorithms.cpp
 dom/ContentVisibilityDocumentState.cpp
@@ -562,13 +555,11 @@ dom/DocumentInlines.h
 dom/DocumentOrShadowRootFullscreen.cpp
 dom/DocumentStorageAccess.cpp
 dom/Element.cpp
-dom/ElementAndTextDescendantIterator.h
 dom/ElementData.cpp
 dom/ElementInlines.h
 dom/ElementInternals.cpp
 dom/ElementIteratorInlines.h
 dom/EmptyScriptExecutionContext.h
-dom/EventListenerMap.cpp
 dom/EventPath.cpp
 dom/EventTarget.cpp
 dom/ExtensionStyleSheets.cpp
@@ -619,7 +610,6 @@ dom/StaticNodeList.cpp
 dom/StaticRange.cpp
 dom/StyledElement.cpp
 dom/Subscriber.cpp
-dom/Text.cpp
 dom/TextDecoderStreamDecoder.h
 dom/Traversal.cpp
 dom/TreeScope.cpp
@@ -654,12 +644,10 @@ editing/InsertParagraphSeparatorCommand.cpp
 editing/InsertTextCommand.cpp
 editing/ModifySelectionListLevel.cpp
 editing/RemoveFormatCommand.cpp
-editing/RenderedPosition.cpp
 editing/ReplaceNodeWithSpanCommand.cpp
 editing/ReplaceSelectionCommand.cpp
 editing/ReplaceSelectionCommand.h
 editing/SelectionGeometryGatherer.cpp
-editing/SimplifyMarkupCommand.cpp
 editing/SpellChecker.cpp
 editing/SplitTextNodeCommand.cpp
 editing/SplitTextNodeContainingElementCommand.cpp
@@ -701,15 +689,12 @@ html/CustomPaintCanvas.cpp
 html/DOMFormData.cpp
 html/DOMTokenList.cpp
 html/DOMURL.cpp
-html/DateInputType.cpp
-html/DateTimeLocalInputType.cpp
 html/DirectoryFileListCreator.cpp
 html/EmailInputType.cpp
 html/FTPDirectoryDocument.cpp
 html/FileInputType.cpp
 html/FormAssociatedCustomElement.cpp
 html/FormAssociatedElement.cpp
-html/FormController.cpp
 html/FormListedElement.cpp
 html/HTMLAllCollection.cpp
 html/HTMLAnchorElement.cpp
@@ -746,7 +731,6 @@ html/HTMLObjectElement.cpp
 html/HTMLOptGroupElement.cpp
 html/HTMLOptionElement.cpp
 html/HTMLOptionsCollection.cpp
-html/HTMLOptionsCollectionInlines.h
 html/HTMLPlugInElement.cpp
 html/HTMLPlugInImageElement.cpp
 html/HTMLProgressElement.cpp
@@ -791,12 +775,10 @@ html/ResetInputType.cpp
 html/SearchInputType.cpp
 html/SubmitInputType.cpp
 html/TextFieldInputType.cpp
-html/TimeInputType.cpp
 html/URLInputType.cpp
 html/ValidatedFormListedElement.cpp
 html/ValidatedFormListedElement.h
 html/ValidationMessage.cpp
-html/WeekInputType.cpp
 html/canvas/CanvasFilterContextSwitcher.cpp
 html/canvas/CanvasGradient.cpp
 html/canvas/CanvasPattern.cpp
@@ -837,7 +819,6 @@ html/parser/HTMLTreeBuilder.cpp
 html/shadow/DateTimeEditElement.cpp
 html/shadow/DateTimeFieldElement.cpp
 html/shadow/MediaControlTextTrackContainerElement.cpp
-html/shadow/ProgressShadowElement.cpp
 html/shadow/SliderThumbElement.cpp
 html/shadow/SpinButtonElement.cpp
 html/shadow/TextControlInnerElements.cpp
@@ -935,7 +916,6 @@ loader/archive/ArchiveResource.cpp
 loader/archive/cf/LegacyWebArchive.cpp
 loader/cache/CachedCSSStyleSheet.cpp
 loader/cache/CachedImage.cpp
-loader/cache/CachedRawResource.cpp
 loader/cache/CachedResourceRequest.cpp
 loader/cache/CachedResourceRequestInitiatorTypes.h
 loader/cache/CachedSVGDocumentReference.cpp
@@ -962,14 +942,12 @@ page/Frame.cpp
 page/FrameDestructionObserver.cpp
 page/FrameSnapshotting.cpp
 page/FrameTree.cpp
-page/FrameView.cpp
 page/History.cpp
 page/ImageAnalysisQueue.cpp
 page/ImageOverlayController.cpp
 page/InteractionRegion.cpp
 page/IntersectionObserver.cpp
 page/LocalDOMWindow.cpp
-page/LocalDOMWindowProperty.cpp
 page/LocalFrame.cpp
 page/LocalFrameView.cpp
 page/LocalFrameViewLayoutContext.cpp
@@ -1194,7 +1172,6 @@ rendering/GlyphDisplayListCache.h
 rendering/HitTestResult.cpp
 rendering/ImageQualityController.cpp
 rendering/InlineBoxPainter.cpp
-rendering/LayerAncestorClippingStack.cpp
 rendering/LegacyInlineFlowBox.cpp
 rendering/LegacyLineLayout.cpp
 rendering/MarkedText.cpp
@@ -1241,7 +1218,6 @@ rendering/RenderTable.cpp
 rendering/RenderTable.h
 rendering/RenderTableCell.cpp
 rendering/RenderTableCell.h
-rendering/RenderTableCol.cpp
 rendering/RenderTableRow.cpp
 rendering/RenderTableSection.cpp
 rendering/RenderTableSection.h
@@ -1258,7 +1234,6 @@ rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
-rendering/TextAutoSizing.cpp
 rendering/TextBoxPainter.cpp
 rendering/TextPaintStyle.cpp
 rendering/cocoa/RenderThemeCocoa.mm
@@ -1290,13 +1265,10 @@ rendering/style/StyleMiscNonInheritedData.cpp
 rendering/style/StyleMultiImage.cpp
 rendering/style/StylePaintImage.cpp
 rendering/svg/RenderSVGEllipse.cpp
-rendering/svg/RenderSVGGradientStop.cpp
 rendering/svg/RenderSVGImage.cpp
 rendering/svg/RenderSVGInline.cpp
 rendering/svg/RenderSVGInlineText.cpp
-rendering/svg/RenderSVGModelObject.cpp
 rendering/svg/RenderSVGRect.cpp
-rendering/svg/RenderSVGResourceContainer.cpp
 rendering/svg/RenderSVGResourceFilterInlines.h
 rendering/svg/RenderSVGResourceFilterPrimitive.cpp
 rendering/svg/RenderSVGResourcePattern.cpp
@@ -1346,10 +1318,8 @@ storage/StorageNamespaceProvider.cpp
 style/AttributeChangeInvalidation.cpp
 style/ChildChangeInvalidation.cpp
 style/ChildChangeInvalidation.h
-style/ContainerQueryEvaluator.cpp
 style/ElementRuleCollector.cpp
 style/IdChangeInvalidation.cpp
-style/InlineTextBoxStyle.cpp
 style/InspectorCSSOMWrappers.cpp
 style/MatchedDeclarationsCache.cpp
 style/PageRuleCollector.cpp
@@ -1363,7 +1333,6 @@ style/StyleBuilder.cpp
 style/StyleBuilderConverter.h
 style/StyleBuilderCustom.h
 style/StyleBuilderState.cpp
-style/StyleInvalidationFunctions.h
 style/StyleInvalidator.cpp
 style/StylePendingResources.cpp
 style/StyleResolveForDocument.cpp
@@ -1411,11 +1380,9 @@ svg/SVGFESpecularLightingElement.h
 svg/SVGFETileElement.h
 svg/SVGFETurbulenceElement.h
 svg/SVGFilterElement.h
-svg/SVGFilterPrimitiveStandardAttributes.cpp
 svg/SVGFilterPrimitiveStandardAttributes.h
 svg/SVGFitToViewBox.h
 svg/SVGFontFaceElement.cpp
-svg/SVGFontFaceFormatElement.cpp
 svg/SVGFontFaceUriElement.cpp
 svg/SVGForeignObjectElement.h
 svg/SVGGeometryElement.h
@@ -1448,7 +1415,6 @@ svg/SVGSVGElement.cpp
 svg/SVGSVGElement.h
 svg/SVGStopElement.h
 svg/SVGTRefElement.cpp
-svg/SVGTSpanElement.cpp
 svg/SVGTextContentElement.cpp
 svg/SVGTextContentElement.h
 svg/SVGTextPathElement.cpp
@@ -1467,7 +1433,6 @@ svg/properties/SVGAnimatedDecoratedProperty.h
 svg/properties/SVGAnimatedPrimitiveProperty.h
 svg/properties/SVGAnimatedPropertyAnimator.h
 svg/properties/SVGAnimatedPropertyAnimatorImpl.h
-svg/properties/SVGAnimatedPropertyList.h
 svg/properties/SVGAnimatedPropertyPairAccessorImpl.h
 svg/properties/SVGAnimatedPropertyPairAnimator.h
 svg/properties/SVGAnimatedPropertyPairAnimatorImpl.h
@@ -1476,8 +1441,6 @@ svg/properties/SVGAnimatedValueProperty.h
 svg/properties/SVGAttributeAnimator.cpp
 svg/properties/SVGPointerMemberAccessor.h
 svg/properties/SVGPrimitivePropertyAnimator.h
-svg/properties/SVGPropertyAccessorImpl.h
-svg/properties/SVGPropertyOwnerRegistry.h
 svg/properties/SVGValuePropertyAnimator.h
 svg/properties/SVGValuePropertyListAnimatorImpl.h
 testing/InternalSettings.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -73,7 +73,6 @@ bindings/js/SerializedScriptValue.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
 css/CSSFontFace.cpp
-css/CSSImageSetValue.cpp
 css/CSSPendingSubstitutionValue.cpp
 css/CSSValue.cpp
 css/CSSVariableReferenceValue.cpp
@@ -109,7 +108,6 @@ html/canvas/CanvasStyle.cpp
 html/canvas/GPUCanvasContextCocoa.mm
 html/canvas/WebGLRenderingContextBase.cpp
 html/track/LoadableTextTrack.cpp
-html/track/TextTrack.cpp
 html/track/TrackBase.cpp
 html/track/TrackListBase.cpp
 html/track/VTTCue.cpp
@@ -165,7 +163,6 @@ rendering/RenderListItem.cpp
 rendering/style/StyleCustomPropertyData.cpp
 rendering/updating/RenderTreePosition.cpp
 rendering/updating/RenderTreeUpdater.cpp
-storage/Storage.cpp
 style/ElementRuleCollector.cpp
 style/StyleBuilderConverter.h
 style/StyleTreeResolver.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -47,7 +47,6 @@ Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
 Modules/model-element/HTMLModelElement.cpp
 Modules/notifications/Notification.cpp
 Modules/paymentrequest/PaymentRequest.cpp
-Modules/permissions/PermissionStatus.cpp
 Modules/permissions/Permissions.cpp
 Modules/pictureinpicture/DocumentPictureInPicture.cpp
 Modules/speech/SpeechRecognition.cpp
@@ -230,7 +229,6 @@ css/CSSKeyframeRule.cpp
 css/CSSLayerBlockRule.cpp
 css/CSSPageRule.cpp
 css/CSSPrimitiveValue.cpp
-css/CSSPrimitiveValueMappings.h
 css/CSSRule.cpp
 css/CSSStyleRule.cpp
 css/CSSStyleSheet.cpp
@@ -259,7 +257,6 @@ css/StyleRuleImport.cpp
 css/StyleSheetContents.cpp
 css/parser/CSSParserImpl.cpp
 css/query/ContainerQueryFeatures.cpp
-css/query/GenericMediaQueryEvaluator.cpp
 css/query/MediaQueryFeatures.cpp
 css/typedom/CSSNumericValue.cpp
 css/typedom/CSSStyleValueFactory.cpp
@@ -290,11 +287,9 @@ dom/DocumentFragment.cpp
 dom/DocumentStorageAccess.cpp
 dom/Element.cpp
 dom/ElementAndTextDescendantIterator.h
-dom/ElementInlines.h
 dom/ElementIteratorInlines.h
 dom/ElementTextDirection.cpp
 dom/ElementTraversal.h
-dom/Event.cpp
 dom/EventPath.cpp
 dom/EventTarget.cpp
 dom/FragmentDirectiveGenerator.cpp
@@ -308,7 +303,6 @@ dom/Node.cpp
 dom/NodeTraversal.cpp
 dom/NodeTraversal.h
 dom/Position.cpp
-dom/Position.h
 dom/QualifiedNameCache.cpp
 dom/RadioButtonGroups.cpp
 dom/Range.cpp
@@ -382,7 +376,6 @@ html/HTMLDetailsElement.cpp
 html/HTMLDialogElement.cpp
 html/HTMLDocument.cpp
 html/HTMLElement.cpp
-html/HTMLEmbedElement.cpp
 html/HTMLFieldSetElement.cpp
 html/HTMLFormControlsCollection.cpp
 html/HTMLFormElement.cpp
@@ -398,13 +391,10 @@ html/HTMLOptionElement.cpp
 html/HTMLPictureElement.cpp
 html/HTMLSelectElement.cpp
 html/HTMLSlotElement.cpp
-html/HTMLSourceElement.cpp
 html/HTMLStyleElement.cpp
 html/HTMLSummaryElement.cpp
-html/HTMLTableCellElement.cpp
 html/HTMLTableElement.cpp
 html/HTMLTableRowElement.cpp
-html/HTMLTableRowsCollection.cpp
 html/HTMLTextFormControlElement.cpp
 html/ImageBitmap.cpp
 html/ImageInputType.cpp
@@ -433,7 +423,6 @@ html/canvas/EXTDisjointTimerQueryWebGL2.cpp
 html/canvas/EXTPolygonOffsetClamp.cpp
 html/canvas/GPUBasedCanvasRenderingContext.cpp
 html/canvas/GPUCanvasContextCocoa.mm
-html/canvas/ImageBitmapRenderingContext.cpp
 html/canvas/OESDrawBuffersIndexed.cpp
 html/canvas/OESVertexArrayObject.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -505,7 +494,6 @@ loader/ApplicationManifestLoader.cpp
 loader/DocumentLoader.cpp
 loader/FrameLoader.cpp
 loader/NavigationAction.cpp
-loader/NavigationDisabler.h
 loader/NavigationScheduler.cpp
 loader/ThreadableLoader.cpp
 loader/WorkerThreadableLoader.cpp
@@ -522,7 +510,6 @@ page/BarProp.cpp
 page/CaptionUserPreferences.cpp
 page/CaptionUserPreferencesMediaAF.cpp
 page/ContextMenuController.cpp
-page/DOMTimer.cpp
 page/DOMWindow.cpp
 page/DebugPageOverlays.cpp
 page/DeviceController.cpp
@@ -554,7 +541,6 @@ page/PageGroupLoadDeferrer.cpp
 page/PageOverlayController.cpp
 page/PageSerializer.cpp
 page/Performance.cpp
-page/PerformanceLogging.cpp
 page/PerformanceMark.cpp
 page/PerformanceNavigation.cpp
 page/PerformanceObserver.cpp
@@ -565,7 +551,6 @@ page/PrintContext.cpp
 page/Quirks.cpp
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
-page/RemoteFrameView.cpp
 page/ResizeObservation.cpp
 page/ResizeObserver.cpp
 page/ScreenOrientation.cpp
@@ -678,14 +663,12 @@ rendering/RenderListBox.cpp
 rendering/RenderListItem.cpp
 rendering/RenderMarquee.cpp
 rendering/RenderMenuList.cpp
-rendering/RenderMeter.cpp
 rendering/RenderObject.cpp
 rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp
 rendering/RenderSlider.cpp
 rendering/RenderTableCell.cpp
-rendering/RenderTableCol.cpp
 rendering/RenderTextControl.cpp
 rendering/RenderTextControlMultiLine.cpp
 rendering/RenderTextControlSingleLine.cpp
@@ -711,12 +694,10 @@ rendering/style/StyleGradientImage.cpp
 rendering/style/StylePaintImage.cpp
 rendering/svg/RenderSVGPath.cpp
 rendering/svg/RenderSVGResourcePattern.cpp
-rendering/svg/RenderSVGRoot.cpp
 rendering/svg/RenderSVGShape.cpp
 rendering/svg/RenderSVGTransformableContainer.cpp
 rendering/svg/SVGRenderSupport.cpp
 rendering/svg/SVGRenderTreeAsText.cpp
-rendering/svg/SVGRenderingContext.cpp
 rendering/svg/SVGTextBoxPainter.cpp
 rendering/svg/SVGTextChunk.cpp
 rendering/svg/SVGTextLayoutEngine.cpp
@@ -782,21 +763,17 @@ svg/SVGFELightElement.cpp
 svg/SVGFEMergeElement.cpp
 svg/SVGFontFaceSrcElement.cpp
 svg/SVGGradientElement.cpp
-svg/SVGLengthContext.cpp
 svg/SVGLinearGradientElement.cpp
 svg/SVGLocatable.cpp
 svg/SVGMPathElement.cpp
 svg/SVGMaskElement.cpp
 svg/SVGSVGElement.cpp
 svg/SVGSwitchElement.cpp
-svg/SVGTextContentElement.cpp
-svg/SVGTextPositioningElement.cpp
 svg/SVGToOTFFontConversion.cpp
 svg/SVGUseElement.cpp
 svg/graphics/SVGImage.cpp
 svg/graphics/SVGImageCache.cpp
 svg/properties/SVGAnimatedString.cpp
-svg/properties/SVGPropertyOwnerRegistry.h
 testing/InternalSettings.cpp
 testing/Internals.cpp
 testing/Internals.mm

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -26,7 +26,6 @@ WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
 WebProcess/InjectedBundle/API/mac/WKDOMInternals.mm
 WebProcess/Network/NetworkProcessConnection.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
-WebProcess/Plugins/PDF/PDFPlugin.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PluginView.cpp
 WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -4,7 +4,6 @@ NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/NetworkLoad.cpp
 NetworkProcess/PingLoad.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
-NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKBrowsingContextController.mm
@@ -19,13 +18,11 @@ UIProcess/SuspendedPageProxy.cpp
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp
 UIProcess/WebContextMenuProxy.cpp
 UIProcess/WebEditCommandProxy.cpp
-UIProcess/WebPageProxy.cpp
 UIProcess/WebURLSchemeTask.cpp
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/Inspector/WebInspectorInternal.cpp
-WebProcess/Plugins/PDF/PDFPlugin.mm
 WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginPasswordField.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -14,7 +14,6 @@ NetworkProcess/PingLoad.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
 NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
-NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
 NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
 NetworkProcess/ServiceWorker/ServiceWorkerSoftUpdateLoader.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
@@ -32,7 +31,6 @@ NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
 Platform/IPC/ArgumentCoders.h
 Shared/API/APIArray.h
 Shared/API/APISerializedScriptValue.h
-Shared/API/Cocoa/WKRemoteObjectCoder.mm
 Shared/API/c/WKArray.cpp
 Shared/API/c/WKContextMenuItem.cpp
 Shared/API/c/WKData.cpp
@@ -180,8 +178,6 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-UIProcess/API/mac/WKWebViewMac.mm
-UIProcess/API/mac/WKWebViewTestingMac.mm
 UIProcess/BackgroundProcessResponsivenessTimer.cpp
 UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
 UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -351,7 +347,6 @@ WebProcess/Network/webrtc/LibWebRTCProvider.cpp
 WebProcess/Network/webrtc/LibWebRTCSocketFactory.cpp
 WebProcess/Network/webrtc/RTCDataChannelRemoteManager.cpp
 WebProcess/Network/webrtc/WebRTCMonitor.cpp
-WebProcess/Plugins/PDF/PDFPlugin.mm
 WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
 WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -8,7 +8,6 @@ UIProcess/Automation/WebAutomationSession.cpp
 UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
 UIProcess/DeviceIdHashSaltStorage.cpp
 UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
-UIProcess/Notifications/WebNotificationManagerProxy.cpp
 UIProcess/SpeechRecognitionPermissionManager.cpp
 UIProcess/UserMediaPermissionRequestManagerProxy.cpp
 UIProcess/UserMediaProcessManager.cpp
@@ -19,13 +18,10 @@ UIProcess/WebAuthentication/Cocoa/CcidService.mm
 UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
 UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
-UIProcess/WebBackForwardList.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
-WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
-WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp
 WebProcess/GPU/media/RemoteImageDecoderAVF.cpp
 WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -39,11 +35,9 @@ WebProcess/Network/WebLoaderStrategy.cpp
 WebProcess/Network/WebSocketChannel.cpp
 WebProcess/Network/webrtc/LibWebRTCNetwork.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
-WebProcess/Plugins/PDF/PDFPlugin.mm
 WebProcess/Plugins/PDF/PDFPluginBase.mm
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Storage/WebSWClientConnection.cpp
-WebProcess/WebCoreSupport/WebPopupMenu.cpp
 WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp
 WebProcess/WebPage/EventDispatcher.cpp
 WebProcess/WebPage/ViewUpdateDispatcher.cpp


### PR DESCRIPTION
#### 365820a9e8f6ed2792ea4f328fefb0d47d224722
<pre>
Unreviewed, unskip files that are no longer failing on the safer c++ bot after the compiler update
<a href="https://bugs.webkit.org/show_bug.cgi?id=287893">https://bugs.webkit.org/show_bug.cgi?id=287893</a>

* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/290556@main">https://commits.webkit.org/290556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c81def65d6de56bf2208e0b8f5d86f35e667566

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90465 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/9997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92517 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/10390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/18316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93466 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/10390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/10390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/83271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/10390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/89245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/17657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/18316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/17915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14225 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/22999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111734 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->