### PR TITLE
Remove FullscreenManager::FullscreenPromise

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-twice-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-twice-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Document#exitFullscreen() called twice promise_test: Unhandled rejection with value: object "TypeError: Pending operation cancelled by exitFullscreen() call."
+PASS Document#exitFullscreen() called twice
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,7 +1,5 @@
 
 
-Harness Error (FAIL), message = Timeout while running cleanup for test named "Check directly that events are fired in right order (from top to bottom)".
-
 FAIL Test subframes receive orientation change events promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 FAIL Check directly that events are fired in right order (from top to bottom) promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-twice-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-twice-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL Document#exitFullscreen() called twice promise_test: Unhandled rejection with value: object "TypeError: Pending operation cancelled by exitFullscreen() call."
-

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -77,7 +77,7 @@ public:
     WEBCORE_EXPORT void willEnterFullscreen(Element&, HTMLMediaElementEnums::VideoFullscreenMode, CompletionHandler<void(ExceptionOr<void>)>&&);
     WEBCORE_EXPORT bool didEnterFullscreen();
     WEBCORE_EXPORT bool willExitFullscreen();
-    WEBCORE_EXPORT bool didExitFullscreen();
+    WEBCORE_EXPORT void didExitFullscreen(CompletionHandler<void(ExceptionOr<void>)>&&);
 
     void dispatchPendingEvents();
 
@@ -117,21 +117,6 @@ private:
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_topDocument;
-
-    class FullscreenPromise {
-    public:
-        ~FullscreenPromise();
-        FullscreenPromise& operator=(CompletionHandler<void(ExceptionOr<void>)>&&);
-
-        void clear();
-        void resolve();
-        void rejectOrResolve(ExceptionOr<void>);
-        void reject(Exception);
-        operator bool() const;
-    private:
-        CompletionHandler<void(ExceptionOr<void>)> m_promise;
-    };
-    FullscreenPromise m_pendingPromise;
 
     RefPtr<Element> m_pendingFullscreenElement;
     RefPtr<Element> m_fullscreenElement;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -494,7 +494,7 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual void updateImageSource(Element&) { }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
-    virtual void exitFullScreenForElement(Element*) { }
+    virtual void exitFullScreenForElement(Element*, CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void setRootFullScreenLayer(GraphicsLayer*) { }
 #endif
 

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -70,12 +70,12 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&);
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
-    void exitFullScreenForElement(WebCore::Element*);
+    void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void()>&&);
 
     void willEnterFullScreen(CompletionHandler<void(WebCore::ExceptionOr<void>)>&&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode = WebCore::HTMLMediaElementEnums::VideoFullscreenModeStandard);
     void didEnterFullScreen();
-    void willExitFullScreen();
-    void didExitFullScreen();
+    void willExitFullScreen(CompletionHandler<void()>&&);
+    void didExitFullScreen(CompletionHandler<void()>&&);
 
     WebCore::Element* element();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1345,7 +1345,7 @@ void WebChromeClient::updateImageSource(Element& element)
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
-void WebChromeClient::exitFullScreenForElement(Element* element)
+void WebChromeClient::exitFullScreenForElement(Element* element, CompletionHandler<void()>&& completionHandler)
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     bool exitingInWindowFullscreen = false;
@@ -1354,7 +1354,7 @@ void WebChromeClient::exitFullScreenForElement(Element* element)
             exitingInWindowFullscreen = videoElement->fullscreenMode() == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
     }
 #endif
-    protectedPage()->fullScreenManager().exitFullScreenForElement(element);
+    protectedPage()->fullScreenManager().exitFullScreenForElement(element, WTFMove(completionHandler));
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     if (exitingInWindowFullscreen)
         clearVideoFullscreenMode(*dynamicDowncast<HTMLVideoElement>(*element), HTMLMediaElementEnums::VideoFullscreenModeInWindow);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -339,7 +339,7 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(WebCore::Element&) final;
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
-    void exitFullScreenForElement(WebCore::Element*) final;
+    void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void()>&&) final;
 #endif // ENABLE(FULLSCREEN_API)
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -559,8 +559,13 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 
 #if ENABLE(FULLSCREEN_API)
     auto* document = m_localFrame->document();
-    if (document && document->fullscreenManager().fullscreenElement())
-        webPage->fullScreenManager().exitFullScreenForElement(webPage->fullScreenManager().element());
+    if (document && document->fullscreenManager().fullscreenElement()) {
+        RefPtr element = webPage->fullScreenManager().element();
+        webPage->fullScreenManager().exitFullScreenForElement(element.get(), [element] {
+            if (element)
+                element->document().fullscreenManager().didExitFullscreen([](auto) { });
+        });
+    }
 #endif
 
     webPage->findController().hideFindUI();

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -211,7 +211,7 @@ private:
 #if ENABLE(FULLSCREEN_API)
     bool supportsFullScreenForElement(const WebCore::Element&, bool withKeyboard) final;
     void enterFullScreenForElement(WebCore::Element&, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, CompletionHandler<void(WebCore::ExceptionOr<void>)>&&) final;
-    void exitFullScreenForElement(WebCore::Element*) final;
+    void exitFullScreenForElement(WebCore::Element*, CompletionHandler<void()>&&) final;
 #endif
 
     bool selectItemWritingDirectionIsNatural() override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm
@@ -66,8 +66,8 @@ using namespace WebCore;
 
 - (void)webkitDidExitFullScreen
 {
-    if (_element)
-        _element->document().fullscreenManager().didExitFullscreen();
+    if (_completionHandler)
+        _completionHandler({ });
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.h
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.h
@@ -26,6 +26,7 @@
 #if ENABLE(FULLSCREEN_API) && !PLATFORM(IOS_FAMILY)
 
 #import <WebCore/IntPoint.h>
+#import <wtf/CompletionHandler.h>
 #import <wtf/RefPtr.h>
 #import <wtf/RetainPtr.h>
 
@@ -53,7 +54,7 @@ template<typename> class ExceptionOr;
     float _savedScale;
 
     BOOL _isEnteringFullScreen;
-    BOOL _isExitingFullScreen;
+    CompletionHandler<void()> _exitCompletionHandler;
     BOOL _isFullScreen;
 }
 
@@ -71,7 +72,7 @@ template<typename> class ExceptionOr;
 - (WebCore::Element*)element;
 
 - (void)enterFullScreen:(NSScreen *)screen completionHandler:(CompletionHandler<void(WebCore::ExceptionOr<void>)>&&)completionHandler;
-- (void)exitFullScreen;
+- (void)exitFullScreen:(CompletionHandler<void()>&&)completionHandler;
 - (void)close;
 @end
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -8968,11 +8968,11 @@ FORWARD(toggleUnderline)
     [_private->newFullscreenController enterFullScreen:[[self window] screen] completionHandler:WTFMove(completionHandler)];
 }
 
-- (void)_exitFullScreenForElement:(NakedPtr<WebCore::Element>)element
+- (void)_exitFullScreenForElement:(NakedPtr<WebCore::Element>)element completionHandler:(CompletionHandler<void()>&&)completionHandler
 {
     if (!_private->newFullscreenController)
-        return;
-    [_private->newFullscreenController exitFullScreen];
+        return completionHandler();
+    [_private->newFullscreenController exitFullScreen:WTFMove(completionHandler)];
 }
 #endif
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -328,7 +328,7 @@ WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 #if ENABLE(FULLSCREEN_API) && !PLATFORM(IOS_FAMILY) && defined(__cplusplus)
 - (BOOL)_supportsFullScreenForElement:(NakedPtr<WebCore::Element>)element withKeyboard:(BOOL)withKeyboard;
 - (void)_enterFullScreenForElement:(NakedPtr<WebCore::Element>)element completionHandler:(CompletionHandler<void(WebCore::ExceptionOr<void>)>&&)completionHandler;
-- (void)_exitFullScreenForElement:(NakedPtr<WebCore::Element>)element;
+- (void)_exitFullScreenForElement:(NakedPtr<WebCore::Element>)element completionHandler:(CompletionHandler<void()>&&)completionHandler;
 #endif
 
 // Conversion functions between WebCore root view coordinates and web view coordinates.


### PR DESCRIPTION
#### 4df703fdc7cc8ca2f8371b7b260f66259def169b
<pre>
Remove FullscreenManager::FullscreenPromise
<a href="https://bugs.webkit.org/show_bug.cgi?id=287898">https://bugs.webkit.org/show_bug.cgi?id=287898</a>
<a href="https://rdar.apple.com/145092075">rdar://145092075</a>

Reviewed by Eric Carlson.

The concept of storing the promise on the FullscreenManager was added in 257668@main
to make sure it was called in all cases.  Now that I&apos;ve gone through the entire flow
of entering and exiting fullscreen and used CompletionHandlers through the whole
flow, we can just pass along a CompletionHandler from begin to end of enter and exit.

* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::cancelFullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
(WebCore::FullscreenManager::clear):
(WebCore::FullscreenManager::FullscreenPromise::~FullscreenPromise): Deleted.
(WebCore::FullscreenManager::FullscreenPromise::operator=): Deleted.
(WebCore::FullscreenManager::FullscreenPromise::clear): Deleted.
(WebCore::FullscreenManager::FullscreenPromise::resolve): Deleted.
(WebCore::FullscreenManager::FullscreenPromise::rejectOrResolve): Deleted.
(WebCore::FullscreenManager::FullscreenPromise::reject): Deleted.
(WebCore::FullscreenManager::FullscreenPromise::operator bool const): Deleted.
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::exitFullScreenForElement):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::exitFullScreenForElement):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::WebFullScreenManager::didExitFullScreen):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::exitFullScreenForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::exitFullScreenForElement):
* Source/WebKitLegacy/mac/WebCoreSupport/WebKitFullScreenListener.mm:
(-[WebKitFullScreenListener webkitDidExitFullScreen]):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.h:
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(-[WebFullScreenController exitFullScreen:]):
(-[WebFullScreenController finishedExitFullScreenAnimation:]):
(-[WebFullScreenController close]):
(-[WebFullScreenController exitFullScreen]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _exitFullScreenForElement:completionHandler:]):
(-[WebView _exitFullScreenForElement:]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:

Canonical link: <a href="https://commits.webkit.org/290619@main">https://commits.webkit.org/290619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b97aacc1fe970f5209e5f1734cdee4142a64527

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41396 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92668 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69733 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93615 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82180 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50082 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40526 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97455 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17806 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78003 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77954 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21018 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14261 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17816 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23155 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17555 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->