### PR TITLE
[ Gardening ] (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm
@@ -3025,7 +3025,8 @@ TEST(WritingTools, ShowPanelWithRangedSelection)
     EXPECT_TRUE(NSEqualRects(expectedRect, selectionRect));
 }
 
-TEST(WritingTools, ShowToolWithRangedSelection)
+// rdar://144725722 (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
+TEST(WritingTools, DISABLED_ShowToolWithRangedSelection)
 {
     __block bool done = false;
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
@@ -3052,7 +3053,8 @@ TEST(WritingTools, ShowToolWithRangedSelection)
     EXPECT_TRUE(NSEqualRects(expectedRect, selectionRect));
 }
 
-TEST(WritingTools, ShowInvalidToolWithRangedSelection)
+// rdar://144725722 (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
+TEST(WritingTools, DISABLED_ShowInvalidToolWithRangedSelection)
 {
     __block bool done = false;
     __block WTRequestedTool requestedTool = WTRequestedToolIndex;
@@ -3167,7 +3169,8 @@ TEST(WritingTools, FocusWebViewAfterProofreadingAnimation)
     EXPECT_EQ([[webView window] firstResponder], webView.get());
 }
 
-TEST(WritingTools, ContextMenuItemsNonEditable)
+// rdar://144725722 (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
+TEST(WritingTools, DISABLED_ContextMenuItemsNonEditable)
 {
     RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
@@ -3202,7 +3205,8 @@ TEST(WritingTools, ContextMenuItemsNonEditable)
     }
 }
 
-TEST(WritingTools, ContextMenuItemsEditable)
+// rdar://144725722 (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
+TEST(WritingTools, DISABLED_ContextMenuItemsEditable)
 {
     RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
@@ -3237,7 +3241,8 @@ TEST(WritingTools, ContextMenuItemsEditable)
     }
 }
 
-TEST(WritingTools, ContextMenuItemsEditableEmpty)
+// rdar://144725722 (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
+TEST(WritingTools, DISABLED_ContextMenuItemsEditableEmpty)
 {
     RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
 
@@ -3529,7 +3534,8 @@ TEST(WritingTools, ContextRangeFromRangeSelection)
     TestWebKitAPI::Util::run(&finished);
 }
 
-TEST(WritingTools, SuggestedTextIsSelectedAfterSmartReply)
+// rdar://144725722 (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
+TEST(WritingTools, DISABLED_SuggestedTextIsSelectedAfterSmartReply)
 {
     auto session = adoptNS([[WTSession alloc] initWithType:WTSessionTypeComposition textViewDelegate:nil]);
     [session setCompositionSessionType:WTCompositionSessionTypeSmartReply];


### PR DESCRIPTION
#### f56b67933689b9e412a52c5f0d186f98326badf6
<pre>
[ Gardening ] (Disable 6x TestWebKitAPI.WritingTools.* (api-tests))
<a href="https://rdar.apple.com/144725722">rdar://144725722</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WritingTools.mm:
(TEST(WritingTools, DISABLED_ShowToolWithRangedSelection)):
(TEST(WritingTools, DISABLED_ShowInvalidToolWithRangedSelection)):
(TEST(WritingTools, DISABLED_ContextMenuItemsNonEditable)):
(TEST(WritingTools, DISABLED_ContextMenuItemsEditable)):
(TEST(WritingTools, DISABLED_ContextMenuItemsEditableEmpty)):
(TEST(WritingTools, DISABLED_SuggestedTextIsSelectedAfterSmartReply)):
(TEST(WritingTools, ShowToolWithRangedSelection)): Deleted.
(TEST(WritingTools, ShowInvalidToolWithRangedSelection)): Deleted.
(TEST(WritingTools, ContextMenuItemsNonEditable)): Deleted.
(TEST(WritingTools, ContextMenuItemsEditable)): Deleted.
(TEST(WritingTools, ContextMenuItemsEditableEmpty)): Deleted.
(TEST(WritingTools, SuggestedTextIsSelectedAfterSmartReply)): Deleted.

Canonical link: <a href="https://commits.webkit.org/290562@main">https://commits.webkit.org/290562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f89ff0e77a1def9d48809270d9b690edc32cc82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90480 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/10012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/45416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92532 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/10405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/18331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93481 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/10405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/45416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/10405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/45416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/10405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/17672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/18331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/17930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/45416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45416 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14231 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->