### PR TITLE
[ Gardening ] ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -1918,7 +1918,8 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
+// rdar://144626088 ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
+TEST(WKWebExtensionAPIMenus, DISABLED_MacImageContextMenuItems)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
@@ -2002,7 +2003,8 @@ TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
+// rdar://144626088 ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
+TEST(WKWebExtensionAPIMenus, DISABLED_MacVideoContextMenuItems)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
@@ -2086,7 +2088,8 @@ TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
+// rdar://144626088 ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
+TEST(WKWebExtensionAPIMenus, DISABLED_MacAudioContextMenuItems)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",


### PR DESCRIPTION
#### 4e064e09f3417eb6f57f9d31386e363c47ffb349
<pre>
[ Gardening ] ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
<a href="https://rdar.apple.com/144626088">rdar://144626088</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287490">https://bugs.webkit.org/show_bug.cgi?id=287490</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, DISABLED_MacImageContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, DISABLED_MacVideoContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, DISABLED_MacAudioContextMenuItems)):
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)): Deleted.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)): Deleted.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)): Deleted.

Canonical link: <a href="https://commits.webkit.org/290564@main">https://commits.webkit.org/290564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a7978fd208e80819d391f1d1909e7678a188bb4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90482 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/10014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/45418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92534 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/10407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/18333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93483 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/10407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/45418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/10407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/45418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/10407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/17674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/18333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/17932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/45418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/10996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14232 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->