### PR TITLE
rdar://145075545 (Queue messages sent with browser.test if we don't have any listeners setup)

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm
@@ -53,6 +53,14 @@ void WebExtensionContext::addListener(WebCore::FrameIdentifier frameIdentifier, 
 
     auto result = m_eventListenerFrames.add({ listenerType, contentWorldType }, WeakFrameCountedSet { });
     result.iterator->value.add(*frame);
+
+    if (listenerType == WebExtensionEventListenerType::TestOnMessage) {
+        if (!hasTestMessageEventListeners()) {
+            m_testMessageListenersCount++;
+            flushTestMessageQueueIfNeeded();
+        } else
+            m_testMessageListenersCount++;
+    }
 }
 
 void WebExtensionContext::removeListener(WebCore::FrameIdentifier frameIdentifier, WebExtensionEventListenerType listenerType, WebExtensionContentWorldType contentWorldType, size_t removedCount)
@@ -81,6 +89,9 @@ void WebExtensionContext::removeListener(WebCore::FrameIdentifier frameIdentifie
         return;
 
     m_eventListenerFrames.remove(iterator);
+
+    if (listenerType == WebExtensionEventListenerType::TestOnMessage && hasTestMessageEventListeners())
+        m_testMessageListenersCount--;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -61,6 +61,7 @@
 #include "WebProcessProxy.h"
 #include <WebCore/ContentRuleListResults.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Deque.h>
 #include <wtf/Forward.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashMap.h>
@@ -1077,6 +1078,19 @@ private:
     RefPtr<WebExtensionStorageSQLiteStore> m_localStorageStore;
     RefPtr<WebExtensionStorageSQLiteStore> m_sessionStorageStore;
     RefPtr<WebExtensionStorageSQLiteStore> m_syncStorageStore;
+
+    struct TestMessage {
+        String message;
+#if PLATFORM(COCOA)
+        RetainPtr<id> argument;
+#endif
+    };
+
+    size_t m_testMessageListenersCount { 0 };
+    Deque<TestMessage> m_testMessageQueue;
+
+    bool hasTestMessageEventListeners() { return m_testMessageListenersCount; }
+    void flushTestMessageQueueIfNeeded();
 };
 
 template<typename T>


### PR DESCRIPTION
#### 0e5ba8ab4eba52c95190e3315a9bcdde1aa374bc
<pre>
<a href="https://rdar.apple.com/145075545">rdar://145075545</a> (Queue messages sent with browser.test if we don&apos;t have any listeners setup)
<a href="https://bugs.webkit.org/show_bug.cgi?id=287899">https://bugs.webkit.org/show_bug.cgi?id=287899</a>
<a href="https://rdar.apple.com/145075545">rdar://145075545</a>

Reviewed by Timothy Hatcher.

This patch makes it so that we queue all messages sent with browser.test.sendMessage are
queued if there aren&apos;t currently any event listeners. We flush these queued messages
whenever the first listener is added.

This is useful if an extension starts sending test messages as soon as it&apos;s loaded, but
the listener isn&apos;t set up until later (e.g. in a content script that&apos;s injected later).

* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIEventCocoa.mm:
(WebKit::WebExtensionContext::addListener):
Increment the count of how many listeners we have for test messages. If it&apos;s the first
listener being added, flush the message queue.

(WebKit::WebExtensionContext::removeListener):
Decrement the count of how many listeners we have for test messages.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::sendTestMessage):
If there aren&apos;t any test message listeners, queue the message.

(WebKit::WebExtensionContext::flushTestMessageQueueIfNeeded):
Send all of the queued test messages, if there are any.

* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
Introduce all of the private state that we need to keep track of a test message queue.

(WebKit::WebExtensionContext::hasTestMessageEventListeners):
Return whether or not the context has any test message event listeners.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPITest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITest, SendMessageBeforeListenerAdded)):
Write a new test to ensure that this patch behaves as expected.

Canonical link: <a href="https://commits.webkit.org/290601@main">https://commits.webkit.org/290601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac082182ed8d0f1ccb8dc8ab8abc49e00b36e2a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10048 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95527 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41298 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69653 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82087 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50001 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36442 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40428 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97356 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78641 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77871 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19242 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20935 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23050 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17457 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->