### PR TITLE
Move setRelatedPage call back to where it was before 285310@main

### DIFF
--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable.html
@@ -16,13 +16,8 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner) {
-                if (testRunner.isWebKit2) {
-                    shouldBe("testRunner.windowCount()", "2");
-                } else {
-                    shouldBe("testRunner.windowCount()", "3");
-                }
-            }
+            if (window.testRunner)
+                shouldBe("testRunner.windowCount()", "3");
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2-expected.txt
@@ -5,7 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS w is null
 PASS w.location.href is "about:blank"
-PASS testRunner.windowCount() is 2
+PASS testRunner.windowCount() is 3
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
+++ b/LayoutTests/http/tests/dom/noopener-window-not-targetable2.html
@@ -16,13 +16,8 @@ onload = function() {
         w = open("/navigation/resources/otherpage.html", "foo"); // Should create a new window.
         shouldBeEqualToString("w.location.href", "about:blank");
         w.onload = function() {
-            if (window.testRunner) {
-                if (testRunner.isWebKit2) {
-                    shouldBe("testRunner.windowCount()", "2");
-                } else {
-                    shouldBe("testRunner.windowCount()", "3");
-                }
-            }
+            if (window.testRunner)
+                shouldBe("testRunner.windowCount()", "3");
             finishJSTest();
         }
     }, 100);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-coep-sandbox.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-coep-sandbox.https-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
-CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
 
 PASS <iframe sandbox="allow-popups allow-scripts allow-same-origin"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error
 PASS <iframe sandbox="allow-popups allow-scripts"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error

--- a/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox.https-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
-CONSOLE MESSAGE: Navigation was blocked by Cross-Origin-Opener-Policy
 
 PASS <iframe sandbox="allow-popups allow-scripts allow-same-origin"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error
 PASS <iframe sandbox="allow-popups allow-scripts"> Sandboxed Cross-Origin-Opener-Policy popup should result in a network error

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8460,9 +8460,10 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
     configuration->setInitialSandboxFlags(effectiveSandboxFlags);
     configuration->setWindowFeatures(WTFMove(windowFeatures));
     configuration->setOpenedMainFrameName(openedMainFrameName);
+    if (!m_preferences->siteIsolationEnabled())
+        configuration->setRelatedPage(*this);
 
     if (RefPtr openerFrame = WebFrameProxy::webFrame(originatingFrameInfoData.frameID); navigationActionData.hasOpener && openerFrame) {
-        configuration->setRelatedPage(*this);
         configuration->setOpenerInfo({ {
             openerFrame->frameProcess().process(),
             *originatingFrameInfoData.frameID
@@ -8473,8 +8474,6 @@ void WebPageProxy::createNewPage(IPC::Connection& connection, WindowFeatures&& w
         configuration->setOpenerInfo(std::nullopt);
         configuration->setBrowsingContextGroup(BrowsingContextGroup::create());
         configuration->setOpenedSite(WebCore::Site(request.url()));
-        if (openedBlobURL)
-            configuration->setRelatedPage(*this);
     }
 
     trySOAuthorization(configuration.copyRef(), WTFMove(navigationAction), *this, WTFMove(completionHandler), [this, protectedThis = Ref { *this }, configuration] (Ref<API::NavigationAction>&& navigationAction, CompletionHandler<void(RefPtr<WebPageProxy>&&)>&& completionHandler) mutable {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -1441,7 +1441,7 @@ TEST(ProcessSwap, CrossSiteWindowOpenWithOpener)
 
 enum class ExpectSwap : bool { No, Yes };
 enum class WindowHasName : bool { No, Yes };
-static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName)
+static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName, ExpectSwap expectSwap)
 {
     auto processPoolConfiguration = psonProcessPoolConfiguration();
     auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
@@ -1482,7 +1482,10 @@ static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName)
     EXPECT_TRUE(!!pid2);
 
     // Since there is no opener, we process-swap, even though the navigation is same-site.
-    EXPECT_NE(pid1, pid2);
+    if (expectSwap == ExpectSwap::Yes)
+        EXPECT_NE(pid1, pid2);
+    else
+        EXPECT_EQ(pid1, pid2);
 
     done = false;
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/popup2.html"]];
@@ -1500,12 +1503,12 @@ static void runSameSiteWindowOpenNoOpenerTest(WindowHasName windowHasName)
 TEST(ProcessSwap, SameSiteWindowOpenNoOpener)
 {
     // We process-swap even though the navigation is same-site, because the popup has no opener.
-    runSameSiteWindowOpenNoOpenerTest(WindowHasName::No);
+    runSameSiteWindowOpenNoOpenerTest(WindowHasName::No, ExpectSwap::Yes);
 }
 
 TEST(ProcessSwap, SameSiteWindowOpenWithNameNoOpener)
 {
-    runSameSiteWindowOpenNoOpenerTest(WindowHasName::Yes);
+    runSameSiteWindowOpenNoOpenerTest(WindowHasName::Yes, ExpectSwap::No);
 }
 
 TEST(ProcessSwap, CrossSiteBlankTargetWithOpener)


### PR DESCRIPTION
#### 768cdbcff6bccbf7033ca062a554268451e3012c
<pre>
Move setRelatedPage call back to where it was before 285310@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=287907">https://bugs.webkit.org/show_bug.cgi?id=287907</a>
<a href="https://rdar.apple.com/143198196">rdar://143198196</a>

Reviewed by Charlie Wolfe and Mike Wyrzykowski.

I moved a call for some site isolation work.  It caused a subtle change in behavior
with popups.  This reverts that change when site isolation is off.

A few test results based on process sharing also revert their expectations to before
that change when site isolation is off.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::createNewPage):

Canonical link: <a href="https://commits.webkit.org/290596@main">https://commits.webkit.org/290596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b37b3f3c98e0d8120165981653555c40185a39aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45506 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95579 "Hash b37b3f3c for PR 40804 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41350 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18419 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/95579 "Hash b37b3f3c for PR 40804 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93569 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82138 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/95579 "Hash b37b3f3c for PR 40804 does not build (failure)") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40480 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17760 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18018 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77963 "Exiting early after 10 failures. 28 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77915 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22355 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/20979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14250 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17770 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17509 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/20964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->