### PR TITLE
Flatenning may be triggered before tree is connected, and the function crashes when reaching a non-connected parent.

### DIFF
--- a/LayoutTests/fast/transforms/flatten_disconnected_parent_crash-expected.txt
+++ b/LayoutTests/fast/transforms/flatten_disconnected_parent_crash-expected.txt
@@ -1,0 +1,18 @@
+
+This test passes if webkit doesn't crash
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/LayoutTests/fast/transforms/flatten_disconnected_parent_crash.html
+++ b/LayoutTests/fast/transforms/flatten_disconnected_parent_crash.html
@@ -1,0 +1,50 @@
+<html>
+<head>
+    <style>
+        .class7 {
+            perspective: 0px;
+        }
+
+        :not(.active) {
+            grid;
+            white-space-collapse: preserve-breaks;
+            container: a0 / inline-size;
+            -webkit-mask-box-image: url();
+        }
+    </style>
+    <script>
+        function runTest() {
+            body = document.body;
+            body.style.setProperty("border-bottom-width", "thin");
+            something = document.elementFromPoint(0, 0);
+            htmlElement = document.documentElement;
+            htmlElement.append(body);
+            testRunner?.dumpAsText();
+            testRunner?.notifyDone();
+        }
+
+        testRunner?.waitUntilDone();
+    </script>
+</head>
+
+<body onload=runTest()>
+    <title>Title</title>
+    <p>This test passes if webkit doesn't crash</p>
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+    <br />
+    <form class="class7">
+        <keygen />
+    </form>
+    <br />
+    <br />
+    <br />
+    <br />
+</body>
+</html>
+

--- a/Source/WebCore/html/HTMLTitleElement.cpp
+++ b/Source/WebCore/html/HTMLTitleElement.cpp
@@ -60,11 +60,18 @@ Node::InsertedIntoAncestorResult HTMLTitleElement::insertedIntoAncestor(Insertio
 {
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
 
-    if (insertionType.connectedToDocument) {
-        m_title = computedTextWithDirection();
-        document().titleElementAdded(*this);
-    }
+    if (insertionType.connectedToDocument)
+        return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
+
     return InsertedIntoAncestorResult::Done;
+}
+
+void HTMLTitleElement::didFinishInsertingNode()
+{
+    HTMLElement::didFinishInsertingNode();
+
+    m_title = computedTextWithDirection();
+    document().titleElementAdded(*this);
 }
 
 void HTMLTitleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/html/HTMLTitleElement.h
+++ b/Source/WebCore/html/HTMLTitleElement.h
@@ -38,6 +38,8 @@ public:
 
     const StringWithDirection& textWithDirection() const { return m_title; }
 
+    void didFinishInsertingNode() final;
+
 private:
     HTMLTitleElement(const QualifiedName&, Document&);
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4476,7 +4476,7 @@ static RefPtr<Element> flattenedParent(Element* element)
         return nullptr;
     RefPtr parent = element->parentElementInComposedTree();
     while (parent) {
-        if (parent->computedStyle()->display() != DisplayType::Contents)
+        if (!parent->isConnected() || parent->computedStyle()->display() != DisplayType::Contents)
             break;
         parent = parent->parentElementInComposedTree();
     }


### PR DESCRIPTION
#### 4810d0915bd9625d7ed965fd5bd29fa31a08bf2f
<pre>
Flatenning may be triggered before tree is connected, and the function crashes when reaching a non-connected parent.
<a href="https://rdar.apple.com/143296083">rdar://143296083</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287905">https://bugs.webkit.org/show_bug.cgi?id=287905</a>

Reviewed by Ryosuke Niwa, Simon Fraser, and Matt Woodrow.

This fixes the bug by stopping the flatten on a disconnected parent and
waiting until node insertion in the title element before using parent
reference

* LayoutTests/fast/transforms/flatten_disconnected_parent_crash-expected.txt: Added.
* LayoutTests/fast/transforms/flatten_disconnected_parent_crash.html: Added.
* Source/WebCore/html/HTMLTitleElement.cpp:
(WebCore::HTMLTitleElement::insertedIntoAncestor):
(WebCore::HTMLTitleElement::didFinishInsertingNode):
* Source/WebCore/html/HTMLTitleElement.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::flattenedParent):

Canonical link: <a href="https://commits.webkit.org/290774@main">https://commits.webkit.org/290774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a68f1f1d29a68ab9fad9308d2689abbf3610fdca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/30 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96046 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41813 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93071 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69974 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27494 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82510 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50300 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/26 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40937 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/25 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98020 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18220 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78983 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18480 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78182 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22669 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/43 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18227 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23594 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17962 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19747 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->