### PR TITLE
attr() name should support namespace

### DIFF
--- a/LayoutTests/fast/css/attr-namespace.xhtml
+++ b/LayoutTests/fast/css/attr-namespace.xhtml
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:foo="https://ntim.me">
+<style>
+    @namespace foo url("https://ntim.me");
+    @namespace webkit url("https://webkit.org");
+    div::after {
+        content: attr(foo|id);
+    }
+    div::before {
+        content: attr(webkit|id);
+    }
+</style>
+<div foo:id="this should be shown" id="this should not be shown"></div>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
@@ -324,13 +324,13 @@ PASS content: counter(par-num, decimal)
 PASS content: counter(par-num, upper-roman)
 PASS content: attr(foo-bar)
 PASS content: attr(foo_bar)
-FAIL content: attr(|bar) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
-FAIL content: attr( |bar ) assert_equals: content raw inline style declaration expected "attr(bar)" but got ""
+PASS content: attr(|bar)
+PASS content: attr( |bar )
 PASS content: attr(foo-bar, "fallback")
 PASS content: attr(foo_bar, "fallback")
-FAIL content: attr(|bar, "fallback") assert_equals: content raw inline style declaration expected "attr(bar, \"fallback\")" but got ""
+PASS content: attr(|bar, "fallback")
 PASS content: attr(foo, "")
-FAIL content: attr( |foo ,  "" ) assert_equals: content raw inline style declaration expected "attr(foo)" but got ""
+PASS content: attr( |foo ,  "" )
 PASS content: inherit
 PASS cursor: auto
 PASS cursor: crosshair

--- a/LayoutTests/platform/mac/fast/css/attr-namespace-expected.txt
+++ b/LayoutTests/platform/mac/fast/css/attr-namespace-expected.txt
@@ -1,0 +1,10 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x18
+  RenderBlock {html} at (0,0) size 800x18
+    RenderBlock {div} at (0,0) size 800x18
+      RenderInline (generated) at (0,0) size 0x18
+        RenderText at (0,0) size 0x0
+      RenderInline (generated) at (0,0) size 135x18
+        RenderText at (0,0) size 135x18
+          text run at (0,0) width 135: "this should be shown"

--- a/Source/WebCore/css/CSSAttrValue.cpp
+++ b/Source/WebCore/css/CSSAttrValue.cpp
@@ -31,9 +31,9 @@
 
 namespace WebCore {
 
-Ref<CSSAttrValue> CSSAttrValue::create(String attributeName, RefPtr<CSSValue>&& fallback)
+Ref<CSSAttrValue> CSSAttrValue::create(String attributeName, String namespacePrefix, RefPtr<CSSValue>&& fallback)
 {
-    return adoptRef(*new CSSAttrValue(WTFMove(attributeName), WTFMove(fallback)));
+    return adoptRef(*new CSSAttrValue(WTFMove(attributeName), WTFMove(namespacePrefix), WTFMove(fallback)));
 }
 
 bool CSSAttrValue::equals(const CSSAttrValue& other) const

--- a/Source/WebCore/css/CSSAttrValue.h
+++ b/Source/WebCore/css/CSSAttrValue.h
@@ -35,21 +35,24 @@ class Element;
 
 class CSSAttrValue final : public CSSValue {
 public:
-    static Ref<CSSAttrValue> create(String attributeName, RefPtr<CSSValue>&& fallback = nullptr);
+    static Ref<CSSAttrValue> create(String attributeName, String namespacePrefix, RefPtr<CSSValue>&& fallback = nullptr);
     const String attributeName() const { return m_attributeName; }
+    const String namespacePrefix() const { return m_namespacePrefix; }
     const CSSValue* fallback() const { return m_fallback.get(); }
     bool equals(const CSSAttrValue& other) const;
     String customCSSText(const CSS::SerializationContext&) const;
 
 private:
-    explicit CSSAttrValue(String&& attributeName, RefPtr<CSSValue>&& fallback)
+    explicit CSSAttrValue(String&& attributeName, String&& namespacePrefix, RefPtr<CSSValue>&& fallback)
         : CSSValue(ClassType::Attr)
         , m_attributeName(WTFMove(attributeName))
+        , m_namespacePrefix(WTFMove(namespacePrefix))
         , m_fallback(WTFMove(fallback))
     {
     }
 
     String m_attributeName;
+    String m_namespacePrefix;
     RefPtr<CSSValue> m_fallback;
 };
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp
@@ -31,6 +31,7 @@
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSPropertyParserConsumer+Primitives.h"
+#include "CommonAtomStrings.h"
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
@@ -45,33 +46,53 @@ RefPtr<CSSValue> consumeAttr(CSSParserTokenRange args, const CSSParserContext& c
     // <attr-type> = type( <syntax> ) | string | <attr-unit>
     // https://drafts.csswg.org/css-values-5/#funcdef-attr
 
-    // FIXME: Add support for complete <attr-name> syntax, including namespace support.
-    // FIXME: Add support for <attr-type> syntax
+    AtomString namespacePrefix = nullAtom();
+    AtomString attrName = nullAtom();
 
-    if (args.peek().type() != IdentToken)
+    // Process <attr-name> syntax.
+    args.consumeWhitespace();
+    if (args.peek().type() == IdentToken) {
+        attrName = args.peek().value().toAtomString();
+        args.consume();
+    } else if (args.peek().type() == DelimiterToken && args.peek().delimiter() == '*') {
+        attrName = starAtom();
+        args.consume();
+    } else if (args.peek().type() == DelimiterToken && args.peek().delimiter() == '|')
+        attrName = emptyAtom();
+    else
         return nullptr;
 
-    CSSParserToken token = args.consumeIncludingWhitespace();
+    // If namespace delimiter is detected, attribute name must follow.
+    if (args.peek().type() == DelimiterToken && args.peek().delimiter() == '|') {
+        namespacePrefix = attrName;
+        args.consume();
+        if (args.peek().type() == IdentToken) {
+            attrName = args.peek().value().toAtomString();
+            args.consume();
+        } else
+            return nullptr;
+    }
 
-    AtomString attrName;
     if (context.isHTMLDocument)
-        attrName = token.value().convertToASCIILowercaseAtom();
-    else
-        attrName = token.value().toAtomString();
+        attrName = attrName.convertToASCIILowercase();
 
+    // FIXME: Add support for <attr-type> syntax
+
+    args.consumeWhitespace();
     if (!args.atEnd() && !consumeCommaIncludingWhitespace(args))
         return nullptr;
 
+    // Process <declaration-value> syntax.
     RefPtr<CSSValue> fallback;
     if (args.peek().type() == StringToken) {
-        token = args.consumeIncludingWhitespace();
+        CSSParserToken token = args.consumeIncludingWhitespace();
         fallback = CSSPrimitiveValue::create(token.value().toString());
     }
 
     if (!args.atEnd())
         return nullptr;
 
-    auto attr = CSSAttrValue::create(WTFMove(attrName), WTFMove(fallback));
+    auto attr = CSSAttrValue::create(WTFMove(attrName), WTFMove(namespacePrefix), WTFMove(fallback));
     // FIXME: Consider moving to a CSSFunctionValue with a custom-ident rather than a special CSS_ATTR primitive value.
 
     return CSSPrimitiveValue::create(WTFMove(attr));

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -59,6 +59,7 @@
 #include "StyleImageSet.h"
 #include "StyleResolver.h"
 #include "StyleScope.h"
+#include "StyleSheetContents.h"
 #include "StyleTextShadow.h"
 #include "TextSizeAdjustment.h"
 
@@ -1306,11 +1307,31 @@ inline void BuilderCustom::applyValueContent(BuilderState& builderState, CSSValu
             const_cast<RenderStyle&>(builderState.parentStyle()).setHasAttrContent();
 
         auto value = primitiveValue.cssAttrValue();
-        QualifiedName attr(nullAtom(), value->attributeName().impl(), nullAtom());
-        const AtomString& attributeValue = builderState.element() ? builderState.element()->getAttribute(attr) : nullAtom();
+        AtomString attrName(value->attributeName());
+        AtomString namespacePrefix(value->namespacePrefix());
+        AtomString namespaceURI = nullAtom();
+
+        // Determine the namespace URI given the current prefix.
+        if (namespacePrefix.isEmpty())
+            namespaceURI = emptyAtom();
+        else if (namespacePrefix == starAtom())
+            namespaceURI = starAtom();
+        else {
+            for (const auto& styleSheet : builderState.document().styleScope().activeStyleSheets()) {
+                auto& styleSheetContents = styleSheet->contents();
+                namespaceURI = styleSheetContents.namespaceURIFromPrefix(namespacePrefix);
+                if (!namespaceURI.isNull())
+                    break;
+            }
+        }
+
+        QualifiedName qualifiedName = (namespacePrefix.isNull() || namespaceURI.isNull())
+            ? QualifiedName(nullAtom(), attrName, nullAtom())
+            : QualifiedName(namespacePrefix, attrName, namespaceURI);
+        const AtomString& attributeValue = builderState.element() ? builderState.element()->getAttribute(qualifiedName) : nullAtom();
 
         // Register the fact that the attribute value affects the style.
-        builderState.registerContentAttribute(attr.localName());
+        builderState.registerContentAttribute(qualifiedName.localName());
 
         if (attributeValue.isNull()) {
             auto fallback = dynamicDowncast<CSSPrimitiveValue>(value->fallback());


### PR DESCRIPTION
#### 08feb70ebeecd07b22d927d15806ecb80ef7219b
<pre>
attr() name should support namespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=283279">https://bugs.webkit.org/show_bug.cgi?id=283279</a>
<a href="https://rdar.apple.com/140525205">rdar://140525205</a>

Reviewed by NOBODY (OOPS!).

Parse namespace from attr() function and resolve to URI.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt:
* Source/WebCore/css/CSSAttrValue.cpp:
(WebCore::CSSAttrValue::create):
(WebCore::CSSAttrValue::equals const):
(WebCore::CSSAttrValue::customCSSText const):
* Source/WebCore/css/CSSAttrValue.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Attr.cpp:
(WebCore::CSSPropertyParserHelpers::consumeAttr):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueContent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08feb70ebeecd07b22d927d15806ecb80ef7219b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96103 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41864 "Hash 08feb70e for PR 40806 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19214 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70014 "Found 1 new test failure: fast/css/attr-namespace.xhtml (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/41864 "Hash 08feb70e for PR 40806 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94097 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8421 "Found 1 new test failure: fast/css/attr-namespace.xhtml (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82545 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8192 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/111 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40994 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78514 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98084 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13578 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79028 "Found 1 new test failure: fast/css/attr-namespace.xhtml (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78229 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22726 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/82 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11510 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23634 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18028 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->