### PR TITLE
Deploy More SmartPointers in NativePromise.h

### DIFF
--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -323,7 +323,8 @@ public:
         ASSERT(m_callback);
         if (!m_callback)
             return;
-        RefPtr { std::exchange(m_callback, nullptr) }->disconnect();
+        RefPtr callback = std::exchange(m_callback, nullptr);
+        callback->disconnect();
     }
 
 private:
@@ -972,7 +973,7 @@ private:
             return promise;
         }
 
-        Ref<NativePromise> m_promise;
+        const Ref<NativePromise> m_promise;
         RefPtr<ThenCallbackType> m_thenCallback;
         const Logger::LogSiteIdentifier m_logSiteIdentifier;
     };
@@ -1334,7 +1335,7 @@ public:
         , m_creationSite(creationSite)
     {
         if constexpr (PromiseType::IsExclusive)
-            m_promise->setDispatchMode(dispatchMode, creationSite);
+            protectedPromise()->setDispatchMode(dispatchMode, creationSite);
     }
 
     template<typename RejectValueT_ = RejectValueT, typename = std::enable_if<AutoRejectNonVoid>>
@@ -1353,8 +1354,8 @@ public:
     ~NativePromiseProducer()
     {
         if constexpr (AutoReject) {
-            if (m_promise && !m_promise->isSettled()) {
-                PROMISE_LOG("Non settled AutoRejectProducer, reject with default value", *m_promise);
+            if (m_promise && !protectedPromise()->isSettled()) {
+                PROMISE_LOG("Non settled AutoRejectProducer, reject with default value", *protectedPromise());
                 if constexpr (std::is_void_v<RejectValueT>)
                     reject();
                 else
@@ -1367,13 +1368,13 @@ public:
     bool isSettled() const
     {
         ASSERT(m_promise, "used after moved");
-        return m_promise && m_promise->isSettled();
+        return m_promise && protectedPromise()->isSettled();
     }
     explicit operator bool() const { return isSettled(); }
     bool isNothing() const
     {
         ASSERT(m_promise, "used after moved");
-        return m_promise && !m_promise->isSettled();
+        return m_promise && !protectedPromise()->isSettled();
     }
 
     template<typename ResolveValueType_, typename = std::enable_if<!std::is_void_v<ResolveValueT>>>
@@ -1381,10 +1382,10 @@ public:
     {
         ASSERT(isNothing());
         if (!isNothing()) {
-            PROMISE_LOG(resolveSite, " ignored already resolved or rejected ", *m_promise);
+            PROMISE_LOG(resolveSite, " ignored already resolved or rejected ", *protectedPromise());
             return;
         }
-        m_promise->resolve(std::forward<ResolveValueType_>(resolveValue), resolveSite);
+        protectedPromise()->resolve(std::forward<ResolveValueType_>(resolveValue), resolveSite);
     }
 
     template<typename = std::enable_if<std::is_void_v<ResolveValueT>>>
@@ -1392,10 +1393,10 @@ public:
     {
         ASSERT(isNothing());
         if (!isNothing()) {
-            PROMISE_LOG(resolveSite, " ignored already resolved or rejected ", *m_promise);
+            PROMISE_LOG(resolveSite, " ignored already resolved or rejected ", *protectedPromise());
             return;
         }
-        m_promise->resolve(resolveSite);
+        protectedPromise()->resolve(resolveSite);
     }
 
     template<typename RejectValueType_, typename = std::enable_if<!std::is_void_v<RejectValueT>>>
@@ -1403,10 +1404,10 @@ public:
     {
         ASSERT(isNothing());
         if (!isNothing()) {
-            PROMISE_LOG(rejectSite, " ignored already resolved or rejected ", *m_promise);
+            PROMISE_LOG(rejectSite, " ignored already resolved or rejected ", *protectedPromise());
             return;
         }
-        m_promise->reject(std::forward<RejectValueType_>(rejectValue), rejectSite);
+        protectedPromise()->reject(std::forward<RejectValueType_>(rejectValue), rejectSite);
     }
 
     template<typename = std::enable_if<std::is_void_v<RejectValueT>>>
@@ -1414,10 +1415,10 @@ public:
     {
         ASSERT(isNothing());
         if (!isNothing()) {
-            PROMISE_LOG(rejectSite, " ignored already resolved or rejected ", *m_promise);
+            PROMISE_LOG(rejectSite, " ignored already resolved or rejected ", *protectedPromise());
             return;
         }
-        m_promise->reject(rejectSite);
+        protectedPromise()->reject(rejectSite);
     }
 
     template<typename SettleValue>
@@ -1425,13 +1426,13 @@ public:
     {
         ASSERT(isNothing());
         if (!isNothing()) {
-            PROMISE_LOG(site, " ignored already resolved or rejected ", *m_promise);
+            PROMISE_LOG(site, " ignored already resolved or rejected ", *protectedPromise());
             return;
         }
         if constexpr (PromiseType::IsExclusive && std::is_invocable_r_v<typename PromiseType::Result, SettleValue>)
-            m_promise->settleWithFunction(WTFMove(result), site);
+            protectedPromise()->settleWithFunction(WTFMove(result), site);
         else
-            m_promise->settle(std::forward<SettleValue>(result), site);
+            protectedPromise()->settle(std::forward<SettleValue>(result), site);
     }
 
     template<typename = std::enable_if<PromiseType::IsExclusive>>
@@ -1439,10 +1440,10 @@ public:
     {
         ASSERT(isNothing());
         if (!isNothing()) {
-            PROMISE_LOG(site, " ignored already resolved or rejected ", *m_promise);
+            PROMISE_LOG(site, " ignored already resolved or rejected ", *protectedPromise());
             return;
         }
-        m_promise->settleWithFunction(WTFMove(resultRunnable), site);
+        protectedPromise()->settleWithFunction(WTFMove(resultRunnable), site);
     }
 
     operator Ref<PromiseType>() const
@@ -1519,14 +1520,19 @@ private:
     void setDispatchMode(PromiseDispatchMode dispatchMode, const Logger::LogSiteIdentifier& callSite) const
     {
         ASSERT(m_promise, "used after move");
-        m_promise->setDispatchMode(dispatchMode, callSite);
+        protectedPromise()->setDispatchMode(dispatchMode, callSite);
     }
 
     friend PromiseType;
     void assertIsDead() const
     {
         if (m_promise)
-            m_promise->assertIsDead();
+            protectedPromise()->assertIsDead();
+    }
+
+    RefPtr<PromiseType> protectedPromise() const
+    {
+        return m_promise;
     }
 
     // The Producer may be moved to resolve/reject the completion promise.


### PR DESCRIPTION
#### 06b78e414b58e034038e812c53ec77d1d27d229b
<pre>
Deploy More SmartPointers in NativePromise.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=287910">https://bugs.webkit.org/show_bug.cgi?id=287910</a>

Reviewed by Ryosuke Niwa.

Addressed the remaining smart pointer static analyzer warnings in NativePromise.h

* Source/WTF/wtf/NativePromise.h:
(WTF::NativePromiseRequest::disconnect):

Canonical link: <a href="https://commits.webkit.org/290819@main">https://commits.webkit.org/290819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a0c2bd15cacf49f4a73b438684de0820ac513a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/42 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41797 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70023 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27488 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8321 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82513 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50349 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/36 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40921 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83825 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/34 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98003 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89777 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18203 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13374 "Found 1 new test failure: imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78973 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18463 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78316 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78171 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19356 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/51 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11461 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23579 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112347 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17946 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32638 "Found 17 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->