### PR TITLE
Copy Link to Highlight doesn't work when selecting text that is its own block and that text exists higher up in the document.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt
@@ -1,1 +1,1 @@
-:~:text=document
+:~:text=a%20very%20simple-,document,-.%20There%20is%20no

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-prefix-and-suffix-in-different-blocks-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-prefix-and-suffix-in-different-blocks-expected.txt
@@ -1,0 +1,1 @@
+:~:text=very%20Simple%20Document.-,Simple%20Document,-There%20is%20no

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-prefix-and-suffix-in-different-blocks.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-prefix-and-suffix-in-different-blocks.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we can generate a fragment where the prefix and suffix are in differnt blocks than the highlighted text.</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>This is a very Simple Document.<div id="test">Simple Document</div>There is no text before 'this'.</body>
+</html>
+

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 namespace FragmentDirectiveUtilities {
 
 // https://wicg.github.io/scroll-to-text-fragment/#nearest-block-ancestor
-const Node& nearestBlockAncestor(const Node& node)
+Node& nearestBlockAncestor(Node& node)
 {
     for (RefPtr currentNode = &node; currentNode; currentNode = currentNode->parentNode()) {
         if (!currentNode->isTextNode() && currentNode->renderer() && currentNode->renderer()->style().isDisplayBlockLevel())

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.h
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.h
@@ -41,7 +41,7 @@ struct ParsedTextDirective {
 
 namespace FragmentDirectiveUtilities {
 
-const Node& nearestBlockAncestor(const Node&);
+Node& nearestBlockAncestor(Node&);
 
 }
 


### PR DESCRIPTION
#### 4daa274dd30c8d0537ad986b8f720705f14acf5a
<pre>
Copy Link to Highlight doesn&apos;t work when selecting text that is its own block and that text exists higher up in the document.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287915">https://bugs.webkit.org/show_bug.cgi?id=287915</a>
<a href="https://rdar.apple.com/144392379">rdar://144392379</a>

Reviewed by Wenson Hsieh.

The scroll to text fragment generation code has checked to make sure that the elements are within the same block. This is correct
but when we start the fragment at the visible position at the beginning of the selection, and the selection is at the beginning or
at the end of a block, then the is-same-block check will fail. What we really want to do is start at the end of the previous block.
Add beforeStartOfCurrentBlock and afterEndOfCurrentBlock to help facilitate this. Then the checks for if we are in the same block
are correct.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt:
* LayoutTests/http/tests/scroll-to-text-fragment/generation-prefix-and-suffix-in-different-blocks-expected.txt: Copied from LayoutTests/http/tests/scroll-to-text-fragment/generation-does-not-pass-block-boundaries-expected.txt.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-prefix-and-suffix-in-different-blocks.html: Added.
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::beforeStartOfCurrentBlock):
(WebCore::afterEndOfCurrentBlock):
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):

Canonical link: <a href="https://commits.webkit.org/290683@main">https://commits.webkit.org/290683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d47027659f2a789494cfafbcd29fcc3244a9df36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45730 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93785 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8157 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82304 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36691 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37758 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17979 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78142 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19279 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22497 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17988 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17727 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21183 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->