### PR TITLE
Rename TimelineScope to NameScope

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -745,7 +745,6 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     animation/StyleOriginatedTimelinesController.h
     animation/TimelineRange.h
     animation/TimelineRangeOffset.h
-    animation/TimelineScope.h
     animation/ViewTimeline.h
     animation/ViewTimelineOptions.h
     animation/WebAnimationTime.h
@@ -941,6 +940,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     css/MediaList.h
     css/MediaQueryParserContext.h
     css/MutableStyleProperties.h
+    css/NameScope.h
     css/Quad.h
     css/Rect.h
     css/RectBase.h

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -76,7 +76,7 @@ Vector<WeakStyleable> StyleOriginatedTimelinesController::relatedTimelineScopeEl
 {
     Vector<WeakStyleable> timelineScopeElements;
     for (auto& scope : m_timelineScopeEntries) {
-        if (scope.second && (scope.first.type == TimelineScope::Type::All || (scope.first.type == TimelineScope::Type::Ident && scope.first.scopeNames.contains(name))))
+        if (scope.second && (scope.first.type == NameScope::Type::All || (scope.first.type == NameScope::Type::Ident && scope.first.names.contains(name))))
             timelineScopeElements.append(scope.second);
     }
     return timelineScopeElements;
@@ -168,7 +168,7 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
     for (auto& entry : m_timelineScopeEntries) {
         if (auto entryElement = entry.second.styleable()) {
             Ref protectedEntryElement { entryElement->element };
-            if (Ref { timelineElement->element }->isDescendantOf(protectedEntryElement.get()) && (entry.first.type == TimelineScope::Type::All ||  entry.first.scopeNames.contains(name)))
+            if (Ref { timelineElement->element }->isDescendantOf(protectedEntryElement.get()) && (entry.first.type == NameScope::Type::All ||  entry.first.names.contains(name)))
                 matchedTimelineScopeElements.appendIfNotContains(*entryElement);
         }
     }
@@ -399,7 +399,7 @@ static void updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>> entries,
     }
 }
 
-void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(const TimelineScope& scope, const Styleable& styleable)
+void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(const NameScope& scope, const Styleable& styleable)
 {
     LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope: " << scope << " styleable: " << styleable);
 
@@ -408,24 +408,24 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
     // (such as a named scroll progress timeline or named view progress timeline) to be referenced by elements outside the timeline-defining element’s
     // subtree—​for example, by siblings, cousins, or ancestors.
     switch (scope.type) {
-    case TimelineScope::Type::None:
+    case NameScope::Type::None:
         for (auto& entry : m_nameToTimelineMap) {
             for (auto& timeline : entry.value) {
                 if (timeline->timelineScopeDeclaredElement() == &styleable.element)
                     timeline->clearTimelineScopeDeclaredElement();
             }
         }
-        m_timelineScopeEntries.removeAllMatching([&] (const std::pair<TimelineScope, WeakStyleable> entry) {
+        m_timelineScopeEntries.removeAllMatching([&] (const std::pair<NameScope, WeakStyleable> entry) {
             return entry.second == styleable;
         });
         break;
-    case TimelineScope::Type::All:
+    case NameScope::Type::All:
         for (auto& entry : m_nameToTimelineMap)
             updateTimelinesForTimelineScope(entry.value, styleable);
         m_timelineScopeEntries.append(std::make_pair(scope, styleable));
         break;
-    case TimelineScope::Type::Ident:
-        for (auto& name : scope.scopeNames) {
+    case NameScope::Type::Ident:
+        for (auto& name : scope.names) {
             auto it = m_nameToTimelineMap.find(name);
             if (it != m_nameToTimelineMap.end())
                 updateTimelinesForTimelineScope(it->value, styleable);

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -26,9 +26,9 @@
 #pragma once
 
 #include "CSSAnimation.h"
+#include "NameScope.h"
 #include "ScrollAxis.h"
 #include "Styleable.h"
-#include "TimelineScope.h"
 #include <wtf/CheckedRef.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/AtomStringHash.h>
@@ -72,7 +72,7 @@ public:
     void registerNamedViewTimeline(const AtomString&, const Styleable&, ScrollAxis, ViewTimelineInsets&&);
     void unregisterNamedTimeline(const AtomString&, const Styleable&);
     void setTimelineForName(const AtomString&, const Styleable&, CSSAnimation&);
-    void updateNamedTimelineMapForTimelineScope(const TimelineScope&, const Styleable&);
+    void updateNamedTimelineMapForTimelineScope(const NameScope&, const Styleable&);
     void updateTimelineForTimelineScope(const Ref<ScrollTimeline>&, const AtomString&);
     void unregisterNamedTimelinesAssociatedWithElement(const Styleable&);
     void removePendingOperationsForCSSAnimation(const CSSAnimation&);
@@ -92,7 +92,7 @@ private:
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);
 
     Vector<TimelineMapAttachOperation> m_pendingAttachOperations;
-    Vector<std::pair<TimelineScope, WeakStyleable>> m_timelineScopeEntries;
+    Vector<std::pair<NameScope, WeakStyleable>> m_timelineScopeEntries;
     UncheckedKeyHashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
     HashSet<Ref<ScrollTimeline>> m_removedTimelines;
 };

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -11224,7 +11224,7 @@
                 "all"
             ],
            "codegen-properties": {
-               "style-builder-converter": "TimelineScope",
+               "style-builder-converter": "NameScope",
                "parser-grammar": "none | all | <dashed-ident>#",
                "settings-flag": "scrollDrivenAnimationsEnabled"
            },

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3298,7 +3298,7 @@ static Ref<CSSValue> valueForPositionArea(const std::optional<PositionArea>& pos
     return CSSPropertyParserHelpers::valueForPositionArea(blockOrXAxisKeyword, inlineOrYAxisKeyword).releaseNonNull();
 }
 
-static Ref<CSSValue> valueForTimelineScopeNames(const Vector<AtomString>& names)
+static Ref<CSSValue> valueForNameScopeNames(const Vector<AtomString>& names)
 {
     if (names.isEmpty())
         return CSSPrimitiveValue::create(CSSValueNone);
@@ -5005,12 +5005,12 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     }
     case CSSPropertyTimelineScope:
         switch (style.timelineScope().type) {
-        case TimelineScope::Type::None:
+        case NameScope::Type::None:
             return CSSPrimitiveValue::create(CSSValueNone);
-        case TimelineScope::Type::All:
+        case NameScope::Type::All:
             return CSSPrimitiveValue::create(CSSValueAll);
-        case TimelineScope::Type::Ident:
-            return valueForTimelineScopeNames(style.timelineScope().scopeNames);
+        case NameScope::Type::Ident:
+            return valueForNameScopeNames(style.timelineScope().names);
         }
         ASSERT_NOT_REACHED();
         return CSSPrimitiveValue::create(CSSValueNone);

--- a/Source/WebCore/css/NameScope.h
+++ b/Source/WebCore/css/NameScope.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2024-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,26 +30,26 @@
 
 namespace WebCore {
 
-struct TimelineScope {
+struct NameScope {
     enum class Type : uint8_t { None, All, Ident };
 
     Type type { Type::None };
-    Vector<AtomString> scopeNames;
+    Vector<AtomString> names;
 
-    bool operator==(const TimelineScope& other) const = default;
+    bool operator==(const NameScope& other) const = default;
 };
 
-inline TextStream& operator<<(TextStream& ts, const TimelineScope& timelineScope)
+inline TextStream& operator<<(TextStream& ts, const NameScope& scope)
 {
-    switch (timelineScope.type) {
-    case TimelineScope::Type::None:
+    switch (scope.type) {
+    case NameScope::Type::None:
         ts << "none";
         break;
-    case TimelineScope::Type::All:
+    case NameScope::Type::All:
         ts << "all";
         break;
-    case TimelineScope::Type::Ident:
-        ts << "ident: " << timelineScope.scopeNames;
+    case NameScope::Type::Ident:
+        ts << "ident: " << scope.names;
         break;
     }
     return ts;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -272,7 +272,7 @@ struct ScrollSnapAlign;
 struct ScrollSnapType;
 struct ScrollbarGutter;
 struct ScrollbarColor;
-struct TimelineScope;
+struct NameScope;
 struct ViewTimelineInsets;
 
 struct TabSize;
@@ -1023,9 +1023,9 @@ public:
     inline void setViewTimelineInsets(const Vector<ViewTimelineInsets>&);
     inline void setViewTimelineNames(const Vector<AtomString>&);
 
-    static inline const TimelineScope initialTimelineScope();
-    inline const TimelineScope& timelineScope() const;
-    inline void setTimelineScope(const TimelineScope&);
+    static inline const NameScope initialTimelineScope();
+    inline const NameScope& timelineScope() const;
+    inline void setTimelineScope(const NameScope&);
 
     inline const AnimationList* animations() const;
     inline const AnimationList* transitions() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -544,7 +544,7 @@ inline Vector<ViewTimelineInsets> RenderStyle::initialViewTimelineInsets() { ret
 inline Vector<Style::ScopedName> RenderStyle::initialViewTransitionClasses() { return { }; }
 inline Style::ViewTransitionName RenderStyle::initialViewTransitionName() { return Style::ViewTransitionName::createWithNone(); }
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
-inline const TimelineScope RenderStyle::initialTimelineScope() { return { }; }
+inline const NameScope RenderStyle::initialTimelineScope() { return { }; }
 constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
 constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
 inline Length RenderStyle::initialLetterSpacing() { return zeroLength(); }
@@ -720,7 +720,7 @@ inline const Vector<Ref<ViewTimeline>>& RenderStyle::viewTimelines() const { ret
 inline const Vector<ScrollAxis>& RenderStyle::viewTimelineAxes() const { return m_nonInheritedData->rareData->viewTimelineAxes; }
 inline const Vector<ViewTimelineInsets>& RenderStyle::viewTimelineInsets() const { return m_nonInheritedData->rareData->viewTimelineInsets; }
 inline const Vector<AtomString>& RenderStyle::viewTimelineNames() const { return m_nonInheritedData->rareData->viewTimelineNames; }
-inline const TimelineScope& RenderStyle::timelineScope() const { return m_nonInheritedData->rareData->timelineScope; }
+inline const NameScope& RenderStyle::timelineScope() const { return m_nonInheritedData->rareData->timelineScope; }
 inline std::optional<ScrollbarColor> RenderStyle::scrollbarColor() const { return m_rareInheritedData->scrollbarColor.asOptional(); }
 inline const Style::Color& RenderStyle::scrollbarThumbColor() const { return m_rareInheritedData->scrollbarColor->thumbColor; }
 inline const Style::Color& RenderStyle::scrollbarTrackColor() const { return m_rareInheritedData->scrollbarColor->trackColor; }

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -285,7 +285,7 @@ inline void RenderStyle::setScrollTimelineNames(const Vector<AtomString>& names)
 inline void RenderStyle::setViewTimelineAxes(const Vector<ScrollAxis>& axes) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineAxes, axes); }
 inline void RenderStyle::setViewTimelineInsets(const Vector<ViewTimelineInsets>& insets) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineInsets, insets); }
 inline void RenderStyle::setViewTimelineNames(const Vector<AtomString>& names) { SET_NESTED(m_nonInheritedData, rareData, viewTimelineNames, names); }
-inline void RenderStyle::setTimelineScope(const TimelineScope& scope) { SET_NESTED(m_nonInheritedData, rareData, timelineScope, scope); }
+inline void RenderStyle::setTimelineScope(const NameScope& scope) { SET_NESTED(m_nonInheritedData, rareData, timelineScope, scope); }
 inline void RenderStyle::setScrollbarColor(const std::optional<ScrollbarColor>& color) { SET(m_rareInheritedData, scrollbarColor, color); }
 inline void RenderStyle::setScrollbarThumbColor(const Style::Color& color) { m_rareInheritedData.access().scrollbarColor->thumbColor = color; }
 inline void RenderStyle::setScrollbarTrackColor(const Style::Color& color) { m_rareInheritedData.access().scrollbarColor->trackColor = color; }

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -30,6 +30,7 @@
 #include "GapLength.h"
 #include "LengthPoint.h"
 #include "LineClampValue.h"
+#include "NameScope.h"
 #include "NinePieceImage.h"
 #include "OffsetRotation.h"
 #include "PathOperation.h"
@@ -52,7 +53,6 @@
 #include "StyleSelfAlignmentData.h"
 #include "StyleTextEdge.h"
 #include "TextDecorationThickness.h"
-#include "TimelineScope.h"
 #include "TouchAction.h"
 #include "TranslateTransformOperation.h"
 #include "ViewTimeline.h"
@@ -208,7 +208,7 @@ public:
     Vector<ViewTimelineInsets> viewTimelineInsets;
     Vector<AtomString> viewTimelineNames;
 
-    TimelineScope timelineScope;
+    NameScope timelineScope;
 
     ScrollbarGutter scrollbarGutter;
 

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -253,7 +253,7 @@ public:
 
     static RefPtr<TimingFunction> convertTimingFunction(BuilderState&, const CSSValue&);
 
-    static TimelineScope convertTimelineScope(BuilderState&, const CSSValue&);
+    static NameScope convertNameScope(BuilderState&, const CSSValue&);
 
     static SingleTimelineRange convertAnimationRangeStart(BuilderState&, const CSSValue&);
     static SingleTimelineRange convertAnimationRangeEnd(BuilderState&, const CSSValue&);
@@ -2696,16 +2696,16 @@ inline RefPtr<TimingFunction> BuilderConverter::convertTimingFunction(BuilderSta
     return Style::createTimingFunction(value, builderState.cssToLengthConversionData());
 }
 
-inline TimelineScope BuilderConverter::convertTimelineScope(BuilderState& builderState, const CSSValue& value)
+inline NameScope BuilderConverter::convertNameScope(BuilderState& builderState, const CSSValue& value)
 {
     if (auto* primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         switch (primitiveValue->valueID()) {
         case CSSValueNone:
             return { };
         case CSSValueAll:
-            return { TimelineScope::Type::All, { } };
+            return { NameScope::Type::All, { } };
         default:
-            return { TimelineScope::Type::Ident, { AtomString { primitiveValue->stringValue() } } };
+            return { NameScope::Type::Ident, { AtomString { primitiveValue->stringValue() } } };
         }
     }
 
@@ -2713,7 +2713,7 @@ inline TimelineScope BuilderConverter::convertTimelineScope(BuilderState& builde
     if (!list)
         return { };
 
-    return { TimelineScope::Type::Ident, WTF::map(*list, [&](auto& item) {
+    return { NameScope::Type::Ident, WTF::map(*list, [&](auto& item) {
         return AtomString { item.stringValue() };
     }) };
 }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -684,7 +684,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             styleable.updateCSSViewTimelines(oldStyle, *resolvedStyle.style);
         }
 
-        if ((oldStyle && oldStyle->timelineScope().type != TimelineScope::Type::None) || resolvedStyle.style->timelineScope().type != TimelineScope::Type::None) {
+        if ((oldStyle && oldStyle->timelineScope().type != NameScope::Type::None) || resolvedStyle.style->timelineScope().type != NameScope::Type::None) {
             CheckedRef styleOriginatedTimelinesController = element.protectedDocument()->ensureStyleOriginatedTimelinesController();
             styleOriginatedTimelinesController->updateNamedTimelineMapForTimelineScope(resolvedStyle.style->timelineScope(), styleable);
         }


### PR DESCRIPTION
#### 281fcf894db63e79b6c35fce751bd8a5a4046379
<pre>
Rename TimelineScope to NameScope
<a href="https://rdar.apple.com/145093024">rdar://145093024</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287900">https://bugs.webkit.org/show_bug.cgi?id=287900</a>

Reviewed by Antoine Quint and Alan Baradlay.

Rename TimelineScope to NameScope so it can be reused for anchor-scope.
Also shorten NameScope::scopeNames to ::names.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::relatedTimelineScopeElements):
(WebCore::StyleOriginatedTimelinesController::updateTimelineForTimelineScope):
(WebCore::StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope):
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForNameScopeNames):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle const):
(WebCore::valueForTimelineScopeNames): Deleted.
* Source/WebCore/css/NameScope.h: Renamed from Source/WebCore/animation/TimelineScope.h.
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialTimelineScope):
(WebCore::RenderStyle::timelineScope const):
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setTimelineScope):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertNameScope):
(WebCore::Style::BuilderConverter::convertTimelineScope): Deleted.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Canonical link: <a href="https://commits.webkit.org/290635@main">https://commits.webkit.org/290635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/726854db66037d5775d71c039c7db96978222283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41426 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69761 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27308 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82211 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50104 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7828 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36593 "Found 4 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html http/tests/security/file-system-access-via-dataTransfer.html http/tests/xmlhttprequest/cross-origin-cookie-storage.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40555 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78146 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97488 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17831 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78790 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77987 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19261 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21049 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17841 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23187 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17580 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19367 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->