### PR TITLE
Adopt more smart pointers in LocalSampleBufferDisplayLayer.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1065,7 +1065,6 @@ platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
-platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.mm
 platform/graphics/avfoundation/objc/WebAVContentKeyGroup.mm
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -139,7 +139,6 @@ platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/InbandChapterTrackPrivateAVFObjC.mm
-platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
 platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
 platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/filters/FilterOperation.cpp

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -105,7 +105,7 @@ private:
     RetainPtr<PlatformLayer> m_rootLayer;
     RenderPolicy m_renderPolicy { RenderPolicy::TimingInfo };
 
-    Ref<WorkQueue> m_processingQueue;
+    const Ref<WorkQueue> m_processingQueue;
 
     // Only accessed through m_processingQueue or if m_processingQueue is null.
     using PendingSampleQueue = Deque<Ref<VideoFrame>>;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -210,13 +210,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void LocalSampleBufferDisplayLayer::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)
 {
-    ensureOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }, shouldMaintainAspectRatio]() mutable {
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, shouldMaintainAspectRatio]() mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
         runWithoutAnimations([&] {
-            m_sampleBufferDisplayLayer.get().videoGravity = shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize;
+            protectedThis->m_sampleBufferDisplayLayer.get().videoGravity = shouldMaintainAspectRatio ? AVLayerVideoGravityResizeAspect : AVLayerVideoGravityResize;
         });
     });
 }
@@ -225,12 +225,13 @@ void LocalSampleBufferDisplayLayer::layerStatusDidChange()
 {
     ASSERT(isMainThread());
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    if (m_client && m_sampleBufferDisplayLayer.get().status == AVQueuedSampleBufferRenderingStatusFailed) {
+    RefPtr client = m_client.get();
+    if (client && m_sampleBufferDisplayLayer.get().status == AVQueuedSampleBufferRenderingStatusFailed) {
 ALLOW_DEPRECATED_DECLARATIONS_END
         RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerStatusDidChange going to failed status (%{public}s) ", m_logIdentifier.utf8().data());
         if (!m_didFail) {
             m_didFail = true;
-            m_client->sampleBufferDisplayLayerStatusDidFail();
+            client->sampleBufferDisplayLayerStatusDidFail();
         }
     }
 }
@@ -239,10 +240,11 @@ void LocalSampleBufferDisplayLayer::layerErrorDidChange()
 {
     ASSERT(isMainThread());
     RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::layerErrorDidChange (%{public}s) ", m_logIdentifier.utf8().data());
-    if (!m_client || m_didFail)
+    RefPtr client = m_client.get();
+    if (!client || m_didFail)
         return;
     m_didFail = true;
-    m_client->sampleBufferDisplayLayerStatusDidFail();
+    client->sampleBufferDisplayLayerStatusDidFail();
 }
 
 PlatformLayer* LocalSampleBufferDisplayLayer::displayLayer()
@@ -289,54 +291,57 @@ void LocalSampleBufferDisplayLayer::updateBoundsAndPosition(CGRect bounds, std::
 
 void LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition(std::optional<CGRect> bounds)
 {
-    ensureOnMainThread([this, weakThis = ThreadSafeWeakPtr { *this }, bounds, rotation = m_videoFrameRotation, affineTransform = m_affineTransform]() mutable {
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, bounds, rotation = m_videoFrameRotation, affineTransform = m_affineTransform]() mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        auto layerBounds = bounds.value_or(m_rootLayer.get().bounds);
+        RetainPtr rootLayer = protectedThis->m_rootLayer;
+        auto layerBounds = bounds.value_or(rootLayer.get().bounds);
         CGPoint layerPosition { layerBounds.size.width / 2, layerBounds.size.height / 2 };
         if (rotation == VideoFrame::Rotation::Right || rotation == VideoFrame::Rotation::Left)
             std::swap(layerBounds.size.width, layerBounds.size.height);
         runWithoutAnimations([&] {
             if (bounds) {
-                m_rootLayer.get().position = { bounds->size.width / 2, bounds->size.height / 2 };
-                m_rootLayer.get().bounds = *bounds;
+                rootLayer.get().position = { bounds->size.width / 2, bounds->size.height / 2 };
+                rootLayer.get().bounds = *bounds;
             }
-            m_sampleBufferDisplayLayer.get().affineTransform = affineTransform;
-            m_sampleBufferDisplayLayer.get().position = layerPosition;
-            m_sampleBufferDisplayLayer.get().bounds = layerBounds;
+
+            RetainPtr sampleBufferDisplayLayer = protectedThis->m_sampleBufferDisplayLayer;
+            sampleBufferDisplayLayer.get().affineTransform = affineTransform;
+            sampleBufferDisplayLayer.get().position = layerPosition;
+            sampleBufferDisplayLayer.get().bounds = layerBounds;
         });
     });
 }
 
 void LocalSampleBufferDisplayLayer::flush()
 {
-    m_processingQueue->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }] {
+    m_processingQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        [m_sampleBufferDisplayLayer flush];
+        [protectedThis->m_sampleBufferDisplayLayer flush];
 ALLOW_DEPRECATED_DECLARATIONS_END
     });
 }
 
 void LocalSampleBufferDisplayLayer::flushAndRemoveImage()
 {
-    m_processingQueue->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }] {
+    m_processingQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
         @try {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [m_sampleBufferDisplayLayer flushAndRemoveImage];
+            [protectedThis->m_sampleBufferDisplayLayer flushAndRemoveImage];
 ALLOW_DEPRECATED_DECLARATIONS_END
         } @catch(id exception) {
             RELEASE_LOG_ERROR(WebRTC, "LocalSampleBufferDisplayLayer::flushAndRemoveImage failed");
-            layerErrorDidChange();
+            protectedThis->layerErrorDidChange();
         }
     });
 }
@@ -381,13 +386,13 @@ void LocalSampleBufferDisplayLayer::enqueueVideoFrame(VideoFrame& videoFrame)
         updateSampleLayerBoundsAndPosition({ });
     }
 
-    m_processingQueue->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }, pixelBuffer = RetainPtr { videoFrame.pixelBuffer() }, presentationTime = videoFrame.presentationTime()]() mutable {
+    m_processingQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }, pixelBuffer = RetainPtr { videoFrame.pixelBuffer() }, presentationTime = videoFrame.presentationTime()]() mutable {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        assertIsCurrent(workQueue());
-        enqueueBufferInternal(pixelBuffer.get(), presentationTime);
+        assertIsCurrent(protectedThis->workQueue());
+        protectedThis->enqueueBufferInternal(pixelBuffer.get(), presentationTime);
     });
 }
 
@@ -462,14 +467,14 @@ void LocalSampleBufferDisplayLayer::addVideoFrameToPendingQueue(Ref<VideoFrame>&
 
 void LocalSampleBufferDisplayLayer::clearVideoFrames()
 {
-    m_processingQueue->dispatch([this, weakThis = ThreadSafeWeakPtr { *this }] {
+    m_processingQueue->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
-        assertIsCurrent(workQueue());
+        assertIsCurrent(protectedThis->workQueue());
 
-        m_pendingVideoFrameQueue.clear();
+        protectedThis->m_pendingVideoFrameQueue.clear();
     });
 }
 
@@ -484,20 +489,20 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (!protectedThis)
             return;
 
-        m_processingQueue->dispatch([this, weakThis] {
+        m_processingQueue->dispatch([weakThis] {
             auto protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
 
-            [m_sampleBufferDisplayLayer stopRequestingMediaData];
+            [protectedThis->m_sampleBufferDisplayLayer stopRequestingMediaData];
 
-            while (!m_pendingVideoFrameQueue.isEmpty()) {
-                if (![m_sampleBufferDisplayLayer isReadyForMoreMediaData]) {
-                    requestNotificationWhenReadyForVideoData();
+            while (!protectedThis->m_pendingVideoFrameQueue.isEmpty()) {
+                if (![protectedThis->m_sampleBufferDisplayLayer isReadyForMoreMediaData]) {
+                    protectedThis->requestNotificationWhenReadyForVideoData();
                     return;
                 }
-                auto videoFrame = m_pendingVideoFrameQueue.takeFirst();
-                enqueueBufferInternal(videoFrame->pixelBuffer(), videoFrame->presentationTime());
+                auto videoFrame = protectedThis->m_pendingVideoFrameQueue.takeFirst();
+                protectedThis->enqueueBufferInternal(videoFrame->pixelBuffer(), videoFrame->presentationTime());
             }
         });
     }];


### PR DESCRIPTION
#### 2103a91dc922a2a1fc4b6f8ebdb7ccace9dd3f88
<pre>
Adopt more smart pointers in LocalSampleBufferDisplayLayer.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=287917">https://bugs.webkit.org/show_bug.cgi?id=287917</a>
<a href="https://rdar.apple.com/145101954">rdar://145101954</a>

Reviewed by Chris Dumez and Geoffrey Garen.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm:
(WebCore::LocalSampleBufferDisplayLayer::setShouldMaintainAspectRatio):
(WebCore::LocalSampleBufferDisplayLayer::layerStatusDidChange):
(WebCore::LocalSampleBufferDisplayLayer::layerErrorDidChange):
(WebCore::LocalSampleBufferDisplayLayer::updateSampleLayerBoundsAndPosition):
(WebCore::LocalSampleBufferDisplayLayer::flush):
(WebCore::LocalSampleBufferDisplayLayer::flushAndRemoveImage):
(WebCore::LocalSampleBufferDisplayLayer::enqueueVideoFrame):
(WebCore::LocalSampleBufferDisplayLayer::clearVideoFrames):
(WebCore::LocalSampleBufferDisplayLayer::requestNotificationWhenReadyForVideoData):

Canonical link: <a href="https://commits.webkit.org/290824@main">https://commits.webkit.org/290824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa26b6badbc14aadd9e150900027a1c7a1a6125c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91066 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69988 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27515 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50314 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8170 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/88 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78492 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98058 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78196 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22705 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/62 "Found 1 new test failure: imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-to-same-origin.https.html?7-8 (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11492 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14405 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23613 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18007 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21468 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->