### PR TITLE
[CSS] Allow declarations inside @scope rule without style rule ancestor

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-declarations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-declarations-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Scoped declarations apply to the scoping root assert_equals: expected "1" but got "auto"
-FAIL Scoped declarations apply to implicit scoping root assert_equals: expected "1" but got "auto"
-FAIL Scoped declarations apply with zero specificity assert_equals: expected "2" but got "1"
-FAIL Declarations are parsed into CSSNestedDeclarations, prelude=(.a) assert_equals: expected 5 but got 0
-FAIL Declarations are parsed into CSSNestedDeclarations, prelude= assert_equals: expected 5 but got 0
+PASS Scoped declarations apply to the scoping root
+PASS Scoped declarations apply to implicit scoping root
+PASS Scoped declarations apply with zero specificity
+PASS Declarations are parsed into CSSNestedDeclarations, prelude=(.a)
+PASS Declarations are parsed into CSSNestedDeclarations, prelude=
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt
@@ -20,6 +20,6 @@ PASS Scoped nested within another scope
 PASS Implicit (prelude-less) @scope as a nested group rule
 PASS Insert a nested style rule within @scope, &
 PASS Insert a nested style rule within @scope, :scope
-FAIL Insert a CSSNestedDeclarations rule directly in top-level @scope The string did not match the expected pattern.
+PASS Insert a CSSNestedDeclarations rule directly in top-level @scope
 PASS Mutating selectorText on outer style rule causes correct inner specificity
 

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -88,7 +88,8 @@ ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsi
     }();
     RefPtr newRule = CSSParser::parseRule(ruleString, parserContext(), styleSheet ? &styleSheet->contents() : nullptr, CSSParser::AllowedRules::ImportRules, nestedContextWithCurrentRule);
     if (!newRule) {
-        if (!hasStyleRuleAncestor())
+        // CSSNestedDeclarations parsing is allowed if there is an ancestor style rule or an ancestor scope rule.
+        if (!nestedContextWithCurrentRule)
             return Exception { ExceptionCode::SyntaxError };
         newRule = CSSParser::parseNestedDeclarations(parserContext(), ruleString);
         if (!newRule)

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -537,8 +537,10 @@ bool StyleSheetContents::hasNestingRules() const
     if (m_hasNestingRulesCache)
         return *m_hasNestingRulesCache;
 
-    m_hasNestingRulesCache = traverseRulesInVector(m_childRules, [&] (auto& rule) {
+    m_hasNestingRulesCache = traverseRulesInVector(m_childRules, [&] (const auto& rule) {
         if (rule.isStyleRuleWithNesting())
+            return true;
+        if (rule.isNestedDeclarationsRule())
             return true;
         return false;
     });


### PR DESCRIPTION
#### c6177048cd501236c4297419b0597518b490f586
<pre>
[CSS] Allow declarations inside @scope rule without style rule ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=287909">https://bugs.webkit.org/show_bug.cgi?id=287909</a>
<a href="https://rdar.apple.com/145101643">rdar://145101643</a>

Reviewed by Antti Koivisto.

<a href="https://github.com/w3c/csswg-drafts/issues/10389">https://github.com/w3c/csswg-drafts/issues/10389</a>

<a href="https://drafts.csswg.org/css-cascade-6/#scope-scope">https://drafts.csswg.org/css-cascade-6/#scope-scope</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-declarations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/scope-nesting-expected.txt:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::insertRule):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::hasNestingRules const):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeNestedGroupRules):
(WebCore::CSSParser::consumeBlockContent):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::addStyleRule):

Canonical link: <a href="https://commits.webkit.org/296262@main">https://commits.webkit.org/296262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9ffe0a23350f8ad07f064f01d76cba1ca33020f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/107551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/27234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/17644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/112768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/58093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/109515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/27925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/35735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/81655 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/110480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/22134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/96940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/62036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/21571 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/15079 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/57531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/91504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/15113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/115869 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/34619 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/25530 "Found 3 new test failures: inspector/model/remote-object-get-properties.html inspector/runtime/getDisplayableProperties.html inspector/runtime/getProperties.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/90691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/34995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/93191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/90432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/23137 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/35350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/13130 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/30382 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/34540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/40096 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/34286 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/37646 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/35949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->