### PR TITLE
Adopt more smart pointers in GlyphPageCoreText, MediaSelectionGroupAVFObjC, ScrollingStateTree

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -71,7 +71,6 @@ platform/graphics/ComplexTextController.h
 platform/graphics/DrawGlyphsRecorder.h
 platform/graphics/GraphicsLayer.h
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
-platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
 platform/graphics/avfoundation/objc/MediaSourcePrivateAVFObjC.h
 platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/TileController.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -992,7 +992,6 @@ page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp
 page/scrolling/ScrollSnapOffsetsInfo.cpp
 page/scrolling/ScrollingCoordinator.cpp
-page/scrolling/ScrollingStateTree.cpp
 page/scrolling/ScrollingThread.cpp
 page/scrolling/ScrollingTreeGestureState.cpp
 page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -1051,7 +1050,6 @@ platform/graphics/TransparencyLayerContextSwitcher.cpp
 platform/graphics/WidthIterator.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/InbandMetadataTextTrackPrivateAVF.cpp
-platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -601,7 +601,6 @@ platform/graphics/ca/TileGrid.cpp
 platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
 platform/graphics/cocoa/controls/ApplePayButtonCocoa.mm
 platform/graphics/coretext/ComplexTextControllerCoreText.mm
-platform/graphics/coretext/GlyphPageCoreText.cpp
 platform/graphics/displaylists/DisplayListItem.cpp
 platform/graphics/displaylists/DisplayListItems.cpp
 platform/graphics/displaylists/DisplayListRecorder.cpp

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -75,8 +75,8 @@ std::optional<ScrollingStateTree> ScrollingStateTree::createAfterReconstruction(
     ScrollingStateTree tree(hasNewRootStateNode, hasChangedProperties, WTFMove(rootStateNode));
 
     bool allIdentifiersUnique { true };
-    if (tree.m_rootStateNode) {
-        tree.m_rootStateNode->traverse([&] (auto& node) {
+    if (RefPtr rootStateNode = tree.m_rootStateNode) {
+        rootStateNode->traverse([&] (auto& node) {
             auto addResult = tree.m_stateNodeMap.add(node.scrollingNodeID(), node);
             if (!addResult.isNewEntry)
                 allIdentifiersUnique = false;
@@ -101,9 +101,9 @@ void ScrollingStateTree::attachDeserializedNodes()
     // into a ScrollingStateTree then move to a std::unique_ptr<ScrollingStateTree> and if we
     // did this in the constructor, createAfterReconstruction would be setting nodes' tree pointers
     // to the wrong ScrollingStateTree.
-    if (m_rootStateNode) {
-        m_rootStateNode->attachAfterDeserialization(*this);
-        ASSERT(m_rootStateNode->parentPointersAreCorrect());
+    if (RefPtr rootStateNode = m_rootStateNode) {
+        rootStateNode->attachAfterDeserialization(*this);
+        ASSERT(rootStateNode->parentPointersAreCorrect());
     }
 }
 
@@ -347,8 +347,8 @@ std::unique_ptr<ScrollingStateTree> ScrollingStateTree::commit(LayerRepresentati
     auto treeStateClone = makeUnique<ScrollingStateTree>();
     treeStateClone->setPreferredLayerRepresentation(preferredLayerRepresentation);
 
-    if (m_rootStateNode)
-        treeStateClone->setRootStateNode(downcast<ScrollingStateFrameScrollingNode>(m_rootStateNode->cloneAndReset(*treeStateClone)));
+    if (RefPtr rootStateNode = m_rootStateNode)
+        treeStateClone->setRootStateNode(downcast<ScrollingStateFrameScrollingNode>(rootStateNode->cloneAndReset(*treeStateClone)));
 
     // Now the clone tree has changed properties, and the original tree does not.
     treeStateClone->m_hasChangedProperties = std::exchange(m_hasChangedProperties, false);
@@ -367,11 +367,12 @@ void ScrollingStateTree::traverse(const ScrollingStateNode& node, NOESCAPE const
 
 bool ScrollingStateTree::isValid() const
 {
-    if (!m_rootStateNode)
+    RefPtr rootStateNode = m_rootStateNode;
+    if (!rootStateNode)
         return true;
 
     bool isValid = true;
-    traverse(*m_rootStateNode, [&](const ScrollingStateNode& node) {
+    traverse(*rootStateNode, [&](const ScrollingStateNode& node) {
         switch (node.nodeType()) {
         case ScrollingNodeType::MainFrame:
             break;

--- a/Source/WebCore/platform/graphics/Font.cpp
+++ b/Source/WebCore/platform/graphics/Font.cpp
@@ -92,6 +92,7 @@ Font::Font(const FontPlatformData& platformData, Origin origin, IsInterstitial i
     , m_shouldNotBeUsedForArabic(false)
 #endif
 {
+    relaxAdoptionRequirement();
     platformInit();
     platformGlyphInit();
     platformCharWidthInit();

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
@@ -31,7 +31,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>
@@ -45,7 +45,7 @@ namespace WebCore {
 
 class MediaSelectionGroupAVFObjC;
 
-class MediaSelectionOptionAVFObjC : public RefCounted<MediaSelectionOptionAVFObjC> {
+class MediaSelectionOptionAVFObjC : public RefCountedAndCanMakeWeakPtr<MediaSelectionOptionAVFObjC> {
 public:
     static Ref<MediaSelectionOptionAVFObjC> create(MediaSelectionGroupAVFObjC&, AVMediaSelectionOption *);
 
@@ -64,17 +64,17 @@ private:
 
     void clearGroup() { m_group = nullptr; }
 
-    MediaSelectionGroupAVFObjC* m_group;
+    WeakPtr<MediaSelectionGroupAVFObjC> m_group;
     RetainPtr<AVMediaSelectionOption> m_mediaSelectionOption;
 };
 
-class MediaSelectionGroupAVFObjC : public RefCounted<MediaSelectionGroupAVFObjC> {
+class MediaSelectionGroupAVFObjC : public RefCountedAndCanMakeWeakPtr<MediaSelectionGroupAVFObjC> {
 public:
     static Ref<MediaSelectionGroupAVFObjC> create(AVPlayerItem*, AVMediaSelectionGroup*, const Vector<String>& characteristics);
     ~MediaSelectionGroupAVFObjC();
 
     void setSelectedOption(MediaSelectionOptionAVFObjC*);
-    MediaSelectionOptionAVFObjC* selectedOption() const { return m_selectedOption; }
+    MediaSelectionOptionAVFObjC* selectedOption() const { return m_selectedOption.get(); }
 
     void updateOptions(const Vector<String>& characteristics);
 
@@ -92,7 +92,7 @@ private:
     RetainPtr<AVPlayerItem> m_playerItem;
     RetainPtr<AVMediaSelectionGroup> m_mediaSelectionGroup;
     OptionContainer m_options;
-    MediaSelectionOptionAVFObjC* m_selectedOption { nullptr };
+    WeakPtr<MediaSelectionOptionAVFObjC> m_selectedOption;
     Timer m_selectionTimer;
     bool m_shouldSelectOptionAutomatically { true };
 };

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
@@ -58,13 +58,14 @@ MediaSelectionOptionAVFObjC::MediaSelectionOptionAVFObjC(MediaSelectionGroupAVFO
 
 void MediaSelectionOptionAVFObjC::setSelected(bool selected)
 {
-    if (!m_group)
+    RefPtr group = m_group.get();
+    if (!group)
         return;
 
     if (selected == this->selected())
         return;
 
-    m_group->setSelectedOption(selected ? this : nullptr);
+    group->setSelectedOption(selected ? this : nullptr);
 }
 
 bool MediaSelectionOptionAVFObjC::selected() const

--- a/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp
@@ -52,20 +52,20 @@ bool GlyphPage::fill(std::span<const UChar> buffer)
 {
     ASSERT(buffer.size() == GlyphPage::size || buffer.size() == 2 * GlyphPage::size);
 
-    const Font& font = this->font();
+    Ref<const Font> font = this->font();
     Vector<CGGlyph, 512> glyphs(buffer.size());
     unsigned glyphStep = buffer.size() / GlyphPage::size;
 
     if (shouldFillWithVerticalGlyphs(buffer, font))
-        CTFontGetVerticalGlyphsForCharacters(font.platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
+        CTFontGetVerticalGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
     else
-        CTFontGetGlyphsForCharacters(font.platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
+        CTFontGetGlyphsForCharacters(font->platformData().ctFont(), reinterpret_cast<const UniChar*>(buffer.data()), glyphs.data(), buffer.size());
 
     bool haveGlyphs = false;
     for (unsigned i = 0; i < GlyphPage::size; ++i) {
         auto theGlyph = glyphs[i * glyphStep];
         if (theGlyph && theGlyph != deletedGlyph) {
-            setGlyphForIndex(i, theGlyph, font.colorGlyphType(theGlyph));
+            setGlyphForIndex(i, theGlyph, font->colorGlyphType(theGlyph));
             haveGlyphs = true;
         }
     }


### PR DESCRIPTION
#### a2fed17afc244c40b709b501c6b1c1ec3621da5d
<pre>
Adopt more smart pointers in GlyphPageCoreText, MediaSelectionGroupAVFObjC, ScrollingStateTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=287920">https://bugs.webkit.org/show_bug.cgi?id=287920</a>
<a href="https://rdar.apple.com/145102824">rdar://145102824</a>

Reviewed by Ryosuke Niwa.

Smart pointer adoption as per the static analyzer.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::createAfterReconstruction):
(WebCore::ScrollingStateTree::attachDeserializedNodes):
(WebCore::ScrollingStateTree::commit):
(WebCore::ScrollingStateTree::isValid const):
* Source/WebCore/platform/graphics/Font.cpp:
(WebCore::m_shouldNotBeUsedForArabic):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h:
(WebCore::MediaSelectionGroupAVFObjC::selectedOption const):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm:
(WebCore::MediaSelectionOptionAVFObjC::setSelected):
* Source/WebCore/platform/graphics/coretext/GlyphPageCoreText.cpp:
(WebCore::GlyphPage::fill):

Canonical link: <a href="https://commits.webkit.org/290965@main">https://commits.webkit.org/290965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa649bf146ae49df38a9b4917f5475573d6f8a6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91420 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10952 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42109 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70193 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27714 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82816 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50519 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41278 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98391 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18582 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13626 "Found 3 new test failures: fast/dom/crash-with-bad-url.html imported/w3c/web-platform-tests/screen-orientation/unlock.html webrtc/vp8-then-h264-gpu-process-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79216 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78420 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/19439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22941 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11714 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14507 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23856 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->