### PR TITLE
[iOS] Various tests hit debug assertions underneath `baseTextDirection` when turning on `BidiContentAwarePasteEnabled`

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -578,8 +578,6 @@ size_t TextUtil::firstUserPerceivedCharacterLength(const InlineTextItem& inlineT
 
 TextDirection TextUtil::directionForTextContent(StringView content)
 {
-    if (content.is8Bit())
-        return TextDirection::LTR;
     return baseTextDirection(content).value_or(TextDirection::LTR);
 }
 

--- a/Source/WebCore/platform/text/UnicodeHelpers.cpp
+++ b/Source/WebCore/platform/text/UnicodeHelpers.cpp
@@ -33,6 +33,9 @@ namespace WebCore {
 
 std::optional<TextDirection> baseTextDirection(StringView content)
 {
+    if (content.is8Bit())
+        return TextDirection::LTR;
+
     auto characters = content.span16();
     switch (ubidi_getBaseDirection(characters.data(), characters.size())) {
     case UBIDI_RTL:


### PR DESCRIPTION
#### edf1c2158c6247c06987622dd2bf15fd4b05849b
<pre>
[iOS] Various tests hit debug assertions underneath `baseTextDirection` when turning on `BidiContentAwarePasteEnabled`
<a href="https://bugs.webkit.org/show_bug.cgi?id=287911">https://bugs.webkit.org/show_bug.cgi?id=287911</a>
<a href="https://rdar.apple.com/145098905">rdar://145098905</a>

Reviewed by Abrar Rahman Protyasha.

When `BidiContentAwarePasteEnabled` is enabled, `ReplaceSelectionCommand` now attempts to check the
base writing direction of the pasted text, in order to automatically adjust base writing direction
prior to inserting the pasted content as a fragment in the DOM. To do this, it uses the
`baseTextDirection` helper, which returns an optional `TextDirection` enum.

However, this `baseTextDirection` helper function asserts in debug when passed an 8-bit (`LChar`)
string, since we immediately call `span16()` on it. This logic was pulled from `Layout::TextUtil`,
which (correctly) handles this case.

To fix this, we simply lower the `is8Bit()` into `baseTextDirection`, and return LTR before calling
into `ubidi_getBaseDirection` with `UChar` data.

* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::directionForTextContent):
* Source/WebCore/platform/text/UnicodeHelpers.cpp:
(WebCore::baseTextDirection):

Canonical link: <a href="https://commits.webkit.org/290590@main">https://commits.webkit.org/290590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1346b6b27d40020621ecfc5a366750e597c94782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45470 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95545 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18385 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69666 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/7981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50014 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36457 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40446 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97374 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/17984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77922 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77883 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19237 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/20946 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17736 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17475 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/20930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->