### PR TITLE
[CoreIPC] heap-use-after-free in WebCore::PathCG::create

### DIFF
--- a/LayoutTests/ipc/invalid-path-segments-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-path-segments-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-path-segments-crash.html
+++ b/LayoutTests/ipc/invalid-path-segments-crash.html
@@ -1,0 +1,79 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.setTimeout(async () => {
+  if (!window.IPC)
+      return window.testRunner?.notifyDone();
+
+  const { CoreIPC } = await import('./coreipc.js');
+
+
+  const createRepeatedPath = (pathSegments, repeatCount) => Array(repeatCount).fill(pathSegments).flat();
+
+  const connection = CoreIPC.newStreamConnection();
+  CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+    renderingBackendIdentifier: 393217,
+    connectionHandle: connection
+  });
+
+  const renderingBackend = connection.newInterface("RemoteRenderingBackend", 393217);
+
+  renderingBackend.CreateImageBuffer({
+    logicalSize: { width: 91, height: 119 },
+    renderingMode: 3,
+    renderingPurpose: 1,
+    resolutionScale: 57,
+    colorSpace: {
+      serializableColorSpace: {
+        alias: {
+          m_cgColorSpace: { alias: { variantType: 'WebCore::ColorSpace', variant: 19 } }
+        }
+      }
+    },
+    pixelFormat: 1,
+    renderingResourceIdentifier: 393224
+  });
+
+  const imageBufferIdentifier = 393224;
+  const imageBuffer = connection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+  const displayListRecorder = connection.newInterface("RemoteDisplayListRecorder", imageBufferIdentifier);
+  const pageID = IPC.pageID;
+
+  displayListRecorder.DrawFocusRingPath({
+    path: {
+      segments: createRepeatedPath([
+        { data: { alias: { variantType: 'WebCore::PathMoveTo', variant: { point: { x: 43, y: 22 } } } } },
+        { data: { alias: { variantType: 'WebCore::PathQuadCurveTo', variant: { controlPoint: { x: 7, y: 12 }, endPoint: { x: 91, y: 109 } } } } },
+        { data: { alias: { variantType: 'WebCore::PathDataQuadCurve', variant: { start: { x: 122, y: 46 }, controlPoint: { x: 54, y: 69 }, endPoint: { x: 70, y: 506806141048 } } } } },
+        { data: { alias: { variantType: 'WebCore::PathArcTo', variant: { controlPoint1: { x: 62, y: 18 }, controlPoint2: { x: 72, y: 88 }, radius: 37 } } } },
+        { data: { alias: { variantType: 'WebCore::PathRect', variant: { rect: { location: { x: 67, y: 60 }, size: { width: 31, height: 4875397766316111 } } } } } },
+        { data: { alias: { variantType: 'WebCore::PathRoundedRect', variant: { roundedRect: { rect: { location: { x: 55834574893, y: 275066885505103 }, size: { width: 118, height: 91 } }, radiiTopLeft: { width: 50, height: 102 }, radiiTopRight: { width: 20, height: 125 }, radiiBottomLeft: { width: 66, height: 119 }, radiiBottomRight: { width: 322123005958, height: 122 } }, strategy: 0 } } } },
+        { data: { alias: { variantType: 'WebCore::PathArcTo', variant: { controlPoint1: { x: 19, y: 335008760447 }, controlPoint2: { x: 197568495714, y: 124 }, radius: 65 } } } },
+        { data: { alias: { variantType: 'WebCore::PathArc', variant: { center: { x: 1, y: 79 }, radius: 97, startAngle: 83, endAngle: 19, direction: 1 } } } },
+        { data: { alias: { variantType: 'WebCore::PathMoveTo', variant: { point: { x: 106, y: 14 } } } } }
+      ], 1120)
+    },
+    outlineWidth: 240518168607,
+    color: {
+      data: {
+        optionalValue: {
+          isSemantic: false,
+          usesFunctionSerialization: false,
+          data: { variantType: 'WebCore::PackedColor::RGBA', variant: { value: 122 } }
+        }
+      }
+    }
+  });
+
+  renderingBackend.DidDrawRemoteToPDF({ pageID, imageBufferIdentifier, snapshotIdentifier: 262145 });
+  imageBuffer.GetShareableBitmap({ preserveResolution: true });
+
+  window.testRunner?.notifyDone();
+}, 20);
+</script>

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -270,13 +270,10 @@ void RemoteRenderingBackend::didDrawRemoteToPDF(PageIdentifier pageID, Rendering
     }
 
     ASSERT(imageBufferIdentifier == imageBuffer->renderingResourceIdentifier());
+    auto data = imageBuffer->sinkIntoPDFDocument();
 
-    callOnMainRunLoop([protectedThis = Ref { *this }, pageID, imageBuffer = WTFMove(imageBuffer), snapshotIdentifier]() mutable {
-        auto data = imageBuffer->sinkIntoPDFDocument();
+    callOnMainRunLoop([pageID, data = WTFMove(data), snapshotIdentifier]() mutable {
         GPUProcess::singleton().didDrawRemoteToPDF(pageID, WTFMove(data), snapshotIdentifier);
-
-        // Ensure destruction happens on creation thread.
-        protectedThis->protectedWorkQueue()->dispatch([imageBuffer = WTFMove(imageBuffer)] () mutable { });
     });
 }
 #endif


### PR DESCRIPTION
#### 33efffb67232e0fc5de51557781e49b3f7d84fd8
<pre>
[CoreIPC] heap-use-after-free in WebCore::PathCG::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=287879">https://bugs.webkit.org/show_bug.cgi?id=287879</a>
<a href="https://rdar.apple.com/144939884">rdar://144939884</a>

Reviewed by Said Abou-Hallawa.

Reverted back to use sinkIntoPDFDocument() on RemoteRenderingBackend work queue.

* LayoutTests/ipc/invalid-path-segments-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-path-segments-crash.html: Added.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::didDrawRemoteToPDF):

Canonical link: <a href="https://commits.webkit.org/291031@main">https://commits.webkit.org/291031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de0e6539e2d407c0b5778b53e36ec68ab42d6dd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42336 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19652 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70383 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27891 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50709 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/644 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98652 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18827 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13877 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-abort.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79412 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78625 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23143 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/495 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11930 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14550 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24082 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18525 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21982 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->