### PR TITLE
Address safer C++ static analysis warnings in WKWebView.mm

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -13,7 +13,6 @@ Shared/UserData.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
-UIProcess/API/Cocoa/WKWebView.mm
 UIProcess/API/Cocoa/WKWebViewConfiguration.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/API/Cocoa/_WKDataTask.mm

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -7,7 +7,6 @@ NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKBrowsingContextController.mm
-UIProcess/API/Cocoa/WKWebView.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/Inspector/InspectorTargetProxy.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -27,7 +27,6 @@ UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
 UIProcess/API/Cocoa/WKNavigationAction.mm
 UIProcess/API/Cocoa/WKProcessPool.mm
-UIProcess/API/Cocoa/WKWebView.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKDownload.mm

--- a/Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h
@@ -54,6 +54,8 @@ public:
     virtual void logDiagnosticMessageWithValueDictionary(WebKit::WebPageProxy*, const WTF::String& message, const WTF::String& description, Ref<API::Dictionary>&&) = 0;
 
     virtual void logDiagnosticMessageWithDomain(WebKit::WebPageProxy*, const WTF::String&, WebCore::DiagnosticLoggingDomain) { }
+
+    virtual bool isWebKitDiagnosticLoggingClient() const { return false; }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APIFindClient.h
+++ b/Source/WebKit/UIProcess/API/APIFindClient.h
@@ -53,6 +53,8 @@ public:
 
     virtual void didAddLayerForFindOverlay(WebKit::WebPageProxy*, PlatformLayer*) { }
     virtual void didRemoveLayerForFindOverlay(WebKit::WebPageProxy*) { }
+
+    virtual bool isWebKitFindClient() const { return false; }
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -244,8 +244,8 @@ struct PerWebProcessState {
     RetainPtr<WKWebViewConfiguration> _configuration;
     const RefPtr<WebKit::WebPageProxy> _page;
 
-    std::unique_ptr<WebKit::NavigationState> _navigationState;
-    std::unique_ptr<WebKit::UIDelegate> _uiDelegate;
+    const std::unique_ptr<WebKit::NavigationState> _navigationState;
+    const std::unique_ptr<WebKit::UIDelegate> _uiDelegate;
     std::unique_ptr<WebKit::IconLoadingDelegate> _iconLoadingDelegate;
     std::unique_ptr<WebKit::ResourceLoadDelegate> _resourceLoadDelegate;
 

--- a/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h
@@ -52,6 +52,8 @@ private:
     void logDiagnosticMessageWithValueDictionary(WebPageProxy*, const String& message, const String& description, Ref<API::Dictionary>&&) override;
     void logDiagnosticMessageWithDomain(WebPageProxy*, const String& message, WebCore::DiagnosticLoggingDomain) override;
 
+    bool isWebKitDiagnosticLoggingClient() const final { return true; }
+
     WKWebView *m_webView;
     WeakObjCPtr<id <_WKDiagnosticLoggingDelegate>> m_delegate;
 
@@ -66,3 +68,7 @@ private:
 };
 
 } // WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::DiagnosticLoggingClient) \
+    static bool isType(const API::DiagnosticLoggingClient& client) { return client.isWebKitDiagnosticLoggingClient(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/Cocoa/FindClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/FindClient.h
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef FindClient_h
-#define FindClient_h
+#pragma once
 
 #import "WKFoundation.h"
 
@@ -53,6 +52,8 @@ private:
 
     virtual void didAddLayerForFindOverlay(WebKit::WebPageProxy*, CALayer *);
     virtual void didRemoveLayerForFindOverlay(WebKit::WebPageProxy*);
+
+    bool isWebKitFindClient() const final { return true; }
     
     WKWebView *m_webView;
     WeakObjCPtr<id <_WKFindDelegate>> m_delegate;
@@ -68,4 +69,6 @@ private:
     
 } // namespace WebKit
 
-#endif // FindClient_h
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::FindClient) \
+    static bool isType(const API::FindClient& client) { return client.isWebKitFindClient(); } \
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 988ad1fd139a4b42e51df94c94e5bbf259ba34a6
<pre>
Address safer C++ static analysis warnings in WKWebView.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=287942">https://bugs.webkit.org/show_bug.cgi?id=287942</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/UIProcess/API/APIDiagnosticLoggingClient.h:
(API::DiagnosticLoggingClient::isWebKitDiagnosticLoggingClient const):
* Source/WebKit/UIProcess/API/APIFindClient.h:
(API::FindClient::isWebKitFindClient const):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _initializeWithConfiguration:]):
(-[WKWebView _setupPageConfiguration:withPool:]):
(-[WKWebView goToBackForwardListItem:]):
(-[WKWebView title]):
(-[WKWebView URL]):
(-[WKWebView isLoading]):
(-[WKWebView estimatedProgress]):
(-[WKWebView hasOnlySecureContent]):
(-[WKWebView canGoBack]):
(-[WKWebView canGoForward]):
(-[WKWebView closeAllMediaPresentationsWithCompletionHandler:]):
(-[WKWebView printOperationWithPrintInfo:]):
(-[WKWebView _storeAppHighlight:]):
(-[WKWebView createPDFWithConfiguration:completionHandler:]):
(-[WKWebView fullscreenState]):
(-[WKWebView _inspector]):
(-[WKWebView _mainFrame]):
(-[WKWebView _negotiatedLegacyTLS]):
(-[WKWebView _startTextManipulationsWithConfiguration:completion:]):
(-[WKWebView _startImageAnalysis:target:]):
(-[WKWebView _requestTargetedElementInfo:completionHandler:]):
(-[WKWebView _mainFrameURL]):
(-[WKWebView _certificateChain]):
(-[WKWebView _provisionalWebProcessIdentifier]):
(-[WKWebView _webProcessIsResponsive]):
(-[WKWebView _killWebContentProcess]):
(-[WKWebView _killWebContentProcessAndResetState]):
(-[WKWebView _clearBackForwardCache]):
(-[WKWebView _allMediaPresentationsClosed]):
(-[WKWebView _updateWebpagePreferences:]):
(-[WKWebView _saveResources:suggestedFileName:completionHandler:]):
(-[WKWebView _archiveWithConfiguration:completionHandler:]):
(-[WKWebView _getMainResourceDataWithCompletionHandler:]):
(-[WKWebView _diagnosticLoggingDelegate]):
(-[WKWebView _setDiagnosticLoggingDelegate:]):
(-[WKWebView _findDelegate]):
(-[WKWebView _setFindDelegate:]):
(-[WKWebView _saveBackForwardSnapshotForItem:]):
(-[WKWebView _serviceWorkersEnabled:]):
(-[WKWebView _isDisplayingPDF]):
(-[WKWebView _isDisplayingStandaloneImageDocument]):
(-[WKWebView _isDisplayingStandaloneMediaDocument]):
(-[WKWebView _isInFullscreen]):
(elementsFromWKElements):
(-[WKWebView _requestTextExtraction:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/DiagnosticLoggingClient.h:
(isType):
* Source/WebKit/UIProcess/Cocoa/FindClient.h:
(isType):

Canonical link: <a href="https://commits.webkit.org/290616@main">https://commits.webkit.org/290616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/544f023a4b7b232c16e3fe8a63f7269ae6e1985d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90619 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95631 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41401 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18470 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93620 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7801 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40531 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97460 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17811 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77959 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19253 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21023 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17821 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23160 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21016 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->