### PR TITLE
Use FlatDynamicRangeLimit in media

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2206,6 +2206,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/PlatformAudioTrackConfiguration.h
     platform/graphics/PlatformColorSpace.h
     platform/graphics/PlatformDisplay.h
+    platform/graphics/PlatformDynamicRangeLimit.h
     platform/graphics/PlatformGraphicsContext.h
     platform/graphics/PlatformImage.h
     platform/graphics/PlatformLayer.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2555,6 +2555,7 @@ platform/graphics/PixelBuffer.cpp
 platform/graphics/PixelBufferConversion.cpp
 platform/graphics/PixelBufferFormat.cpp
 platform/graphics/PixelFormat.cpp
+platform/graphics/PlatformDynamicRangeLimit.cpp
 platform/graphics/PlatformTimeRanges.cpp
 platform/graphics/PositionedGlyphs.cpp
 platform/graphics/Region.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2852,6 +2852,7 @@
 		7263D505292C472D00CA9D10 /* GraphicsStyle.h in Headers */ = {isa = PBXBuildFile; fileRef = 7263D503292C472B00CA9D10 /* GraphicsStyle.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726516E62C9CB75600647895 /* ContentsFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516E42C9BB70E00647895 /* ContentsFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726516F72CA4B4A300647895 /* ContentsFormatCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516F52CA4AEDC00647895 /* ContentsFormatCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		726516E62C9CB75600647896 /* PlatformDynamicRangeLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516E42C9BB70E00647896 /* PlatformDynamicRangeLimit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726CDE202759735000A445B2 /* FilterEffectGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 729661A2275960A500E7DF9B /* FilterEffectGeometry.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726D56E2253AE28D0002EF90 /* PlatformImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 726D56E1253AE0430002EF90 /* PlatformImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726D56E3253AE3660002EF90 /* NativeImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 55A336F61D8209F40022C4C7 /* NativeImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -13410,6 +13411,8 @@
 		726516E42C9BB70E00647895 /* ContentsFormat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentsFormat.h; sourceTree = "<group>"; };
 		726516E52C9CB59900647895 /* ContentsFormat.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ContentsFormat.cpp; sourceTree = "<group>"; };
 		726516F52CA4AEDC00647895 /* ContentsFormatCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentsFormatCocoa.h; sourceTree = "<group>"; };
+		726516E42C9BB70E00647896 /* PlatformDynamicRangeLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformDynamicRangeLimit.h; sourceTree = "<group>"; };
+		726516E52C9CB59900647896 /* PlatformDynamicRangeLimit.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDynamicRangeLimit.cpp; sourceTree = "<group>"; };
 		7266F0132241BCE200833975 /* SVGPropertyAnimatorFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPropertyAnimatorFactory.h; sourceTree = "<group>"; };
 		7266F0142241BFB200833975 /* SVGPrimitivePropertyAnimatorImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPrimitivePropertyAnimatorImpl.h; sourceTree = "<group>"; };
 		7266F0152241C09800833975 /* SVGPrimitivePropertyAnimator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPrimitivePropertyAnimator.h; sourceTree = "<group>"; };
@@ -34154,6 +34157,8 @@
 				BCA55912263DBD79007F19B3 /* PixelFormat.h */,
 				CDD08ABF277E54F000EA3755 /* PlatformAudioTrackConfiguration.h */,
 				BC3E62422659791700548ACD /* PlatformColorSpace.h */,
+				726516E52C9CB59900647896 /* PlatformDynamicRangeLimit.cpp */,
+				726516E42C9BB70E00647896 /* PlatformDynamicRangeLimit.h */,
 				722AF2E127E1C4030078D997 /* PlatformGraphicsContext.h */,
 				726D56E1253AE0430002EF90 /* PlatformImage.h */,
 				0562F9601573F88F0031CA16 /* PlatformLayer.h */,
@@ -43443,6 +43448,7 @@
 				BC3E62432659791800548ACD /* PlatformColorSpace.h in Headers */,
 				A14978711ABAF3A500CEF7E4 /* PlatformContentFilter.h in Headers */,
 				72A645212949049700C14BA3 /* PlatformControl.h in Headers */,
+				726516E62C9CB75600647896 /* PlatformDynamicRangeLimit.h in Headers */,
 				BC5C762B1497FE1400BC4775 /* PlatformEvent.h in Headers */,
 				F4CCD04E2A9917ED00536C6B /* PlatformEvent.serialization.in in Headers */,
 				26601EBF14B3B9AD0012C0FE /* PlatformEventFactoryIOS.h in Headers */,

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2853,6 +2853,7 @@
 		726516E62C9CB75600647895 /* ContentsFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516E42C9BB70E00647895 /* ContentsFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726516F72CA4B4A300647895 /* ContentsFormatCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516F52CA4AEDC00647895 /* ContentsFormatCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726516E62C9CB75600647896 /* PlatformDynamicRangeLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516E42C9BB70E00647896 /* PlatformDynamicRangeLimit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		726516F72CA4B4A300647896 /* PlatformDynamicRangeLimitCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 726516F52CA4AEDC00647896 /* PlatformDynamicRangeLimitCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726CDE202759735000A445B2 /* FilterEffectGeometry.h in Headers */ = {isa = PBXBuildFile; fileRef = 729661A2275960A500E7DF9B /* FilterEffectGeometry.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726D56E2253AE28D0002EF90 /* PlatformImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 726D56E1253AE0430002EF90 /* PlatformImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		726D56E3253AE3660002EF90 /* NativeImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 55A336F61D8209F40022C4C7 /* NativeImage.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -13413,6 +13414,7 @@
 		726516F52CA4AEDC00647895 /* ContentsFormatCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContentsFormatCocoa.h; sourceTree = "<group>"; };
 		726516E42C9BB70E00647896 /* PlatformDynamicRangeLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformDynamicRangeLimit.h; sourceTree = "<group>"; };
 		726516E52C9CB59900647896 /* PlatformDynamicRangeLimit.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDynamicRangeLimit.cpp; sourceTree = "<group>"; };
+		726516F52CA4AEDC00647896 /* PlatformDynamicRangeLimitCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformDynamicRangeLimitCocoa.h; sourceTree = "<group>"; };
 		7266F0132241BCE200833975 /* SVGPropertyAnimatorFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPropertyAnimatorFactory.h; sourceTree = "<group>"; };
 		7266F0142241BFB200833975 /* SVGPrimitivePropertyAnimatorImpl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPrimitivePropertyAnimatorImpl.h; sourceTree = "<group>"; };
 		7266F0152241C09800833975 /* SVGPrimitivePropertyAnimator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGPrimitivePropertyAnimator.h; sourceTree = "<group>"; };
@@ -26103,6 +26105,7 @@
 				4958782012A57DDF007238AC /* PlatformCALayerCocoa.mm */,
 				0FA2B233276817540020C7C1 /* PlatformCALayerContentsDelayedReleaser.h */,
 				0FA2B235276817550020C7C1 /* PlatformCALayerContentsDelayedReleaser.mm */,
+				726516F52CA4AEDC00647896 /* PlatformDynamicRangeLimitCocoa.h */,
 				31DEA4541B39F4D900F77178 /* WebSystemBackdropLayer.h */,
 				31DEA4531B39F4D900F77178 /* WebSystemBackdropLayer.mm */,
 				0F580FA11496939100FB5BD8 /* WebTiledBackingLayer.h */,
@@ -43449,6 +43452,7 @@
 				A14978711ABAF3A500CEF7E4 /* PlatformContentFilter.h in Headers */,
 				72A645212949049700C14BA3 /* PlatformControl.h in Headers */,
 				726516E62C9CB75600647896 /* PlatformDynamicRangeLimit.h in Headers */,
+				726516F72CA4B4A300647896 /* PlatformDynamicRangeLimitCocoa.h in Headers */,
 				BC5C762B1497FE1400BC4775 /* PlatformEvent.h in Headers */,
 				F4CCD04E2A9917ED00536C6B /* PlatformEvent.serialization.in in Headers */,
 				26601EBF14B3B9AD0012C0FE /* PlatformEventFactoryIOS.h in Headers */,

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7927,6 +7927,7 @@ void HTMLMediaElement::createMediaPlayer() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 
     m_player = MediaPlayer::create(*this);
     RefPtr player = m_player;
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " HTMLMediaElement[" << this << "]::createMediaPlayer -> m_player[" << player.get() << "]");
     player->setBufferingPolicy(m_bufferingPolicy);
     player->setPreferredDynamicRangeMode(m_overrideDynamicRangeMode.value_or(preferredDynamicRangeMode(document().protectedView().get())));
     player->setShouldDisableHDR(shouldDisableHDR());
@@ -8365,6 +8366,16 @@ void HTMLMediaElement::setOverridePreferredDynamicRangeMode(DynamicRangeMode mod
     Ref player = *m_player;
     player->setPreferredDynamicRangeMode(mode);
     player->setShouldDisableHDR(shouldDisableHDR());
+}
+
+void HTMLMediaElement::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+    if (!m_player)
+        return;
+
+    Ref player = *m_player;
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " HTMLMediaElement[" << this << "]::setPlatformDynamicRangeLimit(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") -> m_player[" << player.ptr() << "]->setPlatformDynamicRangeLimit(" << platformDynamicRangeLimit << ")...");
+    player->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
 }
 
 Vector<String> HTMLMediaElement::mediaPlayerPreferredAudioCharacteristics() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -649,6 +649,7 @@ public:
 
     WEBCORE_EXPORT void setOverridePreferredDynamicRangeMode(DynamicRangeMode);
     void setPreferredDynamicRangeMode(DynamicRangeMode);
+    void setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit);
 
     void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) override;
 

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -133,6 +133,7 @@ bool HTMLVideoElement::supportsAcceleratedRendering() const
 void HTMLVideoElement::mediaPlayerRenderingModeChanged()
 {
     HTMLVIDEOELEMENT_RELEASE_LOG(HTMLVIDEOELEMENT_MEDIAPLAYERRENDERINGMODECHANGED);
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " HTMLVideoElement[" << this << "]::mediaPlayerRenderingModeChanged() - platformLayer=" << platformLayer());
 
     // Kick off a fake recalcStyle that will update the compositing tree.
     computeAcceleratedRenderingStateAndUpdateMediaPlayer();

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -662,6 +662,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
             if (m_shouldContinueAfterKeyNeeded)
                 playerPrivate->setShouldContinueAfterKeyNeeded(m_shouldContinueAfterKeyNeeded);
 #endif
+            ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayer[" << this << "]::loadWithNextMediaEngine -> m_private[" << playerPrivate.get() << "] -> prepareForPlayback()...");
             playerPrivate->prepareForPlayback(m_inPrivateBrowsingMode, m_preload, m_preservesPitch, m_shouldPrepareToPlay, m_shouldPrepareToRender);
 #if HAVE(SPATIAL_TRACKING_LABEL)
             playerPrivate->setDefaultSpatialTrackingLabel(m_defaultSpatialTrackingLabel);
@@ -1895,6 +1896,17 @@ void MediaPlayer::setPreferredDynamicRangeMode(DynamicRangeMode mode)
 {
     m_preferredDynamicRangeMode = mode;
     m_private->setPreferredDynamicRangeMode(mode);
+}
+
+void MediaPlayer::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+    if (platformDynamicRangeLimit == m_platformDynamicRangeLimit) {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayer[" << this << "]::setPlatformDynamicRangeLimit(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") - no change, stop here");
+        return;
+    }
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayer[" << this << "]::setPlatformDynamicRangeLimit(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") - was " << m_platformDynamicRangeLimit << " -> m_private->setPlatformDynamicRangeLimit()...");
+    m_platformDynamicRangeLimit = platformDynamicRangeLimit;
+    m_private->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
 }
 
 void MediaPlayer::audioOutputDeviceChanged()

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -29,6 +29,7 @@
 
 #include "ContentType.h"
 #include "Cookie.h"
+#include "PlatformDynamicRangeLimit.h"
 #include "FourCC.h"
 #include "GraphicsTypesGL.h"
 #include "LayoutRect.h"
@@ -746,6 +747,8 @@ public:
 
     DynamicRangeMode preferredDynamicRangeMode() const { return m_preferredDynamicRangeMode; }
     void setPreferredDynamicRangeMode(DynamicRangeMode);
+    PlatformDynamicRangeLimit platformDynamicRangeLimit() const { return m_platformDynamicRangeLimit; }
+    void setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit);
 
     String audioOutputDeviceId() const;
     String audioOutputDeviceIdOverride() const;
@@ -830,6 +833,7 @@ private:
     bool m_shouldPrepareToRender { false };
     bool m_initializingMediaEngine { false };
     DynamicRangeMode m_preferredDynamicRangeMode;
+    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { };
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
     RefPtr<PlatformMediaResourceLoader> m_mediaResourceLoader;
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -68,6 +68,7 @@ public:
 
     virtual void prepareForPlayback(bool privateMode, MediaPlayer::Preload preload, bool preservesPitch, bool prepareToPlay, bool prepareToRender)
     {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateInterface[" << this << "]::prepareForPlayback() - minimal base implementation");
         setPrivateBrowsingMode(privateMode);
         setPreload(preload);
         setPreservesPitch(preservesPitch);
@@ -323,6 +324,9 @@ public:
     virtual bool shouldIgnoreIntrinsicSize() { return false; }
 
     virtual void setPreferredDynamicRangeMode(DynamicRangeMode) { }
+    virtual void setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit) {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateInterface[" << this << "]::setPlatformDynamicRangeLimit(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") - empty base implementation");
+    }
 
     virtual void audioOutputDeviceChanged() { }
 

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformDynamicRangeLimit.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+float PlatformDynamicRangeLimit::normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent)
+{
+    if (!std::isfinite(standardPercent) || standardPercent < 0 || standardPercent > 100 || !std::isfinite(constrainedHighPercent) || constrainedHighPercent < 0 || constrainedHighPercent > 100 || !std::isfinite(noLimitPercent) || noLimitPercent < 0 || noLimitPercent > 100) {
+        ASSERT(std::isfinite(standardPercent));
+        ASSERT(standardPercent >= 0);
+        ASSERT(standardPercent <= 100);
+        ASSERT(std::isfinite(constrainedHighPercent));
+        ASSERT(constrainedHighPercent >= 0);
+        ASSERT(constrainedHighPercent <= 100);
+        ASSERT(std::isfinite(noLimitPercent));
+        ASSERT(noLimitPercent >= 0);
+        ASSERT(noLimitPercent <= 100);
+        // Unexpected value -> Clamp HDR down to prevent misuses.
+        return standardValue;
+    }
+
+    float sum = standardPercent + constrainedHighPercent + noLimitPercent;
+    if (!sum) {
+        ASSERT(sum);
+        return standardValue;
+    }
+
+    float weightedSum = standardPercent * standardValue + constrainedHighPercent * constrainedHighValue + noLimitPercent * noLimitValue;
+    float weightedAverage = WTF::safeFPDivision(weightedSum, sum);
+    return std::clamp(weightedAverage, 0.0f, 1.0f);
+}
+
+TextStream& operator<<(TextStream& ts, PlatformDynamicRangeLimit dynamicRangeLimit)
+{
+    ts << dynamicRangeLimit.value();
+    return ts;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <wtf/ArgumentCoder.h>
+
+namespace WTF {
+class TextStream;
+}
+
+namespace WebCore {
+
+namespace Style {
+struct DynamicRangeLimit;
+}
+
+class PlatformDynamicRangeLimit {
+public:
+    constexpr PlatformDynamicRangeLimit() = default;
+
+    static constexpr PlatformDynamicRangeLimit standard() { return PlatformDynamicRangeLimit(standardValue); }
+    static constexpr PlatformDynamicRangeLimit constrainedHigh() { return PlatformDynamicRangeLimit(constrainedHighValue); }
+    static constexpr PlatformDynamicRangeLimit noLimit() { return PlatformDynamicRangeLimit(noLimitValue); }
+
+    // `dynamic-range-limit` mapped to PlatformDynamicRangeLimit.value():
+    // ["standard", "constrainedHigh"] -> [standard().value(), constrainedHigh().value()],
+    // ["constrainedHigh", "noLimit"] -> [constrainedHigh().value(), noLimit().value()]
+    constexpr float value() const { return m_value; }
+
+    constexpr auto operator<=>(const PlatformDynamicRangeLimit&) const = default;
+
+private:
+    friend struct IPC::ArgumentCoder<WebCore::PlatformDynamicRangeLimit, void>;
+    friend Style::DynamicRangeLimit;
+
+    constexpr PlatformDynamicRangeLimit(float value) : m_value(std::clamp(value, 0.0f, 1.0f)) { }
+
+    constexpr PlatformDynamicRangeLimit(float standardPercent, float constrainedHighPercent, float noLimitPercent) : m_value(normalizedAverage(standardPercent, constrainedHighPercent, noLimitPercent)) { }
+
+    static float normalizedAverage(float standardPercent, float constrainedHighPercent, float noLimitPercent);
+
+    static constexpr float standardValue = 0;
+    static constexpr float constrainedHighValue = 0.5;
+    static constexpr float noLimitValue = 1;
+
+    float m_value = noLimitValue;
+};
+
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformDynamicRangeLimit);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -342,6 +342,8 @@ private:
     void setShouldObserveTimeControlStatus(bool);
 
     void setPreferredDynamicRangeMode(DynamicRangeMode) final;
+    void setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit) final;
+
     void audioOutputDeviceChanged() final;
 
     void currentTimeDidChange(MediaTime&&) const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -55,6 +55,7 @@
 #import "MediaSessionManagerCocoa.h"
 #import "OutOfBandTextTrackPrivateAVF.h"
 #import "PixelBufferConformerCV.h"
+#import "PlatformDynamicRangeLimitCocoa.h"
 #import "PlatformMediaResourceLoader.h"
 #import "PlatformScreen.h"
 #import "PlatformTextTrack.h"
@@ -429,6 +430,7 @@ MediaPlayerPrivateAVFoundationObjC::MediaPlayerPrivateAVFoundationObjC(MediaPlay
     , m_loaderDelegate(adoptNS([[WebCoreAVFLoaderDelegate alloc] initWithPlayer:*this]))
     , m_cachedItemStatus(MediaPlayerAVPlayerItemStatusDoesNotExist)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateAVFoundationObjC[" << this << "]::MediaPlayerPrivateAVFoundationObjC(MediaPlayer[" << player << "]) - m_videoLayerManager[" << m_videoLayerManager.get() << "]");
     ALWAYS_LOG(LOGIDENTIFIER);
     m_muted = player->muted();
 #if HAVE(SPATIAL_TRACKING_LABEL)
@@ -650,6 +652,8 @@ void MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer()
     [m_videoLayer addObserver:m_objcObserver.get() forKeyPath:@"readyForDisplay" options:NSKeyValueObservingOptionNew context:(void *)MediaPlayerAVFoundationObservationContextAVPlayerLayer];
     updateVideoLayerGravity();
     [m_videoLayer setContentsScale:player->playerContentsScale()];
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateAVFoundationObjC[" << this << "]::createAVPlayerLayer() -> setPlatformDynamicRangeLimit() and m_videoLayerManager->setVideoLayer(new AVPlayerLayer[" << m_videoLayer.get() << "])");
+    setPlatformDynamicRangeLimit(player->platformDynamicRangeLimit());
     m_videoLayerManager->setVideoLayer(m_videoLayer.get(), player->presentationSize());
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
@@ -671,6 +675,7 @@ void MediaPlayerPrivateAVFoundationObjC::destroyVideoLayer()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateAVFoundationObjC[" << this << "]::destroyVideoLayer m_videoLayerManager->setVideoLayer(new AVPlayerLayer[" << m_videoLayer.get() << "])");
     [m_videoLayer removeObserver:m_objcObserver.get() forKeyPath:@"readyForDisplay"];
     [m_videoLayer setPlayer:nil];
     m_videoLayerManager->didDestroyVideoLayer();
@@ -4004,6 +4009,15 @@ void MediaPlayerPrivateAVFoundationObjC::setPreferredDynamicRangeMode(DynamicRan
 #else
     UNUSED_PARAM(mode);
 #endif
+}
+
+void MediaPlayerPrivateAVFoundationObjC::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+    assertIsMainThread();
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateAVFoundationObjC[" << this << "]::setPlatformDynamicRangeLimit(" << platformDynamicRangeLimit << ") - m_videoLayer[" << m_videoLayer.get() << "]." << ([m_videoLayer respondsToSelector:@selector(setPreferredDynamicRange:)] ? "" : "NOT-RESPONDING!") << "setPreferredDynamicRange:" << platformDynamicRangeLimitString(platformDynamicRangeLimit));
+
+    if ([m_videoLayer respondsToSelector:@selector(setPreferredDynamicRange:)])
+        [m_videoLayer setPreferredDynamicRange:platformDynamicRangeLimitString(platformDynamicRangeLimit)];
 }
 
 void MediaPlayerPrivateAVFoundationObjC::setShouldDisableHDR(bool shouldDisable)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm
@@ -72,6 +72,7 @@ void VideoLayerManagerObjC::setVideoLayer(PlatformLayer *videoLayer, FloatSize c
     [m_videoLayer web_disableAllActions];
 
     m_videoInlineLayer = adoptNS([[WebVideoContainerLayer alloc] init]);
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " VideoLayerManagerObjC[" << this << "]::setVideoLayer(PlatformLayer m_videoLayer=[" << videoLayer << "]) -> m_videoInlineLayer[" << m_videoInlineLayer.get() << "]");
     [m_videoInlineLayer setName:@"WebVideoContainerLayer"];
     [m_videoInlineLayer setFrame:CGRectMake(0, 0, contentSize.width(), contentSize.height())];
     [m_videoInlineLayer setContentsGravity:kCAGravityResizeAspect];

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(COCOA)
+
+#import "PlatformDynamicRangeLimit.h"
+#import <QuartzCore/CALayerPrivate.h>
+
+namespace WebCore {
+
+constexpr NSString *platformDynamicRangeLimitString(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+    if (platformDynamicRangeLimit.value() < (PlatformDynamicRangeLimit::standard().value() + PlatformDynamicRangeLimit::constrainedHigh().value()) / 2)
+        return CADynamicRangeStandard;
+
+    if (platformDynamicRangeLimit.value() < (PlatformDynamicRangeLimit::constrainedHigh().value() + PlatformDynamicRangeLimit::noLimit().value()) / 2)
+        return CADynamicRangeConstrainedHigh;
+
+    return CADynamicRangeHigh;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -42,12 +42,16 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderMedia);
 RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style)
     : RenderImage(type, element, WTFMove(style), ReplacedFlag::IsMedia)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RenderMedia[" << this << "]::RenderMedia(t,e,s) has called RenderImage[" << static_cast<RenderImage*>(this) << "]::RenderImage() -> element.setPlatformDynamicRangeLimit(" << this->style().dynamicRangeLimit().toPlatformDynamicRangeLimit() << ")");
+    element.setPlatformDynamicRangeLimit(this->style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
     setHasShadowControls(true);
 }
 
 RenderMedia::RenderMedia(Type type, HTMLMediaElement& element, RenderStyle&& style, const IntSize& intrinsicSize)
     : RenderImage(type, element, WTFMove(style), ReplacedFlag::IsMedia)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RenderMedia[" << this << "]::RenderMedia(t,e,s,s) has called RenderImage[" << static_cast<RenderImage*>(this) << "]::RenderImage() -> element.setPlatformDynamicRangeLimit(" << this->style().dynamicRangeLimit().toPlatformDynamicRangeLimit() << ")");
+    element.setPlatformDynamicRangeLimit(this->style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
     setIntrinsicSize(intrinsicSize);
     setHasShadowControls(true);
 }
@@ -71,6 +75,11 @@ void RenderMedia::styleDidChange(StyleDifference difference, const RenderStyle* 
     RenderImage::styleDidChange(difference, oldStyle);
     if (!oldStyle || style().usedVisibility() != oldStyle->usedVisibility())
         mediaElement().visibilityDidChange();
+
+    if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit()) {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RenderMedia[" << this << "]::styleDidChange() -> mediaElement().setPlatformDynamicRangeLimit(" << style().dynamicRangeLimit().toPlatformDynamicRangeLimit() << ")...");
+        mediaElement().setPlatformDynamicRangeLimit(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -55,6 +55,7 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(RenderVideo);
 RenderVideo::RenderVideo(HTMLVideoElement& element, RenderStyle&& style)
     : RenderMedia(Type::Video, element, WTFMove(style))
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RenderVideo[" << this << "]::RenderVideo(e,s) has called RenderMedia[" << static_cast<RenderMedia*>(this) << "]::RenderMedia()");
     setIntrinsicSize(calculateIntrinsicSize());
     ASSERT(isRenderVideo());
 }

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
@@ -29,6 +29,7 @@
 #include "AnimationUtilities.h"
 #include "CSSDynamicRangeLimit.h"
 #include "CSSDynamicRangeLimitMix.h"
+#include "PlatformDynamicRangeLimit.h"
 #include "StyleDynamicRangeLimitMix.h"
 #include <wtf/text/TextStream.h>
 
@@ -98,6 +99,22 @@ auto Blending<DynamicRangeLimit>::blend(const DynamicRangeLimit& from, const Dyn
     addWeightedLimitTo(function, to, toMixPercentage);
 
     return resolve(WTFMove(function));
+}
+
+// MARK: - Conversion to platform object
+
+PlatformDynamicRangeLimit DynamicRangeLimit::toPlatformDynamicRangeLimit() const
+{
+    return WTF::switchOn(*this, [&]<typename Kind>(const Kind& kind) -> PlatformDynamicRangeLimit {
+        if constexpr (std::is_same_v<Kind, CSS::Keyword::Standard>)
+            return PlatformDynamicRangeLimit::standard();
+        else if constexpr (std::is_same_v<Kind, CSS::Keyword::ConstrainedHigh>)
+            return PlatformDynamicRangeLimit::constrainedHigh();
+        else if constexpr (std::is_same_v<Kind, CSS::Keyword::NoLimit>)
+            return PlatformDynamicRangeLimit::noLimit();
+        else if constexpr (std::is_same_v<Kind, Style::DynamicRangeLimitMixFunction>)
+            return PlatformDynamicRangeLimit(float(kind->standard.value), float(kind->constrainedHigh.value), float(kind->noLimit.value));
+    });
 }
 
 // MARK: - Logging

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -32,6 +32,8 @@
 
 namespace WebCore {
 
+class PlatformDynamicRangeLimit;
+
 namespace CSS {
 struct DynamicRangeLimit;
 }
@@ -51,6 +53,8 @@ struct DynamicRangeLimit {
     DynamicRangeLimit& operator=(const DynamicRangeLimit&);
 
     template<typename... F> decltype(auto) switchOn(F&&...) const;
+
+    WEBCORE_EXPORT PlatformDynamicRangeLimit toPlatformDynamicRangeLimit() const;
 
     bool operator==(const DynamicRangeLimit&) const = default;
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -217,14 +217,16 @@ void RemoteMediaPlayerProxy::cancelLoad()
     protectedPlayer()->cancelLoad();
 }
 
-void RemoteMediaPlayerProxy::prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload preload, bool preservesPitch, WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, WebCore::DynamicRangeMode preferredDynamicRangeMode)
+void RemoteMediaPlayerProxy::prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload preload, bool preservesPitch, WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, WebCore::DynamicRangeMode preferredDynamicRangeMode, PlatformDynamicRangeLimit platformDynamicRangeLimit)
 {
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RemoteMediaPlayerProxy[" << this << "]::prepareForPlayback(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") -> player->setPlatformDynamicRangeLimit()...");
     RefPtr player = m_player;
     player->setPrivateBrowsingMode(privateMode);
     player->setPreload(preload);
     player->setPreservesPitch(preservesPitch);
     player->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
     player->setPreferredDynamicRangeMode(preferredDynamicRangeMode);
+    player->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
     player->setPresentationSize(presentationSize);
     if (prepareToPlay)
         player->prepareToPlay();
@@ -1217,6 +1219,14 @@ void RemoteMediaPlayerProxy::setPreferredDynamicRangeMode(DynamicRangeMode mode)
 {
     if (RefPtr player = m_player)
         player->setPreferredDynamicRangeMode(mode);
+}
+
+void RemoteMediaPlayerProxy::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+    if (RefPtr player = m_player) {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RemoteMediaPlayerProxy[" << this << "]::setPlatformDynamicRangeLimit(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") -> player->setPlatformDynamicRangeLimit()...");
+        player->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
+    }
 }
 
 void RemoteMediaPlayerProxy::createAudioSourceProvider()

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -39,6 +39,7 @@
 #include "SandboxExtension.h"
 #include "ScopedRenderingResourcesRequest.h"
 #include <WebCore/Cookie.h>
+#include <WebCore/PlatformDynamicRangeLimit.h>
 #include <WebCore/InbandTextTrackPrivate.h>
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MediaPlayerIdentifier.h>
@@ -145,7 +146,7 @@ public:
 
     void getConfiguration(RemoteMediaPlayerConfiguration&);
 
-    void prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload, bool preservesPitch, WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, WebCore::DynamicRangeMode);
+    void prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload, bool preservesPitch, WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, WebCore::DynamicRangeMode, WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit);
     void prepareForRendering();
 
     void load(URL&&, std::optional<SandboxExtension::Handle>&&, const WebCore::MediaPlayerLoadOptions&, CompletionHandler<void(RemoteMediaPlayerConfiguration&&)>&&);
@@ -230,6 +231,7 @@ public:
     void setVideoPlaybackMetricsUpdateInterval(double);
 
     void setPreferredDynamicRangeMode(WebCore::DynamicRangeMode);
+    void setPlatformDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit);
 
     RefPtr<WebCore::PlatformMediaResource> requestResource(WebCore::ResourceRequest&&, WebCore::PlatformMediaResourceLoader::LoadOptions);
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<WTF::Seconds, WebCore::ResourceError>&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -29,7 +29,7 @@
     EnabledBy=UseGPUProcessForMediaEnabled
 ]
 messages -> RemoteMediaPlayerProxy {
-    PrepareForPlayback(bool privateMode, enum:uint8_t WebCore::MediaPlayerPreload preload, bool preservesPitch, enum:uint8_t WebCore::MediaPlayerPitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, enum:uint8_t WebCore::DynamicRangeMode mode)
+    PrepareForPlayback(bool privateMode, enum:uint8_t WebCore::MediaPlayerPreload preload, bool preservesPitch, enum:uint8_t WebCore::MediaPlayerPitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, enum:uint8_t WebCore::DynamicRangeMode mode, WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit)
 
     Load(URL url, std::optional<WebKit::SandboxExtensionHandle> sandboxExtension, struct WebCore::MediaPlayerLoadOptions options) -> (struct WebKit::RemoteMediaPlayerConfiguration playerConfiguration)
 #if ENABLE(MEDIA_SOURCE)
@@ -117,6 +117,7 @@ messages -> RemoteMediaPlayerProxy {
     SetVideoPlaybackMetricsUpdateInterval(double interval)
 
     SetPreferredDynamicRangeMode(enum:uint8_t WebCore::DynamicRangeMode mode)
+    setPlatformDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit)
 
 #if PLATFORM(IOS_FAMILY)
     ErrorLog() -> (String errorLog) Synchronous

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -70,6 +70,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     auto* layer = protectedPlayer()->platformLayer();
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RemoteMediaPlayerProxy[" << this << "]::mediaPlayerRenderingModeChanged() - layer=" << layer);
     if (layer && !m_inlineLayerHostingContext) {
         LayerHostingContextOptions contextOptions;
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "PlatformCAAnimationRemote.h"
+#include <WebCore/PlatformDynamicRangeLimit.h>
 #include <WebCore/PlatformCALayer.h>
 
 namespace WebKit {
@@ -49,6 +50,7 @@ enum class LayerChangeIndex : size_t {
     VisibleRectChanged,
 #endif
     ContentsFormatChanged,
+    PlatformDynamicRangeLimitChanged,
 #if HAVE(CORE_MATERIAL)
     AppleVisualEffectChanged,
 #endif
@@ -110,6 +112,7 @@ enum class LayerChange : uint64_t {
     VisibleRectChanged                  = 1LLU << static_cast<size_t>(LayerChangeIndex::VisibleRectChanged),
 #endif
     ContentsFormatChanged               = 1LLU << static_cast<size_t>(LayerChangeIndex::ContentsFormatChanged),
+    PlatformDynamicRangeLimitChanged        = 1LLU << static_cast<size_t>(LayerChangeIndex::PlatformDynamicRangeLimitChanged),
 #if HAVE(CORE_MATERIAL)
     AppleVisualEffectChanged            = 1LLU << static_cast<size_t>(LayerChangeIndex::AppleVisualEffectChanged),
 #endif
@@ -211,6 +214,7 @@ struct LayerProperties {
     WebCore::FloatRect visibleRect;
 #endif
     WebCore::ContentsFormat contentsFormat { WebCore::ContentsFormat::RGBA8 };
+    WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit;
 #if HAVE(CORE_MATERIAL)
     WebCore::AppleVisualEffectData appleVisualEffectData;
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -77,6 +77,7 @@ header: "RemoteLayerTreeTransaction.h"
     VisibleRectChanged
 #endif
     ContentsFormatChanged
+    PlatformDynamicRangeLimitChanged
 #if HAVE(CORE_MATERIAL)
     AppleVisualEffectChanged
 #endif
@@ -282,6 +283,7 @@ headers: "LayerProperties.h" "PlatformCALayerRemote.h"
     [OptionalTupleBit=WebKit::LayerChange::VisibleRectChanged] WebCore::FloatRect visibleRect;
 #endif
     [OptionalTupleBit=WebKit::LayerChange::ContentsFormatChanged] WebCore::ContentsFormat contentsFormat;
+    [OptionalTupleBit=WebKit::LayerChange::PlatformDynamicRangeLimitChanged] WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit;
 #if HAVE(CORE_MATERIAL)
     [OptionalTupleBit=WebKit::LayerChange::AppleVisualEffectChanged] WebCore::AppleVisualEffectData appleVisualEffectData;
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -36,6 +36,7 @@
 #import <WebCore/ContentsFormatCocoa.h>
 #import <WebCore/MediaPlayerEnumsCocoa.h>
 #import <WebCore/PlatformCAFilters.h>
+#import <WebCore/PlatformDynamicRangeLimitCocoa.h>
 #import <WebCore/ScrollbarThemeMac.h>
 #import <WebCore/WebAVPlayerLayer.h>
 #import <WebCore/WebCoreCALayerExtras.h>
@@ -536,6 +537,11 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
             [layer setToneMapMode:CAToneMapModeIfSupported];
         }
 #endif
+    }
+
+    if ((properties.changedProperties & LayerChange::PlatformDynamicRangeLimitChanged) && [layer respondsToSelector:@selector(setPreferredDynamicRange:)]) {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " RemoteLayerTreePropertyApplier::applyPropertiesToLayer(layer=" << layer << ") - platformDynamicRangeLimit=" << properties.platformDynamicRangeLimit);
+        [layer setPreferredDynamicRange:platformDynamicRangeLimitString(properties.platformDynamicRangeLimit)];
     }
 
 #if HAVE(CORE_MATERIAL)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1836,6 +1836,10 @@ enum class WebCore::ContentsFormat : uint8_t {
 #endif
 };
 
+class WebCore::PlatformDynamicRangeLimit {
+    float m_value;
+};
+
 enum class WebCore::RotationDirection : bool
 
 #if ENABLE(CONTENT_FILTERING)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -227,15 +227,19 @@ MediaPlayerPrivateRemote::~MediaPlayerPrivateRemote()
 void MediaPlayerPrivateRemote::prepareForPlayback(bool privateMode, MediaPlayer::Preload preload, bool preservesPitch, bool prepareToPlay, bool prepareToRender)
 {
     auto player = m_player.get();
-    if (!player)
+    if (!player) {
+        ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateRemote[" << this << "]::prepareForPlayback() - !m_player");
         return;
+    }
 
     auto scale = player->playerContentsScale();
     auto preferredDynamicRangeMode = player->preferredDynamicRangeMode();
+    auto platformDynamicRangeLimit = player->platformDynamicRangeLimit();
     auto presentationSize = player->presentationSize();
     auto pitchCorrectionAlgorithm = player->pitchCorrectionAlgorithm();
 
-    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PrepareForPlayback(privateMode, preload, preservesPitch, pitchCorrectionAlgorithm, prepareToPlay, prepareToRender, presentationSize, scale, preferredDynamicRangeMode), m_id);
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateRemote[" << this << "]::prepareForPlayback() - platformDynamicRangeLimit=" << platformDynamicRangeLimit << " -> send(Messages::RemoteMediaPlayerProxy::PrepareForPlayback)...");
+    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::PrepareForPlayback(privateMode, preload, preservesPitch, pitchCorrectionAlgorithm, prepareToPlay, prepareToRender, presentationSize, scale, preferredDynamicRangeMode, platformDynamicRangeLimit), m_id);
 }
 
 void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options)
@@ -1585,6 +1589,12 @@ void MediaPlayerPrivateRemote::applicationDidBecomeActive()
 void MediaPlayerPrivateRemote::setPreferredDynamicRangeMode(WebCore::DynamicRangeMode mode)
 {
     protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPreferredDynamicRangeMode(mode), m_id);
+}
+
+void MediaPlayerPrivateRemote::setPlatformDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit platformDynamicRangeLimit)
+{
+    ALWAYS_LOG_WITH_STREAM(stream << "__GS__ pid=" << getpid() << " MediaPlayerPrivateRemote[" << this << "]::setPlatformDynamicRangeLimit(platformDynamicRangeLimit=" << platformDynamicRangeLimit << ") -> send(Messages::RemoteMediaPlayerProxy::setPlatformDynamicRangeLimit)...");
+    protectedConnection()->send(Messages::RemoteMediaPlayerProxy::setPlatformDynamicRangeLimit(platformDynamicRangeLimit), m_id);
 }
 
 bool MediaPlayerPrivateRemote::performTaskAtTime(WTF::Function<void()>&& task, const MediaTime& mediaTime)

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -441,6 +441,7 @@ private:
     void applicationWillResignActive() final;
     void applicationDidBecomeActive() final;
     void setPreferredDynamicRangeMode(WebCore::DynamicRangeMode) final;
+    void setPlatformDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit) final;
 
 #if USE(AVFOUNDATION)
     AVPlayer *objCAVFoundationAVPlayer() const final { return nullptr; }

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -220,6 +220,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/ParsedContentRange.cpp
         Tests/WebCore/PathTests.cpp
         Tests/WebCore/PixelBufferConversionTests.cpp
+        Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
         Tests/WebCore/PublicSuffix.cpp
         Tests/WebCore/RegionTests.cpp
         Tests/WebCore/RenderStyleChange.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -360,6 +360,7 @@
 		7A7B0E7F1EAFE4C3006AB8AE /* LimitTitleSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A7B0E7E1EAFE454006AB8AE /* LimitTitleSize.mm */; };
 		7A89BB682331643A0042CB1E /* BundleFormDelegatePlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7A89BB662331635D0042CB1E /* BundleFormDelegatePlugIn.mm */; };
 		7A909A7D1D877480007E10F8 /* AffineTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A6F1D877475007E10F8 /* AffineTransform.cpp */; };
+		7A909A801D877480007E10F9 /* PlatformDynamicRangeLimitTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A721D877475007E10F9 /* PlatformDynamicRangeLimitTests.cpp */; };
 		7A909A7E1D877480007E10F8 /* FloatPointTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A701D877475007E10F8 /* FloatPointTests.cpp */; };
 		7A909A7F1D877480007E10F8 /* FloatRectTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A711D877475007E10F8 /* FloatRectTests.cpp */; };
 		7A909A801D877480007E10F8 /* FloatSizeTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7A909A721D877475007E10F8 /* FloatSizeTests.cpp */; };
@@ -3025,6 +3026,7 @@
 		7A89BB662331635D0042CB1E /* BundleFormDelegatePlugIn.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BundleFormDelegatePlugIn.mm; sourceTree = "<group>"; };
 		7A89BB69233165650042CB1E /* BundleFormDelegateProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BundleFormDelegateProtocol.h; sourceTree = "<group>"; };
 		7A909A6F1D877475007E10F8 /* AffineTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AffineTransform.cpp; sourceTree = "<group>"; };
+		7A909A721D877475007E10F9 /* PlatformDynamicRangeLimitTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformDynamicRangeLimitTests.cpp; sourceTree = "<group>"; };
 		7A909A701D877475007E10F8 /* FloatPointTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatPointTests.cpp; sourceTree = "<group>"; };
 		7A909A711D877475007E10F8 /* FloatRectTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatRectTests.cpp; sourceTree = "<group>"; };
 		7A909A721D877475007E10F8 /* FloatSizeTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FloatSizeTests.cpp; sourceTree = "<group>"; };
@@ -4793,6 +4795,7 @@
 				AA96CAB421C7DB4200FD2F97 /* ParsedContentType.cpp */,
 				0F5EC8BB2C7F76B900B8051B /* PathTests.cpp */,
 				7141156329754422005011D6 /* PlatformCAAnimationKeyPath.cpp */,
+				7A909A721D877475007E10F9 /* PlatformDynamicRangeLimitTests.cpp */,
 				6B0A07F621FA9C2B00D57391 /* PrivateClickMeasurement.cpp */,
 				041A1E33216FFDBC00789E0A /* PublicSuffix.cpp */,
 				EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */,
@@ -7234,6 +7237,7 @@
 				7C83E0531D0A643A00FEBCF3 /* PendingAPIRequestURL.cpp in Sources */,
 				E325C90723E3870200BC7D3B /* PictureInPictureSupport.mm in Sources */,
 				7141156429754422005011D6 /* PlatformCAAnimationKeyPath.cpp in Sources */,
+				7A909A801D877480007E10F9 /* PlatformDynamicRangeLimitTests.cpp in Sources */,
 				7CCE7EA61A411A0F00447C4C /* PlatformUtilitiesMac.mm in Sources */,
 				7CCE7EA71A411A1300447C4C /* PlatformWebViewMac.mm in Sources */,
 				F4010B8324DA267F00A876E2 /* PoseAsClass.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include <WebCore/PlatformDynamicRangeLimit.h>
+
+#include <WebCore/StyleDynamicRangeLimit.h>
+
+namespace TestWebKitAPI {
+
+// Tests rely on these assumptions:
+static_assert(WebCore::PlatformDynamicRangeLimit::standard().value() == 0.0f);
+static_assert(WebCore::PlatformDynamicRangeLimit::constrainedHigh().value() == 0.5f);
+static_assert(WebCore::PlatformDynamicRangeLimit::noLimit().value() == 1.0f);
+
+TEST(PlatformDynamicRangeLimit, DefaultConstruction)
+{
+    auto def = WebCore::PlatformDynamicRangeLimit();
+    EXPECT_EQ(def.value(), 1.0f);
+
+    static_assert(WebCore::PlatformDynamicRangeLimit().value() == 1);
+}
+
+static WebCore::PlatformDynamicRangeLimit mix(float standard, float constrainedHigh, float noLimit)
+{
+    return WebCore::Style::DynamicRangeLimit { WebCore::Style::DynamicRangeLimitMixFunction { WebCore::Style::DynamicRangeLimitMixParameters { .standard = standard, .constrainedHigh = constrainedHigh, .noLimit = noLimit } } }.toPlatformDynamicRangeLimit();
+}
+
+TEST(PlatformDynamicRangeLimit, FromStyleDynamicRangeLimit)
+{
+    struct Test {
+        WebCore::PlatformDynamicRangeLimit dynamicRangeLimit;
+        float expectedValue;
+    };
+    Test tests[] = {
+        // Keywords.
+        { WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit(), 0 },
+        { WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit(), 0.5 },
+        { WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit(), 1 },
+
+        // Mixes equivalent to keywords.
+        { mix(100, 0, 0), 0 },
+        { mix(0, 100, 0), 0.5 },
+        { mix(0, 0, 100), 1 },
+
+        // Other mixes.
+        { mix(80, 20, 0), 0.1 },
+        { mix(50, 0, 50), 0.5 },
+        { mix(10, 10, 80), 0.85 },
+    };
+
+    int testIndex = 0;
+    for (const auto& test : tests) {
+        SCOPED_TRACE(testIndex++);
+        auto dynamicRangeLimit = test.dynamicRangeLimit;
+        EXPECT_FLOAT_EQ(dynamicRangeLimit.value(), test.expectedValue);
+    }
+}
+
+TEST(PlatformDynamicRangeLimit, StaticValues)
+{
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::standard(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::constrainedHigh(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit());
+    EXPECT_EQ(WebCore::PlatformDynamicRangeLimit::noLimit(), WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit());
+}
+
+#if ASSERT_ENABLED
+TEST(PlatformDynamicRangeLimit, DISABLED_FromNonsense)
+#else
+TEST(PlatformDynamicRangeLimit, FromNonsense)
+#endif
+{
+    WebCore::PlatformDynamicRangeLimit tests[] = {
+        mix(0, 0, 0),
+        mix(-1, 0, 0),
+        mix(-1, 0, 2),
+        mix(1, 0, -2),
+        mix(-1, 0, -2),
+        mix(3, 0, -2),
+        mix(0, -1, 3),
+        mix(0, 0, std::numeric_limits<float>::max()),
+        mix(0, 0, std::numeric_limits<float>::infinity()),
+        mix(0, 0, std::numeric_limits<float>::quiet_NaN()),
+    };
+
+    int testIndex = 0;
+    for (const auto& dynamicRangeLimit : tests) {
+        SCOPED_TRACE(testIndex++);
+        // The actual result doesn't matter, but it has to be valid.
+        EXPECT_TRUE(std::isfinite(dynamicRangeLimit.value()));
+        EXPECT_GE(dynamicRangeLimit.value(), 0.0f);
+        EXPECT_LE(dynamicRangeLimit.value(), 1.0f);
+    }
+}
+
+TEST(PlatformDynamicRangeLimit, Comparisons)
+{
+    WebCore::PlatformDynamicRangeLimit sortedTests[] = {
+        WebCore::PlatformDynamicRangeLimit::standard(),
+        WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::Standard()).toPlatformDynamicRangeLimit(),
+        mix(1, 0, 0),
+
+        mix(99, 1, 0),
+
+        mix(80, 20, 0),
+
+        mix(1, 99, 0),
+
+        WebCore::PlatformDynamicRangeLimit::constrainedHigh(),
+        WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::ConstrainedHigh()).toPlatformDynamicRangeLimit(),
+        mix(0, 1, 0),
+        mix(50, 0, 50),
+
+        mix(0, 99, 1),
+
+        mix(10, 10, 80),
+
+        mix(0, 1, 99),
+
+        WebCore::PlatformDynamicRangeLimit::noLimit(),
+        WebCore::Style::DynamicRangeLimit(WebCore::CSS::Keyword::NoLimit()).toPlatformDynamicRangeLimit(),
+        mix(0, 0, 1),
+    };
+
+    int lhsIndex = 0;
+    for (const auto& lhs : sortedTests) {
+        SCOPED_TRACE(lhsIndex++);
+        SCOPED_TRACE(lhs.value());
+        int rhsIndex = 0;
+        for (const auto& rhs : sortedTests) {
+            SCOPED_TRACE(rhsIndex++);
+            SCOPED_TRACE(rhs.value());
+            EXPECT_EQ(lhs == rhs, lhs.value() == rhs.value());
+            EXPECT_EQ(lhs != rhs, lhs.value() != rhs.value());
+            EXPECT_EQ(lhs < rhs, lhs.value() < rhs.value());
+            EXPECT_EQ(lhs <= rhs, lhs.value() <= rhs.value());
+            EXPECT_EQ(lhs >= rhs, lhs.value() >= rhs.value());
+            EXPECT_EQ(lhs > rhs, lhs.value() > rhs.value());
+            EXPECT_EQ(lhs <=> rhs, lhs.value() <=> rhs.value());
+
+            if (rhsIndex == lhsIndex + 1) {
+                EXPECT_LE(lhs, rhs);
+                EXPECT_GE(rhs, lhs);
+            }
+        }
+    }
+}
+
+}


### PR DESCRIPTION
#### 679e63bab870f89dae3588e299456367969f38a8
<pre>
Use FlatDynamicRangeLimit in media
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setPlatformDynamicRangeLimit):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::mediaPlayerRenderingModeChanged):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::setPlatformDynamicRangeLimit):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::prepareForPlayback):
(WebCore::MediaPlayerPrivateInterface::setPlatformDynamicRangeLimit):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::MediaPlayerPrivateAVFoundationObjC):
(WebCore::MediaPlayerPrivateAVFoundationObjC::createAVPlayerLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::destroyVideoLayer):
(WebCore::MediaPlayerPrivateAVFoundationObjC::setPlatformDynamicRangeLimit):
* Source/WebCore/platform/graphics/avfoundation/objc/VideoLayerManagerObjC.mm:
(WebCore::VideoLayerManagerObjC::setVideoLayer):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformDynamicRangeLimitCocoa.h: Added.
(WebCore::platformDynamicRangeLimitString):
* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::RenderMedia):
(WebCore::RenderMedia::styleDidChange):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::RenderVideo):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::prepareForPlayback):
(WebKit::RemoteMediaPlayerProxy::setPlatformDynamicRangeLimit):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
* Source/WebKit/Shared/RemoteLayerTree/LayerProperties.h:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::prepareForPlayback):
(WebKit::MediaPlayerPrivateRemote::setPlatformDynamicRangeLimit):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
</pre>
----------------------------------------------------------------------
#### f79a61d6c724b0310c3f7b089fdfcd4c253dc6ba
<pre>
Add WebCore::PlatformDynamicRangeLimit
<a href="https://bugs.webkit.org/show_bug.cgi?id=287776">https://bugs.webkit.org/show_bug.cgi?id=287776</a>
<a href="https://rdar.apple.com/144952110">rdar://144952110</a>

Reviewed by NOBODY (OOPS!).

PlatformDynamicRangeLimit interprets the `dynamic-range-limit`
CSS property, and stores it in a single [0,1] float.

Combined changes:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.cpp: Added.
(WebCore::PlatformDynamicRangeLimit::normalizedAverage):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h: Added.
(WebCore::PlatformDynamicRangeLimit::standard):
(WebCore::PlatformDynamicRangeLimit::constrainedHigh):
(WebCore::PlatformDynamicRangeLimit::noLimit):
(WebCore::PlatformDynamicRangeLimit::value const):
(WebCore::PlatformDynamicRangeLimit::PlatformDynamicRangeLimit):
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp:
(WebCore::Style::DynamicRangeLimit::toPlatformDynamicRangeLimit const):
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp: Added.
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, DefaultConstruction)):
(TestWebKitAPI::mix):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, FromStyleDynamicRangeLimit)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, StaticValues)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, FromNonsense)):
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, Comparisons)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/679e63bab870f89dae3588e299456367969f38a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/90911 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/10449 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/55/builds/45861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95937 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/92964 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/10843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/18765 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95937 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/93912 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/10843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/55/builds/45861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95937 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/10843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/55/builds/45861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/10843 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97904 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/18106 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/18765 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97904 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18366 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/55/builds/45861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97904 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/55/builds/45861 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/18115 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23466 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19638 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->