### PR TITLE
[scroll-animations] view timeline with its subject inside a shadow root cannot be referenced out of the shadow root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A view timeline with its subject in a shadow root can be referenced outside of that shadow root using "timeline-scope"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<title>A view timeline with its subject in a shadow root can be referenced outside of that shadow root using "timeline-scope"</title>
+<link rel="help" src="https://drafts.csswg.org/scroll-animations-1/#view-timelines">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/web-animations/testcommon.js"></script>
+
+<style>
+
+#container {
+  timeline-scope: --progress;
+}
+
+#shadow {
+  width: 100px;
+  height: 100px;
+}
+
+#shadow::part(scroller) {
+  width: 100%;
+  height: 100%;
+  background-color: blue;
+  overflow: scroll;
+}
+
+#shadow::part(content) {
+  position: relative;
+  top: 25%;
+  width: 100%;
+  height: 50%;
+  background-color: pink;
+
+  view-timeline: --progress block;
+}
+
+#target {
+  position: absolute;
+  width: 10px;
+  height: 100px;
+  background-color: black;
+
+  animation: x linear;
+  animation-timeline: --progress;
+}
+
+@keyframes x {
+  from { width: 0 }
+  to   { width: 100px }
+}
+
+</style>
+
+<div id="container">
+  <div id="shadow"></div>
+  <div id="target"></div>
+</div>
+
+<script>
+
+promise_test(async t => {
+  t.add_cleanup(() => container.remove());
+
+  shadow.attachShadow({ mode: 'open' }).innerHTML = `
+  <div part="scroller">
+    <div part="content"></div>
+  </div>
+  `;
+
+  const animation = document.getAnimations()[0];
+  await animation.ready;
+  assert_equals(getComputedStyle(target).width, '50px');
+}, 'A view timeline with its subject in a shadow root can be referenced outside of that shadow root using "timeline-scope"');
+
+</script>

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -143,7 +143,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
         if (!styleableForTimeline)
             continue;
         Ref protectedElementForTimeline { styleableForTimeline->element };
-        if (&styleableForTimeline->element == &styleable.element || Ref { styleable.element }->isDescendantOf(protectedElementForTimeline.get()))
+        if (&styleableForTimeline->element == &styleable.element || Ref { styleable.element }->isDescendantOrShadowDescendantOf(protectedElementForTimeline.get()))
             matchedTimelines.append(timeline);
     }
     if (matchedTimelines.isEmpty())
@@ -168,7 +168,7 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
     for (auto& entry : m_timelineScopeEntries) {
         if (auto entryElement = entry.second.styleable()) {
             Ref protectedEntryElement { entryElement->element };
-            if (Ref { timelineElement->element }->isDescendantOf(protectedEntryElement.get()) && (entry.first.type == NameScope::Type::All ||  entry.first.names.contains(name)))
+            if (Ref { timelineElement->element }->isDescendantOrShadowDescendantOf(protectedEntryElement.get()) && (entry.first.type == NameScope::Type::All ||  entry.first.names.contains(name)))
                 matchedTimelineScopeElements.appendIfNotContains(*entryElement);
         }
     }
@@ -182,7 +182,7 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
             timeline->setTimelineScopeElement(protectedTimelineScopeElement.get());
             return;
         }
-        element = element->parentElement();
+        element = element->parentElementInComposedTree();
     }
 }
 
@@ -358,7 +358,7 @@ void StyleOriginatedTimelinesController::setTimelineForName(const AtomString& na
             for (auto timelineScopeElement : timelineScopeElements) {
                 ASSERT(timelineScopeElement.element());
                 Ref protectedTimelineScopeElement { *timelineScopeElement.element() };
-                if (styleable == timelineScopeElement.styleable() || Ref { styleable.element }->isDescendantOf(protectedTimelineScopeElement.get()))
+                if (styleable == timelineScopeElement.styleable() || Ref { styleable.element }->isDescendantOrShadowDescendantOf(protectedTimelineScopeElement.get()))
                     return true;
             }
             return false;
@@ -393,7 +393,7 @@ static void updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>> entries,
     for (auto& entry : entries) {
         if (auto entryElement = originatingElementExcludingTimelineScope(entry).styleable()) {
             Ref protectedElement { styleable.element };
-            if (Ref { entryElement->element }->isDescendantOf(protectedElement.get()))
+            if (Ref { entryElement->element }->isDescendantOrShadowDescendantOf(protectedElement.get()))
                 entry->setTimelineScopeElement(protectedElement.get());
         }
     }


### PR DESCRIPTION
#### 00baf1bf9de2d1d7750b3719307ce97214fbd1ee
<pre>
[scroll-animations] view timeline with its subject inside a shadow root cannot be referenced out of the shadow root
<a href="https://bugs.webkit.org/show_bug.cgi?id=287950">https://bugs.webkit.org/show_bug.cgi?id=287950</a>

Reviewed by Antti Koivisto.

The demo at <a href="https://codepen.io/t_afif/full/ZEgjNxm">https://codepen.io/t_afif/full/ZEgjNxm</a> creates a view timeline with the subject being one
of the parts inside a &lt;progress&gt; element&apos;s shadow root. That view timeline is then referenced using
`animation-timeline` outside of that &lt;progress&gt; element&apos;s shadow root.

We need to make sure to traverse shadow root boundaries when considering elements using `animation-timeline`
and `timeline-scope`.

This was not covered in WPT so we add a new test which creates a shadow root with a view timeline subject
within, sets a `timeline-scope` on a parent of the element with that shadow root attached, and reference
that timeline using `animation-timeline` on another element within that parent.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-subject-in-shadow-root-with-timeline-scope.html: Added.
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTimelineForElement):
(WebCore::StyleOriginatedTimelinesController::updateTimelineForTimelineScope):
(WebCore::StyleOriginatedTimelinesController::setTimelineForName):
(WebCore::updateTimelinesForTimelineScope):

Canonical link: <a href="https://commits.webkit.org/290695@main">https://commits.webkit.org/290695@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/551a2602719b086321e25f3ff0bda20341dc0a20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41529 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10674 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18597 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27351 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8134 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82269 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50199 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36750 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97588 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17938 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13165 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78834 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78032 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21100 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14315 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19470 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->