### PR TITLE
[GTK][WPE] Use one fbo per render target instead of a global one in AcceleratedSurfaceDMABuf

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -115,13 +115,22 @@ AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget(uint64_t surfaceID, const W
     : m_id(generateTargetID())
     , m_surfaceID(surfaceID)
 {
+    glGenFramebuffers(1, &m_fbo);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+
     glGenRenderbuffers(1, &m_depthStencilBuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, m_depthStencilBuffer);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, size.width(), size.height());
+
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
 }
 
 AcceleratedSurfaceDMABuf::RenderTarget::~RenderTarget()
 {
+    if (m_fbo)
+        glDeleteFramebuffers(1, &m_fbo);
+
     if (m_depthStencilBuffer)
         glDeleteRenderbuffers(1, &m_depthStencilBuffer);
 
@@ -145,42 +154,26 @@ std::unique_ptr<WebCore::GLFence> AcceleratedSurfaceDMABuf::RenderTarget::create
     return WebCore::GLFence::create();
 }
 
-void AcceleratedSurfaceDMABuf::RenderTarget::willRenderFrame() const
+void AcceleratedSurfaceDMABuf::RenderTarget::willRenderFrame()
 {
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_depthStencilBuffer);
+    if (m_releaseFenceFD) {
+        if (auto fence = WebCore::GLFence::importFD(WTFMove(m_releaseFenceFD)))
+            fence->serverWait();
+    }
+
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+}
+
+void AcceleratedSurfaceDMABuf::RenderTarget::didRenderFrame()
+{
+#if ENABLE(DAMAGE_TRACKING)
+    m_damage = WebCore::Damage { };
+#endif
 }
 
 void AcceleratedSurfaceDMABuf::RenderTarget::setReleaseFenceFD(UnixFileDescriptor&& releaseFence)
 {
     m_releaseFenceFD = WTFMove(releaseFence);
-}
-
-void AcceleratedSurfaceDMABuf::RenderTarget::waitRelease()
-{
-    if (!m_releaseFenceFD)
-        return;
-
-    if (auto fence = WebCore::GLFence::importFD(WTFMove(m_releaseFenceFD)))
-        fence->serverWait();
-}
-
-AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::RenderTargetColorBuffer(uint64_t surfaceID, const WebCore::IntSize& size)
-    : RenderTarget(surfaceID, size)
-{
-    glGenRenderbuffers(1, &m_colorBuffer);
-}
-
-AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::~RenderTargetColorBuffer()
-{
-    if (m_colorBuffer)
-        glDeleteRenderbuffers(1, &m_colorBuffer);
-}
-
-void AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::willRenderFrame() const
-{
-    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
-    RenderTarget::willRenderFrame();
 }
 
 #if USE(GBM)
@@ -276,21 +269,24 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
 }
 
 AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage(uint64_t surfaceID, const WebCore::IntSize& size, EGLImage image, uint32_t format, Vector<UnixFileDescriptor>&& fds, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage usage)
-    : RenderTargetColorBuffer(surfaceID, size)
+    : RenderTarget(surfaceID, size)
     , m_image(image)
 {
+    glGenRenderbuffers(1, &m_colorBuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
     glEGLImageTargetRenderbufferStorageOES(GL_RENDERBUFFER, m_image);
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::DidCreateBuffer(m_id, size, format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier, usage), surfaceID);
 }
 
 AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage()
 {
-    if (!m_image)
-        return;
+    if (m_colorBuffer)
+        glDeleteRenderbuffers(1, &m_colorBuffer);
 
-    WebCore::PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);
+    if (m_image)
+        WebCore::PlatformDisplay::sharedDisplay().destroyEGLImage(m_image);
 }
 #endif
 
@@ -312,13 +308,21 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
 }
 
 AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage(uint64_t surfaceID, const WebCore::IntSize& size, Ref<WebCore::ShareableBitmap>&& bitmap, WebCore::ShareableBitmap::Handle&& bitmapHandle)
-    : RenderTargetColorBuffer(surfaceID, size)
+    : RenderTarget(surfaceID, size)
     , m_bitmap(WTFMove(bitmap))
 {
+    glGenRenderbuffers(1, &m_colorBuffer);
     glBindRenderbuffer(GL_RENDERBUFFER, m_colorBuffer);
     glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA8, size.width(), size.height());
+    glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_colorBuffer);
 
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::DidCreateBufferSHM(m_id, WTFMove(bitmapHandle)), surfaceID);
+}
+
+AcceleratedSurfaceDMABuf::RenderTargetSHMImage::~RenderTargetSHMImage()
+{
+    if (m_colorBuffer)
+        glDeleteRenderbuffers(1, &m_colorBuffer);
 }
 
 void AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didRenderFrame()
@@ -384,6 +388,8 @@ AcceleratedSurfaceDMABuf::RenderTargetTexture::RenderTargetTexture(uint64_t surf
     : RenderTarget(surfaceID, size)
     , m_texture(texture)
 {
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
+
     WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::DidCreateBuffer(m_id, size, format, WTFMove(fds), WTFMove(offsets), WTFMove(strides), modifier, DMABufRendererBufferFormat::Usage::Rendering), surfaceID);
 }
 
@@ -391,12 +397,6 @@ AcceleratedSurfaceDMABuf::RenderTargetTexture::~RenderTargetTexture()
 {
     if (m_texture)
         glDeleteTextures(1, &m_texture);
-}
-
-void AcceleratedSurfaceDMABuf::RenderTargetTexture::willRenderFrame() const
-{
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_texture, 0);
-    RenderTarget::willRenderFrame();
 }
 
 AcceleratedSurfaceDMABuf::SwapChain::SwapChain(uint64_t surfaceID)
@@ -632,20 +632,9 @@ void AcceleratedSurfaceDMABuf::willDestroyCompositingRunLoop()
     WebProcess::singleton().parentProcessConnection()->removeMessageReceiver(Messages::AcceleratedSurfaceDMABuf::messageReceiverName(), m_id);
 }
 
-void AcceleratedSurfaceDMABuf::didCreateGLContext()
-{
-    glGenFramebuffers(1, &m_fbo);
-    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
-}
-
 void AcceleratedSurfaceDMABuf::willDestroyGLContext()
 {
     m_swapChain.reset();
-
-    if (m_fbo) {
-        glDeleteFramebuffers(1, &m_fbo);
-        m_fbo = 0;
-    }
 }
 
 uint64_t AcceleratedSurfaceDMABuf::surfaceID() const
@@ -667,10 +656,6 @@ void AcceleratedSurfaceDMABuf::willRenderFrame()
     m_target = m_swapChain.nextTarget();
     if (!m_target)
         return;
-
-    m_target->waitRelease();
-
-    glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 
     m_target->willRenderFrame();
     if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)


### PR DESCRIPTION
#### 3c971961dbb013fd56c20ce20fee776f4c89ccee
<pre>
[GTK][WPE] Use one fbo per render target instead of a global one in AcceleratedSurfaceDMABuf
<a href="https://bugs.webkit.org/show_bug.cgi?id=287951">https://bugs.webkit.org/show_bug.cgi?id=287951</a>

Reviewed by Nikolas Zimmermann.

Instead of changing the attachments of the fbo every time we render a
frame, we have one fbo per target where attachments are set once on
construction and then we just switch the current fbo before rendering a
new frame. This patch removes the intermediate class
RenderTargetColorBuffer and both RenderTargetEGLImage and
RenderTargetSHMImage create its own color buffer and attach it to the
fbo.

* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::~RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::willRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::setReleaseFenceFD):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::~RenderTargetSHMImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::RenderTargetTexture):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyGLContext):
(WebKit::AcceleratedSurfaceDMABuf::willRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::willRenderFrame const): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::waitRelease): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::RenderTargetColorBuffer): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::~RenderTargetColorBuffer): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::willRenderFrame const): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::willRenderFrame const): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext): Deleted.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:

Co-authored-by: Nikolas Zimmermann &lt;nzimmermann@igalia.com&gt;
Canonical link: <a href="https://commits.webkit.org/290604@main">https://commits.webkit.org/290604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1170c84c9e7c2a9d95ae0ce0856dc6351f801635

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10141 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18460 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93610 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40521 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/37617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97450 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17801 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18059 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/77998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/77952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22389 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14256 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17811 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->