### PR TITLE
Rendering is broken in certain scenarios with preserveDrawingBuffer: true

### DIFF
--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -445,7 +445,8 @@ void GraphicsContextGLANGLE::validateAttributes()
     } else if (attrs.preserveDrawingBuffer) {
         // Needed for preserveDrawingBuffer:true support without antialiasing.
         bool supported = enableExtensionsImpl({ "GL_ANGLE_framebuffer_blit"_s });
-        ASSERT_UNUSED(supported, supported);
+        if (!supported)
+            m_useBlitFallback = true;
     }
 }
 
@@ -773,9 +774,18 @@ void GraphicsContextGLANGLE::prepareTexture()
         // Blit m_preserveDrawingBufferTexture into m_texture.
         ScopedGLCapability scopedScissor(GL_SCISSOR_TEST, GL_FALSE);
         ScopedGLCapability scopedDither(GL_DITHER, GL_FALSE);
-        GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
-        GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
-        GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        if (m_useBlitFallback) {
+            GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+            GLint texture2DBinding = 0;
+            GL_GetIntegerv(GL_TEXTURE_BINDING_2D, &texture2DBinding);
+            GL_BindTexture(GL_TEXTURE_2D, m_texture);
+            GL_CopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, m_currentWidth, m_currentHeight);
+            GL_BindTexture(GL_TEXTURE_2D, texture2DBinding);
+        } else {
+            GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
+            GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, m_fbo);
+            GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        }
 
         if (m_isForWebGL2) {
             GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER, m_state.boundDrawFBO);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -413,7 +413,8 @@ void GraphicsContextGLANGLE::validateAttributes()
     } else if (attrs.preserveDrawingBuffer) {
         // Needed for preserveDrawingBuffer:true support without antialiasing.
         bool supported = enableExtensionsImpl({ "GL_ANGLE_framebuffer_blit"_s });
-        ASSERT_UNUSED(supported, supported);
+        if (!supported)
+            m_useBlitFallback = true;
     }
 }
 
@@ -825,14 +826,23 @@ void GraphicsContextGLANGLE::prepareTexture()
         // Blit m_preserveDrawingBufferTexture into m_texture.
         ScopedGLCapability scopedScissor(GL_SCISSOR_TEST, GL_FALSE);
         ScopedGLCapability scopedDither(GL_DITHER, GL_FALSE);
-        GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
-        // Read m_preserveDrawingBufferTexture through an own framebuffer instead of m_fbo, because
-        // the read buffer of m_fbo, the emulated default framebuffer, is set by the WebGL 2 context
-        // and might be NONE.
-        ScopedFramebuffer readFBO;
-        GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, readFBO);
-        GL_FramebufferTexture2D(GL_READ_FRAMEBUFFER_ANGLE, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_preserveDrawingBufferTexture, 0);
-        GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        if (m_useBlitFallback) {
+            GL_BindFramebuffer(GL_FRAMEBUFFER, m_fbo);
+            GLint texture2DBinding = 0;
+            GL_GetIntegerv(GL_TEXTURE_BINDING_2D, &texture2DBinding);
+            GL_BindTexture(GL_TEXTURE_2D, m_texture);
+            GL_CopyTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, 0, 0, m_currentWidth, m_currentHeight);
+            GL_BindTexture(GL_TEXTURE_2D, texture2DBinding);
+        } else {
+            GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER_ANGLE, m_preserveDrawingBufferFBO);
+            // Read m_preserveDrawingBufferTexture through an own framebuffer instead of m_fbo, because
+            // the read buffer of m_fbo, the emulated default framebuffer, is set by the WebGL 2 context
+            // and might be NONE.
+            ScopedFramebuffer readFBO;
+            GL_BindFramebuffer(GL_READ_FRAMEBUFFER_ANGLE, readFBO);
+            GL_FramebufferTexture2D(GL_READ_FRAMEBUFFER_ANGLE, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_preserveDrawingBufferTexture, 0);
+            GL_BlitFramebufferANGLE(0, 0, m_currentWidth, m_currentHeight, 0, 0, m_currentWidth, m_currentHeight, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+        }
 
         if (m_isForWebGL2) {
             GL_BindFramebuffer(GL_DRAW_FRAMEBUFFER, m_state.boundDrawFBO);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -453,6 +453,7 @@ protected:
     HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglImages;
     HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglSyncs;
     IntSize m_maxInternalFramebufferSize;
+    bool m_useBlitFallback { false };
 };
 
 

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -458,6 +458,7 @@ protected:
     HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglImages;
     HashMap<uint32_t, void*, IntHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_eglSyncs;
     IntSize m_maxInternalFramebufferSize;
+    bool m_useBlitFallback { false };
 };
 
 


### PR DESCRIPTION
#### a7d6744cccffbb1d38a7b54191e7e39f5dc8cd3b
<pre>
Rendering is broken in certain scenarios with preserveDrawingBuffer: true
<a href="https://bugs.webkit.org/show_bug.cgi?id=287952">https://bugs.webkit.org/show_bug.cgi?id=287952</a>

Reviewed by NOBODY (OOPS!).

This change introduces a fallback mechanism that uses GL_CopyTexSubImage2D
instead of GL_BlitFramebufferANGLE when the GL_ANGLE_framebuffer_blit extension
is not supported on a given device.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7d6744cccffbb1d38a7b54191e7e39f5dc8cd3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/182421 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/56368 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/50174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/192655 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/146750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/184283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/57684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/56091 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/142389 "layout-tests (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98888 "5 flakes 19 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/185376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/46099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/163151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/122822 "Passed tests") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/44783 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Checked out pull request; Running run-layout-tests-in-stress-mode; 1 new passes 2 failures; Uploaded test results; 1 new passes 2 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/43049 "Passed tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/155183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/42676 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/3815 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/48999 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/47305 "Found 1 new test failure: http/tests/site-isolation/find-in-page-marker-rects-in-cross-origin-iframe.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/194578 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/56039 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/151821 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/56730 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/39301 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/bfcache/held.tentative.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/151520 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/46102 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/129014 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/124997 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/55241 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/17675 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/54622 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/54861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/54689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->