### PR TITLE
[WPEPlatform] Restrict values used for screen output device scaling

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp
@@ -232,12 +232,18 @@ static void wpe_screen_class_init(WPEScreenClass* screenClass)
      * WPEScreen:scale:
      *
      * The scale factor for the screen.
+     *
+     * Scaling factor applied to views displayed on this screen. Those views
+     * will have the value forwarded to their [property@View:scale] property.
+     *
+     * The accepted values are in the `0.05` to `20.0` range, meaning that
+     * rendering would be done up to 20 times smaller or bigger.
      */
     sObjProperties[PROP_SCALE] =
         g_param_spec_double(
             "scale",
             nullptr, nullptr,
-            0., G_MAXDOUBLE, 1.,
+            0.05, 20., 1.,
             WEBKIT_PARAM_READWRITE);
 
     /**
@@ -480,7 +486,8 @@ gdouble wpe_screen_get_scale(WPEScreen* screen)
 void wpe_screen_set_scale(WPEScreen* screen, double scale)
 {
     g_return_if_fail(WPE_IS_SCREEN(screen));
-    g_return_if_fail(scale > 0);
+    g_return_if_fail(scale >= 0.05);
+    g_return_if_fail(scale <= 20.0);
 
     if (screen->priv->scale == scale)
         return;

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -245,13 +245,21 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
     /**
      * WPEView:scale:
      *
-     * The view scale
+     * The view scale.
+     *
+     * Scaling factor applied to the rendered output. This property follows
+     * the value of [property@Screen:scale] for the screen used to display
+     * the view.
+     *
+     * The [property@View:width] and [property@View:height] logical sizes
+     * are multiplied by this scaling factor to determine the physical size
+     * to be used for displaying the view.
      */
     sObjProperties[PROP_SCALE] =
         g_param_spec_double(
             "scale",
             nullptr, nullptr,
-            0., G_MAXDOUBLE, 1.,
+            0.05, 20., 1.,
             WEBKIT_PARAM_READABLE);
 
     /**


### PR DESCRIPTION
#### d09efa1a1a10d4eecbef2317c29289161cdcd2e2
<pre>
[WPEPlatform] Restrict values used for screen output device scaling
<a href="https://bugs.webkit.org/show_bug.cgi?id=287955">https://bugs.webkit.org/show_bug.cgi?id=287955</a>

Reviewed by Carlos Garcia Campos.

Limit the range of values accepted by the WPEScreen:scale (and its
companion WPEView:scale) to avoid unpractical values for the physical
output size. Allowing to scale in/out twenty times smaller/bigger ought
way more than enough for any use case.

* Source/WebKit/WPEPlatform/wpe/WPEScreen.cpp:
(wpe_screen_class_init): Limit WPEScreen:scale property to the [0.05, 20.0]
range.
(wpe_screen_set_scale): Add checks to ensure the requested scale is
within the allowed range.
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_class_init): Limit WPEView:scale property to the same range as
the WPEScreen:scale one.

Canonical link: <a href="https://commits.webkit.org/290696@main">https://commits.webkit.org/290696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acab57f4d41520006434e4ab118845d727a19355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41392 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18461 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69729 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27284 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50078 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7791 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97451 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78756 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/77999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77953 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22390 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21014 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14316 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17812 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23151 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21007 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->