### PR TITLE
REGRESSION(288458@main): <input type=checkbox switch> no longer calls updateTouchEventHandler()

### DIFF
--- a/LayoutTests/fast/forms/switch/click-disabled.html
+++ b/LayoutTests/fast/forms/switch/click-disabled.html
@@ -6,11 +6,9 @@
 <script>
 function end() {
     document.documentElement.removeAttribute("class");
-    testRunner?.notifyDone();
 }
 
 window.onload = async () => {
-    testRunner?.waitUntilDone();
     if (UIHelper.isIOSFamily()) {
         const eventStreamData = new UIHelper.EventStreamBuilder()
             .begin(10, 10)

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-expected.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-expected.html
@@ -1,3 +1,4 @@
 <!doctype html>
 <html>
 <input type=checkbox switch>
+<div>Switched off.</div>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl-expected.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl-expected.html
@@ -1,3 +1,4 @@
 <!doctype html>
 <html>
 <input type=checkbox switch dir=rtl>
+<div>Switched off.</div>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html
@@ -2,9 +2,9 @@
 <html class="reftest-wait">
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end() dir=rtl>
+<div id=state></div>
 <script>
 window.onload = async () => {
-    testRunner?.waitUntilDone();
     const input = document.querySelector("input");
     const x = input.offsetLeft;
     const y = input.offsetTop;
@@ -13,12 +13,12 @@ window.onload = async () => {
     if (UIHelper.isIOSFamily()) {
         const eventStreamData = new UIHelper.EventStreamBuilder()
             .begin(x + width - 1, y)
-            .move(x, y, 0.1)
-            .move(x + width - 1, y, 0.1)
+            .wait(0.21)
+            .move(x - 1, y, 0.01)
+            .move(x + width - 1, y, 0.01)
             .end()
             .takeResult();
         UIHelper.sendEventStream(eventStreamData);
-        testRunner?.notifyDone();
         return;
     }
     await eventSender.asyncMouseMoveTo(x + width - 1, y);
@@ -26,9 +26,9 @@ window.onload = async () => {
     await eventSender.asyncMouseMoveTo(x, y);
     await eventSender.asyncMouseMoveTo(x + width - 1, y);
     await eventSender.asyncMouseUp();
-    testRunner?.notifyDone();
 }
 function end() {
-    setTimeout(() => document.documentElement.removeAttribute("class"), 200);
+    document.querySelector("#state").textContent = document.querySelector("input").checked ? "Switched on." : "Switched off.";
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
 }
 </script>

--- a/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again.html
+++ b/LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again.html
@@ -2,8 +2,9 @@
 <html class="reftest-wait">
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
+<div id=state></div>
 <script>
-window.onload = () => {
+window.onload = async () => {
     const input = document.querySelector("input");
     const x = input.offsetLeft;
     const y = input.offsetTop;
@@ -12,20 +13,22 @@ window.onload = () => {
     if (UIHelper.isIOSFamily()) {
         const eventStreamData = new UIHelper.EventStreamBuilder()
             .begin(x, y)
-            .move(x + width, y, 0.1)
-            .move(x, y, 0.1)
+            .wait(0.21)
+            .move(x + width, y, 0.01)
+            .move(x, y, 0.01)
             .end()
             .takeResult();
         UIHelper.sendEventStream(eventStreamData);
         return;
     }
-    window.eventSender.mouseMoveTo(x, y);
-    window.eventSender.mouseDown();
-    window.eventSender.mouseMoveTo(x + width, y);
-    window.eventSender.mouseMoveTo(x, y);
-    window.eventSender.mouseUp();
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseDown();
+    await eventSender.asyncMouseMoveTo(x + width, y);
+    await eventSender.asyncMouseMoveTo(x, y);
+    await eventSender.asyncMouseUp();
 }
 function end() {
-    setTimeout(() => document.documentElement.removeAttribute("class"), 200);
+    document.querySelector("#state").textContent = document.querySelector("input").checked ? "Switched on." : "Switched off.";
+    setTimeout(() => document.documentElement.removeAttribute("class"), 50);
 }
 </script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -36,6 +36,16 @@ fast/forms/ios [ Pass ]
 fast/forms/ios/ipad [ Skip ]
 fast/forms/switch [ Pass ]
 
+# Missing public painting code
+fast/forms/switch/click-animation-redundant-checked.html [ ImageOnlyFailure ]
+fast/forms/switch/click-animation-redundant-disabled.html [ ImageOnlyFailure ]
+fast/forms/switch/click-animation.html [ ImageOnlyFailure ]
+
+# These require touch event support
+fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html [ Skip ]
+fast/forms/switch/pointer-tracking-there-and-back-again.html [ Skip ]
+fast/forms/switch/pointer-tracking.html [ Skip ]
+
 # These tests fail or are flaky in non-internal iOS 14 simulator
 fast/forms/ios/inputmode-none-with-hardware-keyboard.html [ Pass Failure ]
 
@@ -6920,12 +6930,6 @@ http/wpt/opener/iframe-access-top-via-windowproxy.html [ Pass ]
 http/wpt/opener/parent-access-child-via-windowproxy.html [ Pass ]
 http/wpt/opener/same-site-child-access-parent-iframe-via-windowproxy.html [ Pass ]
 
-# webkit.org/b/267890 REGRESSION (273260@main): [ iOS17 ] 3 tests in fast/forms/switch regularly timeout
-# fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html [ Timeout ]
-# fast/forms/switch/pointer-tracking-there-and-back-again.html [ Timeout ]
-# fast/forms/switch/pointer-tracking.html [ Timeout ]
-# UNCOMMENT ABOVE AND REMOVE FROM platform/ios-17/TestExpectations WHEN BELOW IS RESOLVED.
-
 webkit.org/b/267796 [ Release ] imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]
 
 webkit.org/b/264296 fast/forms/ios/show-and-dismiss-date-input-in-landscape.html [ Pass Timeout Crash ]
@@ -7307,11 +7311,6 @@ webkit.org/b/284300 imported/w3c/web-platform-tests/scroll-animations/view-timel
 
 webkit.org/b/269506 fast/forms/ios/autocapitalize-words.html [ Pass Failure ]
 
-# webkit.org/b/271850 [iOS] 10 fast/forms/switch/click-animation*.html layout tests are passing.
-fast/forms/switch/click-animation-redundant-checked.html [ ImageOnlyFailure ]
-fast/forms/switch/click-animation-redundant-disabled.html [ ImageOnlyFailure ]
-fast/forms/switch/click-animation.html [ ImageOnlyFailure ]
-
 webkit.org/b/272910 fast/scrolling/ios/video-atop-overflow-scroll.html [ Skip ]
 
 webkit.org/b/273848 [ Release ] imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe-loading-lazy-multiple-times.html [ Pass Failure ]
@@ -7666,9 +7665,6 @@ imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigati
 fast/writing-mode/inline-block-baseline.html [ ImageOnlyFailure ]
 fast/writing-mode/vertical-subst-font-vert-no-dflt.html [ ImageOnlyFailure ]
 
-# webkit.org/b/267890 REGRESSION (273260@main): [ iOS17 ] 3 tests in fast/forms/switch regularly timeout
-fast/forms/switch/pointer-tracking.html [ Timeout ]
-
 # webkit.org/b/288409 [ MacOS iOS ] 3x imported/w3c/web-platform-tests/navigation-api/navigation are consistent failures 
 imported/w3c/web-platform-tests/navigation-api/navigation-activation/activation-traverse-not-in-entries.html [ Failure ]
 imported/w3c/web-platform-tests/navigation-api/navigation-methods/disambigaute-forward.html [ Failure ]
@@ -7685,12 +7681,6 @@ webkit.org/b/286594 http/wpt/cache-storage/quota-third-party.https.html [ Pass F
 webkit.org/b/286318 http/tests/iframe-monitor [ Pass ]
 
 # webkit.org/b/286934 [ Debug ] ipc/create-media-source-with-invalid-constraints-crash.html [ Skip ]
-
-# webkit.org/b/287098 fast/forms/switch/click-animation-twice-fast.html [ Timeout ]
-
-# webkit.org/b/287181 [ iOS ] 2x fast/forms/switch/pointer-tracking-there-and-back-again*.html are constant timeouts
-fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html [ Timeout ]
-fast/forms/switch/pointer-tracking-there-and-back-again.html [ Timeout ]
 
 webkit.org/b/287204 [ Release ] fast/forms/date/date-input-rendering-basic.html [ Pass Failure ]
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -881,17 +881,17 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         if (document().settings().switchControlEnabled()) {
             auto hasSwitchAttribute = !newValue.isNull();
             m_hasSwitchAttribute = hasSwitchAttribute;
+#if ENABLE(TOUCH_EVENTS)
+            updateTouchEventHandler();
+#endif
             if (attributeModificationReason != AttributeModificationReason::Directly)
-                return; // initializeInputTypeAfterParsingOrCloning and updateUserAgentShadowTree will take care of this.
+                return; // updateUserAgentShadowTree will take care of this.
             if (isSwitch())
                 m_inputType->createShadowSubtreeIfNeeded();
             else if (isCheckbox())
                 m_inputType->removeShadowSubtree();
             if (renderer())
                 invalidateStyleAndRenderersForSubtree();
-#if ENABLE(TOUCH_EVENTS)
-            updateTouchEventHandler();
-#endif
         }
         break;
     case AttributeNames::alphaAttr:


### PR DESCRIPTION
#### 3138a5facd50b7419690bba1267edb85a75c3f34
<pre>
REGRESSION(288458@main): &lt;input type=checkbox switch&gt; no longer calls updateTouchEventHandler()
<a href="https://bugs.webkit.org/show_bug.cgi?id=287181">https://bugs.webkit.org/show_bug.cgi?id=287181</a>
<a href="https://rdar.apple.com/130619586">rdar://130619586</a>

Reviewed by Aditya Keerthi.

When the parser calls initializeInputTypeAfterParsingOrCloning() the
switch attribute is not initialized yet and we have not updated
initializeInputTypeAfterParsingOrCloning() to account for the switch
attribute, so when descendants of that method call
updateTouchEventHandler(), isSwitch() still returns false. This means
no touch event listeners are registered. (The switch attribute is
initialized immediately after
initializeInputTypeAfterParsingOrCloning() is invoked.)

So we update the comment in HTMLInputElement::attributeChanged to
indicate we solely rely on updateUserAgentShadowTree() for the switch
attribute and move up updateTouchEventHandler() before the early return
to ensure it&apos;s always called when the switch attribute is initialized.

Then we clean up TestExpectations. We skip all the
&lt;input type=checkbox switch&gt; tests that depend on ENABLE(TOUCH_EVENTS).

And finally we update pointer-tracking-there-and-back-again[-rtl].html.
We port the changes 285662@main made to -rtl to non-rtl, but we remove
the waitUntilDone() infrastructure as we use reftest-wait. We add a
wait(0.21) call to account for 278311@main. We reduce the duration of
the touch moves, but not to 0 as that makes them not register. In -rtl
we also adjust the move to the left so it overshoots x by 1 pixel. This
makes it match the non-rtl version better. And we explicitly log the
current switched state so we can instantly tell if there&apos;s some kind of
regression on that front.

* LayoutTests/fast/forms/switch/click-disabled.html:
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-expected.html:
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl-expected.html:
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again-rtl.html:
* LayoutTests/fast/forms/switch/pointer-tracking-there-and-back-again.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/290692@main">https://commits.webkit.org/290692@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd48e5c4b0c43d637eb938cee34f6ca460be58ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95643 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69754 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27305 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93632 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50095 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36584 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97472 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77970 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21036 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14313 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17833 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23179 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17572 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->