### PR TITLE
Address safer C++ static analysis warnings in

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2548,9 +2548,19 @@ GCActivityCallback* Heap::fullActivityCallback()
     return m_fullActivityCallback.get();
 }
 
+RefPtr<GCActivityCallback> Heap::protectedFullActivityCallback()
+{
+    return m_fullActivityCallback;
+}
+
 GCActivityCallback* Heap::edenActivityCallback()
 {
     return m_edenActivityCallback.get();
+}
+
+RefPtr<GCActivityCallback> Heap::protectedEdenActivityCallback()
+{
+    return m_edenActivityCallback;
 }
 
 IncrementalSweeper& Heap::sweeper()

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -336,7 +336,9 @@ public:
     SlotVisitor& collectorSlotVisitor() { return *m_collectorSlotVisitor; }
 
     JS_EXPORT_PRIVATE GCActivityCallback* fullActivityCallback();
+    JS_EXPORT_PRIVATE RefPtr<GCActivityCallback> protectedFullActivityCallback();
     JS_EXPORT_PRIVATE GCActivityCallback* edenActivityCallback();
+    JS_EXPORT_PRIVATE RefPtr<GCActivityCallback> protectedEdenActivityCallback();
 
     JS_EXPORT_PRIVATE void setFullActivityCallback(RefPtr<GCActivityCallback>&&);
     JS_EXPORT_PRIVATE void setEdenActivityCallback(RefPtr<GCActivityCallback>&&);

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -109,7 +109,6 @@ workers/WorkerConsoleClient.h
 workers/WorkerMessagingProxy.h
 workers/WorkerNotificationClient.h
 workers/WorkerOrWorkletGlobalScope.h
-workers/WorkerOrWorkletScriptController.h
 workers/service/NavigationPreloadManager.h
 workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
 workers/service/context/ServiceWorkerThreadProxy.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -401,8 +401,6 @@ bindings/js/JSXMLHttpRequestCustom.cpp
 bindings/js/ScheduledAction.cpp
 bindings/js/ScriptBufferSourceProvider.h
 bindings/js/ScriptCachedFrameData.cpp
-bindings/js/ScriptController.cpp
-bindings/js/ScriptControllerMac.mm
 bindings/js/ScriptModuleLoader.cpp
 bindings/js/ScriptSourceCode.h
 bindings/js/SerializedScriptValue.cpp
@@ -1462,7 +1460,6 @@ workers/WorkerInspectorProxy.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerNotificationClient.cpp
 workers/WorkerOrWorkletGlobalScope.cpp
-workers/WorkerOrWorkletScriptController.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerRunLoop.cpp
 workers/WorkerScriptLoader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -152,7 +152,6 @@ platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
-platform/network/CacheValidation.cpp
 rendering/BackgroundPainter.cpp
 rendering/BorderPainter.cpp
 rendering/MotionPath.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -203,8 +203,6 @@ bindings/js/JSWorkerGlobalScopeBase.cpp
 bindings/js/JSWorkerGlobalScopeCustom.cpp
 bindings/js/JSXMLHttpRequestCustom.cpp
 bindings/js/ScriptCachedFrameData.cpp
-bindings/js/ScriptController.cpp
-bindings/js/ScriptControllerMac.mm
 bindings/js/ScriptModuleLoader.cpp
 bindings/js/SerializedScriptValue.cpp
 bindings/js/WebCoreJSClientData.cpp
@@ -788,7 +786,6 @@ workers/WorkerConsoleClient.cpp
 workers/WorkerGlobalScope.cpp
 workers/WorkerMessagingProxy.cpp
 workers/WorkerOrWorkletGlobalScope.cpp
-workers/WorkerOrWorkletScriptController.cpp
 workers/WorkerOrWorkletThread.cpp
 workers/WorkerScriptLoader.cpp
 workers/service/ExtendableEvent.cpp

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -95,8 +95,8 @@ DOMWrapperWorld& normalWorld(JSC::VM&);
 WEBCORE_EXPORT DOMWrapperWorld& mainThreadNormalWorldSingleton();
 inline Ref<DOMWrapperWorld> protectedMainThreadNormalWorld() { return mainThreadNormalWorldSingleton(); }
 
-inline DOMWrapperWorld& debuggerWorld() { return mainThreadNormalWorldSingleton(); }
-inline DOMWrapperWorld& pluginWorld() { return mainThreadNormalWorldSingleton(); }
+inline DOMWrapperWorld& debuggerWorldSingleton() { return mainThreadNormalWorldSingleton(); }
+inline DOMWrapperWorld& pluginWorldSingleton() { return mainThreadNormalWorldSingleton(); }
 
 DOMWrapperWorld& currentWorld(JSC::JSGlobalObject&);
 DOMWrapperWorld& worldForDOMObject(JSC::JSObject&);

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -159,6 +159,11 @@ DOMWindow& JSWindowProxy::wrapped() const
     return jsCast<JSDOMWindowBase*>(window)->wrapped();
 }
 
+Ref<DOMWindow> JSWindowProxy::protectedWrapped() const
+{
+    return wrapped();
+}
+
 JSValue toJS(JSGlobalObject* lexicalGlobalObject, WindowProxy& windowProxy)
 {
     auto* jsWindowProxy = windowProxy.jsWindowProxy(currentWorld(*lexicalGlobalObject));

--- a/Source/WebCore/bindings/js/JSWindowProxy.h
+++ b/Source/WebCore/bindings/js/JSWindowProxy.h
@@ -61,6 +61,7 @@ public:
     WindowProxy* windowProxy() const;
 
     DOMWindow& wrapped() const;
+    Ref<DOMWindow> protectedWrapped() const;
     static WindowProxy* toWrapped(JSC::VM&, JSC::JSValue);
 
     DOMWrapperWorld& world();

--- a/Source/WebCore/bindings/js/ScriptController.h
+++ b/Source/WebCore/bindings/js/ScriptController.h
@@ -153,12 +153,13 @@ public:
 
     RefPtr<JSC::Bindings::Instance>  createScriptInstanceForWidget(Widget*);
     WEBCORE_EXPORT JSC::Bindings::RootObject* bindingRootObject();
+    RefPtr<JSC::Bindings::RootObject> protectedBindingRootObject();
     JSC::Bindings::RootObject* cacheableBindingRootObject();
     JSC::Bindings::RootObject* existingCacheableBindingRootObject() const { return m_cacheableBindingRootObject.get(); }
 
     WEBCORE_EXPORT Ref<JSC::Bindings::RootObject> createRootObject(void* nativeHandle);
 
-    void collectIsolatedContexts(Vector<std::pair<JSC::JSGlobalObject*, SecurityOrigin*>>&);
+    void collectIsolatedContexts(Vector<std::pair<JSC::JSGlobalObject*, RefPtr<SecurityOrigin>>>&);
 
 #if PLATFORM(COCOA)
     WEBCORE_EXPORT WebScriptObject* windowScriptObject();
@@ -192,7 +193,7 @@ private:
     WeakRef<LocalFrame> m_frame;
     const URL* m_sourceURL { nullptr };
 
-    bool m_paused;
+    bool m_paused { false };
     bool m_willReplaceWithResultOfExecutingJavascriptURL { false };
 
     // The root object used for objects bound outside the context of a plugin, such

--- a/Source/WebCore/bindings/js/ScriptControllerMac.mm
+++ b/Source/WebCore/bindings/js/ScriptControllerMac.mm
@@ -79,8 +79,8 @@ WebScriptObject *ScriptController::windowScriptObject()
 
     if (!m_windowScriptObject) {
         JSC::JSLockHolder lock(commonVM());
-        JSC::Bindings::RootObject* root = bindingRootObject();
-        m_windowScriptObject = [WebScriptObject scriptObjectForJSObject:toRef(&jsWindowProxy(pluginWorld())) originRootObject:root rootObject:root];
+        RefPtr root = bindingRootObject();
+        m_windowScriptObject = [WebScriptObject scriptObjectForJSObject:toRef(&jsWindowProxy(pluginWorldSingleton())) originRootObject:root.get() rootObject:root.get()];
     }
 
     return m_windowScriptObject.get();
@@ -91,7 +91,7 @@ JSContext *ScriptController::javaScriptContext()
 #if JSC_OBJC_API_ENABLED
     if (!canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return 0;
-    JSContext *context = [JSContext contextWithJSGlobalContextRef:toGlobalRef(bindingRootObject()->globalObject())];
+    JSContext *context = [JSContext contextWithJSGlobalContextRef:toGlobalRef(protectedBindingRootObject()->globalObject())];
     return context;
 #else
     return 0;
@@ -101,8 +101,8 @@ JSContext *ScriptController::javaScriptContext()
 void ScriptController::updatePlatformScriptObjects()
 {
     if (m_windowScriptObject) {
-        JSC::Bindings::RootObject* root = bindingRootObject();
-        [m_windowScriptObject _setOriginRootObject:root andRootObject:root];
+        RefPtr root = bindingRootObject();
+        [m_windowScriptObject _setOriginRootObject:root.get() andRootObject:root.get()];
     }
 }
 

--- a/Source/WebCore/bindings/js/WorkerScriptFetcher.h
+++ b/Source/WebCore/bindings/js/WorkerScriptFetcher.h
@@ -70,6 +70,7 @@ public:
     std::optional<LoadableScript::Error> error() const { return m_error; }
     bool wasCanceled() const { return m_wasCanceled; }
     UniquedStringImpl* moduleKey() const { return m_moduleKey.get(); }
+    RefPtr<UniquedStringImpl> protectedModuleKey() const { return m_moduleKey; }
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 
     void setReferrerPolicy(ReferrerPolicy referrerPolicy)

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -54,6 +54,7 @@ public:
     void notifyLoadWasCanceled();
 
     UniquedStringImpl* moduleKey() const { return m_moduleKey.get(); }
+    RefPtr<UniquedStringImpl> protectedModuleKey() const { return m_moduleKey; }
 
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -188,7 +188,7 @@ void InspectorFrontendClientLocal::windowObjectCleared()
         m_frontendHost->disconnectClient();
     
     m_frontendHost = InspectorFrontendHost::create(this, frontendPage());
-    m_frontendHost->addSelfToGlobalObjectInWorld(debuggerWorld());
+    m_frontendHost->addSelfToGlobalObjectInWorld(debuggerWorldSingleton());
 }
 
 void InspectorFrontendClientLocal::frontendLoaded()

--- a/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -585,7 +585,7 @@ void InspectorFrontendHost::showContextMenu(Event& event, Vector<ContextMenuItem
     RefPtr localMainFrame = m_frontendPage->localMainFrame();
     if (!localMainFrame)
         return;
-    auto& globalObject = *localMainFrame->script().globalObject(debuggerWorld());
+    auto& globalObject = *localMainFrame->script().globalObject(debuggerWorldSingleton());
     auto& vm = globalObject.vm();
     auto value = globalObject.get(&globalObject, JSC::Identifier::fromString(vm, "InspectorFrontendAPI"_s));
     ASSERT(value);

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -404,7 +404,7 @@ Vector<std::pair<String, String>> collectVaryingRequestHeaders(const CookieJar* 
     });
 }
 
-static bool verifyVaryingRequestHeadersInternal(const Vector<std::pair<String, String>>& varyingRequestHeaders, Function<String(const String&)>&& headerValueForVary)
+static bool verifyVaryingRequestHeadersInternal(const Vector<std::pair<String, String>>& varyingRequestHeaders, NOESCAPE const Function<String(const String&)>& headerValueForVary)
 {
     for (auto& varyingRequestHeader : varyingRequestHeaders) {
         // FIXME: Vary: * in response would ideally trigger a cache delete instead of a store.

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.h
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.h
@@ -111,7 +111,8 @@ public:
     void loadAndEvaluateModule(const URL& moduleURL, FetchOptions::Credentials, CompletionHandler<void(std::optional<Exception>&&)>&&);
 
 protected:
-    WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope; }
+    WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
+    RefPtr<WorkerOrWorkletGlobalScope> protectedGlobalScope() const;
 
     void initScriptIfNeeded()
     {
@@ -125,7 +126,7 @@ private:
     void initScriptWithSubclass();
 
     RefPtr<JSC::VM> m_vm;
-    WorkerOrWorkletGlobalScope* m_globalScope;
+    WeakPtr<WorkerOrWorkletGlobalScope> m_globalScope;
     JSC::Strong<JSDOMGlobalObject> m_globalScopeWrapper;
     std::unique_ptr<WorkerConsoleClient> m_consoleClient;
     mutable Lock m_scheduledTerminationLock;

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -379,12 +379,12 @@ static NSURL *createUniqueWebDataURL();
     auto& windowProxy = _private->coreFrame->windowProxy();
 
     // Calling ScriptController::globalObject() would create a window proxy, and dispatch corresponding callbacks, which may be premature
-    // if the script debugger is attached before a document is created.  These calls use the debuggerWorld(), we will need to pass a world
+    // if the script debugger is attached before a document is created. These calls use the debuggerWorldSingleton(), we will need to pass a world
     // to be able to debug isolated worlds.
-    if (!windowProxy.existingJSWindowProxy(WebCore::debuggerWorld()))
+    if (!windowProxy.existingJSWindowProxy(WebCore::debuggerWorldSingleton()))
         return;
 
-    auto* globalObject = windowProxy.globalObject(WebCore::debuggerWorld());
+    auto* globalObject = windowProxy.globalObject(WebCore::debuggerWorldSingleton());
     if (!globalObject)
         return;
 


### PR DESCRIPTION
#### ba52aff5f8c5d0946171d20da706a610bafd3b15
<pre>
Address safer C++ static analysis warnings in CacheValidation.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=287960">https://bugs.webkit.org/show_bug.cgi?id=287960</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::verifyVaryingRequestHeadersInternal):
</pre>
----------------------------------------------------------------------
#### 2f78ff8478b3038f5fbbf9a53919f2d6f77440d0
<pre>
Address safer C++ static analysis warnings in ScriptController
<a href="https://bugs.webkit.org/show_bug.cgi?id=287931">https://bugs.webkit.org/show_bug.cgi?id=287931</a>

Reviewed by NOBODY (OOPS!).

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::protectedFullActivityCallback):
(JSC::Heap::protectedEdenActivityCallback):
* Source/JavaScriptCore/heap/Heap.h:
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::debuggerWorldSingleton):
(WebCore::pluginWorldSingleton):
(WebCore::debuggerWorld): Deleted.
(WebCore::pluginWorld): Deleted.
* Source/WebCore/bindings/js/JSWindowProxy.cpp:
(WebCore::JSWindowProxy::protectedWrapped const):
* Source/WebCore/bindings/js/JSWindowProxy.h:
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::ScriptController):
(WebCore::ScriptController::~ScriptController):
(WebCore::ScriptController::linkAndEvaluateModuleScriptInWorld):
(WebCore::ScriptController::evaluateModule):
(WebCore::ScriptController::initScriptForWindowProxy):
(WebCore::ScriptController::jsWindowProxy):
(WebCore::ScriptController::eventHandlerPosition const):
(WebCore::ScriptController::canAccessFromCurrentOrigin):
(WebCore::ScriptController::cacheableBindingRootObject):
(WebCore::ScriptController::bindingRootObject):
(WebCore::ScriptController::protectedBindingRootObject):
(WebCore::ScriptController::createRootObject):
(WebCore::ScriptController::collectIsolatedContexts):
(WebCore::ScriptController::jsObjectForPluginElement):
* Source/WebCore/bindings/js/ScriptController.h:
* Source/WebCore/bindings/js/ScriptControllerMac.mm:
(WebCore::ScriptController::windowScriptObject):
(WebCore::ScriptController::javaScriptContext):
(WebCore::ScriptController::updatePlatformScriptObjects):
* Source/WebCore/bindings/js/WorkerScriptFetcher.h:
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::windowObjectCleared):
* Source/WebCore/inspector/InspectorFrontendHost.cpp:
(WebCore::InspectorFrontendHost::showContextMenu):
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::addTimerSetNotification):
(WebCore::WorkerOrWorkletScriptController::removeTimerSetNotification):
(WebCore::WorkerOrWorkletScriptController::evaluate):
(WebCore::WorkerOrWorkletScriptController::evaluateModule):
(WebCore::WorkerOrWorkletScriptController::loadModuleSynchronously):
(WebCore::WorkerOrWorkletScriptController::linkAndEvaluateModule):
(WebCore::WorkerOrWorkletScriptController::protectedGlobalScope const):
(WebCore::WorkerOrWorkletScriptController::loadAndEvaluateModule):
(WebCore::WorkerOrWorkletScriptController::initScriptWithSubclass):
* Source/WebCore/workers/WorkerOrWorkletScriptController.h:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _attachScriptDebugger]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba52aff5f8c5d0946171d20da706a610bafd3b15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45566 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18477 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93627 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/83438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/37634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/89407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17818 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18076 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/78017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17828 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111895 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17567 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21023 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->