### PR TITLE
[SwiftUI] Changing the `webViewContentBackground` value doesn't always apply the new value on macOS

### DIFF
--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1195,6 +1195,9 @@ bool RenderLayerCompositor::updateCompositingLayers(CompositingUpdateType update
         m_renderView.setNeedsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly(false);
     }
 
+    if (m_scrolledContentsLayer)
+        updateOverflowControlsLayers();
+
     return true;
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
@@ -52,10 +52,16 @@ struct WebViewRepresentable {
         webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures.value != .disabled
         webView.allowsLinkPreview = environment.webViewAllowsLinkPreview.value != .disabled
 
+        let isOpaque = environment.webViewContentBackground != .hidden
+
 #if os(macOS)
-        webView._drawsBackground = environment.webViewContentBackground != .hidden
+        if webView._drawsBackground != isOpaque {
+            webView._drawsBackground = isOpaque
+        }
 #else
-        webView.isOpaque = environment.webViewContentBackground != .hidden
+        if webView.isOpaque != isOpaque {
+            webView.isOpaque = isOpaque
+        }
 #endif
 
         if EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .always || EquatableScrollBounceBehavior(environment.verticalScrollBounceBehavior) == .automatic {

--- a/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift
@@ -28,4 +28,5 @@ enum AppStorageKeys {
     static let orientationAndMotionAuthorization = "orientationAndMotionAuthorization2"
     static let mediaCaptureAuthorization = "mediaCaptureAuthorization2"
     static let scrollBounceBehaviorBasedOnSize = "scrollBounceBehaviorBasedOnSize"
+    static let backgroundHidden = "backgroundHidden"
 }

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -217,6 +217,7 @@ struct ContentView: View {
     @Environment(BrowserViewModel.self) private var viewModel
 
     @AppStorage(AppStorageKeys.scrollBounceBehaviorBasedOnSize) private var scrollBounceBehaviorBasedOnSize: Bool?
+    @AppStorage(AppStorageKeys.backgroundHidden) private var backgroundHidden: Bool?
 
     #if os(iOS)
     private static let navigationToolbarItemPlacement = ToolbarItemPlacement.bottomBar
@@ -275,6 +276,7 @@ struct ContentView: View {
                         .presentationDetents([.medium, .large])
                 }
                 .scrollBounceBehavior(scrollBounceBehaviorBasedOnSize == true ? .basedOnSize : .automatic)
+                .webViewContentBackground(backgroundHidden == true ? .hidden : .automatic)
                 .webViewContextMenu { element in
                     if let url = element.linkURL {
                         Button("Open Link in New Window") {

--- a/Tools/SwiftBrowser/Source/Views/SettingsView.swift
+++ b/Tools/SwiftBrowser/Source/Views/SettingsView.swift
@@ -40,15 +40,20 @@ private struct PermissionDecisionView: View {
     }
 }
 
-private struct ScrollBounceBehaviorPicker: View {
-    @Binding var basedOnSize: Bool
+private struct BinaryValuePicker: View {
+    @Binding var value: Bool
+
+    let description: String
+
+    let falseLabel: String
+    let trueLabel: String
 
     var body: some View {
-        Picker(selection: $basedOnSize) {
-            Text("Automatic").tag(false)
-            Text("Based on Size").tag(true)
+        Picker(selection: $value) {
+            Text(falseLabel).tag(false)
+            Text(trueLabel).tag(true)
         } label: {
-            Text("Scroll Bounce Behavior")
+            Text(description)
         }
     }
 }
@@ -60,6 +65,7 @@ struct GeneralSettingsView: View {
     @AppStorage(AppStorageKeys.mediaCaptureAuthorization) private var mediaCaptureAuthorization = WKPermissionDecision.prompt
 
     @AppStorage(AppStorageKeys.scrollBounceBehaviorBasedOnSize) private var scrollBounceBehaviorBasedOnSize = false
+    @AppStorage(AppStorageKeys.backgroundHidden) private var backgroundHidden = false
 
     let currentURL: URL?
 
@@ -91,8 +97,19 @@ struct GeneralSettingsView: View {
             }
 
             Section {
-                ScrollBounceBehaviorPicker(basedOnSize: $scrollBounceBehaviorBasedOnSize)
-                    .padding(.top)
+                BinaryValuePicker(
+                    value: $scrollBounceBehaviorBasedOnSize,
+                    description: "Scroll Bounce Behavior",
+                    falseLabel: "Automatic",
+                    trueLabel: "Based on Size"
+                )
+
+                BinaryValuePicker(
+                    value: $backgroundHidden,
+                    description: "Hidden Background Behavior",
+                    falseLabel: "Automatic",
+                    trueLabel: "Always Hide"
+                )
             }
         }
     }


### PR DESCRIPTION
#### a9d2d3b8f58696db838bdff95cdc85fe1a4f3a4e
<pre>
[SwiftUI] Changing the `webViewContentBackground` value doesn&apos;t always apply the new value on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=287963">https://bugs.webkit.org/show_bug.cgi?id=287963</a>
<a href="https://rdar.apple.com/145142533">rdar://145142533</a>

Reviewed by Aditya Keerthi.

Toggling the `webViewContentBackground` view modifier to `.hidden` sometimes has no effect. This is
because of an underlying issue in the existing `_drawsBackground` SPI; specifically, toggling this
value after web content is loaded is not guaranteed to actually hide the background.

This is because after some content is loaded or changed, the `RenderLayerCompositor::updateOverflowControlsLayers` method gets called.
This method checks if an &quot;overhang area&quot; layer is required, and if so, it adds an opaque overhang area layer,
effectively giving the web view an opaque background color. This logic is sound, since the check to determine
if such a layer is required is done via `RenderLayerCompositor::requiresOverhangAreasLayer` which checks to
see if the frame view has an opaque background. If it does not, it returns `false` as expected.

However, the problem is that after the overhang area layer is added, if the web view background is then changed
to a non-opaque color (as is done when `_drawsBackground` is `false`), the `RenderLayerCompositor::updateOverflowControlsLayers`
method isn&apos;t guaranteed to be called again and therefore doesn&apos;t have a chance to update the presence of the
overhang area layer.

To fix, ensure that `updateOverflowControlsLayers` is called whenever the frame view&apos;s background color changes
so that it can properly update the overhang area.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateBackgroundRecursively):

Call `frameViewDidChangeBackground` when the background needs updating.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::frameViewDidChangeBackground):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Add a method similar to `frameViewDidChangeSize`, to ensure `updateOverflowControlsLayers` gets called.

* Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):

Optimization to only call the setters if the value actually changes.

* Tools/SwiftBrowser/Source/ViewModel/AppStorageKeys.swift:
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.backgroundHidden):
(ContentView.body):
* Tools/SwiftBrowser/Source/Views/SettingsView.swift:
(BinaryValuePicker.value):
(BinaryValuePicker.body):
(GeneralSettingsView.body):
(ScrollBounceBehaviorPicker.basedOnSize): Deleted.
(ScrollBounceBehaviorPicker.body): Deleted.

Use this view modifier in SwiftBrowser.

* Tools/TestWebKitAPI/Tests/mac/BackgroundColor.mm:
(TestWebKitAPI::testDrawsBackgroundAfterLoadingWebContent):
(TestWebKitAPI::TEST(WebKit, DrawsBackgroundAfterLoadingWebContentNoToYes)):
(TestWebKitAPI::TEST(WebKit, DrawsBackgroundAfterLoadingWebContentYesToNo)):

Add tests for this.

Canonical link: <a href="https://commits.webkit.org/290935@main">https://commits.webkit.org/290935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a27cfc5d57ee9eae11b488f59cd080fc720896b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91511 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42197 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70270 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27788 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8715 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82906 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8479 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41367 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78799 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/498 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98483 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79294 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18927 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78744 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/78498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23020 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/377 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11797 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14485 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18668 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23946 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->