### PR TITLE
Map getOrInsert should account for value functors modifying the map

### DIFF
--- a/JSTests/stress/test-getOrInsert-selfmodify.js
+++ b/JSTests/stress/test-getOrInsert-selfmodify.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--useMapGetOrInsert=1")
+
+let map = new Map();
+for (let i = 0; i < 100; ++i) {
+    map.set("a" + i, 1);
+}
+
+map.getOrInsertComputed("b", () => {
+    for (let i = 0; i < 100; ++i) {
+        map.delete("a" + i);
+    }
+});
+
+let weakmap = new WeakMap();
+let keys = [];
+for (let i = 0; i < 100; ++i) {
+    keys.push({"key": "a" + i});
+    weakmap.set(keys[i], 1);
+}
+
+let obj = {"key": "b"}
+weakmap.getOrInsertComputed(obj, () => {
+    for (let i = 0; i < 100; ++i) {
+        weakmap.delete(keys[i]);
+    }
+});
+

--- a/Source/JavaScriptCore/runtime/OrderedHashTable.h
+++ b/Source/JavaScriptCore/runtime/OrderedHashTable.h
@@ -228,7 +228,12 @@ public:
             value = getValueFunctor();
             RETURN_IF_EXCEPTION(scope, { });
 
-            Helper::addImpl(globalObject, this, storage, key, value, result);
+            if (Helper::isObsolete(storage)) {
+                // Call to getValueFunctor can modify our state, so we need to re-check the index
+                result = Helper::find(globalObject, storageRef(), key);
+                RETURN_IF_EXCEPTION(scope, { });
+            }
+            Helper::addImpl(globalObject, this, storageRef(), key, value, result);
             RETURN_IF_EXCEPTION(scope, { });
         }
 

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -213,6 +213,10 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
                 RETURN_IF_EXCEPTION(scope, { });
             }
 
+            // FIXME: rdar://145147128 can we optimize this more to detect a rehash like Map does?
+
+            // Call to valueCallback can modify our state, so we need to check if we re-hashed
+            index = map->findBucketIndex(keyCell, hash).first;
             map->addBucket(vm, keyCell, value, hash, index);
         }
     }


### PR DESCRIPTION
#### e06c5efe89af319dc7fd7c369ff13f3af000c359
<pre>
Map getOrInsert should account for value functors modifying the map
<a href="https://bugs.webkit.org/show_bug.cgi?id=287970">https://bugs.webkit.org/show_bug.cgi?id=287970</a>
<a href="https://rdar.apple.com/144969831">rdar://144969831</a>

Reviewed by Yijia Huang.

getOrInsert on a map currently does not recompute the target bucket. However,
if the value functor called modifies the map, this could change the correct
target bucket. This patch updates these methods to recompute the hash in all
cases. We may be able to optimize this further in the future.

* JSTests/stress/test-getOrInsert-selfmodify.js: Added.
* Source/JavaScriptCore/runtime/OrderedHashTable.h:
(JSC::OrderedHashMap::getOrInsert):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/290666@main">https://commits.webkit.org/290666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b5bf927157695bd5d0fa177086f87c160ecc8d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95729 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41500 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18568 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93715 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82261 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36646 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40629 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83530 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97559 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89494 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17909 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78020 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22461 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14295 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17918 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/111983 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17657 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21113 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->