### PR TITLE
Address safer C++ static analysis warnings in WKNavigation

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -99,9 +99,6 @@ UIProcess/API/C/WKInspector.cpp
 UIProcess/API/C/WKMediaKeySystemPermissionCallback.cpp
 UIProcess/API/C/WKMessageListener.cpp
 UIProcess/API/C/WKMockMediaDevice.cpp
-UIProcess/API/C/WKNavigationActionRef.cpp
-UIProcess/API/C/WKNavigationDataRef.cpp
-UIProcess/API/C/WKNavigationResponseRef.cpp
 UIProcess/API/C/WKNotification.cpp
 UIProcess/API/C/WKNotificationManager.cpp
 UIProcess/API/C/WKNotificationPermissionRequest.cpp
@@ -134,9 +131,7 @@ UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKHTTPCookieStore.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
-UIProcess/API/Cocoa/WKNavigation.mm
 UIProcess/API/Cocoa/WKNavigationAction.mm
-UIProcess/API/Cocoa/WKNavigationData.mm
 UIProcess/API/Cocoa/WKOpenPanelParameters.mm
 UIProcess/API/Cocoa/WKPreferences.mm
 UIProcess/API/Cocoa/WKProcessGroup.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -25,7 +25,6 @@ UIProcess/API/Cocoa/WKBrowsingContextController.mm
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKFrameInfo.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
-UIProcess/API/Cocoa/WKNavigationAction.mm
 UIProcess/API/Cocoa/WKProcessPool.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/_WKDataTask.mm

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -131,9 +131,21 @@ auto toAPI(T* t) -> APIType
 }
 
 template<typename T, typename APIType = typename ImplTypeInfo<T>::APIType>
+auto toAPILeakingRef(RefPtr<T>&& t) -> APIType
+{
+    return reinterpret_cast<APIType>(API::Object::wrap(t.leakRef()));
+}
+
+template<typename T, typename APIType = typename ImplTypeInfo<T>::APIType>
 auto toAPI(T& t) -> APIType
 {
     return reinterpret_cast<APIType>(API::Object::wrap(&t));
+}
+
+template<typename T, typename APIType = typename ImplTypeInfo<T>::APIType>
+auto toAPILeakingRef(Ref<T>&& t) -> APIType
+{
+    return reinterpret_cast<APIType>(API::Object::wrap(&t.leakRef()));
 }
 
 template<typename T, typename ImplType = typename APITypeInfo<T>::ImplType>

--- a/Source/WebKit/UIProcess/API/APINavigationAction.h
+++ b/Source/WebKit/UIProcess/API/APINavigationAction.h
@@ -45,6 +45,7 @@ public:
 
     FrameInfo* sourceFrame() const { return m_sourceFrame.get(); }
     FrameInfo* targetFrame() const { return m_targetFrame.get(); }
+    RefPtr<FrameInfo> protectedTargetFrame() const { return m_targetFrame; }
     const WTF::String& targetFrameName() const { return m_targetFrameName; }
 
     const WebCore::ResourceRequest& request() const { return m_request; }
@@ -69,8 +70,10 @@ public:
     bool isProcessingUserGesture() const { return m_userInitiatedAction; }
     bool isProcessingUnconsumedUserGesture() const { return m_userInitiatedAction && !m_userInitiatedAction->consumed(); }
     UserInitiatedAction* userInitiatedAction() const { return m_userInitiatedAction.get(); }
+    RefPtr<UserInitiatedAction> protectedUserInitiatedAction() const { return m_userInitiatedAction; }
 
     Navigation* mainFrameNavigation() const { return m_mainFrameNavigation.get(); }
+    RefPtr<Navigation> protectedMainFrameNavigation() const { return m_mainFrameNavigation; }
 
 #if HAVE(APP_SSO)
     bool shouldPerformSOAuthorization() { return m_shouldPerformSOAuthorization; }

--- a/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp
@@ -41,7 +41,7 @@ bool WKNavigationActionShouldPerformDownload(WKNavigationActionRef action)
 
 WKURLRequestRef WKNavigationActionCopyRequest(WKNavigationActionRef action)
 {
-    return WebKit::toAPI(&API::URLRequest::create(WebKit::toImpl(action)->request()).leakRef());
+    return WebKit::toAPILeakingRef(API::URLRequest::create(WebKit::toImpl(action)->request()));
 }
 
 bool WKNavigationActionGetShouldOpenExternalSchemes(WKNavigationActionRef action)
@@ -51,8 +51,9 @@ bool WKNavigationActionGetShouldOpenExternalSchemes(WKNavigationActionRef action
 
 WKFrameInfoRef WKNavigationActionCopyTargetFrameInfo(WKNavigationActionRef action)
 {
-    RefPtr targetFrame = WebKit::toImpl(action)->targetFrame();
-    return targetFrame ? WebKit::toAPI(targetFrame.leakRef()) : nullptr;
+    if (RefPtr targetFrame = WebKit::toImpl(action)->targetFrame())
+        return WebKit::toAPILeakingRef(targetFrame.releaseNonNull());
+    return nullptr;
 }
 
 WKFrameNavigationType WKNavigationActionGetNavigationType(WKNavigationActionRef action)

--- a/Source/WebKit/UIProcess/API/C/WKNavigationDataRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationDataRef.cpp
@@ -55,5 +55,5 @@ WKURLRef WKNavigationDataCopyNavigationDestinationURL(WKNavigationDataRef naviga
 
 WKURLRequestRef WKNavigationDataCopyOriginalRequest(WKNavigationDataRef navigationData)
 {
-    return toAPI(&API::URLRequest::create(toImpl(navigationData)->originalRequest()).leakRef());
+    return toAPILeakingRef(API::URLRequest::create(toImpl(navigationData)->originalRequest()));
 }

--- a/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp
@@ -41,11 +41,11 @@ bool WKNavigationResponseCanShowMIMEType(WKNavigationResponseRef response)
 
 WKURLResponseRef WKNavigationResponseCopyResponse(WKNavigationResponseRef response)
 {
-    return WebKit::toAPI(API::URLResponse::create(WebKit::toImpl(response)->response()).leakRef());
+    return WebKit::toAPILeakingRef(API::URLResponse::create(WebKit::toImpl(response)->response()));
 }
 
 WKFrameInfoRef WKNavigationResponseCopyFrameInfo(WKNavigationResponseRef response)
 {
     Ref frame = WebKit::toImpl(response)->frame();
-    return WebKit::toAPI(&frame.leakRef());
+    return WebKit::toAPILeakingRef(WTFMove(frame));
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
@@ -41,7 +41,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNavigation.class, self))
         return;
 
-    _navigation->~Navigation();
+    Ref { *_navigation }->~Navigation();
 
     [super dealloc];
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm
@@ -105,12 +105,12 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKFrameInfo *)sourceFrame
 {
-    return wrapper(_navigationAction->sourceFrame());
+    return wrapper(Ref { *_navigationAction }->sourceFrame());
 }
 
 - (WKFrameInfo *)targetFrame
 {
-    return wrapper(_navigationAction->targetFrame());
+    return wrapper(_navigationAction->protectedTargetFrame().get());
 }
 
 - (WKNavigationType)navigationType
@@ -179,7 +179,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (NSURL *)_originalURL
 {
-    return _navigationAction->originalURL();
+    return Ref { *_navigationAction }->originalURL();
 }
 
 - (BOOL)_isUserInitiated
@@ -214,7 +214,7 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (_WKUserInitiatedAction *)_userInitiatedAction
 {
-    return wrapper(_navigationAction->userInitiatedAction());
+    return wrapper(_navigationAction->protectedUserInitiatedAction().get());
 }
 
 - (BOOL)_isRedirect
@@ -224,25 +224,25 @@ static WKSyntheticClickType toWKSyntheticClickType(WebKit::WebMouseEventSyntheti
 
 - (WKNavigation *)_mainFrameNavigation
 {
-    return wrapper(_navigationAction->mainFrameNavigation());
+    return wrapper(_navigationAction->protectedMainFrameNavigation().get());
 }
 
 
 - (void)_storeSKAdNetworkAttribution
 {
-    auto* mainFrameNavigation = _navigationAction->mainFrameNavigation();
+    RefPtr mainFrameNavigation = _navigationAction->mainFrameNavigation();
     if (!mainFrameNavigation)
         return;
     auto& privateClickMeasurement = mainFrameNavigation->privateClickMeasurement();
     if (!privateClickMeasurement || !privateClickMeasurement->isSKAdNetworkAttribution())
         return;
-    auto* sourceFrame = _navigationAction->sourceFrame();
+    RefPtr sourceFrame = _navigationAction->sourceFrame();
     if (!sourceFrame)
         return;
-    auto* page = sourceFrame->page();
+    RefPtr page = sourceFrame->page();
     if (!page)
         return;
-    page->websiteDataStore().storePrivateClickMeasurement(*privateClickMeasurement);
+    page->protectedWebsiteDataStore()->storePrivateClickMeasurement(*privateClickMeasurement);
 }
 
 - (_WKHitTestResult *)_hitTestResult

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm
@@ -40,7 +40,7 @@
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKNavigationData.class, self))
         return;
 
-    _data->~NavigationData();
+    Ref { *_data }->~NavigationData();
 
     [super dealloc];
 }


### PR DESCRIPTION
#### 247f0b232a2904ac04e57c2680641f1817a5610d
<pre>
Address safer C++ static analysis warnings in WKNavigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=287975">https://bugs.webkit.org/show_bug.cgi?id=287975</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPILeakingRef):
* Source/WebKit/UIProcess/API/APINavigationAction.h:
* Source/WebKit/UIProcess/API/C/WKNavigationActionRef.cpp:
(WKNavigationActionCopyRequest):
(WKNavigationActionCopyTargetFrameInfo):
* Source/WebKit/UIProcess/API/C/WKNavigationDataRef.cpp:
(WKNavigationDataCopyOriginalRequest):
* Source/WebKit/UIProcess/API/C/WKNavigationResponseRef.cpp:
(WKNavigationResponseCopyResponse):
(WKNavigationResponseCopyFrameInfo):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm:
(-[WKNavigation dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationAction.mm:
(-[WKNavigationAction sourceFrame]):
(-[WKNavigationAction targetFrame]):
(-[WKNavigationAction _originalURL]):
(-[WKNavigationAction _userInitiatedAction]):
(-[WKNavigationAction _mainFrameNavigation]):
(-[WKNavigationAction _storeSKAdNetworkAttribution]):
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm:
(-[WKNavigationData dealloc]):

Canonical link: <a href="https://commits.webkit.org/290662@main">https://commits.webkit.org/290662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c82145cb3eecb6982184ce08724c96d7a879287a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90751 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/10288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45697 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18605 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93752 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37732 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/17946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78115 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19270 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/17955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->