### PR TITLE
[macOS] Add a vector-based version of range inputs

### DIFF
--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -315,7 +315,7 @@ accentcolortext
 -apple-system-find-highlight-background enable-if=WTF_PLATFORM_MAC
 -apple-system-indigo enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-teal enable-if=WTF_PLATFORM_IOS_FAMILY
--apple-system-opaque-fill enable-if=WTF_PLATFORM_IOS_FAMILY
+-apple-system-opaque-fill enable-if=WTF_PLATFORM_COCOA
 -apple-system-opaque-secondary-fill enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-opaque-secondary-fill-disabled enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-opaque-tertiary-fill enable-if=WTF_PLATFORM_IOS_FAMILY

--- a/Source/WebCore/css/parser/CSSParserIdioms.cpp
+++ b/Source/WebCore/css/parser/CSSParserIdioms.cpp
@@ -45,6 +45,9 @@ bool isColorKeywordAllowedInMode(CSSValueID id, CSSParserMode mode)
 #if PLATFORM(IOS_FAMILY)
     case CSSValueAppleSystemQuaternaryFill:
 #endif
+#if PLATFORM(MAC)
+    case CSSValueAppleSystemOpaqueFill:
+#endif
     case CSSValueInternalDocumentTextColor:
         return isUASheetBehavior(mode);
     default:

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -49,6 +49,8 @@ protected:
     Color platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const override;
     Color platformGrammarMarkerColor(OptionSet<StyleColorOptions>) const override;
 
+    Color controlTintColor(const RenderStyle&, OptionSet<StyleColorOptions>) const;
+
     void adjustCheckboxStyle(RenderStyle&, const Element*) const override;
     bool paintCheckbox(const RenderObject&, const PaintInfo&, const FloatRect&) override;
 
@@ -91,6 +93,7 @@ protected:
     void adjustSliderTrackStyle(RenderStyle&, const Element*) const override;
     bool paintSliderTrack(const RenderObject&, const PaintInfo&, const IntRect&) override;
 
+    void adjustSliderThumbSize(RenderStyle&, const Element*) const override;
     void adjustSliderThumbStyle(RenderStyle&, const Element*) const override;
     bool paintSliderThumb(const RenderObject&, const PaintInfo&, const IntRect&) override;
 

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -28,15 +28,20 @@
 
 #import "AttachmentLayout.h"
 #import "CaretRectComputation.h"
+#import "ColorBlending.h"
 #import "DrawGlyphsRecorder.h"
 #import "FloatRoundedRect.h"
 #import "FontCacheCoreText.h"
 #import "GraphicsContextCG.h"
+#import "HTMLDataListElement.h"
 #import "HTMLInputElement.h"
+#import "HTMLOptionElement.h"
 #import "ImageBuffer.h"
 #import "Page.h"
 #import "RenderProgress.h"
+#import "RenderSlider.h"
 #import "RenderText.h"
+#import "TypedElementDescendantIteratorInlines.h"
 #import "UserAgentScripts.h"
 #import "UserAgentStyleSheets.h"
 #import <CoreGraphics/CoreGraphics.h>
@@ -291,6 +296,14 @@ Color RenderThemeCocoa::platformGrammarMarkerColor(OptionSet<StyleColorOptions> 
         return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
 #endif
     return useDarkMode ? SRGBA<uint8_t> { 50, 215, 75, 217 } : SRGBA<uint8_t> { 25, 175, 50, 191 };
+}
+
+Color RenderThemeCocoa::controlTintColor(const RenderStyle& style, OptionSet<StyleColorOptions> options) const
+{
+    if (!style.hasAutoAccentColor())
+        return style.usedAccentColor(options);
+
+    return systemColor(CSSValueAppleSystemBlue, options);
 }
 
 #if USE(APPLE_INTERNAL_SDK)
@@ -585,6 +598,16 @@ bool RenderThemeCocoa::paintSliderTrack(const RenderObject& box, const PaintInfo
 #endif
 
     return RenderTheme::paintSliderTrack(box, paintInfo, rect);
+}
+
+void RenderThemeCocoa::adjustSliderThumbSize(RenderStyle& style, const Element* element) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (adjustSliderThumbSizeForVectorBasedControls(style, element))
+        return;
+#endif
+
+    RenderTheme::adjustSliderThumbSize(style, element);
 }
 
 void RenderThemeCocoa::adjustSliderThumbStyle(RenderStyle& style, const Element* element) const

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.h
@@ -190,8 +190,6 @@ private:
 
     Color pictureFrameColor(const RenderObject&) override;
 
-    Color controlTintColor(const RenderStyle&, OptionSet<StyleColorOptions>) const;
-
     void adjustMinimumIntrinsicSizeForAppearance(StyleAppearance, RenderStyle&) const;
 };
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -603,11 +603,13 @@ const int kDefaultSliderThumbSize = 16;
 void RenderThemeIOS::adjustSliderTrackStyle(RenderStyle& style, const Element* element) const
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
-    if (adjustSliderTrackStyleForCatalyst(style, element))
+    if (element && element->document().settings().macStyleControlsOnCatalyst()) {
+        RenderThemeCocoa::adjustSliderTrackStyle(style, element);
         return;
+    }
 #endif
 
-    RenderThemeCocoa::adjustSliderTrackStyle(style, element);
+    RenderTheme::adjustSliderTrackStyle(style, element);
 
     // FIXME: We should not be relying on border radius for the appearance of our controls <rdar://problem/7675493>.
     int radius = static_cast<int>(kTrackRadius);
@@ -619,8 +621,8 @@ constexpr auto nativeControlBorderInlineSize = 1.0f;
 bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
-    if (paintSliderTrackForCatalyst(box, paintInfo, rect))
-        return false;
+    if (box.settings().macStyleControlsOnCatalyst())
+        return RenderThemeCocoa::paintSliderTrack(box, paintInfo, rect);
 #endif
 
     auto* renderSlider = dynamicDowncast<RenderSlider>(box);
@@ -698,8 +700,10 @@ bool RenderThemeIOS::paintSliderTrack(const RenderObject& box, const PaintInfo& 
 void RenderThemeIOS::adjustSliderThumbSize(RenderStyle& style, const Element* element) const
 {
 #if ENABLE(MAC_STYLE_CONTROLS_ON_CATALYST)
-    if (adjustSliderThumbSizeForCatalyst(style, element))
+    if (element && element->document().settings().macStyleControlsOnCatalyst()) {
+        RenderThemeCocoa::adjustSliderThumbSize(style, element);
         return;
+    }
 #else
     UNUSED_PARAM(element);
 #endif
@@ -1280,14 +1284,6 @@ Color RenderThemeIOS::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
 Color RenderThemeIOS::pictureFrameColor(const RenderObject& buttonRenderer)
 {
     return buttonRenderer.style().visitedDependentColor(CSSPropertyBorderTopColor);
-}
-
-Color RenderThemeIOS::controlTintColor(const RenderStyle& style, OptionSet<StyleColorOptions> options) const
-{
-    if (!style.hasAutoAccentColor())
-        return style.usedAccentColor(options);
-
-    return systemColor(CSSValueAppleSystemBlue, options);
 }
 
 #if ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -591,6 +591,8 @@ Color RenderThemeMac::systemColor(CSSValueID cssValueID, OptionSet<StyleColorOpt
             case CSSValueAppleSystemQuaternaryLabel:
                 return @selector(quaternaryLabelColor);
 #if HAVE(NSCOLOR_FILL_COLOR_HIERARCHY)
+            case CSSValueAppleSystemOpaqueFill:
+                return @selector(systemFillColor);
             case CSSValueAppleSystemTertiaryFill:
                 return @selector(tertiarySystemFillColor);
 #endif
@@ -1085,8 +1087,9 @@ int RenderThemeMac::minimumMenuListSize(const RenderStyle& style) const
     return sizeForSystemFont(style, menuListSizes()).width();
 }
 
-void RenderThemeMac::adjustSliderTrackStyle(RenderStyle& style, const Element*) const
+void RenderThemeMac::adjustSliderTrackStyle(RenderStyle& style, const Element* element) const
 {
+    RenderThemeCocoa::adjustSliderTrackStyle(style, element);
     style.setBoxShadow(nullptr);
 }
 
@@ -1210,8 +1213,17 @@ int RenderThemeMac::sliderTickOffsetFromTrackCenter() const
 // However, the method currently returns an incorrect value, both with and without a control view associated with the cell.
 constexpr int sliderThumbThickness = 17;
 
-void RenderThemeMac::adjustSliderThumbSize(RenderStyle& style, const Element*) const
+void RenderThemeMac::adjustSliderThumbSize(RenderStyle& style, const Element* element) const
 {
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (element && element->document().settings().vectorBasedControlsOnMacEnabled()) {
+        RenderThemeCocoa::adjustSliderThumbSize(style, element);
+        return;
+    }
+#else
+    UNUSED_PARAM(element);
+#endif
+
     float zoomLevel = style.usedZoom();
     if (style.usedAppearance() == StyleAppearance::SliderThumbHorizontal || style.usedAppearance() == StyleAppearance::SliderThumbVertical) {
         style.setWidth(Length(static_cast<int>(sliderThumbThickness * zoomLevel), LengthType::Fixed));


### PR DESCRIPTION
#### 9bc0c01c3c8806c9c35c3e1695b0ca1eaf65f993
<pre>
[macOS] Add a vector-based version of range inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=287979">https://bugs.webkit.org/show_bug.cgi?id=287979</a>
<a href="https://rdar.apple.com/145151762">rdar://145151762</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebCore/css/CSSValueKeywords.in:

`-apple-system-opaque-fill` should be usable on macOS.

* Source/WebCore/css/parser/CSSParserIdioms.cpp:
(WebCore::isColorKeywordAllowedInMode):

`-apple-system-opaque-fill` should not be web-exposed.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:

Move `controlTintColor` to `RenderThemeCocoa` to share code.

* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::controlTintColor const):
(WebCore::RenderThemeCocoa::adjustSliderThumbSize const):
* Source/WebCore/rendering/ios/RenderThemeIOS.h:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:

Call into the shared implementation for Catalyst controls, since they should
match macOS.

(WebCore::RenderThemeIOS::adjustSliderTrackStyle const):
(WebCore::RenderThemeIOS::paintSliderTrack):
(WebCore::RenderThemeIOS::adjustSliderThumbSize const):
(WebCore::RenderThemeIOS::controlTintColor const): Deleted.
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::systemColor const):
(WebCore::RenderThemeMac::adjustSliderTrackStyle const):
(WebCore::RenderThemeMac::adjustSliderThumbSize const):

Canonical link: <a href="https://commits.webkit.org/290653@main">https://commits.webkit.org/290653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a409e1e9d1f4fd304f2abf0d91a91d66f43dda6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95679 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69776 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27320 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50118 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36607 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40579 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17859 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78798 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/77995 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21063 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14286 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23211 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21063 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->