### PR TITLE
Store a per-origin salt for use with MediaKeys

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/CDM.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.cpp
@@ -59,23 +59,24 @@ bool CDM::supportsKeySystem(const String& keySystem)
     return false;
 }
 
-Ref<CDM> CDM::create(Document& document, const String& keySystem)
+Ref<CDM> CDM::create(Document& document, const String& keySystem, const String& mediaKeysHashSalt)
 {
-    return adoptRef(*new CDM(document, keySystem));
+    return adoptRef(*new CDM(document, keySystem, mediaKeysHashSalt));
 }
 
-CDM::CDM(Document& document, const String& keySystem)
+CDM::CDM(Document& document, const String& keySystem, const String& mediaKeysHashSalt)
     : ContextDestructionObserver(&document)
 #if !RELEASE_LOG_DISABLED
     , m_logger(document.logger())
     , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 #endif
     , m_keySystem(keySystem)
+    , m_mediaKeysHashSalt { mediaKeysHashSalt }
 {
     ASSERT(supportsKeySystem(keySystem));
     for (auto* factory : CDMFactory::registeredFactories()) {
         if (factory->supportsKeySystem(keySystem)) {
-            m_private = factory->createCDM(keySystem, *this);
+            m_private = factory->createCDM(keySystem, m_mediaKeysHashSalt, *this);
 #if !RELEASE_LOG_DISABLED
             m_private->setLogIdentifier(m_logIdentifier);
 #endif

--- a/Source/WebCore/Modules/encryptedmedia/CDM.h
+++ b/Source/WebCore/Modules/encryptedmedia/CDM.h
@@ -59,7 +59,7 @@ public:
     static bool supportsKeySystem(const String&);
     static bool isPersistentType(MediaKeySessionType);
 
-    static Ref<CDM> create(Document&, const String& keySystem);
+    static Ref<CDM> create(Document&, const String& keySystem, const String& mediaKeysHashSalt);
     ~CDM();
 
     using SupportedConfigurationCallback = Function<void(std::optional<MediaKeySystemConfiguration>)>;
@@ -82,19 +82,22 @@ public:
 
     String storageDirectory() const;
 
+    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
 #endif
 
 private:
-    CDM(Document&, const String& keySystem);
+    CDM(Document&, const String& keySystem, const String& mediaKeysHashSalt);
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
 #endif
     String m_keySystem;
+    String m_mediaKeysHashSalt;
     std::unique_ptr<CDMPrivate> m_private;
 };
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -57,7 +57,7 @@ MediaKeySystemRequest::MediaKeySystemRequest(Document& document, const String& k
 MediaKeySystemRequest::~MediaKeySystemRequest()
 {
     if (m_allowCompletionHandler)
-        m_allowCompletionHandler(WTFMove(m_promise));
+        m_allowCompletionHandler({ }, WTFMove(m_promise));
 }
 
 SecurityOrigin* MediaKeySystemRequest::topLevelDocumentOrigin() const
@@ -85,14 +85,14 @@ void MediaKeySystemRequest::start()
     controller->requestMediaKeySystem(*this);
 }
 
-void MediaKeySystemRequest::allow()
+void MediaKeySystemRequest::allow(String&& mediaKeysHashSalt)
 {
     if (!scriptExecutionContext())
         return;
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
+    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this, mediaKeysHashSalt = WTFMove(mediaKeysHashSalt)] () mutable {
         if (auto allowCompletionHandler = std::exchange(m_allowCompletionHandler, { }))
-            allowCompletionHandler(WTFMove(m_promise));
+            allowCompletionHandler(WTFMove(mediaKeysHashSalt), WTFMove(m_promise));
     });
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h
@@ -51,10 +51,10 @@ public:
     WEBCORE_EXPORT static Ref<MediaKeySystemRequest> create(Document&, const String& keySystem, Ref<DeferredPromise>&&);
     virtual ~MediaKeySystemRequest();
 
-    void setAllowCallback(CompletionHandler<void(Ref<DeferredPromise>&&)>&& callback) { m_allowCompletionHandler = WTFMove(callback); }
+    void setAllowCallback(CompletionHandler<void(String&& mediaKeysHashSalt, Ref<DeferredPromise>&&)>&& callback) { m_allowCompletionHandler = WTFMove(callback); }
     WEBCORE_EXPORT void start();
 
-    WEBCORE_EXPORT void allow();
+    WEBCORE_EXPORT void allow(String&& mediaKeysHashSalt);
     WEBCORE_EXPORT void deny(const String& errorMessage = emptyString());
 
     WEBCORE_EXPORT SecurityOrigin* topLevelDocumentOrigin() const;
@@ -71,7 +71,7 @@ private:
     String m_keySystem;
     Ref<DeferredPromise> m_promise;
 
-    CompletionHandler<void(Ref<DeferredPromise>&&)> m_allowCompletionHandler;
+    CompletionHandler<void(String&&, Ref<DeferredPromise>&&)> m_allowCompletionHandler;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -104,14 +104,14 @@ void NavigatorEME::requestMediaKeySystemAccess(Navigator& navigator, Document& d
     }
 
     auto request = MediaKeySystemRequest::create(document, keySystem, WTFMove(promise));
-    request->setAllowCallback([keySystem, supportedConfigurations = WTFMove(supportedConfigurations), weakDocument = WeakPtr { document }, logger = WTFMove(logger), identifier = WTFMove(identifier)](Ref<DeferredPromise>&& promise) mutable {
+    request->setAllowCallback([keySystem, supportedConfigurations = WTFMove(supportedConfigurations), weakDocument = WeakPtr { document }, logger = WTFMove(logger), identifier = WTFMove(identifier)](String&& mediaKeysHashSalt, Ref<DeferredPromise>&& promise) mutable {
         RefPtr document = weakDocument.get();
         if (!document) {
             promise->reject(ExceptionCode::InvalidStateError);
             return;
         }
 
-        document->postTask([promise = WTFMove(promise), keySystem, logger = WTFMove(logger), identifier = WTFMove(identifier), supportedConfigurations = WTFMove(supportedConfigurations)] (ScriptExecutionContext& context) mutable {
+        document->postTask([promise = WTFMove(promise), keySystem, logger = WTFMove(logger), identifier = WTFMove(identifier), supportedConfigurations = WTFMove(supportedConfigurations), mediaKeysHashSalt = WTFMove(mediaKeysHashSalt)] (ScriptExecutionContext& context) mutable {
             // 3. Let document be the calling context's Document.
             // 4. Let origin be the origin of document.
             // 5. Let promise be a new promise.
@@ -126,7 +126,7 @@ void NavigatorEME::requestMediaKeySystemAccess(Navigator& navigator, Document& d
 
             // 6.2. Let implementation be the implementation of keySystem.
             auto& document = downcast<Document>(context);
-            auto implementation = CDM::create(document, keySystem);
+            auto implementation = CDM::create(document, keySystem, mediaKeysHashSalt);
             tryNextSupportedConfiguration(document, WTFMove(implementation), WTFMove(supportedConfigurations), WTFMove(promise), WTFMove(logger), WTFMove(identifier));
         });
     });

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -438,6 +438,11 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVSampleBufferDisplayL
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
 #define AVSampleBufferAttachContentKey PAL::softLink_AVFoundation_AVSampleBufferAttachContentKey
 
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVContentKeyRequestShouldRandomizeDeviceIdentifierKey, NSString *)
+#define AVContentKeyRequestShouldRandomizeDeviceIdentifierKey PAL::get_AVFoundation_AVContentKeyRequestShouldRandomizeDeviceIdentifierKey()
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_HEADER(PAL, AVFoundation, AVContentKeyRequestRandomDeviceIdentifierSeedKey, NSString *)
+#define AVContentKeyRequestRandomDeviceIdentifierSeedKey PAL::get_AVFoundation_AVContentKeyRequestRandomDeviceIdentifierSeedKey()
+
 SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferAudioRenderer, PAL::getAVSampleBufferAudioRendererClass())
 SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferDisplayLayer, PAL::getAVSampleBufferDisplayLayerClass())
 SPECIALIZE_OBJC_TYPE_TRAITS(AVSampleBufferVideoRenderer, PAL::getAVSampleBufferVideoRendererClass())

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
@@ -311,4 +311,7 @@ SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVSampleBu
 
 SOFT_LINK_FUNCTION_FOR_SOURCE(PAL, AVFoundation, AVSampleBufferAttachContentKey, BOOL, (CMSampleBufferRef sbuf, AVContentKey *contentKey, NSError **outError), (sbuf, contentKey, outError))
 
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVContentKeyRequestShouldRandomizeDeviceIdentifierKey, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_MAY_FAIL_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVContentKeyRequestRandomDeviceIdentifierSeedKey, NSString *, PAL_EXPORT)
+
 #endif // USE(AVFOUNDATION)

--- a/Source/WebCore/platform/encryptedmedia/CDMFactory.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMFactory.h
@@ -46,7 +46,7 @@ class CDMPrivateClient;
 class CDMFactory {
 public:
     virtual ~CDMFactory() { };
-    virtual std::unique_ptr<CDMPrivate> createCDM(const String&, const CDMPrivateClient&) = 0;
+    virtual std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) = 0;
     virtual bool supportsKeySystem(const String&) = 0;
 
     WEBCORE_EXPORT static Vector<CDMFactory*>& registeredFactories();

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp
@@ -258,9 +258,10 @@ CDMFactoryClearKey& CDMFactoryClearKey::singleton()
 CDMFactoryClearKey::CDMFactoryClearKey() = default;
 CDMFactoryClearKey::~CDMFactoryClearKey() = default;
 
-std::unique_ptr<CDMPrivate> CDMFactoryClearKey::createCDM(const String& keySystem, const CDMPrivateClient&)
+std::unique_ptr<CDMPrivate> CDMFactoryClearKey::createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&)
 {
     ASSERT_UNUSED(keySystem, supportsKeySystem(keySystem));
+    UNUSED_PARAM(mediaKeysHashSalt);
     return makeUnique<CDMPrivateClearKey>();
 }
 

--- a/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
+++ b/Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h
@@ -60,7 +60,7 @@ public:
 
     virtual ~CDMFactoryClearKey();
 
-    std::unique_ptr<CDMPrivate> createCDM(const String&, const CDMPrivateClient&) final;
+    std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) final;
     bool supportsKeySystem(const String&) final;
 
 private:

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -297,12 +297,12 @@ CDMFactoryFairPlayStreaming& CDMFactoryFairPlayStreaming::singleton()
 CDMFactoryFairPlayStreaming::CDMFactoryFairPlayStreaming() = default;
 CDMFactoryFairPlayStreaming::~CDMFactoryFairPlayStreaming() = default;
 
-std::unique_ptr<CDMPrivate> CDMFactoryFairPlayStreaming::createCDM(const String& keySystem, const CDMPrivateClient& client)
+std::unique_ptr<CDMPrivate> CDMFactoryFairPlayStreaming::createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient& client)
 {
     if (!supportsKeySystem(keySystem))
         return nullptr;
 
-    return makeUnique<CDMPrivateFairPlayStreaming>(client);
+    return makeUnique<CDMPrivateFairPlayStreaming>(mediaKeysHashSalt, client);
 }
 
 bool CDMFactoryFairPlayStreaming::supportsKeySystem(const String& keySystem)
@@ -312,9 +312,10 @@ bool CDMFactoryFairPlayStreaming::supportsKeySystem(const String& keySystem)
     return keySystem == "com.apple.fps"_s || keySystem.startsWith("com.apple.fps."_s);
 }
 
-CDMPrivateFairPlayStreaming::CDMPrivateFairPlayStreaming(const CDMPrivateClient& client)
+CDMPrivateFairPlayStreaming::CDMPrivateFairPlayStreaming(const String& mediaKeysHashSalt, const CDMPrivateClient& client)
+    : m_mediaKeysHashSalt { mediaKeysHashSalt }
 #if !RELEASE_LOG_DISABLED
-    : m_logger(client.logger())
+    , m_logger { client.logger() }
 #endif
 {
 }

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~CDMFactoryFairPlayStreaming();
 
-    std::unique_ptr<CDMPrivate> createCDM(const String&, const CDMPrivateClient&) override;
+    std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) override;
     bool supportsKeySystem(const String&) override;
 
 private:
@@ -55,7 +55,7 @@ private:
 class CDMPrivateFairPlayStreaming final : public CDMPrivate {
     WTF_MAKE_TZONE_ALLOCATED(CDMPrivateFairPlayStreaming);
 public:
-    CDMPrivateFairPlayStreaming(const CDMPrivateClient&);
+    CDMPrivateFairPlayStreaming(const String& mediaKeysHashSalt, const CDMPrivateClient&);
     virtual ~CDMPrivateFairPlayStreaming();
 
 #if !RELEASE_LOG_DISABLED
@@ -102,7 +102,11 @@ public:
     static Vector<Ref<SharedBuffer>> keyIDsForRequest(AVContentKeyRequest *);
 #endif
 
+    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
+
 private:
+    String m_mediaKeysHashSalt;
+
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h
@@ -157,6 +157,8 @@ public:
     ASCIILiteral logClassName() const { return "CDMInstanceFairPlayStreamingAVFObjC"_s; }
 #endif
 
+    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
+
 private:
     void handleUnexpectedRequests(Vector<RetainPtr<AVContentKeyRequest>>&&);
 
@@ -169,6 +171,8 @@ private:
     Vector<WeakPtr<CDMInstanceSessionFairPlayStreamingAVFObjC>> m_sessions;
     UncheckedKeyHashSet<RetainPtr<AVContentKeyRequest>> m_unexpectedKeyRequests;
     WeakHashSet<KeyStatusesChangedObserver> m_keyStatusChangedObservers;
+    String m_mediaKeysHashSalt;
+
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     uint64_t m_logIdentifier { 0 };

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.cpp
@@ -106,8 +106,9 @@ CDMFactoryThunder& CDMFactoryThunder::singleton()
     return s_factory;
 }
 
-std::unique_ptr<CDMPrivate> CDMFactoryThunder::createCDM(const String& keySystem, const CDMPrivateClient&)
+std::unique_ptr<CDMPrivate> CDMFactoryThunder::createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&)
 {
+    UNUSED_PARAM(mediaKeysHashSalt);
     ASSERT(supportsKeySystem(keySystem));
     return makeUnique<CDMPrivateThunder>(keySystem);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMThunder.h
@@ -60,7 +60,7 @@ public:
 
     virtual ~CDMFactoryThunder() = default;
 
-    std::unique_ptr<CDMPrivate> createCDM(const String&, const CDMPrivateClient&) final;
+    std::unique_ptr<CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&) final;
     RefPtr<CDMProxy> createCDMProxy(const String&) final;
     bool supportsKeySystem(const String&) final;
     const Vector<String>& supportedKeySystems() const;

--- a/Source/WebCore/testing/MockCDMFactory.cpp
+++ b/Source/WebCore/testing/MockCDMFactory.cpp
@@ -116,13 +116,14 @@ void MockCDMFactory::setSupportedDataTypes(Vector<String>&& types)
         m_supportedDataTypes.append(type);
 }
 
-std::unique_ptr<CDMPrivate> MockCDMFactory::createCDM(const String&, const CDMPrivateClient&)
+std::unique_ptr<CDMPrivate> MockCDMFactory::createCDM(const String&, const String& mediaKeysHashSalt, const CDMPrivateClient&)
 {
-    return makeUnique<MockCDM>(*this);
+    return makeUnique<MockCDM>(*this, mediaKeysHashSalt);
 }
 
-MockCDM::MockCDM(WeakPtr<MockCDMFactory> factory)
+MockCDM::MockCDM(WeakPtr<MockCDMFactory> factory, const String& mediaKeysHashSalt)
     : m_factory(WTFMove(factory))
+    , m_mediaKeysHashSalt { mediaKeysHashSalt }
 {
 }
 

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -93,7 +93,7 @@ public:
 
 private:
     MockCDMFactory();
-    std::unique_ptr<CDMPrivate> createCDM(const String&, const CDMPrivateClient&) final;
+    std::unique_ptr<CDMPrivate> createCDM(const String&, const String& mediaKeysHashSalt, const CDMPrivateClient&) final;
     bool supportsKeySystem(const String&) final;
 
     MediaKeysRequirement m_distinctiveIdentifiersRequirement { MediaKeysRequirement::Optional };
@@ -112,9 +112,10 @@ private:
 class MockCDM : public CDMPrivate {
     WTF_MAKE_TZONE_ALLOCATED(MockCDM);
 public:
-    MockCDM(WeakPtr<MockCDMFactory>);
+    MockCDM(WeakPtr<MockCDMFactory>, const String&);
 
     MockCDMFactory* factory() { return m_factory.get(); }
+    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
 
 private:
     friend class MockCDMInstance;
@@ -136,6 +137,7 @@ private:
     std::optional<String> sanitizeSessionId(const String&) const final;
 
     WeakPtr<MockCDMFactory> m_factory;
+    String m_mediaKeysHashSalt;
 };
 
 class MockCDMInstance : public CDMInstance, public CanMakeWeakPtr<MockCDMInstance> {

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp
@@ -67,7 +67,7 @@ static CDMFactory* factoryForKeySystem(const String& keySystem)
     return factories[foundIndex];
 }
 
-void RemoteCDMFactoryProxy::createCDM(const String& keySystem, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&& completion)
+void RemoteCDMFactoryProxy::createCDM(const String& keySystem, const String& mediaKeysHashSalt, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&& completion)
 {
     auto factory = factoryForKeySystem(keySystem);
     if (!factory) {
@@ -75,7 +75,7 @@ void RemoteCDMFactoryProxy::createCDM(const String& keySystem, CompletionHandler
         return;
     }
 
-    auto privateCDM = factory->createCDM(keySystem, *this);
+    auto privateCDM = factory->createCDM(keySystem, mediaKeysHashSalt, *this);
     if (!privateCDM) {
         completion(std::nullopt, { });
         return;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h
@@ -99,7 +99,7 @@ private:
     bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     // Messages
-    void createCDM(const String& keySystem, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&&);
+    void createCDM(const String& keySystem, const String& mediaKeysHashSalt, CompletionHandler<void(std::optional<RemoteCDMIdentifier>&&, RemoteCDMConfiguration&&)>&&);
     void supportsKeySystem(const String& keySystem, CompletionHandler<void(bool)>&&);
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in
@@ -31,7 +31,7 @@
     EnabledBy=EncryptedMediaAPIEnabled
 ]
 messages -> RemoteCDMFactoryProxy {
-    CreateCDM(String keySystem) -> (std::optional<WebKit::RemoteCDMIdentifier> identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
+    CreateCDM(String keySystem, String mediaKeysHashSalt) -> (std::optional<WebKit::RemoteCDMIdentifier> identifier, struct WebKit::RemoteCDMConfiguration configuration) Synchronous
     SupportsKeySystem(String keySystem) -> (bool result) Synchronous
     RemoveInstance(WebKit::RemoteCDMInstanceIdentifier identifier)
     RemoveSession(WebKit::RemoteCDMInstanceSessionIdentifier identifier)

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h
@@ -52,7 +52,7 @@ public:
 
     void invalidatePendingRequests();
 
-    Ref<MediaKeySystemPermissionRequestProxy> createRequestForFrame(WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem);
+    void createRequestForFrame(WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& mediaKeyRequestOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem, CompletionHandler<void(Ref<MediaKeySystemPermissionRequestProxy>&&)>&&);
 
     void grantRequest(MediaKeySystemPermissionRequestProxy&);
     void denyRequest(MediaKeySystemPermissionRequestProxy&, const String& message = { });

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.cpp
@@ -35,11 +35,12 @@
 namespace WebKit {
 using namespace WebCore;
 
-MediaKeySystemPermissionRequestProxy::MediaKeySystemPermissionRequestProxy(MediaKeySystemPermissionRequestManagerProxy& manager, MediaKeySystemRequestIdentifier mediaKeySystemID, FrameIdentifier mainFrameID, FrameIdentifier frameID, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem)
+MediaKeySystemPermissionRequestProxy::MediaKeySystemPermissionRequestProxy(MediaKeySystemPermissionRequestManagerProxy& manager, MediaKeySystemRequestIdentifier mediaKeySystemID, FrameIdentifier mainFrameID, FrameIdentifier frameID, Ref<WebCore::SecurityOrigin>&& userMediaSecurityOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem)
     : m_manager(manager)
     , m_mediaKeySystemID(mediaKeySystemID)
     , m_mainFrameID(mainFrameID)
     , m_frameID(frameID)
+    , m_mediaKeyRequestSecurityOrigin(WTFMove(userMediaSecurityOrigin))
     , m_topLevelDocumentSecurityOrigin(WTFMove(topLevelDocumentOrigin))
     , m_keySystem(keySystem)
 {

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h
@@ -43,9 +43,9 @@ class MediaKeySystemPermissionRequestManagerProxy;
 
 class MediaKeySystemPermissionRequestProxy : public RefCounted<MediaKeySystemPermissionRequestProxy> {
 public:
-    static Ref<MediaKeySystemPermissionRequestProxy> create(MediaKeySystemPermissionRequestManagerProxy& manager, WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier frameID, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem)
+    static Ref<MediaKeySystemPermissionRequestProxy> create(MediaKeySystemPermissionRequestManagerProxy& manager, WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier frameID, Ref<WebCore::SecurityOrigin>&& mediaOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem)
     {
-        return adoptRef(*new MediaKeySystemPermissionRequestProxy(manager, mediaKeySystemID, mainFrameID, frameID, WTFMove(topLevelDocumentOrigin), keySystem));
+        return adoptRef(*new MediaKeySystemPermissionRequestProxy(manager, mediaKeySystemID, mainFrameID, frameID, WTFMove(mediaOrigin), WTFMove(topLevelDocumentOrigin), keySystem));
     }
 
     void allow();
@@ -57,22 +57,30 @@ public:
     WebCore::FrameIdentifier mainFrameID() const { return m_mainFrameID; }
     WebCore::FrameIdentifier frameID() const { return m_frameID; }
 
+    WebCore::SecurityOrigin& mediaKeyRequestSecurityOrigin() { return m_mediaKeyRequestSecurityOrigin.get(); }
+    const WebCore::SecurityOrigin& mediaKeyRequestSecurityOrigin() const { return m_mediaKeyRequestSecurityOrigin.get(); }
+
     WebCore::SecurityOrigin& topLevelDocumentSecurityOrigin() { return m_topLevelDocumentSecurityOrigin.get(); }
     const WebCore::SecurityOrigin& topLevelDocumentSecurityOrigin() const { return m_topLevelDocumentSecurityOrigin.get(); }
 
     const String& keySystem() const { return m_keySystem; }
 
+    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
+    void setMediaKeysHashSalt(String&& salt) { m_mediaKeysHashSalt = WTFMove(salt); }
+
     void doDefaultAction();
 
 private:
-    MediaKeySystemPermissionRequestProxy(MediaKeySystemPermissionRequestManagerProxy&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem);
+    MediaKeySystemPermissionRequestProxy(MediaKeySystemPermissionRequestManagerProxy&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier mainFrameID, WebCore::FrameIdentifier, Ref<WebCore::SecurityOrigin>&& userMediaSecurityOrigin, Ref<WebCore::SecurityOrigin>&& topLevelDocumentOrigin, const String& keySystem);
 
     WeakPtr<MediaKeySystemPermissionRequestManagerProxy> m_manager;
     WebCore::MediaKeySystemRequestIdentifier m_mediaKeySystemID;
     WebCore::FrameIdentifier m_mainFrameID;
     WebCore::FrameIdentifier m_frameID;
+    Ref<WebCore::SecurityOrigin> m_mediaKeyRequestSecurityOrigin;
     Ref<WebCore::SecurityOrigin> m_topLevelDocumentSecurityOrigin;
     String m_keySystem;
+    String m_mediaKeysHashSalt;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2846,7 +2846,7 @@ private:
     MediaKeySystemPermissionRequestManagerProxy& mediaKeySystemPermissionRequestManager();
     Ref<MediaKeySystemPermissionRequestManagerProxy> protectedMediaKeySystemPermissionRequestManager();
 #endif
-    void requestMediaKeySystemPermissionForFrame(IPC::Connection&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, const WebCore::SecurityOriginData& topLevelDocumentOriginIdentifier, const String&);
+    void requestMediaKeySystemPermissionForFrame(IPC::Connection&, WebCore::MediaKeySystemRequestIdentifier, WebCore::FrameIdentifier, WebCore::ClientOrigin&&, const String&);
 
     void runModal();
     void notifyScrollerThumbIsVisibleInRect(const WebCore::IntRect&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -311,7 +311,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    [EnabledBy=EncryptedMediaAPIEnabled] RequestMediaKeySystemPermissionForFrame(WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID, WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData topLevelDocumentOriginIdentifier, String keySystem)
+    [EnabledBy=EncryptedMediaAPIEnabled] RequestMediaKeySystemPermissionForFrame(WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID, WebCore::FrameIdentifier frameID, struct WebCore::ClientOrigin clientOrigin, String keySystem)
 #endif
 
     # Notification messages

--- a/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
+++ b/Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
@@ -526,6 +526,16 @@ String WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(const String& 
     return websiteDataDirectoryFileSystemRepresentation("DeviceIdHashSalts"_s);
 }
 
+#if ENABLE(ENCRYPTED_MEDIA)
+String WebsiteDataStore::defaultMediaKeysHashSaltsStorageDirectory(const String& baseDirectory)
+{
+    if (!baseDirectory.isEmpty())
+        return FileSystem::pathByAppendingComponent(baseDirectory, "MediaKeysHashSalts"_s);
+
+    return websiteDataDirectoryFileSystemRepresentation("MediaKeysHashSalts"_s);
+}
+#endif
+
 String WebsiteDataStore::defaultWebSQLDatabaseDirectory(const String& baseDirectory)
 {
     if (!baseDirectory.isEmpty())

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -298,6 +298,11 @@ public:
     DeviceIdHashSaltStorage& ensureDeviceIdHashSaltStorage();
     Ref<DeviceIdHashSaltStorage> ensureProtectedDeviceIdHashSaltStorage();
 
+#if ENABLE(ENCRYPTED_MEDIA)
+    DeviceIdHashSaltStorage& ensureMediaKeysHashSaltStorage();
+    Ref<DeviceIdHashSaltStorage> ensureProtectedMediaKeysHashSaltStorage();
+#endif
+
     WebsiteDataStoreParameters parameters();
     static Vector<WebsiteDataStoreParameters> parametersFromEachWebsiteDataStore();
 
@@ -387,6 +392,9 @@ public:
     static String defaultMediaCacheDirectory(const String& baseCacheDirectory = nullString());
     static String defaultMediaKeysStorageDirectory(const String& baseDataDirectory = nullString());
     static String defaultDeviceIdHashSaltsStorageDirectory(const String& baseDataDirectory = nullString());
+#if ENABLE(ENCRYPTED_MEDIA)
+    static String defaultMediaKeysHashSaltsStorageDirectory(const String& baseDataDirectory = nullString());
+#endif
     static String defaultJavaScriptConfigurationDirectory(const String& baseDataDirectory = nullString());
 
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -581,6 +589,9 @@ private:
     Ref<const WebsiteDataStoreConfiguration> m_configuration;
     bool m_hasResolvedDirectories { false };
     RefPtr<DeviceIdHashSaltStorage> m_deviceIdHashSaltStorage;
+#if ENABLE(ENCRYPTED_MEDIA)
+    RefPtr<DeviceIdHashSaltStorage> m_mediaKeysHashSaltStorage;
+#endif
 #if PLATFORM(IOS_FAMILY)
     String m_resolvedContainerCachesWebContentDirectory;
     String m_resolvedContainerCachesNetworkingDirectory;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -111,6 +111,9 @@ void WebsiteDataStoreConfiguration::initializePaths()
     setMediaKeysStorageDirectory(WebsiteDataStore::defaultMediaKeysStorageDirectory(m_baseDataDirectory));
     setResourceLoadStatisticsDirectory(WebsiteDataStore::defaultResourceLoadStatisticsDirectory(m_baseDataDirectory));
     setDeviceIdHashSaltsStorageDirectory(WebsiteDataStore::defaultDeviceIdHashSaltsStorageDirectory(m_baseDataDirectory));
+#if ENABLE(ENCRYPTED_MEDIA)
+    setMediaKeysHashSaltsStorageDirectory(WebsiteDataStore::defaultMediaKeysHashSaltsStorageDirectory(m_baseDataDirectory));
+#endif
     setJavaScriptConfigurationDirectory(WebsiteDataStore::defaultJavaScriptConfigurationDirectory(m_baseDataDirectory));
     setGeneralStorageDirectory(WebsiteDataStore::defaultGeneralStorageDirectory(m_baseDataDirectory));
 #if PLATFORM(COCOA)
@@ -191,6 +194,9 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
         crossThreadCopy(cacheStorageDirectory),
         crossThreadCopy(cookieStorageFile),
         crossThreadCopy(deviceIdHashSaltsStorageDirectory),
+#if ENABLE(ENCRYPTED_MEDIA)
+        crossThreadCopy(mediaKeysHashSaltsStorageDirectory),
+#endif
         crossThreadCopy(generalStorageDirectory),
         crossThreadCopy(hstsStorageDirectory),
         crossThreadCopy(indexedDBDatabaseDirectory),
@@ -221,6 +227,9 @@ WebsiteDataStoreConfiguration::Directories WebsiteDataStoreConfiguration::Direct
         crossThreadCopy(WTFMove(cacheStorageDirectory)),
         crossThreadCopy(WTFMove(cookieStorageFile)),
         crossThreadCopy(WTFMove(deviceIdHashSaltsStorageDirectory)),
+#if ENABLE(ENCRYPTED_MEDIA)
+        crossThreadCopy(WTFMove(mediaKeysHashSaltsStorageDirectory)),
+#endif
         crossThreadCopy(WTFMove(generalStorageDirectory)),
         crossThreadCopy(WTFMove(hstsStorageDirectory)),
         crossThreadCopy(WTFMove(indexedDBDatabaseDirectory)),

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -161,6 +161,11 @@ public:
     const String& deviceIdHashSaltsStorageDirectory() const { return m_directories.deviceIdHashSaltsStorageDirectory; }
     void setDeviceIdHashSaltsStorageDirectory(String&& directory) { m_directories.deviceIdHashSaltsStorageDirectory = WTFMove(directory); }
 
+#if ENABLE(ENCRYPTED_MEDIA)
+    const String& mediaKeysHashSaltsStorageDirectory() const { return m_directories.mediaKeysHashSaltsStorageDirectory; }
+    void setMediaKeysHashSaltsStorageDirectory(String&& directory) { m_directories.mediaKeysHashSaltsStorageDirectory = WTFMove(directory); }
+#endif
+
     const String& cookieStorageFile() const { return m_directories.cookieStorageFile; }
     void setCookieStorageFile(String&& directory) { m_directories.cookieStorageFile = WTFMove(directory); }
     
@@ -261,6 +266,9 @@ public:
         String cacheStorageDirectory;
         String cookieStorageFile;
         String deviceIdHashSaltsStorageDirectory;
+#if ENABLE(ENCRYPTED_MEDIA)
+        String mediaKeysHashSaltsStorageDirectory;
+#endif
         String generalStorageDirectory;
         String hstsStorageDirectory;
         String indexedDBDatabaseDirectory;

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -33,7 +33,7 @@
 #include "WebFrame.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
-#include <WebCore/Document.h>
+#include <WebCore/DocumentInlines.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/LocalFrame.h>
@@ -75,7 +75,13 @@ void MediaKeySystemPermissionRequestManager::startMediaKeySystemRequest(MediaKey
 
 void MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest(MediaKeySystemRequest& userRequest)
 {
-    auto* frame = userRequest.document() ? userRequest.document()->frame() : nullptr;
+    RefPtr document = userRequest.document();
+    if (!document) {
+        userRequest.deny(emptyString());
+        return;
+    }
+
+    RefPtr frame = document->frame();
     if (!frame) {
         userRequest.deny(emptyString());
         return;
@@ -86,8 +92,7 @@ void MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest(MediaKeyS
     auto webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
-    auto* topLevelDocumentOrigin = userRequest.topLevelDocumentOrigin();
-    Ref { m_page.get() }->send(Messages::WebPageProxy::RequestMediaKeySystemPermissionForFrame(userRequest.identifier(), webFrame->frameID(), topLevelDocumentOrigin->data(), userRequest.keySystem()));
+    Ref { m_page.get() }->send(Messages::WebPageProxy::RequestMediaKeySystemPermissionForFrame(userRequest.identifier(), webFrame->frameID(), document->clientOrigin(), userRequest.keySystem()));
 }
 
 void MediaKeySystemPermissionRequestManager::cancelMediaKeySystemRequest(MediaKeySystemRequest& request)
@@ -124,13 +129,13 @@ void MediaKeySystemPermissionRequestManager::mediaCanStart(Document& document)
         sendMediaKeySystemRequest(pendingRequest);
 }
 
-void MediaKeySystemPermissionRequestManager::mediaKeySystemWasGranted(MediaKeySystemRequestIdentifier requestID)
+void MediaKeySystemPermissionRequestManager::mediaKeySystemWasGranted(MediaKeySystemRequestIdentifier requestID, String&& mediaKeysHashSalt)
 {
     auto request = m_ongoingMediaKeySystemRequests.take(requestID);
     if (!request)
         return;
 
-    request->allow();
+    request->allow(WTFMove(mediaKeysHashSalt));
 }
 
 void MediaKeySystemPermissionRequestManager::mediaKeySystemWasDenied(MediaKeySystemRequestIdentifier requestID, String&& message)

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h
@@ -52,7 +52,7 @@ public:
 
     void startMediaKeySystemRequest(WebCore::MediaKeySystemRequest&);
     void cancelMediaKeySystemRequest(WebCore::MediaKeySystemRequest&);
-    void mediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier);
+    void mediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier, String&& mediaKeysHashSalt);
     void mediaKeySystemWasDenied(WebCore::MediaKeySystemRequestIdentifier, String&&);
 
 private:

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp
@@ -42,15 +42,16 @@ namespace WebKit {
 
 using namespace WebCore;
 
-std::unique_ptr<RemoteCDM> RemoteCDM::create(WeakPtr<RemoteCDMFactory>&& factory, RemoteCDMIdentifier&& identifier, RemoteCDMConfiguration&& configuration)
+std::unique_ptr<RemoteCDM> RemoteCDM::create(WeakPtr<RemoteCDMFactory>&& factory, RemoteCDMIdentifier&& identifier, RemoteCDMConfiguration&& configuration, const String& mediaKeysHashSalt)
 {
-    return std::unique_ptr<RemoteCDM>(new RemoteCDM(WTFMove(factory), WTFMove(identifier), WTFMove(configuration)));
+    return std::unique_ptr<RemoteCDM>(new RemoteCDM(WTFMove(factory), WTFMove(identifier), WTFMove(configuration), mediaKeysHashSalt));
 }
 
-RemoteCDM::RemoteCDM(WeakPtr<RemoteCDMFactory>&& factory, RemoteCDMIdentifier&& identifier, RemoteCDMConfiguration&& configuration)
+RemoteCDM::RemoteCDM(WeakPtr<RemoteCDMFactory>&& factory, RemoteCDMIdentifier&& identifier, RemoteCDMConfiguration&& configuration, const String& mediaKeysHashSalt)
     : m_factory(WTFMove(factory))
     , m_identifier(WTFMove(identifier))
     , m_configuration(WTFMove(configuration))
+    , m_mediaKeysHashSalt { mediaKeysHashSalt }
 {
 }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDM.h
@@ -37,11 +37,11 @@ namespace WebKit {
 
 class RemoteCDM final : public WebCore::CDMPrivate {
 public:
-    static std::unique_ptr<RemoteCDM> create(WeakPtr<RemoteCDMFactory>&&, RemoteCDMIdentifier&&, RemoteCDMConfiguration&&);
+    static std::unique_ptr<RemoteCDM> create(WeakPtr<RemoteCDMFactory>&&, RemoteCDMIdentifier&&, RemoteCDMConfiguration&&, const String& mediaKeysHashSalt);
     virtual ~RemoteCDM() = default;
 
 private:
-    RemoteCDM(WeakPtr<RemoteCDMFactory>&&, RemoteCDMIdentifier&&, RemoteCDMConfiguration&&);
+    RemoteCDM(WeakPtr<RemoteCDMFactory>&&, RemoteCDMIdentifier&&, RemoteCDMConfiguration&&, const String& mediaKeysHashSalt);
 
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(uint64_t) final;
@@ -69,6 +69,7 @@ private:
     WeakPtr<RemoteCDMFactory> m_factory;
     RemoteCDMIdentifier m_identifier;
     RemoteCDMConfiguration m_configuration;
+    String m_mediaKeysHashSalt;
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp
@@ -81,13 +81,13 @@ bool RemoteCDMFactory::supportsKeySystem(const String& keySystem)
     return supported;
 }
 
-std::unique_ptr<CDMPrivate> RemoteCDMFactory::createCDM(const String& keySystem, const CDMPrivateClient&)
+std::unique_ptr<CDMPrivate> RemoteCDMFactory::createCDM(const String& keySystem, const String& mediaKeysHashSalt, const CDMPrivateClient&)
 {
-    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteCDMFactoryProxy::CreateCDM(keySystem), { });
+    auto sendResult = gpuProcessConnection().connection().sendSync(Messages::RemoteCDMFactoryProxy::CreateCDM(keySystem, mediaKeysHashSalt), { });
     auto [identifier, configuration] = sendResult.takeReplyOr(std::nullopt, RemoteCDMConfiguration { });
     if (!identifier)
         return nullptr;
-    return RemoteCDM::create(*this, WTFMove(*identifier), WTFMove(configuration));
+    return RemoteCDM::create(*this, WTFMove(*identifier), WTFMove(configuration), mediaKeysHashSalt);
 }
 
 void RemoteCDMFactory::addSession(RemoteCDMInstanceSession& session)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h
@@ -78,7 +78,7 @@ public:
     void removeInstance(RemoteCDMInstanceIdentifier);
 
 private:
-    std::unique_ptr<WebCore::CDMPrivate> createCDM(const String&, const WebCore::CDMPrivateClient&) final;
+    std::unique_ptr<WebCore::CDMPrivate> createCDM(const String& keySystem, const String& mediaKeysHashSalt, const WebCore::CDMPrivateClient&) final;
     bool supportsKeySystem(const String&) final;
 
     WeakRef<WebProcess> m_webProcess;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5938,9 +5938,9 @@ Ref<MediaKeySystemPermissionRequestManager> WebPage::protectedMediaKeySystemPerm
     return m_mediaKeySystemPermissionRequestManager.get();
 }
 
-void WebPage::mediaKeySystemWasGranted(MediaKeySystemRequestIdentifier mediaKeySystemID)
+void WebPage::mediaKeySystemWasGranted(MediaKeySystemRequestIdentifier mediaKeySystemID, String&& mediaKeysHashSalt)
 {
-    protectedMediaKeySystemPermissionRequestManager()->mediaKeySystemWasGranted(mediaKeySystemID);
+    protectedMediaKeySystemPermissionRequestManager()->mediaKeySystemWasGranted(mediaKeySystemID, WTFMove(mediaKeysHashSalt));
 }
 
 void WebPage::mediaKeySystemWasDenied(MediaKeySystemRequestIdentifier mediaKeySystemID, String&& message)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2273,7 +2273,7 @@ private:
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    void mediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier);
+    void mediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier, String&& mediaKeysHashSalt);
     void mediaKeySystemWasDenied(WebCore::MediaKeySystemRequestIdentifier, String&& message);
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -434,7 +434,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    MediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID)
+    MediaKeySystemWasGranted(WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID, String mediaKeysHashSalt)
     MediaKeySystemWasDenied(WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID, String message)
 #endif
 

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm
@@ -46,7 +46,7 @@ void WebMediaKeySystemClient::requestMediaKeySystem(MediaKeySystemRequest& reque
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
-    request.allow();
+    request.allow({ });
 
     END_BLOCK_OBJC_EXCEPTIONS
 }


### PR DESCRIPTION
#### b7fbec9c0f1ad34999eb6a962f84984c629498ec
<pre>
Store a per-origin salt for use with MediaKeys
<a href="https://bugs.webkit.org/show_bug.cgi?id=287965">https://bugs.webkit.org/show_bug.cgi?id=287965</a>
&lt;<a href="https://rdar.apple.com/problem/145146068">rdar://problem/145146068</a>&gt;

Reviewed by Eric Carlson.

The EME specification requires identifiers used in implementations to be
&quot;unique per origin and profile, non-associable, and clearable&quot;. In other
contexts, like media capture, this kind of requirement has been achieved
through the use of per-domain &quot;salts&quot; used to hash those identifiers.

Add support for these salt values by re-using the DeviceIdHashSaltStorage
class and passing these salt values down to the CDM by way of the
MediaKeySystemRequest and MediaKeySystemPermissionRequestManager/Proxy
classes.

* Source/WebCore/Modules/encryptedmedia/CDM.cpp:
(WebCore::CDM::create):
(WebCore::CDM::CDM):
* Source/WebCore/Modules/encryptedmedia/CDM.h:
(WebCore::CDM::mediaKeysHashSalt const):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::~MediaKeySystemRequest):
(WebCore::MediaKeySystemRequest::allow):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.h:
(WebCore::MediaKeySystemRequest::setAllowCallback):
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
(WebCore::NavigatorEME::requestMediaKeySystemAccess):
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm:
* Source/WebCore/platform/encryptedmedia/CDMFactory.h:
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.cpp:
(WebCore::CDMFactoryClearKey::createCDM):
* Source/WebCore/platform/encryptedmedia/clearkey/CDMClearKey.h:
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::CDMFactoryFairPlayStreaming::createCDM):
(WebCore::CDMPrivateFairPlayStreaming::CDMPrivateFairPlayStreaming):
(WebCore::m_logger):
* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm:
(WebCore::CDMInstanceFairPlayStreamingAVFObjC::CDMInstanceFairPlayStreamingAVFObjC):
(WebCore::m_logger):
(WebCore::CDMInstanceSessionFairPlayStreamingAVFObjC::didProvideRequest):
* Source/WebCore/testing/MockCDMFactory.cpp:
(WebCore::MockCDMFactory::createCDM):
(WebCore::MockCDM::MockCDM):
* Source/WebCore/testing/MockCDMFactory.h:
(WebCore::MockCDM::mediaKeysHashSalt const):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.cpp:
(WebKit::RemoteCDMFactoryProxy::createCDM):
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMFactoryProxy.messages.in:
* Source/WebKit/Shared/WebsiteData/WebsiteData.cpp:
(WebKit::WebsiteData::ownerProcess):
* Source/WebKit/Shared/WebsiteData/WebsiteDataType.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::grantRequest):
(WebKit::MediaKeySystemPermissionRequestManagerProxy::createRequestForFrame):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestProxy::MediaKeySystemPermissionRequestProxy):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h:
(WebKit::MediaKeySystemPermissionRequestProxy::create):
(WebKit::MediaKeySystemPermissionRequestProxy::userMediaSecurityOrigin):
(WebKit::MediaKeySystemPermissionRequestProxy::userMediaSecurityOrigin const):
(WebKit::MediaKeySystemPermissionRequestProxy::mediaKeysHashSalt const):
(WebKit::MediaKeySystemPermissionRequestProxy::setMediaKeysHashSalt):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::requestMediaKeySystemPermissionForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::WebsiteDataStore::defaultMediaKeysHashSaltsStorageDirectory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::resolveDirectories):
(WebKit::WebsiteDataStore::fetchDataAndApply):
(WebKit::WebsiteDataStore::removeData):
(WebKit::WebsiteDataStore::ensureMediaKeysHashSaltStorage):
(WebKit::WebsiteDataStore::ensureProtectedMediaKeysHashSaltStorage):
(WebKit::WebsiteDataStore::defaultMediaKeysHashSaltsStorageDirectory):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::initializePaths):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy const):
(WebKit::WebsiteDataStoreConfiguration::Directories::isolatedCopy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::mediaKeysHashSaltsStorageDirectory const):
(WebKit::WebsiteDataStoreConfiguration::setMediaKeysHashSaltsStorageDirectory):
* Source/WebKit/UIProcess/ios/WKVideoView.mm:
(-[WKVideoView removeFromSuperview]):
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
(WebKit::MediaKeySystemPermissionRequestManager::sendMediaKeySystemRequest):
(WebKit::MediaKeySystemPermissionRequestManager::mediaKeySystemWasGranted):
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.cpp:
(WebKit::RemoteCDM::create):
(WebKit::RemoteCDM::RemoteCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteCDM.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.cpp:
(WebKit::RemoteCDMFactory::createCDM):
* Source/WebKit/WebProcess/GPU/media/RemoteCDMFactory.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::mediaKeySystemWasGranted):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.mm:
(WebMediaKeySystemClient::requestMediaKeySystem):

Canonical link: <a href="https://commits.webkit.org/290685@main">https://commits.webkit.org/290685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2291900b79c0da8919150db16f20562bbdb5d69f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41509 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18577 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69809 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27343 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93724 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8125 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50144 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7882 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36645 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17918 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78023 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19280 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22467 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21091 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23270 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17666 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->