### PR TITLE
[Site Isolation] Main frame history state may be incorrectly created when navigating during iframe creation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe-expected.txt
@@ -1,0 +1,10 @@
+Verifies that navigating the main frame while adding an iframe only increments history.length by one.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS history.length is 3
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that navigating the main frame while adding an iframe only increments history.length by one.");
+jsTestIsAsync = true;
+
+onmessage = () => {
+    setTimeout(() => {
+        sessionStorage.didNavigate = true;
+        location.href = 'data:text/html,<script> history.back(); <\/script>';
+    }, 10);
+}
+
+onload = () => {
+    if (sessionStorage.didNavigate) {
+        delete sessionStorage.didNavigate;
+        shouldBe("history.length", "3");
+        finishJSTest();
+    } else { 
+        setInterval(() => {
+            const iframe = document.createElement('iframe');
+            iframe.src = 'http://localhost:8000/site-isolation/resources/green-background.html';
+            document.body.appendChild(iframe);
+        }, 1);
+    }
+}
+</script>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9583,7 +9583,8 @@ void WebPageProxy::backForwardAddItemShared(IPC::Connection& connection, Ref<Fra
     if (RefPtr targetFrame = WebFrameProxy::webFrame(navigatedFrameState->frameID)) {
         if (RefPtr pendingChildBackForwardItem = targetFrame->takePendingChildBackForwardItem())
             return pendingChildBackForwardItem->setChild(WTFMove(navigatedFrameState));
-    }
+    } else
+        return;
 
     RefPtr provisionalPage = m_provisionalPage;
     const bool isRemoteFrameNavigation = m_legacyMainFrameProcess != *process && (!provisionalPage || provisionalPage->process() != *process);


### PR DESCRIPTION
#### da11536420a63001e81fbd98f6b546a1848bc8a7
<pre>
[Site Isolation] Main frame history state may be incorrectly created when navigating during iframe creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=287998">https://bugs.webkit.org/show_bug.cgi?id=287998</a>
<a href="https://rdar.apple.com/145164046">rdar://145164046</a>

Reviewed by Alex Christensen.

Site Isolation introduces an unavoidable race condition where the history state committed by a web
process may have been created for a frame that the UI process has already destroyed. When this happens,
we should return early instead of adding an incorrect back/forward item.

* LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardAddItemShared):

Canonical link: <a href="https://commits.webkit.org/290673@main">https://commits.webkit.org/290673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b82fa5b9a8994a1ba683e0c9f06a1fbf36c8f072

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41493 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69791 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27339 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7873 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36637 "Found 3 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html http/tests/xmlhttprequest/cross-origin-cookie-storage.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40622 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78187 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97552 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17902 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13146 "Build is in progress. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18161 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78124 "Exiting early after 10 failures. 90 tests run. 1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78015 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22456 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21083 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14301 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23254 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->