### PR TITLE
Fix the logic of resource eligibility check by ResourceMonitoring.

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource-expected.txt
@@ -1,0 +1,11 @@
+Test iframe won't be unloaded by just using eligible subresource.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is true
+PASS document.querySelector('iframe[name=frame1]').srcdoc is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource.html
+++ b/LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="./resources/monitor-setup.js"></script>
+</head>
+
+<body>
+    <script>
+        description("Test iframe won't be unloaded by just using eligible subresource.");
+        window.jsTestIsAsync = true;
+        var result;
+
+        onload = async () => {
+            if (!await setup()) {
+                return;
+            }
+
+            // Make sure iframe load is done after rule is set correctly.
+            const stage = document.querySelector('#stage');
+            const base = 'http://localhost:8080/iframe-monitor/resources';
+
+            stage.innerHTML = `<iframe name="frame1" src="${base}/iframe-with-eligible-subresource.html"></iframe>`;
+
+            window.addEventListener('message', async (event) => {
+                await pause(100);
+                result = event.data;
+
+                shouldBeTrue('result');
+                shouldBe(`document.querySelector('iframe[name=frame1]').srcdoc`, '""');
+                finishJSTest();
+            });
+        }
+    </script>
+
+    <div id="stage"></div>
+</body>
+
+</html>

--- a/LayoutTests/http/tests/iframe-monitor/resources/iframe-with-eligible-subresource.html
+++ b/LayoutTests/http/tests/iframe-monitor/resources/iframe-with-eligible-subresource.html
@@ -1,0 +1,9 @@
+Using significant resources and eligible for resource monitoring.
+
+<script>
+    const size = 20 * 1024;
+    fetch(`./generate-byte.py?size=${size}&eligibility=--eligible--`).then(async (response) => {
+        const body = await response.blob();
+        parent.postMessage(true, "*");
+    });
+</script>

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -629,11 +629,6 @@ void ResourceLoader::didReceiveResponse(const ResourceResponse& r, CompletionHan
     RefPtr frameLoader = this->frameLoader();
     if (frameLoader && m_options.sendLoadCallbacks == SendCallbackPolicy::SendCallbacks)
         frameLoader->notifier().didReceiveResponse(this, m_response);
-
-#if ENABLE(CONTENT_EXTENSIONS)
-    if (RefPtr monitor = resourceMonitorIfExists())
-        monitor->didReceiveResponse(m_response.url(), m_resourceType);
-#endif
 }
 
 void ResourceLoader::didReceiveData(const SharedBuffer& buffer, long long encodedDataLength, DataPayloadType dataPayloadType)


### PR DESCRIPTION
#### b73789151968b8f4f32b4c218a0c6ad5f633fb19
<pre>
Fix the logic of resource eligibility check by ResourceMonitoring.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287988">https://bugs.webkit.org/show_bug.cgi?id=287988</a>
<a href="https://rdar.apple.com/145155530">rdar://145155530</a>

Reviewed by Chris Dumez.

If the iframe is not eligible and it just uses eligible sub resources, we shouldn&apos;t treat the iframe as eligible.

* LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource-expected.txt: Added.
* LayoutTests/http/tests/iframe-monitor/just-use-eligible-subresource.html: Added.
* LayoutTests/http/tests/iframe-monitor/resources/iframe-with-eligible-subresource.html: Added.
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::didReceiveResponse):

Canonical link: <a href="https://commits.webkit.org/290660@main">https://commits.webkit.org/290660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/776fbc90f7f03eb83346df84f0f82a171b1b0d46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95725 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92763 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18564 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69792 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93711 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50134 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36639 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40625 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97555 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17905 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19271 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22464 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/17914 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17653 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21109 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19437 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->