### PR TITLE
AX: Defer isolated tree node removals so they are batched with other queued node updates

### DIFF
--- a/LayoutTests/accessibility/accessibility-object-detached-expected.txt
+++ b/LayoutTests/accessibility/accessibility-object-detached-expected.txt
@@ -1,9 +1,7 @@
 This test makes sure that AccessibilityObjects are detached when the node they point to is detached.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: expectedButtonRole != expectedDetachedRole === true
 
-
-PASS expectedButtonRole != expectedDetachedRole is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/accessibility-object-detached.html
+++ b/LayoutTests/accessibility/accessibility-object-detached.html
@@ -1,15 +1,16 @@
 <!DOCTYPE HTML>
 <html>
 <body>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/accessibility-helper.js"></script>
 
 <canvas id="canvas"></canvas>
 
-<div id="console"></div>
 <script>
-description("This test makes sure that AccessibilityObjects are detached when the node they point to is detached.");
+var output = "This test makes sure that AccessibilityObjects are detached when the node they point to is detached.\n\n";
 
 if (window.testRunner && window.accessibilityController) {
+    window.jsTestIsAsync = true;
     window.testRunner.dumpAsText();
 
     // Create a button on the page, focus it and get its accessibility role.
@@ -22,12 +23,16 @@ if (window.testRunner && window.accessibilityController) {
     // Now remove the node from the tree and get the role of the detached accessibility object.
     // We detect that it's detached just by checking that the role is different (empty or unknown).
     document.body.removeChild(button);
-    window.expectedDetachedRole = axElement.role;
-    shouldBeTrue("expectedButtonRole != expectedDetachedRole");
+    setTimeout(async function() {
+        await waitFor(() => expectedButtonRole != axElement.role);
+        window.expectedDetachedRole = axElement.role;
+        output += await expectAsync("expectedButtonRole != expectedDetachedRole", "true");
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 
 </script>
 
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/canvas-fallback-content-expected.txt
+++ b/LayoutTests/accessibility/canvas-fallback-content-expected.txt
@@ -1,101 +1,99 @@
-Link  Button
-Focusable
-ARIA button
-ARIA link
 This test makes sure that focusable elements in canvas fallback content are accessible.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 link1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 button1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 text1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXTextField"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXTextField"
 
 checkbox1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXCheckBox"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXCheckBox"
 
 radio1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXRadioButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXRadioButton"
 
 submit1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 combobox1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXComboBox"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXComboBox"
 
 focusable1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXGroup"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXGroup"
 
 aria-button1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 aria-link1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 link2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 button2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 text2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXTextField"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXTextField"
 
 checkbox2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXCheckBox"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXCheckBox"
 
 radio2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXRadioButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXRadioButton"
 
 submit2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 combobox2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXComboBox"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXComboBox"
 
 focusable2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXGroup"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXGroup"
 
 aria-button2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 aria-link2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 focusable1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 focusable2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
+
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
+Link  Button
+Focusable
+ARIA button
+ARIA link
 

--- a/LayoutTests/accessibility/canvas-fallback-content.html
+++ b/LayoutTests/accessibility/canvas-fallback-content.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 <script src="../resources/accessibility-helper.js"></script>
 
 <style>
@@ -38,132 +38,130 @@ myelement {
   <div id="aria-link2" tabindex="0" role="link">ARIA link</div>
 </canvas>
 
-<div id="console"></div>
-
 <script>
-    description("This test makes sure that focusable elements in canvas fallback content are accessible.");
+var output = "This test makes sure that focusable elements in canvas fallback content are accessible.\n\n";
 
-    if (window.testRunner && window.accessibilityController) {
-        window.jsTestIsAsync = true;
-        window.testRunner.dumpAsText();
+if (window.testRunner && window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    window.testRunner.dumpAsText();
 
-        var comboBoxRole = platformRoleForComboBox(accessibilityController.platformName);
+    var comboBoxRole = platformRoleForComboBox(accessibilityController.platformName);
 
-        function check(id, expectedRole) {
-            window.element = document.getElementById(id);
-            element.focus();
+    function check(id, expectedRole) {
+        window.element = document.getElementById(id);
+        element.focus();
 
-            window.axElement = accessibilityController.focusedElement;
-            if (axElement.role == expectedRole) {
-                // Do all the logging here and return true.
-                debug(id);
-                shouldBe("document.activeElement == element", "true");
-                shouldBe("axElement.role", "\"" + expectedRole + "\"");
-                debug("");
-                return true;
-            }
-
-            return false;
+        window.axElement = accessibilityController.focusedElement;
+        if (axElement.role == expectedRole) {
+            // Do all the logging here and return true.
+            output += `${id}\n`;
+            output += expect("document.activeElement == element", "true");
+            output += expect("axElement.role", "\"" + expectedRole + "\"");
+            output += "\n";
+            return true;
         }
 
-        setTimeout(async function() {
-            // Check rendered controls.
-            await waitFor(() => {
-                return check("link1", "AXRole: AXLink");
-            });
-
-            await waitFor(() => {
-                return check("button1", "AXRole: AXButton");
-            });
-
-            await waitFor(() => {
-                return check("text1", "AXRole: AXTextField");
-            });
-
-            await waitFor(() => {
-                return check("checkbox1", "AXRole: AXCheckBox");
-            });
-
-            await waitFor(() => {
-                return check("radio1", "AXRole: AXRadioButton");
-            });
-
-            await waitFor(() => {
-                return check("submit1", "AXRole: AXButton");
-            });
-
-            await waitFor(() => {
-                return check("combobox1", comboBoxRole);
-            });
-
-            await waitFor(() => {
-                return check("focusable1", "AXRole: AXGroup");
-            });
-
-            await waitFor(() => {
-                return check("aria-button1", "AXRole: AXButton");
-            });
-
-            await waitFor(() => {
-                return check("aria-link1", "AXRole: AXLink");
-            });
-
-            // Check unrendered controls inside a canvas.
-            await waitFor(() => {
-                return check("link2", "AXRole: AXLink");
-            });
-
-            await waitFor(() => {
-                return check("button2", "AXRole: AXButton");
-            });
-
-            await waitFor(() => {
-                return check("text2", "AXRole: AXTextField");
-            });
-
-            await waitFor(() => {
-                return check("checkbox2", "AXRole: AXCheckBox");
-            });
-
-            await waitFor(() => {
-                return check("radio2", "AXRole: AXRadioButton");
-            });
-
-            await waitFor(() => {
-                return check("submit2", "AXRole: AXButton");
-            });
-
-            await waitFor(() => {
-                return check("combobox2", comboBoxRole);
-            });
-
-            await waitFor(() => {
-                return check("focusable2", "AXRole: AXGroup");
-            });
-
-            await waitFor(() => {
-                return check("aria-button2", "AXRole: AXButton");
-            });
-
-            await waitFor(() => {
-                return check("aria-link2", "AXRole: AXLink");
-            });
-
-            // Check that the role is updated when the element changes.
-            document.getElementById('focusable1').setAttribute('role', 'button');
-            await waitFor(() => {
-                return check("focusable1", "AXRole: AXButton");
-            });
-
-            document.getElementById('focusable2').setAttribute('role', 'button');
-            await waitFor(() => {
-                return check("focusable2", "AXRole: AXButton");
-            });
-
-            finishJSTest();
-        }, 0);
+        return false;
     }
+
+    setTimeout(async function() {
+        // Check rendered controls.
+        await waitFor(() => {
+            return check("link1", "AXRole: AXLink");
+        });
+
+        await waitFor(() => {
+            return check("button1", "AXRole: AXButton");
+        });
+
+        await waitFor(() => {
+            return check("text1", "AXRole: AXTextField");
+        });
+
+        await waitFor(() => {
+            return check("checkbox1", "AXRole: AXCheckBox");
+        });
+
+        await waitFor(() => {
+            return check("radio1", "AXRole: AXRadioButton");
+        });
+
+        await waitFor(() => {
+            return check("submit1", "AXRole: AXButton");
+        });
+
+        await waitFor(() => {
+            return check("combobox1", comboBoxRole);
+        });
+
+        await waitFor(() => {
+            return check("focusable1", "AXRole: AXGroup");
+        });
+
+        await waitFor(() => {
+            return check("aria-button1", "AXRole: AXButton");
+        });
+
+        await waitFor(() => {
+            return check("aria-link1", "AXRole: AXLink");
+        });
+
+        // Check unrendered controls inside a canvas.
+        await waitFor(() => {
+            return check("link2", "AXRole: AXLink");
+        });
+
+        await waitFor(() => {
+            return check("button2", "AXRole: AXButton");
+        });
+
+        await waitFor(() => {
+            return check("text2", "AXRole: AXTextField");
+        });
+
+        await waitFor(() => {
+            return check("checkbox2", "AXRole: AXCheckBox");
+        });
+
+        await waitFor(() => {
+            return check("radio2", "AXRole: AXRadioButton");
+        });
+
+        await waitFor(() => {
+            return check("submit2", "AXRole: AXButton");
+        });
+
+        await waitFor(() => {
+            return check("combobox2", comboBoxRole);
+        });
+
+        await waitFor(() => {
+            return check("focusable2", "AXRole: AXGroup");
+        });
+
+        await waitFor(() => {
+            return check("aria-button2", "AXRole: AXButton");
+        });
+
+        await waitFor(() => {
+            return check("aria-link2", "AXRole: AXLink");
+        });
+
+        // Check that the role is updated when the element changes.
+        document.getElementById('focusable1').setAttribute('role', 'button');
+        await waitFor(() => {
+            return check("focusable1", "AXRole: AXButton");
+        });
+
+        document.getElementById('focusable2').setAttribute('role', 'button');
+        await waitFor(() => {
+            return check("focusable2", "AXRole: AXButton");
+        });
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/datetime/input-date-field-labels-and-value-changes-expected.txt
+++ b/LayoutTests/accessibility/datetime/input-date-field-labels-and-value-changes-expected.txt
@@ -35,6 +35,7 @@ Press up arrow to increment the year field.
 PASS: subfields[4].intValue === 2013
 
 Set the date via JavaScript.
+PASS: axDateInput.childAtIndex(0).childAtIndex(0).children[4].intValue === 2023
 AXDescription: month AXRole: AXIncrementor AXValue: 12
 AXDescription:  AXRole: AXStaticText AXValue: /
 AXDescription: day AXRole: AXIncrementor AXValue: 31

--- a/LayoutTests/accessibility/datetime/input-date-field-labels-and-value-changes.html
+++ b/LayoutTests/accessibility/datetime/input-date-field-labels-and-value-changes.html
@@ -29,7 +29,7 @@ if (window.accessibilityController) {
         return subfields;
     }
 
-    output+= "Original subfield values:\n";
+    output += "Original subfield values:\n";
     var subfields = getAndLogSubfields(axDateInput);
 
     setTimeout(async () => {
@@ -73,8 +73,12 @@ if (window.accessibilityController) {
 
         output += "\nSet the date via JavaScript.\n";
         dateInput.value = "2023-12-31";
-        await waitFor(() => axDateInput.childAtIndex(0).childAtIndex(0).children[4] != null);
-        await expectAsync("axDateInput.childAtIndex(0).childAtIndex(0).children[4].intValue", "2023");
+        await waitFor(() => {
+            var dateObject = axDateInput.childAtIndex(0).childAtIndex(0);
+            return dateObject.childrenCount >= 5 ? !!dateObject.children[4] : null;
+        });
+
+        output += await expectAsync("axDateInput.childAtIndex(0).childAtIndex(0).children[4].intValue", "2023");
         getAndLogSubfields(axDateInput);
 
         debug(output);

--- a/LayoutTests/accessibility/mac/element-is-ignored-expected.txt
+++ b/LayoutTests/accessibility/mac/element-is-ignored-expected.txt
@@ -1,12 +1,9 @@
-test test
 This tests that if you access an element that has been removed, it return the correct value for isIgnored (true, that is, it is ignored).
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: element1.isIgnored === false
+PASS: element1.isIgnored === true
 
-
-PASS element1.isIgnored is false
-PASS element1.isIgnored is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+test test

--- a/LayoutTests/accessibility/mac/element-is-ignored.html
+++ b/LayoutTests/accessibility/mac/element-is-ignored.html
@@ -1,7 +1,8 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
@@ -11,27 +12,29 @@ test
 
 test
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
+var output = "This tests that if you access an element that has been removed, it return the correct value for isIgnored (true, that is, it is ignored).\n\n";
+var element1;
 
-    description("This tests that if you access an element that has been removed, it return the correct value for isIgnored (true, that is, it is ignored).");
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-    if (window.accessibilityController) {
-        document.getElementById("element1").focus();
-        var element1 = accessibilityController.focusedElement;
+    document.getElementById("element1").focus();
+    setTimeout(async function() {
+        element1 = accessibilityController.focusedElement;
 
         // The element should not be ignored (it should be a group)
-        shouldBeFalse("element1.isIgnored");
+        output += await expectAsync("element1.isIgnored", "false");
 
         // Remove the element, it should become ignored
         document.getElementById("body").removeChild(document.getElementById("element1"));
-        shouldBeTrue("element1.isIgnored");
-    }
+        output += await expectAsync("element1.isIgnored", "true");
 
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/focus-moves-cursor-expected.txt
+++ b/LayoutTests/accessibility/mac/focus-moves-cursor-expected.txt
@@ -1,14 +1,11 @@
-
 This tests that when setting focus, the cursor moves.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: textfield.stringValue === 'AXValue: '
+PASS: textfield.stringValue === 'AXValue: '
+PASS: textfield.isFocused === true
+PASS: document.activeElement == document.getElementById('textfield') === true
+PASS: textfield.stringValue === 'AXValue: a'
 
-
-PASS textfield.stringValue is 'AXValue: '
-PASS textfield.stringValue is 'AXValue: '
-PASS textfield.isFocused is true
-PASS document.activeElement is document.getElementById('textfield')
-PASS textfield.stringValue is 'AXValue: a'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/focus-moves-cursor.html
+++ b/LayoutTests/accessibility/mac/focus-moves-cursor.html
@@ -1,40 +1,41 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body>
 
 <input id="textfield" onfocus="setTimeout('sendTestEvents()', 0);">
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This tests that when setting focus, the cursor moves.");
+var output = "This tests that when setting focus, the cursor moves.\n\n";
+var textfield;
 
-    var windowEventSender = window.eventSender;    
-    if (window.accessibilityController && window.eventSender) {
-        window.jsTestIsAsync = true;
-        var textfield = accessibilityController.accessibleElementById("textfield");
-        shouldBe("textfield.stringValue", "'AXValue: '");
+var windowEventSender = window.eventSender;    
+if (window.accessibilityController && window.eventSender) {
+    window.jsTestIsAsync = true;
+    textfield = accessibilityController.accessibleElementById("textfield");
+    output += expect("textfield.stringValue", "'AXValue: '");
+    eventSender.keyDown("a");
+    output += expect("textfield.stringValue", "'AXValue: '");
+
+    textfield.takeFocus();
+}
+
+function sendTestEvents() {
+    textfield = accessibilityController.accessibleElementById("textfield");
+    setTimeout(async function() {
+        output += await expectAsync("textfield.isFocused", "true");
+        output += await expectAsync("document.activeElement == document.getElementById('textfield')", "true");
+
         eventSender.keyDown("a");
-        shouldBe("textfield.stringValue", "'AXValue: '");
-
-        textfield.takeFocus();
-    }
-
-    function sendTestEvents() {
-        var textfield = accessibilityController.accessibleElementById("textfield");
-        shouldBeTrue("textfield.isFocused");
-        shouldBe("document.activeElement", "document.getElementById('textfield')");
-
-        eventSender.keyDown("a");
-        shouldBe("textfield.stringValue", "'AXValue: a'");
+        output += await expectAsync("textfield.stringValue", "'AXValue: a'");
+        debug(output);
         finishJSTest();
-    }
+    }, 0);
+}
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/slider-thumb-value-crash-expected.txt
+++ b/LayoutTests/accessibility/mac/slider-thumb-value-crash-expected.txt
@@ -1,9 +1,7 @@
 This tests that getting the indicator's value from a removed slider won't cause crash.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: indicator.intValue === 0
 
-
-PASS indicator.intValue is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/mac/slider-thumb-value-crash.html
+++ b/LayoutTests/accessibility/mac/slider-thumb-value-crash.html
@@ -1,32 +1,33 @@
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 </head>
 <body id="body">
 
 <input id="range1" type="range">
 
-<p id="description"></p>
-<div id="console"></div>
-<div id="notifications"></div>
-
 <script>
 
-    description("This tests that getting the indicator's value from a removed slider won't cause crash.");
+var output = "This tests that getting the indicator's value from a removed slider won't cause crash.\n\n";
+var indicator;
 
-    if (window.accessibilityController) {
-
-        var range = accessibilityController.accessibleElementById("range1");
-        var indicator = range.childAtIndex(0);
-        
-        // Remove the slider, make sure we getting value from the indicator won't cause crash.
-        var rangeElement = document.getElementById("range1");
-        document.body.removeChild(rangeElement);
-        shouldBe("indicator.intValue", "0");
-    }
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    var range = accessibilityController.accessibleElementById("range1");
+    indicator = range.childAtIndex(0);
+    
+    // Remove the slider, make sure we getting value from the indicator won't cause crash.
+    var rangeElement = document.getElementById("range1");
+    document.body.removeChild(rangeElement);
+    setTimeout(async function() {
+        output += await expectAsync("indicator.intValue", "0");
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 
 </script>
 
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/stale-textmarker-crash.html
+++ b/LayoutTests/accessibility/mac/stale-textmarker-crash.html
@@ -36,7 +36,7 @@ setTimeout(async () => {
     content1 = accessibilityController.accessibleElementById("content1");
     // Don't crash accessing the text marker that references a stale Node.
     let index = content1.indexForTextMarker(marker);
-    output += expect("content1.isTextMarkerValid(marker)", "false");
+    output += await expectAsync("content1.isTextMarkerValid(marker)", "false");
 
     debug(output);
     finishJSTest();

--- a/LayoutTests/accessibility/mac/textmarker-routines-expected.txt
+++ b/LayoutTests/accessibility/mac/textmarker-routines-expected.txt
@@ -1,18 +1,15 @@
-text
-text
 This verifies usage of isTextMarkerValid, indexForTextMarker and textMarkerForIndex.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: item1.isTextMarkerValid(firstTextMarker) === true
+PASS: item1.indexForTextMarker(firstTextMarker) === 0
+PASS: item1.textMarkerForIndex(0).isEqual(firstTextMarker) === true
+PASS: item1.isTextMarkerValid(firstTextMarker) === false
+PASS: item2.isTextMarkerValid(secondTextMarker) === true
+PASS: item2.indexForTextMarker(secondTextMarker) === 5
+PASS: item2.textMarkerForIndex(item2.indexForTextMarker(secondTextMarker)).isEqual(secondTextMarker) === true
 
-
-PASS item1.isTextMarkerValid(firstTextMarker) is true
-PASS item1.indexForTextMarker(firstTextMarker) is 0
-PASS item1.textMarkerForIndex(0).isEqual(firstTextMarker) is true
-PASS item1.isTextMarkerValid(firstTextMarker) is false
-PASS item2.isTextMarkerValid(secondTextMarker) is true
-PASS item2.indexForTextMarker(secondTextMarker) is 5
-PASS item2.textMarkerForIndex(item2.indexForTextMarker(secondTextMarker)).isEqual(secondTextMarker) is true
 PASS successfullyParsed is true
 
 TEST COMPLETE
-
+text
+text

--- a/LayoutTests/accessibility/mac/textmarker-routines.html
+++ b/LayoutTests/accessibility/mac/textmarker-routines.html
@@ -1,6 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
 <body id="body" tabindex="0">
 
 <div tabindex="0" id="text1">text</div>
@@ -9,34 +10,37 @@ text
 
 <div tabindex="0" id="text2">text</div>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This verifies usage of isTextMarkerValid, indexForTextMarker and textMarkerForIndex.");
+var output = "This verifies usage of isTextMarkerValid, indexForTextMarker and textMarkerForIndex.\n\n";
+var item1, item2, markerRange, firstTextMarker, secondTextMarker;
 
-    if (window.accessibilityController) {
-        var item1 = accessibilityController.accessibleElementById("text1");
-        var markerRange = item1.textMarkerRangeForElement(item1);
-        var firstTextMarker = item1.startTextMarkerForTextMarkerRange(markerRange);
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    item1 = accessibilityController.accessibleElementById("text1");
+    markerRange = item1.textMarkerRangeForElement(item1);
+    firstTextMarker = item1.startTextMarkerForTextMarkerRange(markerRange);
 
-        shouldBeTrue("item1.isTextMarkerValid(firstTextMarker)");
-        shouldBe("item1.indexForTextMarker(firstTextMarker)", "0");
-        shouldBeTrue("item1.textMarkerForIndex(0).isEqual(firstTextMarker)");       
+    output += expect("item1.isTextMarkerValid(firstTextMarker)", "true");
+    output += expect("item1.indexForTextMarker(firstTextMarker)", "0");
+    output += expect("item1.textMarkerForIndex(0).isEqual(firstTextMarker)", "true");
 
-        document.getElementById("body").removeChild(document.getElementById("text1"));
+    document.getElementById("body").removeChild(document.getElementById("text1"));
 
-        shouldBeFalse("item1.isTextMarkerValid(firstTextMarker)");
+    setTimeout(async function() {
+        output += await expectAsync("item1.isTextMarkerValid(firstTextMarker)", "false");
 
-        var item2 = accessibilityController.accessibleElementById("text2");
+        item2 = accessibilityController.accessibleElementById("text2");
         markerRange = item2.textMarkerRangeForElement(item2);
-        var secondTextMarker = item2.startTextMarkerForTextMarkerRange(markerRange);
+        secondTextMarker = item2.startTextMarkerForTextMarkerRange(markerRange);
 
-        shouldBeTrue("item2.isTextMarkerValid(secondTextMarker)");
-        shouldBe("item2.indexForTextMarker(secondTextMarker)", "5");
-        shouldBeTrue("item2.textMarkerForIndex(item2.indexForTextMarker(secondTextMarker)).isEqual(secondTextMarker)");
-    }
+        output += await expectAsync("item2.isTextMarkerValid(secondTextMarker)", "true");
+        output += await expectAsync("item2.indexForTextMarker(secondTextMarker)", "5");
+        output += await expectAsync("item2.textMarkerForIndex(item2.indexForTextMarker(secondTextMarker)).isEqual(secondTextMarker)", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/accessibility/title-ui-element-correctness.html
+++ b/LayoutTests/accessibility/title-ui-element-correctness.html
@@ -110,6 +110,7 @@ if (window.accessibilityController) {
         const isCocoa = platform === "ios" || platform === "mac";
         output += expect("hasTitleUIElement(axElement('control6'))", isCocoa ? "false" : "true");
         output += evalAndReturn("document.getElementById('label6c').remove()");
+        await waitFor(() => axElement('control6').titleUIElement() != null);
         output += await expectAsync("axElement('control6').titleUIElement().isEqual(axElement('label6b'))", "true");
 
         document.getElementById('container').style.display = 'none';

--- a/LayoutTests/platform/mac/accessibility/canvas-fallback-content-expected.txt
+++ b/LayoutTests/platform/mac/accessibility/canvas-fallback-content-expected.txt
@@ -1,101 +1,99 @@
-Link  Button
-Focusable
-ARIA button
-ARIA link
 This test makes sure that focusable elements in canvas fallback content are accessible.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 link1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 button1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 text1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXTextField"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXTextField"
 
 checkbox1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXCheckBox"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXCheckBox"
 
 radio1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXRadioButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXRadioButton"
 
 submit1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 combobox1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXPopUpButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXPopUpButton"
 
 focusable1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXGroup"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXGroup"
 
 aria-button1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 aria-link1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 link2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 button2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 text2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXTextField"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXTextField"
 
 checkbox2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXCheckBox"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXCheckBox"
 
 radio2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXRadioButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXRadioButton"
 
 submit2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 combobox2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXPopUpButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXPopUpButton"
 
 focusable2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXGroup"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXGroup"
 
 aria-button2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 aria-link2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXLink"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXLink"
 
 focusable1
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
 
 focusable2
-PASS document.activeElement == element is true
-PASS axElement.role is "AXRole: AXButton"
+PASS: document.activeElement == element === true
+PASS: axElement.role === "AXRole: AXButton"
+
 
 PASS successfullyParsed is true
 
 TEST COMPLETE
+Link  Button
+Focusable
+ARIA button
+ARIA link
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1141,7 +1141,7 @@ void AXObjectCache::remove(std::optional<AXID> axID)
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (auto tree = AXIsolatedTree::treeForPageID(m_pageID))
-        tree->removeNode(*object);
+        tree->queueNodeRemoval(*object);
 #endif
 
     removeAllRelations(*axID);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -406,9 +406,9 @@ public:
     void addUnconnectedNode(Ref<AccessibilityObject>);
     bool isUnconnectedNode(std::optional<AXID> axID) const { return axID && m_unconnectedNodes.contains(*axID); }
     // Removes the corresponding isolated object and all descendants from the m_nodeMap and queues their removal from the tree.
-    void removeNode(const AccessibilityObject&);
+    void removeNode(AXID, std::optional<AXID> /* parentID */);
     // Removes the given node and all its descendants from m_nodeMap.
-    void removeSubtreeFromNodeMap(std::optional<AXID>, AccessibilityObject*);
+    void removeSubtreeFromNodeMap(std::optional<AXID>, std::optional<AXID> /* parentID */);
 
     void objectBecameIgnored(const AccessibilityObject& object)
     {
@@ -483,6 +483,7 @@ public:
     void setSelectedTextMarkerRange(AXTextMarkerRange&&);
 
     void queueNodeUpdate(AXID, const NodeUpdateOptions&);
+    void queueNodeRemoval(const AccessibilityObject&);
     void processQueuedNodeUpdates();
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
@@ -605,6 +606,8 @@ private:
     ListHashSet<AXID> m_needsUpdateChildren;
     ListHashSet<AXID> m_needsUpdateNode;
     UncheckedKeyHashMap<AXID, AXPropertySet> m_needsPropertyUpdates;
+    // The key is the ID of the node being removed. The value is the ID of the parent in the core tree (if it exists).
+    UncheckedKeyHashMap<AXID, std::optional<AXID>> m_needsNodeRemoval;
 };
 
 inline AXObjectCache* AXIsolatedTree::axObjectCache() const

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2016,7 +2016,7 @@ bool AccessibilityUIElement::isIgnored() const
     BOOL result = NO;
     BEGIN_AX_OBJC_EXCEPTIONS
     s_controller->executeOnAXThreadAndWait([&result, this] {
-        result = [m_element accessibilityIsIgnored];
+        result = m_element ? [m_element accessibilityIsIgnored] : YES;
     });
     END_AX_OBJC_EXCEPTIONS
     return result;


### PR DESCRIPTION
#### 5bc669a03a79ddd5cf785f2b4308d43a2f76e94b
<pre>
AX: Defer isolated tree node removals so they are batched with other queued node updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=288001">https://bugs.webkit.org/show_bug.cgi?id=288001</a>
<a href="https://rdar.apple.com/145164516">rdar://145164516</a>

Reviewed by Tyler Wilcock.

In 271907@main, we added a new mechanism to de-duplicate node changes by batching them and
processing them in batches off of a timer. This included most types of changes, but did not
include node removals. This means that nodes could possibly be removed before other types
of updates happen, causing the tree to be temporarily out of sync.

To fix this, let&apos;s start to queue node changes as well in `queueNodeRemoval`. This changes
handles that and updates `removeNode` to work off of AXIDs instead of object references
which it has before.

Many layout tests were updated to be asynchronous, or to be made more asynchronous, due to
behavior this change exposed.

* LayoutTests/accessibility/accessibility-object-detached-expected.txt:
* LayoutTests/accessibility/accessibility-object-detached.html:
* LayoutTests/accessibility/canvas-fallback-content-expected.txt:
* LayoutTests/accessibility/canvas-fallback-content.html:
* LayoutTests/accessibility/datetime/input-date-field-labels-and-value-changes.html:
* LayoutTests/accessibility/mac/element-is-ignored-expected.txt:
* LayoutTests/accessibility/mac/element-is-ignored.html:
* LayoutTests/accessibility/mac/focus-moves-cursor-expected.txt:
* LayoutTests/accessibility/mac/focus-moves-cursor.html:
* LayoutTests/accessibility/mac/slider-thumb-value-crash-expected.txt:
* LayoutTests/accessibility/mac/slider-thumb-value-crash.html:
* LayoutTests/accessibility/mac/stale-textmarker-crash.html:
* LayoutTests/accessibility/mac/textmarker-routines-expected.txt:
* LayoutTests/accessibility/mac/textmarker-routines.html:
* LayoutTests/accessibility/title-ui-element-correctness.html:
* LayoutTests/platform/mac/accessibility/canvas-fallback-content-expected.txt:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::remove):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::updateChildren):
(WebCore::AXIsolatedTree::removeNode):
(WebCore::AXIsolatedTree::removeSubtreeFromNodeMap):
(WebCore::AXIsolatedTree::queueNodeRemoval):
(WebCore::AXIsolatedTree::processQueuedNodeUpdates):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/290812@main">https://commits.webkit.org/290812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af62ae261ae91e745dda0cf1839fe3dc22efc78b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27538 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50335 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/109 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40995 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78509 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18302 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79017 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78218 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19347 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22729 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/80 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23635 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->