### PR TITLE
Limit recursion depth for ContainerNode::cloneChildNodes

### DIFF
--- a/LayoutTests/fast/dom/Node/cloneChild-recursion-limit-expected.txt
+++ b/LayoutTests/fast/dom/Node/cloneChild-recursion-limit-expected.txt
@@ -1,0 +1,5 @@
+Test to validate upper limit on recursion depth for cloneChild.
+
+Should say PASS:
+PASS
+

--- a/LayoutTests/fast/dom/Node/cloneChild-recursion-limit.html
+++ b/LayoutTests/fast/dom/Node/cloneChild-recursion-limit.html
@@ -1,0 +1,36 @@
+<html>
+    <head>
+        <title>Limit cloneChild Recursion Test</title>
+        <script>
+            window?.testRunner?.dumpAsText();
+
+            function runTest() {
+                const rootContainer = document.createElement("div");
+                document.body.appendChild(rootContainer);
+
+                let tempNode = rootContainer;
+                for (let i = 0; i < 1030; i++) {
+                    tempNode.appendChild(document.createElement("div"));
+                    tempNode = tempNode.children[0];
+                }
+
+                let clonedRootContainer = rootContainer.cloneNode(true);
+                let totalDepth = 0;
+                while (clonedRootContainer.childNodes.length > 0) {
+                    totalDepth++;
+                    clonedRootContainer = clonedRootContainer.childNodes[0];
+                }
+                document.getElementById("result").innerHTML =
+                    totalDepth == 1024
+                        ? "PASS"
+                        : `FAIL (Actual depth: ${totalDepth})`;
+            }
+        </script>
+    </head>
+
+    <body onload="runTest()">
+        <p>Test to validate upper limit on recursion depth for cloneChild.</p>
+        <div>Should say PASS:</div>
+        <div id="result"></div>
+    </body>
+</html>

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1026,8 +1026,11 @@ void ContainerNode::childrenChanged(const ChildChange& change)
     }
 }
 
-void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* registry, ContainerNode& clone)
+void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* registry, ContainerNode& clone, size_t currentDepth)
 {
+    if (currentDepth == 1024)
+        return;
+
     NodeVector postInsertionNotificationTargets;
     bool hadElement = false;
     for (RefPtr child = firstChild(); child; child = child->nextSibling()) {
@@ -1044,7 +1047,7 @@ void ContainerNode::cloneChildNodes(Document& document, CustomElementRegistry* r
             hadElement = hadElement || is<Element>(clonedChild);
         }
         if (RefPtr childAsContainerNode = dynamicDowncast<ContainerNode>(*child))
-            childAsContainerNode->cloneChildNodes(document, registry, downcast<ContainerNode>(clonedChild));
+            childAsContainerNode->cloneChildNodes(document, registry, downcast<ContainerNode>(clonedChild), currentDepth + 1);
     }
     clone.childrenChanged(makeChildChangeForCloneInsertion(hadElement ? ClonedChildIncludesElements::Yes : ClonedChildIncludesElements::No));
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -77,7 +77,7 @@ public:
 
     void takeAllChildrenFrom(ContainerNode*);
 
-    void cloneChildNodes(Document&, CustomElementRegistry*, ContainerNode& clone);
+    void cloneChildNodes(Document&, CustomElementRegistry*, ContainerNode& clone, size_t currentDepth = 0);
 
     enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
     struct ChildChange {


### PR DESCRIPTION
#### 80914b1cad4092f109f366cde070d9acbd4a1a1f
<pre>
Limit recursion depth for ContainerNode::cloneChildNodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=277031">https://bugs.webkit.org/show_bug.cgi?id=277031</a>
<a href="https://rdar.apple.com/132430642">rdar://132430642</a>

Reviewed by Ryosuke Niwa.

Add a stack recursion limit to `ContainerNode::cloneChildNodes`,
currently set at 1024, at which point we start rejecting any deeper
clones.

Add a test in /fast/ to validate this new limit.

* LayoutTests/fast/dom/Node/cloneChild-recursion-limit-expected.txt: Added.
* LayoutTests/fast/dom/Node/cloneChild-recursion-limit.html: Added.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::cloneChildNodes):
* Source/WebCore/dom/ContainerNode.h:

Canonical link: <a href="https://commits.webkit.org/290680@main">https://commits.webkit.org/290680@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/810a3176af2178901a4d06f728f22caef0e368b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10336 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45745 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18653 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/95818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93800 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/95818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/7929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37767 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/17994 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/97644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18253 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78151 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/97644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19277 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22507 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18003 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/17742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->