### PR TITLE
Enable filtering of SerializedScriptValue JS types

### DIFF
--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7971,6 +7971,7 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
 #endif
     [NotSerialized] Vector<WebCore::URLKeepingBlobAlive> blobHandles;
     [NotSerialized] size_t memoryCost;
+    [NotSerialized] WebCore::SerializationTypeFilter filter;
 };
 
 [RefCounted] class WebCore::SerializedScriptValue {


### PR DESCRIPTION
#### 7940ebeb345a1a6308bb4f3d71c180bc27b44631
<pre>
Filter SerializedScriptValue deserialization allowed types in UIProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=288017">https://bugs.webkit.org/show_bug.cgi?id=288017</a>
<a href="https://rdar.apple.com/145172704">rdar://145172704</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::deserialize):
(WebCore::CloneDeserializer::setTypeFilter):
(WebCore::CloneDeserializer::CloneDeserializer):
(WebCore::CloneDeserializer::tagAllowed):
(WebCore::CloneDeserializer::readTerminal):
(WebCore::validateSerializedResult):
(WebCore::SerializedScriptValue::SerializedScriptValue):
(WebCore::SerializedScriptValue::deserialize):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
(WebCore::SerializedScriptValue::createFromWireBytes):
(WebCore::SerializedScriptValue::SerializedScriptValue):
* Source/WebKit/Shared/API/APISerializedScriptValue.h:
(API::SerializedScriptValue::createFromWireBytes):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab):
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.cpp:
(WebKit::WebUserContentControllerProxy::didPostMessage):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(ReturnTypes)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9abe8f5d6616220df568ce198630d7d66a4eac39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92756 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1947 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28438 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83958 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51334 "Found 10 new API test failures: /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received, /WPE/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-in-world-received, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-controls-associated-signal, /WPE/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WPE/TestWebKitWebView:/webkit/WebKitWebView/notification, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WPE/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WPE/TestWebsiteData:/webkit/WebKitWebsiteData/databases (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42595 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79523 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80018 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79852 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79320 "Found 10 new API test failures: /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/databases, /WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-in-world-received, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification-initial-permission-allowed, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/notification, /WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/run-javascript, /WebKitGTK/TestWebKitWebContext:/webkit/WebKitWebContext/timezone-worker, /WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/form-controls-associated-signal, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/configuration, /WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/dom-cache, /WebKitGTK/TestWebKitUserContentManager:/webkit/WebKitUserContentManager/script-message-received (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23843 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24968 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19479 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->