### PR TITLE
[HDR] Add test infrastructure to enable HDR images in layout tests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2493,6 +2493,8 @@ fast/images/animated-jpegxl-loop-count.html [ Skip ]
 
 # Only applicable on platforms with HDR support
 compositing/hdr/hdr-basic-canvas.html [ Skip ]
+compositing/hdr/hdr-basic-image.html [ Skip ]
+fast/images/hdr-basic-image.html [ Skip ]
 
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]

--- a/LayoutTests/compositing/hdr/hdr-basic-image.html
+++ b/LayoutTests/compositing/hdr/hdr-basic-image.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .image-box {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+</style>
+<body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <img class="image-box">
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="image-box"></div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+ 
+        var image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHeadroomForTesting(image, 5);
+
+            var divElement = document.querySelector("div.image-box");
+            divElement.style.backgroundImage = 'url(' + image.src + ')';
+
+            var imgElement = document.querySelector("img.image-box");
+            imgElement.src = image.src;
+
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        });
+        image.src = "../../fast/images/resources/green-400x400.png";
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-basic-image-expected.html
+++ b/LayoutTests/fast/images/hdr-basic-image-expected.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .image-box {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="image-box" style="background-color: rgb(255 215 0);">
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="image-box" style="background-color: green;"></div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-basic-image.html
+++ b/LayoutTests/fast/images/hdr-basic-image.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .image-box {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <img class="image-box">
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="image-box"></div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            testRunner.waitUntilDone();
+        }
+ 
+        var image = new Image;
+        image.onload = (() => {
+            if (window.internals)
+                internals.setHeadroomForTesting(image, 5);
+
+            var divElement = document.querySelector("div.image-box");
+            divElement.style.backgroundImage = 'url(' + image.src + ')';
+
+            var imgElement = document.querySelector("img.image-box");
+            imgElement.src = image.src;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+        image.src = "resources/green-400x400.png";
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4510,6 +4510,8 @@ fast/images/pagewide-play-pause-offscreen-animations.html [ Pass ]
 
 # Only applicable on platforms with HDR support
 compositing/hdr/hdr-basic-canvas.html [ Pass ]
+compositing/hdr/hdr-basic-image.html [ Pass ]
+webkit.org/b/287985 fast/images/hdr-basic-image.html [ ImageOnlyFailure ]
 
 # Re-enabling tests fixed by DocumentManager in iOS16+ rdar://102159271
 fast/forms/ios/file-upload-panel-capture.html [ Pass Crash ] # remove crash after this is resolved: webkit.org/b/268568

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt
@@ -1,0 +1,45 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 205.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 220.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1521,6 +1521,8 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 
 # Only applicable on platforms with HDR support
 [ Sequoia+ ] compositing/hdr/hdr-basic-canvas.html [ Pass ]
+[ Sequoia+ ] compositing/hdr/hdr-basic-image.html [ Pass ]
+webkit.org/b/287985 [ Sequoia+ ] fast/images/hdr-basic-image.html [ ImageOnlyFailure ]
 
 # The direct image codepath is not used with the remote layer tree.
 [ Sonoma+ ] compositing/images/direct-image-object-fit.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-expected.txt
@@ -1,0 +1,45 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 2
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 204.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 220.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -125,7 +125,12 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
         if (headroom == Headroom::FromImage)
             headroom = currentFrameHeadroom();
 
-        context.drawNativeImage(*nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
+        constexpr static auto goldenColor = SRGBA<uint8_t> { 255, 215, 0 };
+
+        if (headroomForTesting().value_or(Headroom::None) > Headroom::None)
+            fillWithSolidColor(context, destinationRect, goldenColor, options.compositeOperator());
+        else
+            context.drawNativeImage(*nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
     }
 
     if (auto observer = imageObserver())

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -72,7 +72,7 @@ public:
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->size(orientation); }
     FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return m_source->sourceSize(orientation); }
     DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
-    Headroom headroom() const final { return m_source->headroom(); }
+    Headroom headroom() const final { return headroomForTesting().value_or(m_source->headroom()); }
     ImageOrientation orientation() const final { return m_source->orientation(); }
     unsigned frameCount() const final { return m_source->frameCount(); }
 #if ASSERT_ENABLED
@@ -91,6 +91,8 @@ public:
     bool isAsyncDecodingEnabledForTesting() const { return m_source->isAsyncDecodingEnabledForTesting(); }
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) { m_source->setClearDecoderAfterAsyncFrameRequestForTesting(enabled); }
+    void setHeadroomForTesting(Headroom headroom) { m_source->setHeadroomForTesting(headroom); }
+    std::optional<Headroom> headroomForTesting() const { return m_source->headroomForTesting(); }
     unsigned decodeCountForTesting() const { return m_source->decodeCountForTesting(); }
     unsigned blankDrawCountForTesting() const { return m_source->blankDrawCountForTesting(); }
 

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -189,6 +189,8 @@ private:
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) final { m_clearDecoderAfterAsyncFrameRequestForTesting = enabled; }
     void setAsyncDecodingEnabledForTesting(bool enabled) final { m_isAsyncDecodingEnabledForTesting = enabled; }
     bool isAsyncDecodingEnabledForTesting() const final { return m_isAsyncDecodingEnabledForTesting; }
+    void setHeadroomForTesting(Headroom headroom) final { m_headroomForTesting = headroom; }
+    std::optional<Headroom> headroomForTesting() const final { return m_headroomForTesting; }
 
     void dump(TextStream&) const final;
 
@@ -214,6 +216,7 @@ private:
     unsigned m_blankDrawCountForTesting { 0 };
     bool m_isAsyncDecodingEnabledForTesting { false };
     bool m_clearDecoderAfterAsyncFrameRequestForTesting { false };
+    std::optional<Headroom> m_headroomForTesting;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -111,6 +111,8 @@ public:
     virtual void setClearDecoderAfterAsyncFrameRequestForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual void setAsyncDecodingEnabledForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual bool isAsyncDecodingEnabledForTesting() const { return false; }
+    virtual void setHeadroomForTesting(Headroom) { RELEASE_ASSERT_NOT_REACHED(); }
+    virtual std::optional<Headroom> headroomForTesting() const { return std::nullopt; }
 
     virtual void dump(WTF::TextStream&) const { }
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1253,6 +1253,12 @@ void Internals::setForceUpdateImageDataEnabledForTesting(HTMLImageElement& eleme
         cachedImage->setForceUpdateImageDataEnabledForTesting(enabled);
 }
 
+void Internals::setHeadroomForTesting(HTMLImageElement& element, float headroom)
+{
+    if (auto* bitmapImage = bitmapImageFromImageElement(element))
+        bitmapImage->setHeadroomForTesting(headroom);
+}
+
 #if ENABLE(WEB_CODECS)
 bool Internals::hasPendingActivity(const WebCodecsVideoDecoder& decoder) const
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -267,6 +267,7 @@ public:
     unsigned remoteImagesCountForTesting() const;
     void setAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);
     void setForceUpdateImageDataEnabledForTesting(HTMLImageElement&, bool enabled);
+    void setHeadroomForTesting(HTMLImageElement&, float headroom);
 
 #if ENABLE(WEB_CODECS)
     bool hasPendingActivity(const WebCodecsVideoDecoder&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -733,6 +733,7 @@ enum ContentsFormat {
     unsigned long remoteImagesCountForTesting();
     undefined setAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);
     undefined setForceUpdateImageDataEnabledForTesting(HTMLImageElement element, boolean enabled);
+    undefined setHeadroomForTesting(HTMLImageElement element, float headroom);
 
     [Conditional=WEB_CODECS] boolean hasPendingActivity(WebCodecsVideoDecoder decoder);
 


### PR DESCRIPTION
#### 0f0ff23d36e8a0f0fb8627b7038275a1cc569eeb
<pre>
[HDR] Add test infrastructure to enable HDR images in layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=288020#">https://bugs.webkit.org/show_bug.cgi?id=288020#</a>
<a href="https://rdar.apple.com/145173897">rdar://145173897</a>

Reviewed by Simon Fraser.

An internal API called setHeadroomForTesting() will be added. The inputs of this
API are: HTMLImageElement and a headroom as a float. This API will will override
the image headroom value.

This API will eventually sets an std::optional&lt;Headroom&gt; member in BitmapImageSource.
This setting will force the CALayer to be an HDR layer. Plus it will change the
display of this image. BitmapImage::draw() will check if setHeadroomForTesting()
was called for this image. And if this happened, it will display a golden rectangle
regardless of the original contents.

* LayoutTests/TestExpectations:
* LayoutTests/compositing/hdr/hdr-basic-image.html: Added.
* LayoutTests/fast/images/hdr-basic-image-expected.html: Added.
* LayoutTests/fast/images/hdr-basic-image.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/compositing/hdr/hdr-basic-image-expected.txt: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-basic-image-expected.txt: Added.
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::setHeadroomForTesting):
(WebCore::ImageSource::headroomForTesting const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setHeadroomForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/290704@main">https://commits.webkit.org/290704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a8cb764cf23b68bddbbce306129725e5bebc6f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69846 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27380 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93834 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8188 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82339 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36730 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40748 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78257 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97826 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18028 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19288 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22531 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21155 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23382 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->