### PR TITLE
Reduce ODR violations when using Objective-C ARC

### DIFF
--- a/Source/WTF/wtf/BlockPtr.h
+++ b/Source/WTF/wtf/BlockPtr.h
@@ -70,6 +70,7 @@
 // both ways, we need a separate copy of our code when ARC is enabled.
 #if __has_feature(objc_arc)
 #define BlockPtr BlockPtrArc
+#define makeBlockPtr makeBlockPtrArc
 #endif
 
 namespace WTF {

--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -23,6 +23,13 @@
 #include <stddef.h>
 #include <wtf/Platform.h>
 
+#if defined(__has_feature)
+#if __has_feature(objc_arc)
+#define OSObjectPtr OSObjectPtrArc
+#define RetainPtr RetainPtrArc
+#endif
+#endif
+
 namespace WTF {
 
 class ASCIILiteral;

--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -34,6 +34,7 @@
 #define adoptOSObject adoptOSObjectArc
 #define retainOSObject retainOSObjectArc
 #define releaseOSObject releaseOSObjectArc
+#define OSObjectPtr OSObjectPtrArc
 #endif
 
 namespace WTF {

--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -57,6 +57,7 @@ typedef struct objc_object *id;
 // both ways, we need a separate copy of our code when ARC is enabled.
 #if __has_feature(objc_arc)
 #define adoptNS adoptNSArc
+#define RetainPtr RetainPtrArc
 #endif
 
 namespace WTF {

--- a/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
+++ b/Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp
@@ -55,14 +55,11 @@ void WorkQueueBase::dispatch(Function<void()>&& function)
 
 void WorkQueueBase::dispatchWithQOS(Function<void()>&& function, QOS qos)
 {
-    dispatch_block_t blockWithQOS = dispatch_block_create_with_qos_class(DISPATCH_BLOCK_ENFORCE_QOS_CLASS, Thread::dispatchQOSClass(qos), 0, makeBlockPtr([function = WTFMove(function)] () mutable {
+    auto blockWithQOS = adoptOSObject(dispatch_block_create_with_qos_class(DISPATCH_BLOCK_ENFORCE_QOS_CLASS, Thread::dispatchQOSClass(qos), 0, makeBlockPtr([function = WTFMove(function)] () mutable {
         function();
         function = { };
-    }).get());
-    dispatch_async(m_dispatchQueue.get(), blockWithQOS);
-#if !__has_feature(objc_arc)
-    Block_release(blockWithQOS);
-#endif
+    }).get()));
+    dispatch_async(m_dispatchQueue.get(), blockWithQOS.get());
 }
 
 void WorkQueueBase::dispatchAfter(Seconds duration, Function<void()>&& function)

--- a/Source/WebKit/Shared/API/APIData.h
+++ b/Source/WebKit/Shared/API/APIData.h
@@ -73,7 +73,7 @@ public:
     }
 
 #if PLATFORM(COCOA)
-    static Ref<Data> createWithoutCopying(RetainPtr<NSData>);
+    static Ref<Data> createWithoutCopying(NSData *);
 #endif
 
     ~Data()

--- a/Source/WebKit/Shared/Cocoa/APIDataCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/APIDataCocoa.mm
@@ -30,10 +30,10 @@
 
 namespace API {
 
-Ref<Data> Data::createWithoutCopying(RetainPtr<NSData> data)
+Ref<Data> Data::createWithoutCopying(NSData *data)
 {
-    auto dataSpan = WTF::span(data.get());
-    return createWithoutCopying(dataSpan, [data = WTFMove(data)] { });
+    auto dataSpan = WTF::span(data);
+    return createWithoutCopying(dataSpan, [data = RetainPtr { data }] { });
 }
 
 } // namespace API

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
@@ -463,7 +463,7 @@ static void softUpdateTest(IsAppInitiated isAppInitiated)
         TestWebKitAPI::HTTPServer server1({
             { "/"_s, { mainSWBytes } },
             { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, js } },
-        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity());
+        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity().get());
         serverPort = server1.port();
 
         NSURLRequest *request = server1.request();
@@ -483,7 +483,7 @@ static void softUpdateTest(IsAppInitiated isAppInitiated)
         TestWebKitAPI::HTTPServer server2({
             { "/"_s, { mainSWBytes } },
             { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, js } }
-        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity2(), serverPort);
+        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity2().get(), serverPort);
 
         NSMutableURLRequest *request2 = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", server2.port()]]];
         auto attributionValue = isAppInitiated == IsAppInitiated::Yes ? NSURLRequestAttributionDeveloper : NSURLRequestAttributionUser;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -2725,7 +2725,7 @@ TEST(ServiceWorkers, ChangeOfServerCertificate)
         TestWebKitAPI::HTTPServer server1({
             { "/"_s, { main } },
             { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, js } }
-        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity());
+        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity().get());
         serverPort = server1.port();
 
         [webView1 loadRequest:server1.request()];
@@ -2740,7 +2740,7 @@ TEST(ServiceWorkers, ChangeOfServerCertificate)
         TestWebKitAPI::HTTPServer server2({
             { "/"_s, { main } },
             { "/sw.js"_s, { {{ "Content-Type"_s, "application/javascript"_s }}, js } }
-        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity2(), serverPort);
+        }, TestWebKitAPI::HTTPServer::Protocol::Https, nullptr, testIdentity2().get(), serverPort);
 
         [webView2 loadRequest:server2.request()];
         EXPECT_WK_STREQ([webView2 _test_waitForAlert], "new worker");

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -47,7 +47,7 @@ public:
     enum class Protocol : uint8_t { Http, Https, HttpsWithLegacyTLS, Http2, HttpsProxy, HttpsProxyWithAuthentication };
     using CertificateVerifier = Function<void(sec_protocol_metadata_t, sec_trust_t, sec_protocol_verify_complete_t)>;
 
-    HTTPServer(std::initializer_list<std::pair<String, HTTPResponse>>, Protocol = Protocol::Http, CertificateVerifier&& = nullptr, RetainPtr<SecIdentityRef>&& = nullptr, std::optional<uint16_t> port = { });
+    HTTPServer(std::initializer_list<std::pair<String, HTTPResponse>>, Protocol = Protocol::Http, CertificateVerifier&& = nullptr, SecIdentityRef = nullptr, std::optional<uint16_t> port = { });
     HTTPServer(Function<void(Connection)>&&, Protocol = Protocol::Http);
     enum class UseCoroutines : bool { Yes };
     HTTPServer(UseCoroutines, Function<Task(Connection)>&&, Protocol = Protocol::Http);

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -201,9 +201,9 @@ void HTTPServer::terminateAllConnections(CompletionHandler<void()>&& completionH
         connection.terminate([aggregator] { });
 }
 
-HTTPServer::HTTPServer(std::initializer_list<std::pair<String, HTTPResponse>> responses, Protocol protocol, CertificateVerifier&& verifier, RetainPtr<SecIdentityRef>&& identity, std::optional<uint16_t> port)
+HTTPServer::HTTPServer(std::initializer_list<std::pair<String, HTTPResponse>> responses, Protocol protocol, CertificateVerifier&& verifier, SecIdentityRef identity, std::optional<uint16_t> port)
     : m_requestData(adoptRef(*new RequestData(responses)))
-    , m_listener(adoptNS(nw_listener_create(listenerParameters(protocol, WTFMove(verifier), WTFMove(identity), port).get())))
+    , m_listener(adoptNS(nw_listener_create(listenerParameters(protocol, WTFMove(verifier), identity, port).get())))
     , m_protocol(protocol)
 {
     nw_listener_set_queue(m_listener.get(), dispatch_get_main_queue());


### PR DESCRIPTION
#### 0164d04ec7e4eadc7c63b2ff2689a42e660ef471
<pre>
Reduce ODR violations when using Objective-C ARC
<a href="https://bugs.webkit.org/show_bug.cgi?id=288032">https://bugs.webkit.org/show_bug.cgi?id=288032</a>
<a href="https://rdar.apple.com/145180401">rdar://145180401</a>

Reviewed by Ryosuke Niwa and David Kilzer.

When an ARC file and a non-ARC file both #include the same header, for each
inline function in the header, the compiler emits two versions — the ARC
version and the non-ARC version.

This includes implicitly generated inline functions like constructors,
assignment operators, and destructors.

Technically, having two versions of an inline function is always a violation of
C++&apos;s &quot;One Definition Rule&quot;, and is always undef, even if both functions have
similar behavior (&quot;...each definition of D shall consist of the same sequence
of tokens... implicit calls... shall refer to the same function...&quot;)

In practice, you only get a leak or a crash when the ARC version and the non-ARC
version have different behavior, for example:
    * when the function initializes, modifies, or destroys a stored property
    * when the function returns a pointer to an ARC type
    * when the function declares NS_RETURNS_RETAINED or NS_RELEASES_ARGUMENT

Example: <a href="https://rdar.apple.com/73620184">rdar://73620184</a>.

I haven’t figured out how to solve this yet.

For now, this patch extends our existing workaround to make mistakes less
likely as we roll out smart pointers across WebKit. Specifically, it gives
makeBlockPtr, RetainPtr, and OSObjectPtr different names in ARC and non-ARC
files. This ensures that their inline functions can’t conflict with each other
across files.

As a consequence, it is no longer possible to pass a RetainPtr argument
from an ARC file to a non-ARC file, or vice-versa.

* Source/WTF/wtf/BlockPtr.h:
* Source/WTF/wtf/Forward.h:
* Source/WTF/wtf/OSObjectPtr.h:
* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/cocoa/WorkQueueCocoa.cpp:
(WTF::WorkQueueBase::dispatchWithQOS):
* Source/WebKit/Shared/API/APIData.h:
* Source/WebKit/Shared/Cocoa/APIDataCocoa.mm:
(API::Data::createWithoutCopying):

Canonical link: <a href="https://commits.webkit.org/290734@main">https://commits.webkit.org/290734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe7582e599a01ec46a319c48d4de195ff98cf2f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95944 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18776 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50246 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8042 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36816 "Found 60 new test failures: fast/workers/worker-page-cache.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html imported/w3c/web-platform-tests/css/css-conditional/css-supports-033.xht imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-004.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-005.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-001.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-002.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline-grid-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-align-baseline.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40837 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83742 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97917 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89696 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18120 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18379 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78117 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22600 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21215 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14343 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18125 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112262 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17862 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21320 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->