### PR TITLE
Address safer C++ static analysis warnings in WKWebViewConfiguration

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -13,7 +13,6 @@ Shared/UserData.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKDownload.mm
 UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
-UIProcess/API/Cocoa/WKWebViewConfiguration.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKInspectorConfiguration.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -136,7 +136,6 @@ UIProcess/API/Cocoa/WKProcessPool.mm
 UIProcess/API/Cocoa/WKURLSchemeTask.mm
 UIProcess/API/Cocoa/WKUserContentController.mm
 UIProcess/API/Cocoa/WKUserScript.mm
-UIProcess/API/Cocoa/WKWebViewConfiguration.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebpagePreferences.mm
 UIProcess/API/Cocoa/WKWebsiteDataRecord.mm

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -181,6 +181,11 @@ WebUserContentControllerProxy& PageConfiguration::userContentController() const
     return m_data.userContentController.get();
 }
 
+Ref<WebUserContentControllerProxy> PageConfiguration::protectedUserContentController() const
+{
+    return userContentController();
+}
+
 void PageConfiguration::setUserContentController(RefPtr<WebUserContentControllerProxy>&& userContentController)
 {
     m_data.userContentController = WTFMove(userContentController);
@@ -202,6 +207,11 @@ WebExtensionController* PageConfiguration::webExtensionController() const
     return m_data.webExtensionController.get();
 }
 
+RefPtr<WebExtensionController> PageConfiguration::protectedWebExtensionController() const
+{
+    return webExtensionController();
+}
+
 void PageConfiguration::setWebExtensionController(RefPtr<WebExtensionController>&& webExtensionController)
 {
     m_data.webExtensionController = WTFMove(webExtensionController);
@@ -210,6 +220,11 @@ void PageConfiguration::setWebExtensionController(RefPtr<WebExtensionController>
 WebExtensionController* PageConfiguration::weakWebExtensionController() const
 {
     return m_data.weakWebExtensionController.get();
+}
+
+RefPtr<WebExtensionController> PageConfiguration::protectedWeakWebExtensionController() const
+{
+    return weakWebExtensionController();
 }
 
 void PageConfiguration::setWeakWebExtensionController(WebExtensionController* webExtensionController)
@@ -243,6 +258,11 @@ void PageConfiguration::setPageGroup(RefPtr<WebPageGroup>&& pageGroup)
 WebPreferences& PageConfiguration::preferences() const
 {
     return m_data.preferences.get();
+}
+
+Ref<WebPreferences> PageConfiguration::protectedPreferences() const
+{
+    return preferences();
 }
 
 void PageConfiguration::setPreferences(RefPtr<WebPreferences>&& preferences)
@@ -280,6 +300,11 @@ WebKit::VisitedLinkStore& PageConfiguration::visitedLinkStore() const
     return m_data.visitedLinkStore.get();
 }
 
+Ref<WebKit::VisitedLinkStore> PageConfiguration::protectedVisitedLinkStore() const
+{
+    return visitedLinkStore();
+}
+
 void PageConfiguration::setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&& visitedLinkStore)
 {
     m_data.visitedLinkStore = WTFMove(visitedLinkStore);
@@ -295,6 +320,11 @@ WebsiteDataStore& PageConfiguration::websiteDataStore() const
 WebKit::WebsiteDataStore* PageConfiguration::websiteDataStoreIfExists() const
 {
     return m_data.websiteDataStore.get();
+}
+
+RefPtr<WebKit::WebsiteDataStore> PageConfiguration::protectedWebsiteDataStoreIfExists() const
+{
+    return websiteDataStoreIfExists();
 }
 
 Ref<WebsiteDataStore> PageConfiguration::protectedWebsiteDataStore() const
@@ -378,6 +408,11 @@ bool PageConfiguration::isLockdownModeExplicitlySet() const
 ApplicationManifest* PageConfiguration::applicationManifest() const
 {
     return m_data.applicationManifest.get();
+}
+
+RefPtr<ApplicationManifest> PageConfiguration::protectedApplicationManifest() const
+{
+    return applicationManifest();
 }
 
 void PageConfiguration::setApplicationManifest(RefPtr<ApplicationManifest>&& applicationManifest)

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -134,6 +134,7 @@ public:
     void setProcessPool(RefPtr<WebKit::WebProcessPool>&&);
 
     WebKit::WebUserContentControllerProxy& userContentController() const;
+    Ref<WebKit::WebUserContentControllerProxy> protectedUserContentController() const;
     void setUserContentController(RefPtr<WebKit::WebUserContentControllerProxy>&&);
 
 #if ENABLE(WK_WEB_EXTENSIONS)
@@ -141,9 +142,11 @@ public:
     void setRequiredWebExtensionBaseURL(WTF::URL&&);
 
     WebKit::WebExtensionController* webExtensionController() const;
+    RefPtr<WebKit::WebExtensionController> protectedWebExtensionController() const;
     void setWebExtensionController(RefPtr<WebKit::WebExtensionController>&&);
 
     WebKit::WebExtensionController* weakWebExtensionController() const;
+    RefPtr<WebKit::WebExtensionController> protectedWeakWebExtensionController() const;
     void setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
@@ -151,6 +154,7 @@ public:
     void setPageGroup(RefPtr<WebKit::WebPageGroup>&&);
 
     WebKit::WebPreferences& preferences() const;
+    Ref<WebKit::WebPreferences> protectedPreferences() const;
     void setPreferences(RefPtr<WebKit::WebPreferences>&&);
 
     WebKit::WebPageProxy* relatedPage() const;
@@ -163,10 +167,12 @@ public:
     void setAlternateWebViewForNavigationGestures(WeakPtr<WebKit::WebPageProxy>&&);
 
     WebKit::VisitedLinkStore& visitedLinkStore() const;
+    Ref<WebKit::VisitedLinkStore> protectedVisitedLinkStore() const;
     void setVisitedLinkStore(RefPtr<WebKit::VisitedLinkStore>&&);
 
     WebKit::WebsiteDataStore& websiteDataStore() const;
     WebKit::WebsiteDataStore* websiteDataStoreIfExists() const;
+    RefPtr<WebKit::WebsiteDataStore> protectedWebsiteDataStoreIfExists() const;
     Ref<WebKit::WebsiteDataStore> protectedWebsiteDataStore() const;
     void setWebsiteDataStore(RefPtr<WebKit::WebsiteDataStore>&&);
 
@@ -257,6 +263,7 @@ public:
 
 #if ENABLE(APPLICATION_MANIFEST)
     ApplicationManifest* applicationManifest() const;
+    RefPtr<ApplicationManifest> protectedApplicationManifest() const;
     void setApplicationManifest(RefPtr<ApplicationManifest>&&);
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -120,9 +120,14 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebViewConfiguration.class, self))
         return;
 
-    _pageConfiguration->API::PageConfiguration::~PageConfiguration();
+    self._protectedPageConfiguration->API::PageConfiguration::~PageConfiguration();
 
     [super dealloc];
+}
+
+- (Ref<API::PageConfiguration>)_protectedPageConfiguration
+{
+    return *_pageConfiguration;
 }
 
 - (void)setAllowsInlinePredictions:(BOOL)enabled
@@ -315,7 +320,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (id)copyWithZone:(NSZone *)zone
 {
     WKWebViewConfiguration *configuration = [(WKWebViewConfiguration *)[[self class] allocWithZone:zone] init];
-    configuration->_pageConfiguration->copyDataFrom(*_pageConfiguration);
+    [configuration _protectedPageConfiguration]->copyDataFrom(self._protectedPageConfiguration);
     return configuration;
 }
 
@@ -342,38 +347,38 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKProcessPool *)processPool
 {
-    return wrapper(_pageConfiguration->processPool());
+    return wrapper(self._protectedPageConfiguration->protectedProcessPool().get());
 }
 
 - (void)setProcessPool:(WKProcessPool *)processPool
 {
-    _pageConfiguration->setProcessPool(processPool ? processPool->_processPool.get() : nullptr);
+    self._protectedPageConfiguration->setProcessPool(processPool ? processPool->_processPool.get() : nullptr);
 }
 
 - (WKPreferences *)preferences
 {
-    return wrapper(_pageConfiguration->preferences());
+    return wrapper(self._protectedPageConfiguration->protectedPreferences().get());
 }
 
 - (void)setPreferences:(WKPreferences *)preferences
 {
-    _pageConfiguration->setPreferences(preferences ? preferences->_preferences.get() : nullptr);
+    self._protectedPageConfiguration->setPreferences(preferences ? preferences->_preferences.get() : nullptr);
 }
 
 - (WKUserContentController *)userContentController
 {
-    return wrapper(_pageConfiguration->userContentController());
+    return wrapper(self._protectedPageConfiguration->protectedUserContentController().get());
 }
 
 - (void)setUserContentController:(WKUserContentController *)userContentController
 {
-    _pageConfiguration->setUserContentController(userContentController ? userContentController->_userContentControllerProxy.get() : nullptr);
+    self._protectedPageConfiguration->setUserContentController(userContentController ? userContentController->_userContentControllerProxy.get() : nullptr);
 }
 
 - (NSURL *)_requiredWebExtensionBaseURL
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return _pageConfiguration->requiredWebExtensionBaseURL();
+    return self._protectedPageConfiguration->requiredWebExtensionBaseURL();
 #else
     return nil;
 #endif
@@ -382,14 +387,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_setRequiredWebExtensionBaseURL:(NSURL *)baseURL
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    _pageConfiguration->setRequiredWebExtensionBaseURL(baseURL);
+    self._protectedPageConfiguration->setRequiredWebExtensionBaseURL(baseURL);
 #endif
 }
 
 - (WKWebExtensionController *)_strongWebExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return wrapper(_pageConfiguration->webExtensionController());
+    return wrapper(self._protectedPageConfiguration->protectedWebExtensionController().get());
 #else
     return nil;
 #endif
@@ -398,7 +403,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (WKWebExtensionController *)_weakWebExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    return wrapper(_pageConfiguration->weakWebExtensionController());
+    return wrapper(self._protectedPageConfiguration->protectedWeakWebExtensionController().get());
 #else
     return nil;
 #endif
@@ -407,7 +412,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)_setWeakWebExtensionController:(WKWebExtensionController *)webExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    _pageConfiguration->setWeakWebExtensionController(webExtensionController ? &webExtensionController._webExtensionController : nullptr);
+    self._protectedPageConfiguration->setWeakWebExtensionController(webExtensionController ? Ref { webExtensionController._webExtensionController }.ptr() : nullptr);
 #endif
 }
 
@@ -423,7 +428,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)setWebExtensionController:(WKWebExtensionController *)webExtensionController
 {
 #if ENABLE(WK_WEB_EXTENSIONS)
-    _pageConfiguration->setWebExtensionController(webExtensionController ? &webExtensionController._webExtensionController : nullptr);
+    self._protectedPageConfiguration->setWebExtensionController(webExtensionController ? Ref { webExtensionController._webExtensionController }.ptr() : nullptr);
 #endif
 }
 
@@ -455,7 +460,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKWebsiteDataStore *)websiteDataStore
 {
-    return wrapper(_pageConfiguration->websiteDataStore());
+    return wrapper(self._protectedPageConfiguration->protectedWebsiteDataStore().get());
 }
 
 - (WKAudiovisualMediaTypes)mediaTypesRequiringUserActionForPlayback
@@ -490,17 +495,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)setWebsiteDataStore:(WKWebsiteDataStore *)websiteDataStore
 {
-    _pageConfiguration->setWebsiteDataStore(websiteDataStore ? websiteDataStore->_websiteDataStore.get() : nullptr);
+    self._protectedPageConfiguration->setWebsiteDataStore(websiteDataStore ? websiteDataStore->_websiteDataStore.get() : nullptr);
 }
 
 - (WKWebpagePreferences *)defaultWebpagePreferences
 {
-    return wrapper(_pageConfiguration->defaultWebsitePolicies());
+    return wrapper(self._protectedPageConfiguration->protectedDefaultWebsitePolicies().get());
 }
 
 - (void)setDefaultWebpagePreferences:(WKWebpagePreferences *)defaultWebpagePreferences
 {
-    _pageConfiguration->setDefaultWebsitePolicies(defaultWebpagePreferences ? defaultWebpagePreferences->_websitePolicies.get() : nullptr);
+    self._protectedPageConfiguration->setDefaultWebsitePolicies(defaultWebpagePreferences ? defaultWebpagePreferences->_websitePolicies.get() : nullptr);
 }
 
 static NSString *defaultApplicationNameForUserAgent()
@@ -529,12 +534,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (_WKVisitedLinkStore *)_visitedLinkStore
 {
-    return wrapper(_pageConfiguration->visitedLinkStore());
+    return wrapper(self._protectedPageConfiguration->protectedVisitedLinkStore().get());
 }
 
 - (void)_setVisitedLinkStore:(_WKVisitedLinkStore *)visitedLinkStore
 {
-    _pageConfiguration->setVisitedLinkStore(visitedLinkStore ? visitedLinkStore->_visitedLinkStore.get() : nullptr);
+    self._protectedPageConfiguration->setVisitedLinkStore(visitedLinkStore ? visitedLinkStore->_visitedLinkStore.get() : nullptr);
 }
 
 - (void)setURLSchemeHandler:(id <WKURLSchemeHandler>)urlSchemeHandler forURLScheme:(NSString *)urlScheme
@@ -546,10 +551,10 @@ static NSString *defaultApplicationNameForUserAgent()
     if (!canonicalScheme)
         [NSException raise:NSInvalidArgumentException format:@"'%@' is not a valid URL scheme", urlScheme];
 
-    if (_pageConfiguration->urlSchemeHandlerForURLScheme(*canonicalScheme))
+    if (self._protectedPageConfiguration->urlSchemeHandlerForURLScheme(*canonicalScheme))
         [NSException raise:NSInvalidArgumentException format:@"URL scheme '%@' already has a registered URL scheme handler", urlScheme];
 
-    _pageConfiguration->setURLSchemeHandlerForURLScheme(WebKit::WebURLSchemeHandlerCocoa::create(urlSchemeHandler), *canonicalScheme);
+    self._protectedPageConfiguration->setURLSchemeHandlerForURLScheme(WebKit::WebURLSchemeHandlerCocoa::create(urlSchemeHandler), *canonicalScheme);
 }
 
 - (id <WKURLSchemeHandler>)urlSchemeHandlerForURLScheme:(NSString *)urlScheme
@@ -558,11 +563,11 @@ static NSString *defaultApplicationNameForUserAgent()
     if (!canonicalScheme)
         return nil;
 
-    auto handler = _pageConfiguration->urlSchemeHandlerForURLScheme(*canonicalScheme);
+    auto handler = self._protectedPageConfiguration->urlSchemeHandlerForURLScheme(*canonicalScheme);
     if (!handler || !handler->isAPIHandler())
         return nil;
 
-    return static_cast<WebKit::WebURLSchemeHandlerCocoa*>(handler.get())->apiHandler();
+    return downcast<WebKit::WebURLSchemeHandlerCocoa>(handler.get())->apiHandler();
 }
 
 + (BOOL)_isValidCustomScheme:(NSString *)urlScheme
@@ -627,7 +632,7 @@ static NSString *defaultApplicationNameForUserAgent()
 - (WKWebView *)_relatedWebView
 {
     // FIXME: Remove when rdar://134318457, rdar://134318538 and rdar://125369363 are complete.
-    if (RefPtr page = _pageConfiguration->relatedPage())
+    if (RefPtr page = self._protectedPageConfiguration->relatedPage())
         return page->cocoaView().autorelease();
     return nil;
 }
@@ -642,7 +647,7 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (WKWebView *)_webViewToCloneSessionStorageFrom
 {
-    if (RefPtr page = _pageConfiguration->pageToCloneSessionStorageFrom())
+    if (RefPtr page = self._protectedPageConfiguration->pageToCloneSessionStorageFrom())
         return page->cocoaView().autorelease();
     return nil;
 }
@@ -650,14 +655,14 @@ static NSString *defaultApplicationNameForUserAgent()
 - (void)_setWebViewToCloneSessionStorageFrom:(WKWebView *)webViewToCloneSessionStorageFrom
 {
     if (webViewToCloneSessionStorageFrom)
-        _pageConfiguration->setPageToCloneSessionStorageFrom(webViewToCloneSessionStorageFrom->_page.get());
+        self._protectedPageConfiguration->setPageToCloneSessionStorageFrom(webViewToCloneSessionStorageFrom->_page.get());
     else
-        _pageConfiguration->setPageToCloneSessionStorageFrom(nullptr);
+        self._protectedPageConfiguration->setPageToCloneSessionStorageFrom(nullptr);
 }
 
 - (WKWebView *)_alternateWebViewForNavigationGestures
 {
-    if (RefPtr page = _pageConfiguration->alternateWebViewForNavigationGestures())
+    if (RefPtr page = self._protectedPageConfiguration->alternateWebViewForNavigationGestures())
         return page->cocoaView().autorelease();
     return nil;
 }
@@ -665,9 +670,9 @@ static NSString *defaultApplicationNameForUserAgent()
 - (void)_setAlternateWebViewForNavigationGestures:(WKWebView *)alternateView
 {
     if (alternateView)
-        _pageConfiguration->setAlternateWebViewForNavigationGestures(alternateView->_page.get());
+        self._protectedPageConfiguration->setAlternateWebViewForNavigationGestures(alternateView->_page.get());
     else
-        _pageConfiguration->setAlternateWebViewForNavigationGestures(nullptr);
+        self._protectedPageConfiguration->setAlternateWebViewForNavigationGestures(nullptr);
 }
 
 - (NSString *)_groupIdentifier
@@ -682,12 +687,12 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (BOOL)_respectsImageOrientation
 {
-    return self.preferences->_preferences->shouldRespectImageOrientation();
+    return Ref { *self.preferences->_preferences }->shouldRespectImageOrientation();
 }
 
 - (void)_setRespectsImageOrientation:(BOOL)respectsImageOrientation
 {
-    self.preferences->_preferences->setShouldRespectImageOrientation(respectsImageOrientation);
+    Ref { *self.preferences->_preferences }->setShouldRespectImageOrientation(respectsImageOrientation);
 }
 
 - (BOOL)_printsBackgrounds
@@ -982,7 +987,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     if (attachmentFileWrapperClass && ![attachmentFileWrapperClass isSubclassOfClass:[NSFileWrapper class]])
         [NSException raise:NSInvalidArgumentException format:@"Class %@ does not inherit from NSFileWrapper", attachmentFileWrapperClass];
 
-    _pageConfiguration->setAttachmentFileWrapperClass(attachmentFileWrapperClass);
+    self._protectedPageConfiguration->setAttachmentFileWrapperClass(attachmentFileWrapperClass);
 }
 
 - (BOOL)_colorFilterEnabled
@@ -1017,7 +1022,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (WKWebsiteDataStore *)_websiteDataStoreIfExists
 {
-    return wrapper(_pageConfiguration->websiteDataStoreIfExists());
+    return wrapper(self._protectedPageConfiguration->protectedWebsiteDataStoreIfExists().get());
 }
 
 - (NSArray<NSString *> *)_corsDisablingPatterns
@@ -1027,12 +1032,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (void)_setCORSDisablingPatterns:(NSArray<NSString *> *)patterns
 {
-    _pageConfiguration->setCORSDisablingPatterns(makeVector<String>(patterns));
+    self._protectedPageConfiguration->setCORSDisablingPatterns(makeVector<String>(patterns));
 }
 
 - (NSSet<NSString *> *)_maskedURLSchemes
 {
-    const auto& schemes = _pageConfiguration->maskedURLSchemes();
+    const auto& schemes = self._protectedPageConfiguration->maskedURLSchemes();
     NSMutableSet<NSString *> *set = [NSMutableSet setWithCapacity:schemes.size()];
     for (const auto& scheme : schemes)
         [set addObject:scheme];
@@ -1044,12 +1049,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     HashSet<String> set;
     for (NSString *scheme in schemes)
         set.add(scheme);
-    _pageConfiguration->setMaskedURLSchemes(WTFMove(set));
+    self._protectedPageConfiguration->setMaskedURLSchemes(WTFMove(set));
 }
 
 - (void)_setLoadsFromNetwork:(BOOL)loads
 {
-    _pageConfiguration->setAllowedNetworkHosts(loads ? std::nullopt : std::optional { MemoryCompactLookupOnlyRobinHoodHashSet<String> { } });
+    self._protectedPageConfiguration->setAllowedNetworkHosts(loads ? std::nullopt : std::optional { MemoryCompactLookupOnlyRobinHoodHashSet<String> { } });
 }
 
 - (BOOL)_loadsFromNetwork
@@ -1060,11 +1065,11 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 - (void)_setAllowedNetworkHosts:(NSSet<NSString *> *)hosts
 {
     if (!hosts)
-        return _pageConfiguration->setAllowedNetworkHosts(std::nullopt);
+        return self._protectedPageConfiguration->setAllowedNetworkHosts(std::nullopt);
     MemoryCompactLookupOnlyRobinHoodHashSet<String> set;
     for (NSString *host in hosts)
         set.add(host);
-    _pageConfiguration->setAllowedNetworkHosts(WTFMove(set));
+    self._protectedPageConfiguration->setAllowedNetworkHosts(WTFMove(set));
 }
 
 - (NSSet<NSString *> *)_allowedNetworkHosts
@@ -1186,12 +1191,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (_WKApplicationManifest *)_applicationManifest
 {
-    return wrapper(_pageConfiguration->applicationManifest());
+    return wrapper(self._protectedPageConfiguration->protectedApplicationManifest().get());
 }
 
 - (void)_setApplicationManifest:(_WKApplicationManifest *)applicationManifest
 {
-    _pageConfiguration->setApplicationManifest(applicationManifest ? applicationManifest->_applicationManifest.get() : nullptr);
+    self._protectedPageConfiguration->setApplicationManifest(applicationManifest ? applicationManifest->_applicationManifest.get() : nullptr);
 }
 
 #if PLATFORM(MAC)
@@ -1269,7 +1274,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 - (BOOL)_applePayEnabled
 {
 #if ENABLE(APPLE_PAY)
-    return _pageConfiguration->applePayEnabled();
+    return self._protectedPageConfiguration->applePayEnabled();
 #else
     return NO;
 #endif
@@ -1278,7 +1283,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 - (void)_setApplePayEnabled:(BOOL)applePayEnabled
 {
 #if ENABLE(APPLE_PAY)
-    _pageConfiguration->setApplePayEnabled(applePayEnabled);
+    self._protectedPageConfiguration->setApplePayEnabled(applePayEnabled);
 #endif
 }
 
@@ -1343,9 +1348,9 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 - (void)_setAdditionalSupportedImageTypes:(NSArray<NSString *> *)additionalSupportedImageTypes
 {
     if (additionalSupportedImageTypes)
-        _pageConfiguration->setAdditionalSupportedImageTypes(makeVector<String>(additionalSupportedImageTypes));
+        self._protectedPageConfiguration->setAdditionalSupportedImageTypes(makeVector<String>(additionalSupportedImageTypes));
     else
-        _pageConfiguration->setAdditionalSupportedImageTypes(std::nullopt);
+        self._protectedPageConfiguration->setAdditionalSupportedImageTypes(std::nullopt);
 }
 
 - (void)_setLegacyEncryptedMediaAPIEnabled:(BOOL)enabled
@@ -1416,12 +1421,12 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 
 - (BOOL)_delaysWebProcessLaunchUntilFirstLoad
 {
-    return _pageConfiguration->delaysWebProcessLaunchUntilFirstLoad();
+    return self._protectedPageConfiguration->delaysWebProcessLaunchUntilFirstLoad();
 }
 
 - (void)_setDelaysWebProcessLaunchUntilFirstLoad:(BOOL)delaysWebProcessLaunchUntilFirstLoad
 {
-    _pageConfiguration->setDelaysWebProcessLaunchUntilFirstLoad(delaysWebProcessLaunchUntilFirstLoad);
+    self._protectedPageConfiguration->setDelaysWebProcessLaunchUntilFirstLoad(delaysWebProcessLaunchUntilFirstLoad);
 }
 
 - (BOOL)_shouldRelaxThirdPartyCookieBlocking
@@ -1438,7 +1443,7 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     allowed |= WTF::IOSApplication::isMobileSafari() || WTF::IOSApplication::isSafariViewService();
 #endif
 #if ENABLE(WK_WEB_EXTENSIONS)
-    allowed |= _pageConfiguration->requiredWebExtensionBaseURL().isValid();
+    allowed |= self._protectedPageConfiguration->requiredWebExtensionBaseURL().isValid();
 #endif
 
     if (!allowed)

--- a/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h
@@ -45,6 +45,8 @@ public:
 private:
     WebURLSchemeHandlerCocoa(id <WKURLSchemeHandler>);
 
+    bool isWebURLSchemeHandlerCocoa() const final { return true; }
+
     void platformStartTask(WebPageProxy&, WebURLSchemeTask&) final;
     void platformStopTask(WebPageProxy&, WebURLSchemeTask&) final;
 
@@ -53,3 +55,7 @@ private:
 }; // class WebURLSchemeHandler
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebURLSchemeHandlerCocoa) \
+    static bool isType(const WebKit::WebURLSchemeHandler& handler) { return handler.isWebURLSchemeHandlerCocoa(); } \
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.h
@@ -57,6 +57,7 @@ public:
     void taskCompleted(WebPageProxyIdentifier, WebURLSchemeTask&);
 
     virtual bool isAPIHandler() { return false; }
+    virtual bool isWebURLSchemeHandlerCocoa() const { return false; }
 
 protected:
     WebURLSchemeHandler();


### PR DESCRIPTION
#### c3f3b7cda7e892c4109b6c68ce2871ff12b34d63
<pre>
Address safer C++ static analysis warnings in WKWebViewConfiguration
<a href="https://bugs.webkit.org/show_bug.cgi?id=288040">https://bugs.webkit.org/show_bug.cgi?id=288040</a>

Reviewed by Timothy Hatcher and Darin Adler.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration dealloc]):
(-[WKWebViewConfiguration _protectedPageConfiguration]):
(-[WKWebViewConfiguration copyWithZone:]):
(-[WKWebViewConfiguration processPool]):
(-[WKWebViewConfiguration setProcessPool:]):
(-[WKWebViewConfiguration preferences]):
(-[WKWebViewConfiguration setPreferences:]):
(-[WKWebViewConfiguration userContentController]):
(-[WKWebViewConfiguration setUserContentController:]):
(-[WKWebViewConfiguration _requiredWebExtensionBaseURL]):
(-[WKWebViewConfiguration _setRequiredWebExtensionBaseURL:]):
(-[WKWebViewConfiguration _strongWebExtensionController]):
(-[WKWebViewConfiguration _weakWebExtensionController]):
(-[WKWebViewConfiguration _setWeakWebExtensionController:]):
(-[WKWebViewConfiguration setWebExtensionController:]):
(-[WKWebViewConfiguration websiteDataStore]):
(-[WKWebViewConfiguration setWebsiteDataStore:]):
(-[WKWebViewConfiguration defaultWebpagePreferences]):
(-[WKWebViewConfiguration setDefaultWebpagePreferences:]):
(-[WKWebViewConfiguration _visitedLinkStore]):
(-[WKWebViewConfiguration _setVisitedLinkStore:]):
(-[WKWebViewConfiguration setURLSchemeHandler:forURLScheme:]):
(-[WKWebViewConfiguration urlSchemeHandlerForURLScheme:]):
(-[WKWebViewConfiguration _relatedWebView]):
(-[WKWebViewConfiguration _webViewToCloneSessionStorageFrom]):
(-[WKWebViewConfiguration _setWebViewToCloneSessionStorageFrom:]):
(-[WKWebViewConfiguration _alternateWebViewForNavigationGestures]):
(-[WKWebViewConfiguration _setAlternateWebViewForNavigationGestures:]):
(-[WKWebViewConfiguration _respectsImageOrientation]):
(-[WKWebViewConfiguration _setRespectsImageOrientation:]):
(-[WKWebViewConfiguration _setAttachmentFileWrapperClass:]):
(-[WKWebViewConfiguration _websiteDataStoreIfExists]):
(-[WKWebViewConfiguration _setCORSDisablingPatterns:]):
(-[WKWebViewConfiguration _maskedURLSchemes]):
(-[WKWebViewConfiguration _setMaskedURLSchemes:]):
(-[WKWebViewConfiguration _setLoadsFromNetwork:]):
(-[WKWebViewConfiguration _setAllowedNetworkHosts:]):
(-[WKWebViewConfiguration _applicationManifest]):
(-[WKWebViewConfiguration _setApplicationManifest:]):
(-[WKWebViewConfiguration _applePayEnabled]):
(-[WKWebViewConfiguration _setApplePayEnabled:]):
(-[WKWebViewConfiguration _setAdditionalSupportedImageTypes:]):
(-[WKWebViewConfiguration _delaysWebProcessLaunchUntilFirstLoad]):
(-[WKWebViewConfiguration _setDelaysWebProcessLaunchUntilFirstLoad:]):
(-[WKWebViewConfiguration _setShouldRelaxThirdPartyCookieBlocking:]):
* Source/WebKit/UIProcess/Cocoa/WebURLSchemeHandlerCocoa.h:
(isType):
* Source/WebKit/UIProcess/WebURLSchemeHandler.h:
(WebKit::WebURLSchemeHandler::isWebURLSchemeHandlerCocoa const):

Canonical link: <a href="https://commits.webkit.org/290789@main">https://commits.webkit.org/290789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd2a552b82bc25c6d6a4e572358b25152de01572

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/117 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96090 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41852 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18945 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96090 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27527 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94083 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8406 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82534 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96090 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8177 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40982 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98068 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18289 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79003 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18548 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78203 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/71 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14381 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23622 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18016 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19795 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->