### PR TITLE
Fix availability declaration silencing in recent SDKs

### DIFF
--- a/WebKitLibraries/SDKs/appletvos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/appletvos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/appletvsimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/appletvsimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/macosx15.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/macosx15.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/watchos11.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/watchos11.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/watchsimulator11.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/watchsimulator11.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/xros2.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/xros2.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)

--- a/WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
+++ b/WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h
@@ -21,17 +21,13 @@
  * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
  * THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 #pragma once
 
 // Handle __IOS_PROHIBITED and friends.
 #undef __OS_AVAILABILITY
 #define __OS_AVAILABILITY(...)
-
-// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
-#undef __API_AVAILABLE_GET_MACRO
-#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
 
 #undef SWIFT_AVAILABILITY
 #define SWIFT_AVAILABILITY __NULL_AVAILABILITY
@@ -40,8 +36,28 @@
 #undef __API_DEPRECATED_MSG_GET_MACRO
 #define __API_DEPRECATED_MSG_GET_MACRO(...) __NULL_AVAILABILITY
 
+// Take care of {A,S}PI_AVAILABLE{,_BEGIN,_END}
+#undef __API_AVAILABLE_GET_MACRO
+#define __API_AVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
 // Take care of API_UNAVAILABLE{,_BEGIN,_END}
 #undef __API_UNAVAILABLE_GET_MACRO
 #define __API_UNAVAILABLE_GET_MACRO(...) __NULL_AVAILABILITY
+
+// Starting in iOS 18.4 and aligned SDKs, AvailabilityInternal.h has a hash
+// number used to detect accidental use of multiple copies of the library. Keep
+// track of known hashes and undef the hashed macro names. When encountering an
+// unknown hash, emit an error to avoid confusing build failures.
+#define __WEBKIT_OVERRIDDEN_AVAILABILITY_VERSIONS_VERSION_HASH 93585900U
+#if defined(__AVAILABILITY_VERSIONS_VERSION_HASH) && (__AVAILABILITY_VERSIONS_VERSION_HASH != 93585900U)
+#error __AVAILABILITY_VERSIONS_VERSION_HASH not recognized, please add it to WebKit's AvailabilityProhibitedInternal.h to silence availability errors.
+#endif
+
+#ifdef __API_AVAILABLE_GET_MACRO_93585900
+#undef __API_AVAILABLE_GET_MACRO_93585900
+#define __API_AVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#undef __API_UNAVAILABLE_GET_MACRO_93585900
+#define __API_UNAVAILABLE_GET_MACRO_93585900(...) __NULL_AVAILABILITY
+#endif
 
 #define __NULL_AVAILABILITY(...)


### PR DESCRIPTION
#### 6e4c604d51530a246b719663df42b53dee5b580c
<pre>
Fix availability declaration silencing in recent SDKs
<a href="https://rdar.apple.com/145186083">rdar://145186083</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288045">https://bugs.webkit.org/show_bug.cgi?id=288045</a>

Reviewed by Alexey Proskuryakov.

Recent versions of the os_availabilty library include a hash in their
implementation-detail macro names, to detect collisions with other
copies of the Availability headers in a malformed build. Since we
silence availability attributes by selectively undef-ing some of these
macros, adapt to the change by also checking for known hash names of
these macros.

While it&apos;s possible to obtain the Availability hash using
__AVAILABILITY_VERSIONS_VERSION_HASH, its value cannot be used to
un/define a preprocessor token. The best we can do is check for
unhandled hashes and emit an error message describing what to do.

In the future, we should come up with a better way to silence
availability, to avoid this bookkeeping and fix other issues like
<a href="https://bugs.webkit.org/show_bug.cgi?id=280912.">https://bugs.webkit.org/show_bug.cgi?id=280912.</a>

* WebKitLibraries/SDKs/appletvos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/appletvsimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/iphoneos18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/iphonesimulator18.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/macosx15.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/watchos11.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/watchsimulator11.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/xros2.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:
* WebKitLibraries/SDKs/xrsimulator2.0-additions.sdk/usr/local/include/AvailabilityProhibitedInternal.h:

Canonical link: <a href="https://commits.webkit.org/291004@main">https://commits.webkit.org/291004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d61328a88939b7a0b4fac1ebf362c8f1e7da8680

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96667 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19689 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94713 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50734 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41553 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98681 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18857 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78653 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19458 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23174 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18847 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18550 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22007 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->