### PR TITLE
Check for our built-in supported USD types before calling -[UTType typeWithMIMEType].

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIUtilities.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIUtilities.cpp
@@ -47,4 +47,11 @@ TEST(UTIUtilities, RequiredMIMETypesFromUTIForMailPsd)
     EXPECT_TRUE(mimeTypes.contains("application/x-photoshop"_s));
 }
 
+TEST(UTIUtilities, UTIFromMIMETypeForModelTypes)
+{
+    for (auto& mimeType : Vector<String> { "model/usd"_s, "model/vnd.pixar.usd"_s, "model/vnd.usdz+zip"_s })
+        EXPECT_EQ(UTIFromMIMEType(mimeType), "com.pixar.universal-scene-description-mobile"_s);
+    EXPECT_EQ(UTIFromMIMEType("model/vnd.reality"_s), "com.apple.reality"_s);
+}
+
 }; // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6eb104d03a3eb9d8ee7635441c62699be5576a71
<pre>
Check for our built-in supported USD types before calling -[UTType typeWithMIMEType].
<a href="https://bugs.webkit.org/show_bug.cgi?id=288050">https://bugs.webkit.org/show_bug.cgi?id=288050</a>
<a href="https://rdar.apple.com/145151302">rdar://145151302</a>

Reviewed by Mike Wyrzykowski.

-[UTType typeWithMIMEType] can return a dynamically generated UTI when
passed an unknown type, and not return null. To ensure that the
deprecated USD-related types continue to return expected UTIs, check our
built-in list first.

* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::UTIFromPotentiallyUnknownMIMEType):
Renamed from UTIFromUnknownMIMEType. UTType might know about some of these.

(WebCore::UTIFromMIMETypeCachePolicy::createValueForKey):
Check out built-in list first.

* Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestUTIUtilities.cpp:
(TestWebKitAPI::TEST(UTIUtilities, UTIFromMIMETypeForModelTypes)):
Test that the built-in model-related MIME types return expected UTIs.

Canonical link: <a href="https://commits.webkit.org/290733@main">https://commits.webkit.org/290733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1de0ddb54d6556166081a8c64f4e4eb20dc7f4b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10363 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69843 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27377 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50183 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36726 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40741 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97819 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78865 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18280 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78063 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19300 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21151 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23375 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->