### PR TITLE
Generating text fragments fails when the selected text starts and ends in different blocks.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-start-and-end-across-block-boundaries-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-start-and-end-across-block-boundaries-expected.txt
@@ -1,0 +1,1 @@
+:~:text=block,This

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-start-and-end-across-block-boundaries.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-start-and-end-across-block-boundaries.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we don't allow context generation to pass boundaries of block elements</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.setStart(document.getElementById("first").firstChild, 14);
+    range.setEnd(document.getElementById("second").firstChild, 4);
+
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body><div id="first">This is a one block.</div> And some more text. <div id="second">This is a different block.</body>
+</html>
+

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -149,7 +149,7 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
     auto generateDirective = [&] (unsigned wordsOfContext, unsigned wordsOfStartAndEndText) {
         ParsedTextDirective directive;
 
-        if (textFromRange.length() >= maximumInlineStringLength) {
+        if (textFromRange.length() >= maximumInlineStringLength || !positionsHaveSameBlockAncestor(visibleStartPosition, visibleEndPosition)) {
             directive.startText = nextWordsFromPositionInSameBlock(wordsOfStartAndEndText, visibleStartPosition);
             directive.endText = previousWordsFromPositionInSameBlock(wordsOfStartAndEndText, visibleEndPosition);
         } else


### PR DESCRIPTION
#### 2f8e7b5a5c9c9fd5e681639acccd5d0bdf4cc7e0
<pre>
Generating text fragments fails when the selected text starts and ends in different blocks.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288052">https://bugs.webkit.org/show_bug.cgi?id=288052</a>
<a href="https://rdar.apple.com/137761701">rdar://137761701</a>

Reviewed by Wenson Hsieh.

When generating links, we did not test to ensure that the beginning and end of the selected range
were within the same block. The full range does not need to exist in the same block, but each
element of the directive needs to be contained in one block, therefore we need to check that when
deciding if we should make a start and end directive, or just a start. If we decide to make a start
and end, the rest of the checks to keep the directive in the block come into play and give us a
correctly functioning directive.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-start-and-end-across-block-boundaries-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-start-and-end-across-block-boundaries.html: Added.
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):

Canonical link: <a href="https://commits.webkit.org/290748@main">https://commits.webkit.org/290748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa5cbf176bdee35305e164ce80b03f54001f9ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41614 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69840 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27374 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93822 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82331 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50180 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7944 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36721 "Found 60 new test failures: fonts/monospace.html fonts/sans-serif.html fonts/serif.html fonts/unicode-character-font-crash.html fonts/use-typo-metrics-1.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/wpt/css/css-view-transitions/navigation/cross-origin-bfcache.html http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html imported/w3c/web-platform-tests/css/css-contain/contain-layout-baseline-003.html imported/w3c/web-platform-tests/css/css-contain/contain-size-grid-002.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97814 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18016 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78861 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78059 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19308 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22522 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21148 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18025 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23370 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17764 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->