### PR TITLE
[visionOS] Scrolling sometimes drops frames due to spatial document editing context requests

### DIFF
--- a/Source/WebCore/editing/cocoa/AttributedString.mm
+++ b/Source/WebCore/editing/cocoa/AttributedString.mm
@@ -719,7 +719,7 @@ static std::optional<AttributedString::AttributeValue> extractValue(id value, Ta
     }
 #endif
     if ([value isKindOfClass:PlatformNSTextAttachment]) {
-        if ([value image] == webCoreTextAttachmentMissingPlatformImage())
+        if (isWebCoreTextAttachmentMissingPlatformImage(static_cast<CocoaImage *>([value image])))
             return { { TextAttachmentMissingImage() } };
         TextAttachmentFileWrapper textAttachment;
         if (auto accessibilityLabel = [value accessibilityLabel])

--- a/Source/WebCore/editing/cocoa/WebCoreTextAttachment.h
+++ b/Source/WebCore/editing/cocoa/WebCoreTextAttachment.h
@@ -29,8 +29,22 @@
 
 #import <Foundation/Foundation.h>
 
+OBJC_CLASS NSImage;
+OBJC_CLASS UIImage;
+
+namespace WebCore {
+
+#if USE(APPKIT)
+using CocoaImage = NSImage;
+#else
+using CocoaImage = UIImage;
+#endif
+
 // Returns an NSImage or UIImage depending on platform
-id webCoreTextAttachmentMissingPlatformImage();
+CocoaImage *webCoreTextAttachmentMissingPlatformImage();
+bool isWebCoreTextAttachmentMissingPlatformImage(CocoaImage *);
+
+} // namespace WebCore
 
 #if !PLATFORM(IOS_FAMILY)
 @interface NSTextAttachment (WebCoreNSTextAttachment)


### PR DESCRIPTION
#### a364c0f2e2f3a18524009049a2728a37ab764574
<pre>
[visionOS] Scrolling sometimes drops frames due to spatial document editing context requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=288039">https://bugs.webkit.org/show_bug.cgi?id=288039</a>
<a href="https://rdar.apple.com/144889554">rdar://144889554</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

On some configurations of visionOS, UIKit (through RemoteTextInput) requests spatial document
editing contexts with attributed strings, whenever the web view&apos;s visible content bounds change
(e.g. while scrolling); the spatial rect passed in is simply the bounds of the web view (i.e. an
approximation of the visible content rect). While a bit excessive, this is made even worse by two
latent issues in WebKit&apos;s logic for processing spatial document editing contexts:

1.  We currently (naively) hit-test the top left and bottom right corners of the passed-in rect, and
    expand the context range to include all content in between. In the case where we hit-test to an
    out-of-flow container (e.g. popup or banner), however, this often leads to the `rangeOfInterest`
    encompassing the entire contents of the webpage, which defeats the purpose of spatially
    constraining the document context.

    To fix this, we devise a new heuristic that clamps these hit-tested positions to a range around
    the current selection, whose endpoints fall within the requested spatial rect. To achieve this,
    we iterate outwards from the current selection&apos;s endpoints by line, and stop once we hit a
    visible position that does not intersect with the given rect.

2.  The web content process does not have a connection to the windowserver, so calls into
    `+[UIImage imageNamed:inBundle:withConfiguration:]` which indirectly initialize the main
    `UIScreen` in order to read the current trait collection fail after hanging for 5 seconds. When
    creating attributed strings, we end up exercising this codepath via `extractDictionary`, because
    we try to check whether the text attachment&apos;s image is equal to the bundle&apos;s missing attachment
    image:

    ```
        if ([value isKindOfClass:PlatformNSTextAttachment]) {
        if ([value image] == webCoreTextAttachmentMissingPlatformImage())
            return { { TextAttachmentMissingImage() } };
    ```

    Work around this for now by adding a separate `isWebCoreTextAttachmentMissingPlatformImage`
    helper function that takes an image and returns whether or not the image is equal to the
    missing attachment image, crucially *without* forcing the image to be initialized if it has not
    already been.

* Source/WebCore/editing/cocoa/AttributedString.mm:
(WebCore::extractValue):

Fix (2) above by adopting `isWebCoreTextAttachmentMissingPlatformImage`.

* Source/WebCore/editing/cocoa/WebCoreTextAttachment.h:
* Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm:
(WebCore::webCoreTextAttachmentMissingPlatformImageIfExists):
(WebCore::webCoreTextAttachmentMissingPlatformImage):
(WebCore::isWebCoreTextAttachmentMissingPlatformImage):

Add a very cheap way to check if the given image is a missing text attachment, in the case where a
text attachment missing image hasn&apos;t been initialized yet.

(webCoreTextAttachmentMissingPlatformImage): Deleted.
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestDocumentEditingContext):

Fix (1) above.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/DocumentEditingContext.mm:
(TEST(DocumentEditingContext, SpatialAndCurrentSelectionRequest_LimitContextToVisibleText)):

Add an API test to exercise the change.

Canonical link: <a href="https://commits.webkit.org/290710@main">https://commits.webkit.org/290710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/610d6877b7a2f9d731e454bb39b1b5442537a677

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95918 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/92949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18750 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93897 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8234 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/64/builds/36795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/63/builds/37860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97889 "Failed to checkout and rebase branch from PR 40945") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18091 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/97889 "Failed to checkout and rebase branch from PR 40945") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18351 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/78241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/97889 "Failed to checkout and rebase branch from PR 40945") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22585 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/119/builds/21206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14325 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18100 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23445 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17839 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->