### PR TITLE
Address safer C++ static analysis warnings in WKObject.h

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAbstractValue.cpp
@@ -31,6 +31,8 @@
 #include "DFGGraph.h"
 #include "JSCJSValueInlines.h"
 #include "TrackedReferences.h"
+#include <wtf/AlignedStorage.h>
+#include <wtf/StdLibExtras.h>
 
 namespace JSC { namespace DFG {
 
@@ -524,12 +526,8 @@ void AbstractValue::validateReferences(const TrackedReferences& trackedReference
 #if USE(JSVALUE64) && !defined(NDEBUG)
 void AbstractValue::ensureCanInitializeWithZeros()
 {
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    std::aligned_storage<sizeof(AbstractValue), alignof(AbstractValue)>::type zeroFilledStorage;
-    ALLOW_DEPRECATED_DECLARATIONS_END
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    memset(static_cast<void*>(&zeroFilledStorage), 0, sizeof(AbstractValue));
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    AlignedStorage<AbstractValue> zeroFilledStorage;
+    zeroBytes(*zeroFilledStorage);
     ASSERT(*this == *static_cast<AbstractValue*>(static_cast<void*>(&zeroFilledStorage)));
 }
 #endif

--- a/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,4 +1,3 @@
-wtf/NeverDestroyed.h
 wtf/Ref.h
 wtf/RefPtr.h
 wtf/ThreadSpecific.h

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -93,6 +93,7 @@
 		4655743627F5FC4A002D5522 /* ASCIILiteralCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */; };
 		465F34932CD824AF000963B1 /* ObjCRuntimeExtras.mm in Sources */ = {isa = PBXBuildFile; fileRef = 465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */; };
 		466D69112BA4E433005D43F4 /* SpanCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = 466D69102BA4E433005D43F4 /* SpanCocoa.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		466E7A7A2D66E57E0096FDA4 /* AlignedStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 466E7A792D66E57E0096FDA4 /* AlignedStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		467DCD532CD4689A0040C644 /* UnicodeExtras.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */; };
 		468EAFD42D5B1E37005069CF /* SocketPOSIX.h in Headers */ = {isa = PBXBuildFile; fileRef = 468EAFD32D5B1E37005069CF /* SocketPOSIX.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		46B0FB5D2D24BFBA0012184C /* ParsingUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1247,6 +1248,7 @@
 		4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ASCIILiteralCocoa.mm; sourceTree = "<group>"; };
 		465F34922CD824AF000963B1 /* ObjCRuntimeExtras.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ObjCRuntimeExtras.mm; sourceTree = "<group>"; };
 		466D69102BA4E433005D43F4 /* SpanCocoa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpanCocoa.h; sourceTree = "<group>"; };
+		466E7A792D66E57E0096FDA4 /* AlignedStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AlignedStorage.h; sourceTree = "<group>"; };
 		467DCD522CD4689A0040C644 /* UnicodeExtras.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnicodeExtras.cpp; sourceTree = "<group>"; };
 		468EAFD32D5B1E37005069CF /* SocketPOSIX.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SocketPOSIX.h; sourceTree = "<group>"; };
 		46B0FB5C2D24BFBA0012184C /* ParsingUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ParsingUtilities.h; sourceTree = "<group>"; };
@@ -2161,6 +2163,7 @@
 				E3B8E6012961EA7600A8AEE3 /* AccessibleAddress.h */,
 				CDCC9BC422382FCE00FFB51C /* AggregateLogger.h */,
 				CD6D9FCD1EEF3AD4008B0671 /* Algorithms.h */,
+				466E7A792D66E57E0096FDA4 /* AlignedStorage.h */,
 				CE1132832370634900A8C83B /* AnsiColors.h */,
 				E37E96522702AD0700E1C36A /* ApproximateTime.cpp */,
 				E37E96532702AD0700E1C36A /* ApproximateTime.h */,
@@ -3245,6 +3248,7 @@
 				E383AAC92B6C730B00058E60 /* AdaptiveStringSearcher.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,
 				DD3DC96027A4BF8E007E5B61 /* Algorithms.h in Headers */,
+				466E7A7A2D66E57E0096FDA4 /* AlignedStorage.h in Headers */,
 				DD3DC99627A4BF8E007E5B61 /* AnsiColors.h in Headers */,
 				DD3DC92527A4BF8E007E5B61 /* ApproximateTime.h in Headers */,
 				5CB8CB6D28C16CB700539906 /* ArgumentCoder.h in Headers */,

--- a/Source/WTF/wtf/AlignedStorage.h
+++ b/Source/WTF/wtf/AlignedStorage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,36 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import "WKWebExtensionContextPrivate.h"
+#pragma once
 
-#if ENABLE(WK_WEB_EXTENSIONS)
+#include <cstddef>
+#include <wtf/StdLibExtras.h>
 
-#import "WKObject.h"
-#import "WebExtensionContext.h"
-#import <wtf/AlignedStorage.h>
+namespace WTF {
 
-namespace WebKit {
-template<> struct WrapperTraits<WebExtensionContext> {
-    using WrapperClass = WKWebExtensionContext;
+template<typename T>
+class AlignedStorage {
+public:
+    AlignedStorage() = default;
+    AlignedStorage(AlignedStorage&&) = delete;
+    AlignedStorage(const AlignedStorage&) = delete;
+    AlignedStorage& operator=(AlignedStorage&&) = delete;
+    AlignedStorage& operator=(const AlignedStorage&) = delete;
+
+    T* get() { SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast_ptr<T*>(&m_storage); }
+    const T* get() const { SUPPRESS_MEMORY_UNSAFE_CAST return reinterpret_cast_ptr<const T*>(&m_storage); }
+
+    T& operator*() { return *get(); }
+    T* operator->() { return get(); }
+    const T& operator*() const { return *get(); }
+    const T* operator->() const { return get(); }
+
+private:
+    struct alignas(T) Storage {
+        std::byte data[sizeof(T)];
+    } m_storage;
 };
-}
 
-@interface WKWebExtensionContext () <WKObject> {
-@package
-    AlignedStorage<WebKit::WebExtensionContext> _webExtensionContext;
-}
+} // namespace WTF
 
-@property (nonatomic, readonly) WebKit::WebExtensionContext& _webExtensionContext;
-
-@end
-
-#endif // ENABLE(WK_WEB_EXTENSIONS)
+using WTF::AlignedStorage;

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -6,6 +6,7 @@ set(WTF_PUBLIC_HEADERS
     AccessibleAddress.h
     AggregateLogger.h
     Algorithms.h
+    AlignedStorage.h
     AnsiColors.h
     ApproximateTime.h
     ArgumentCoder.h

--- a/Source/WTF/wtf/HashTable.h
+++ b/Source/WTF/wtf/HashTable.h
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <type_traits>
 #include <utility>
+#include <wtf/AlignedStorage.h>
 #include <wtf/Assertions.h>
 #include <wtf/DebugHeap.h>
 #include <wtf/FastMalloc.h>
@@ -650,11 +651,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(HashTable);
         } else if constexpr (HashFunctions::safeToCompareToEmptyOrDeleted) {
             RELEASE_ASSERT(!HashTranslator::equal(KeyTraits::emptyValue(), key));
 
-            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            typename std::aligned_storage<sizeof(ValueType), std::alignment_of<ValueType>::value>::type deletedValueBuffer;
-            ALLOW_DEPRECATED_DECLARATIONS_END
-            ValueType* deletedValuePtr = reinterpret_cast_ptr<ValueType*>(&deletedValueBuffer);
-            ValueType& deletedValue = *deletedValuePtr;
+            AlignedStorage<ValueType> deletedValueBuffer;
+            auto& deletedValue = *deletedValueBuffer;
             Traits::constructDeletedValue(deletedValue);
             RELEASE_ASSERT(!HashTranslator::equal(Extractor::extract(deletedValue), key));
         }

--- a/Source/WTF/wtf/NeverDestroyed.h
+++ b/Source/WTF/wtf/NeverDestroyed.h
@@ -27,6 +27,7 @@
 
 #include <type_traits>
 #include <utility>
+#include <wtf/AlignedStorage.h>
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/MainThread.h>
 #include <wtf/RefCounted.h>
@@ -89,7 +90,7 @@ private:
     PointerType storagePointer() const
     {
         AccessTraits::assertAccess();
-        return const_cast<PointerType>(reinterpret_cast<const T*>(&m_storage));
+        return const_cast<PointerType>(m_storage.get());
     }
 
     template<typename PtrType, bool ShouldRelax = std::is_base_of<RefCountedBase, PtrType>::value> struct MaybeRelax {
@@ -101,9 +102,7 @@ private:
 
     // FIXME: Investigate whether we should allocate a hunk of virtual memory
     // and hand out chunks of it to NeverDestroyed instead, to reduce fragmentation.
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type m_storage;
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    AlignedStorage<T> m_storage;
 };
 
 // FIXME: It's messy to have to repeat the whole class just to make this "lazy" version.
@@ -152,7 +151,7 @@ private:
     PointerType storagePointerWithoutAccessCheck() const
     {
         ASSERT(m_isConstructed);
-        return const_cast<PointerType>(reinterpret_cast<const T*>(&m_storage));
+        return const_cast<PointerType>(m_storage.get());
     }
 
     PointerType storagePointer() const
@@ -176,9 +175,7 @@ private:
 
     // FIXME: Investigate whether we should allocate a hunk of virtual memory
     // and hand out chunks of it to NeverDestroyed instead, to reduce fragmentation.
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type m_storage;
-    ALLOW_DEPRECATED_DECLARATIONS_END
+    AlignedStorage<T> m_storage;
 };
 
 template<typename T> NeverDestroyed(T) -> NeverDestroyed<T>;

--- a/Source/WTF/wtf/RobinHoodHashTable.h
+++ b/Source/WTF/wtf/RobinHoodHashTable.h
@@ -51,6 +51,7 @@
 
 #pragma once
 
+#include <wtf/AlignedStorage.h>
 #include <wtf/HashTable.h>
 #include <wtf/text/StringHash.h>
 
@@ -325,11 +326,8 @@ void RobinHoodHashTable<Key, Value, Extractor, HashFunctions, Traits, KeyTraits,
     if (!HashFunctions::safeToCompareToEmptyOrDeleted)
         return;
     ASSERT(!HashTranslator::equal(KeyTraits::emptyValue(), key));
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typename std::aligned_storage<sizeof(ValueType), std::alignment_of<ValueType>::value>::type deletedValueBuffer;
-    ALLOW_DEPRECATED_DECLARATIONS_END
-    ValueType* deletedValuePtr = reinterpret_cast_ptr<ValueType*>(&deletedValueBuffer);
-    ValueType& deletedValue = *deletedValuePtr;
+    AlignedStorage<ValueType> deletedValueBuffer;
+    auto& deletedValue = *deletedValueBuffer;
     Traits::constructDeletedValue(deletedValue);
     ASSERT(!HashTranslator::equal(Extractor::extract(deletedValue), key));
 }

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/AlignedStorage.h>
 #include <wtf/CodePtr.h>
 #include <wtf/Function.h>
 #include <wtf/Lock.h>
@@ -80,9 +81,7 @@ struct SigInfo {
 };
 
 using SignalHandler = Function<SignalAction(Signal, SigInfo&, PlatformRegisters&)>;
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-using SignalHandlerMemory = std::aligned_storage<sizeof(SignalHandler), std::alignment_of<SignalHandler>::value>::type;
-ALLOW_DEPRECATED_DECLARATIONS_END
+using SignalHandlerMemory = AlignedStorage<SignalHandler>;
 
 struct SignalHandlers {
     static void initialize();

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -8,7 +8,6 @@ Shared/API/c/cf/WKStringCF.mm
 Shared/API/c/cf/WKURLCF.mm
 Shared/APIWebArchive.mm
 Shared/Cocoa/WKNSURL.mm
-Shared/Cocoa/WKObject.h
 Shared/UserData.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKDownload.mm

--- a/Source/WebKit/Shared/API/Cocoa/_WKFrameHandleInternal.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKFrameHandleInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIFrameHandle.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::FrameHandle> {
 
 @interface _WKFrameHandle () <WKObject> {
 @package
-    API::ObjectStorage<API::FrameHandle> _frameHandle;
+    AlignedStorage<API::FrameHandle> _frameHandle;
 }
 @end

--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResultInternal.h
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResultInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIHitTestResult.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -40,7 +41,7 @@ template<> struct WrapperTraits<API::HitTestResult> {
 
 @interface _WKHitTestResult () <WKObject> {
 @package
-    API::ObjectStorage<API::HitTestResult> _hitTestResult;
+    AlignedStorage<API::HitTestResult> _hitTestResult;
 }
 @end
 

--- a/Source/WebKit/Shared/Cocoa/WKNSArray.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSArray.mm
@@ -27,9 +27,10 @@
 #import "WKNSArray.h"
 
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKNSArray {
-    API::ObjectStorage<API::Array> _array;
+    AlignedStorage<API::Array> _array;
 }
 
 - (void)dealloc

--- a/Source/WebKit/Shared/Cocoa/WKNSData.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSData.mm
@@ -27,9 +27,10 @@
 #import "WKNSData.h"
 
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKNSData {
-    API::ObjectStorage<API::Data> _data;
+    AlignedStorage<API::Data> _data;
 }
 
 - (void)dealloc

--- a/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSDictionary.mm
@@ -28,11 +28,12 @@
 
 #import "WKNSArray.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 using namespace WebKit;
 
 @implementation WKNSDictionary {
-    API::ObjectStorage<API::Dictionary> _dictionary;
+    AlignedStorage<API::Dictionary> _dictionary;
 }
 
 - (void)dealloc

--- a/Source/WebKit/Shared/Cocoa/WKNSNumber.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSNumber.mm
@@ -26,14 +26,16 @@
 #import "config.h"
 #import "WKNSNumber.h"
 
+#import <wtf/AlignedStorage.h>
+
 using namespace WebKit;
 
 @implementation WKNSNumber {
     union {
-        API::ObjectStorage<API::Boolean> _boolean;
-        API::ObjectStorage<API::Double> _double;
-        API::ObjectStorage<API::UInt64> _uint64;
-        API::ObjectStorage<API::Int64> _int64;
+        AlignedStorage<API::Boolean> _boolean;
+        AlignedStorage<API::Double> _double;
+        AlignedStorage<API::UInt64> _uint64;
+        AlignedStorage<API::Int64> _int64;
     } _number;
 }
 

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -39,16 +39,6 @@ namespace API {
 
 class Object;
 
-template<typename ObjectClass> struct ObjectStorage {
-    ObjectClass* get() { return reinterpret_cast<ObjectClass*>(&data); }
-    ObjectClass& operator*() { return *get(); }
-    ObjectClass* operator->() { return get(); }
-
-    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    typename std::aligned_storage<sizeof(ObjectClass), std::alignment_of<ObjectClass>::value>::type data;
-    ALLOW_DEPRECATED_DECLARATIONS_END
-};
-
 API::Object* unwrap(void*);
 void* wrap(API::Object*);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm
@@ -29,9 +29,10 @@
 #import "WKBackForwardListItemInternal.h"
 #import "WKNSArray.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKBackForwardList {
-    API::ObjectStorage<WebKit::WebBackForwardList> _list;
+    AlignedStorage<WebKit::WebBackForwardList> _list;
 }
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -28,9 +28,10 @@
 
 #import "WKNSURLExtras.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKBackForwardListItem {
-    API::ObjectStorage<WebKit::WebBackForwardListItem> _item;
+    AlignedStorage<WebKit::WebBackForwardListItem> _item;
 }
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIContentRuleList.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::ContentRuleList> {
 
 @interface WKContentRuleList () <WKObject> {
 @package
-    API::ObjectStorage<API::ContentRuleList> _contentRuleList;
+    AlignedStorage<API::ContentRuleList> _contentRuleList;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStoreInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStoreInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIContentRuleListStore.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::ContentRuleListStore> {
 
 @interface WKContentRuleListStore () <WKObject> {
 @package
-    API::ObjectStorage<API::ContentRuleListStore> _contentRuleListStore;
+    AlignedStorage<API::ContentRuleListStore> _contentRuleListStore;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIContentWorld.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -39,6 +40,6 @@ template<> struct WrapperTraits<API::ContentWorld> {
 
 @interface WKContentWorld () <WKObject> {
 @package
-    API::ObjectStorage<API::ContentWorld> _contentWorld;
+    AlignedStorage<API::ContentWorld> _contentWorld;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoInternal.h
@@ -27,6 +27,8 @@
 #import "WKContextMenuElementInfo.h"
 #import "WKObject.h"
 
+#import <wtf/AlignedStorage.h>
+
 #if PLATFORM(IOS_FAMILY)
 
 namespace WebKit {
@@ -39,7 +41,7 @@ template<> struct WrapperTraits<API::ContextMenuElementInfo> {
 
 @interface WKContextMenuElementInfo () <WKObject> {
 @package
-    API::ObjectStorage<API::ContextMenuElementInfo> _elementInfo;
+    AlignedStorage<API::ContextMenuElementInfo> _elementInfo;
 }
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h
@@ -26,6 +26,7 @@
 #import "DownloadProxy.h"
 #import "WKDownload.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<DownloadProxy> {
 
 @interface WKDownload () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::DownloadProxy> _download;
+    AlignedStorage<WebKit::DownloadProxy> _download;
     WeakObjCPtr<id <WKDownloadDelegate> > _delegate;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIFrameInfo.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::FrameInfo> {
 
 @interface WKFrameInfo () <WKObject> {
 @package
-    API::ObjectStorage<API::FrameInfo> _frameInfo;
+    AlignedStorage<API::FrameInfo> _frameInfo;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStoreInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStoreInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIHTTPCookieStore.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::HTTPCookieStore> {
 
 @interface WKHTTPCookieStore () <WKObject> {
 @package
-    API::ObjectStorage<API::HTTPCookieStore> _cookieStore;
+    AlignedStorage<API::HTTPCookieStore> _cookieStore;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
@@ -29,9 +29,10 @@
 
 #import "APINavigation.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKNavigation {
-    API::ObjectStorage<API::Navigation> _navigation;
+    AlignedStorage<API::Navigation> _navigation;
 }
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionInternal.h
@@ -27,6 +27,7 @@
 
 #import "APINavigationAction.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::NavigationAction> {
 
 @interface WKNavigationAction () <WKObject> {
 @package
-    API::ObjectStorage<API::NavigationAction> _navigationAction;
+    AlignedStorage<API::NavigationAction> _navigationAction;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm
@@ -30,9 +30,10 @@
 #import <WebCore/ResourceRequest.h>
 #import <WebCore/ResourceResponse.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKNavigationData {
-    API::ObjectStorage<API::NavigationData> _data;
+    AlignedStorage<API::NavigationData> _data;
 }
 
 - (void)dealloc

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponseInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponseInternal.h
@@ -27,6 +27,7 @@
 
 #import "APINavigationResponse.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::NavigationResponse> {
 
 @interface WKNavigationResponse () <WKObject> {
 @package
-    API::ObjectStorage<API::NavigationResponse> _navigationResponse;
+    AlignedStorage<API::NavigationResponse> _navigationResponse;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersInternal.h
@@ -26,6 +26,7 @@
 #import "APIOpenPanelParameters.h"
 #import "WKObject.h"
 #import "WKOpenPanelParametersPrivate.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::OpenPanelParameters> {
 
 @interface WKOpenPanelParameters () <WKObject> {
 @package
-    API::ObjectStorage<API::OpenPanelParameters> _openPanelParameters;
+    AlignedStorage<API::OpenPanelParameters> _openPanelParameters;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h
@@ -31,6 +31,7 @@
 
 #import "WKObject.h"
 #import "WebPreferences.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -42,7 +43,7 @@ template<> struct WrapperTraits<WebPreferences> {
 
 @interface WKPreferences () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebPreferences> _preferences;
+    AlignedStorage<WebKit::WebPreferences> _preferences;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebProcessPool.h"
+#import <wtf/AlignedStorage.h>
 
 #if TARGET_OS_IPHONE
 @class WKGeolocationProviderIOS;
@@ -42,7 +43,7 @@ template<> struct WrapperTraits<WebProcessPool> {
 
 @interface WKProcessPool () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebProcessPool> _processPool;
+    AlignedStorage<WebKit::WebProcessPool> _processPool;
 }
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOriginInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKSecurityOriginInternal.h
@@ -26,6 +26,7 @@
 #import <WebKit/WKSecurityOrigin.h>
 
 #import "APISecurityOrigin.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::SecurityOrigin> {
 
 @interface WKSecurityOrigin () <WKObject> {
 @package
-    API::ObjectStorage<API::SecurityOrigin> _securityOrigin;
+    AlignedStorage<API::SecurityOrigin> _securityOrigin;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTaskInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTaskInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebURLSchemeTask.h"
+#import <wtf/AlignedStorage.h>
 
 @interface WKURLSchemeTaskImpl : NSObject <WKURLSchemeTaskPrivate>
 @end
@@ -41,6 +42,6 @@ template<> struct WrapperTraits<WebURLSchemeTask> {
 
 @interface WKURLSchemeTaskImpl () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebURLSchemeTask> _urlSchemeTask;
+    AlignedStorage<WebKit::WebURLSchemeTask> _urlSchemeTask;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebUserContentControllerProxy.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebUserContentControllerProxy> {
@@ -38,7 +39,7 @@ class WebScriptMessageHandler;
 
 @interface WKUserContentController () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebUserContentControllerProxy> _userContentControllerProxy;
+    AlignedStorage<WebKit::WebUserContentControllerProxy> _userContentControllerProxy;
 }
 
 - (void)_addScriptMessageHandler:(WebKit::WebScriptMessageHandler&)scriptMessageHandler;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserScriptInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserScriptInternal.h
@@ -26,6 +26,7 @@
 #import "WKUserScriptPrivate.h"
 
 #import "APIUserScript.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -67,6 +68,6 @@ inline WKUserScriptInjectionTime toWKUserScriptInjectionTime(WebCore::UserScript
 
 @interface WKUserScript () <WKObject> {
 @package
-    API::ObjectStorage<API::UserScript> _userScript;
+    AlignedStorage<API::UserScript> _userScript;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionActionInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionAction.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionAction> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionAction> {
 
 @interface WKWebExtensionAction () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionAction> _webExtensionAction;
+    AlignedStorage<WebKit::WebExtensionAction> _webExtensionAction;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionAction& _webExtensionAction;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionCommand.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionCommand> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionCommand> {
 
 @interface WKWebExtensionCommand () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionCommand> _webExtensionCommand;
+    AlignedStorage<WebKit::WebExtensionCommand> _webExtensionCommand;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionCommand& _webExtensionCommand;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionControllerConfiguration.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionControllerConfiguration> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionControllerConfiguration> {
 
 @interface WKWebExtensionControllerConfiguration () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionControllerConfiguration> _webExtensionControllerConfiguration;
+    AlignedStorage<WebKit::WebExtensionControllerConfiguration> _webExtensionControllerConfiguration;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionControllerConfiguration& _webExtensionControllerConfiguration;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionController.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionController> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionController> {
 
 @interface WKWebExtensionController () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionController> _webExtensionController;
+    AlignedStorage<WebKit::WebExtensionController> _webExtensionController;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionController& _webExtensionController;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecordInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionDataRecord.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
@@ -39,7 +40,7 @@ template<> struct WrapperTraits<WebExtensionDataRecord> {
 
 @interface WKWebExtensionDataRecord () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionDataRecord> _webExtensionDataRecord;
+    AlignedStorage<WebKit::WebExtensionDataRecord> _webExtensionDataRecord;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionDataRecord& _webExtensionDataRecord;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtension.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtension> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtension> {
 
 @interface WKWebExtension () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtension> _webExtension;
+    AlignedStorage<WebKit::WebExtension> _webExtension;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtension& _webExtension;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionMatchPattern.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionMatchPattern> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionMatchPattern> {
 
 @interface WKWebExtensionMatchPattern () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionMatchPattern> _webExtensionMatchPattern;
+    AlignedStorage<WebKit::WebExtensionMatchPattern> _webExtensionMatchPattern;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionMatchPattern& _webExtensionMatchPattern;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePortInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePortInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionMessagePort.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionMessagePort> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionMessagePort> {
 
 @interface WKWebExtensionMessagePort () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionMessagePort> _webExtensionMessagePort;
+    AlignedStorage<WebKit::WebExtensionMessagePort> _webExtensionMessagePort;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionMessagePort& _webExtensionMessagePort;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIPageConfiguration.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/Ref.h>
 
 namespace WebKit {
@@ -41,7 +42,7 @@ template<> struct WrapperTraits<API::PageConfiguration> {
 
 @interface WKWebViewConfiguration () <WKObject> {
 @package
-    API::ObjectStorage<API::PageConfiguration> _pageConfiguration;
+    AlignedStorage<API::PageConfiguration> _pageConfiguration;
 }
 
 @property (nonatomic, readonly, nullable) NSString *_applicationNameForDesktopUserAgent;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesInternal.h
@@ -26,6 +26,7 @@
 #import "APIWebsitePolicies.h"
 #import "WKObject.h"
 #import <WebKit/WKWebpagePreferencesPrivate.h>
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -44,7 +45,7 @@ WebCore::HTTPSByDefaultMode httpsByDefaultMode(WKWebpagePreferencesUpgradeToHTTP
 
 @interface WKWebpagePreferences () <WKObject> {
 @package
-    API::ObjectStorage<API::WebsitePolicies> _websitePolicies;
+    AlignedStorage<API::WebsitePolicies> _websitePolicies;
 }
 
 @property (class, nonatomic, readonly) WKWebpagePreferences *defaultPreferences;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIWebsiteDataRecord.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/OptionSet.h>
 
 namespace WebKit {
@@ -154,6 +155,6 @@ static inline RetainPtr<NSSet> toWKWebsiteDataTypes(OptionSet<WebKit::WebsiteDat
 
 @interface WKWebsiteDataRecord () <WKObject> {
 @package
-    API::ObjectStorage<API::WebsiteDataRecord> _websiteDataRecord;
+    AlignedStorage<API::WebsiteDataRecord> _websiteDataRecord;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStoreInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStoreInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebsiteDataStore.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
@@ -39,7 +40,7 @@ template<> struct WrapperTraits<WebsiteDataStore> {
 
 @interface WKWebsiteDataStore () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebsiteDataStore> _websiteDataStore;
+    AlignedStorage<WebKit::WebsiteDataStore> _websiteDataStore;
     WeakObjCPtr<id <_WKWebsiteDataStoreDelegate> > _delegate;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeaturesInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWindowFeaturesInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIWindowFeatures.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::WindowFeatures> {
 
 @interface WKWindowFeatures () <WKObject> {
 @package
-    API::ObjectStorage<API::WindowFeatures> _windowFeatures;
+    AlignedStorage<API::WindowFeatures> _windowFeatures;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifestInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifestInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIApplicationManifest.h"
 #import "_WKApplicationManifest.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
@@ -39,7 +40,7 @@ template<> struct WrapperTraits<API::ApplicationManifest> {
 
 @interface _WKApplicationManifest () <WKObject> {
 @package
-    API::ObjectStorage<API::ApplicationManifest> _applicationManifest;
+    AlignedStorage<API::ApplicationManifest> _applicationManifest;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAttachmentInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAttachmentInternal.h
@@ -25,6 +25,7 @@
 
 #import "APIAttachment.h"
 #import <WebKit/_WKAttachment.h>
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -36,7 +37,7 @@ template<> struct WrapperTraits<API::Attachment> {
 
 @interface _WKAttachment () <WKObject> {
 @package
-    API::ObjectStorage<API::Attachment> _attachment;
+    AlignedStorage<API::Attachment> _attachment;
 }
 
 - (void)setData:(NSData *)data newContentType:(NSString *)newContentType;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebAutomationSession.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<WebAutomationSession> {
 
 @interface _WKAutomationSession () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebAutomationSession> _session;
+    AlignedStorage<WebKit::WebAutomationSession> _session;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListActionInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIContentRuleListAction.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::ContentRuleListAction> {
 
 @interface _WKContentRuleListAction () <WKObject> {
 @package
-    API::ObjectStorage<API::ContentRuleListAction> _action;
+    AlignedStorage<API::ContentRuleListAction> _action;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfoInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIContextMenuElementInfoMac.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -40,7 +41,7 @@ template<> struct WrapperTraits<API::ContextMenuElementInfoMac> {
 
 @interface _WKContextMenuElementInfo () <WKObject> {
 @package
-    API::ObjectStorage<API::ContextMenuElementInfoMac> _contextMenuElementInfoMac;
+    AlignedStorage<API::ContextMenuElementInfoMac> _contextMenuElementInfoMac;
 }
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFieldsInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFieldsInternal.h
@@ -26,6 +26,7 @@
 #import "APICustomHeaderFields.h"
 #import "WKObject.h"
 #import "_WKCustomHeaderFields.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::CustomHeaderFields> {
 
 @interface _WKCustomHeaderFields () <WKObject> {
 @package
-    API::ObjectStorage<API::CustomHeaderFields> _fields;
+    AlignedStorage<API::CustomHeaderFields> _fields;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKDataTaskInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKDataTaskInternal.h
@@ -26,6 +26,7 @@
 #import "APIDataTask.h"
 #import "WKObject.h"
 #import "_WKDataTask.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<API::DataTask> {
 
 @interface _WKDataTask () <WKObject> {
 @package
-    API::ObjectStorage<API::DataTask> _dataTask;
+    AlignedStorage<API::DataTask> _dataTask;
     RetainPtr<id <_WKDataTaskDelegate> > _delegate;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFeatureInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFeatureInternal.h
@@ -26,6 +26,7 @@
 #import "APIFeature.h"
 #import "WKObject.h"
 #import "_WKFeature.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::Feature> {
 
 @interface _WKFeature () <WKObject> {
 @package
-    API::ObjectStorage<API::Feature> _wrappedFeature;
+    AlignedStorage<API::Feature> _wrappedFeature;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNodeInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNodeInternal.h
@@ -26,6 +26,7 @@
 #import "APIFrameTreeNode.h"
 #import "WKObject.h"
 #import "_WKFrameTreeNode.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::FrameTreeNode> {
 
 @interface _WKFrameTreeNode () <WKObject> {
 @package
-    API::ObjectStorage<API::FrameTreeNode> _node;
+    AlignedStorage<API::FrameTreeNode> _node;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPositionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPositionInternal.h
@@ -28,6 +28,7 @@
 #if TARGET_OS_IPHONE
 
 #import "WebGeolocationPosition.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -39,7 +40,7 @@ template<> struct WrapperTraits<WebGeolocationPosition> {
 
 @interface _WKGeolocationPosition () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebGeolocationPosition> _geolocationPosition;
+    AlignedStorage<WebKit::WebGeolocationPosition> _geolocationPosition;
 }
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfigurationInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIInspectorConfiguration.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -42,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface _WKInspectorConfiguration () <WKObject> {
 @package
-    API::ObjectStorage<API::InspectorConfiguration> _configuration;
+    AlignedStorage<API::InspectorConfiguration> _configuration;
 }
 
 - (void)applyToWebViewConfiguration:(WKWebViewConfiguration *)webViewConfiguration;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfoInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIDebuggableInfo.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<API::DebuggableInfo> {
 
 @interface _WKInspectorDebuggableInfo () <WKObject> {
 @package
-    API::ObjectStorage<API::DebuggableInfo> _debuggableInfo;
+    AlignedStorage<API::DebuggableInfo> _debuggableInfo;
 }
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtensionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtensionInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIInspectorExtension.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 class InspectorExtensionDelegate;
@@ -44,7 +45,7 @@ template<> struct WrapperTraits<API::InspectorExtension> {
 
 @interface _WKInspectorExtension () <WKObject> {
 @package
-    API::ObjectStorage<API::InspectorExtension> _extension;
+    AlignedStorage<API::InspectorExtension> _extension;
     std::unique_ptr<WebKit::InspectorExtensionDelegate> _delegate;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebInspectorUIProxy.h"
+#import <wtf/AlignedStorage.h>
 #import <wtf/WeakObjCPtr.h>
 
 namespace WebKit {
@@ -39,7 +40,7 @@ template<> struct WrapperTraits<WebInspectorUIProxy> {
 
 @interface _WKInspector () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebInspectorUIProxy> _inspector;
+    AlignedStorage<WebKit::WebInspectorUIProxy> _inspector;
     WeakObjCPtr<id <_WKInspectorDelegate> > _delegate;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfigurationInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIProcessPoolConfiguration.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::ProcessPoolConfiguration> {
 
 @interface _WKProcessPoolConfiguration () <WKObject> {
 @package
-    API::ObjectStorage<API::ProcessPoolConfiguration> _processPoolConfiguration;
+    AlignedStorage<API::ProcessPoolConfiguration> _processPoolConfiguration;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfoInternal.h
@@ -26,6 +26,7 @@
 #import "APIResourceLoadInfo.h"
 #import "WKObject.h"
 #import "_WKResourceLoadInfo.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::ResourceLoadInfo> {
 
 @interface _WKResourceLoadInfo () <WKObject> {
 @package
-    API::ObjectStorage<API::ResourceLoadInfo> _info;
+    AlignedStorage<API::ResourceLoadInfo> _info;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstPartyInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstPartyInternal.h
@@ -26,6 +26,7 @@
 #import "APIResourceLoadStatisticsFirstParty.h"
 #import "WKObject.h"
 #import "_WKResourceLoadStatisticsFirstParty.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::ResourceLoadStatisticsFirstParty> {
 
 @interface _WKResourceLoadStatisticsFirstParty () <WKObject> {
 @package
-    API::ObjectStorage<API::ResourceLoadStatisticsFirstParty> _firstParty;
+    AlignedStorage<API::ResourceLoadStatisticsFirstParty> _firstParty;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdPartyInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdPartyInternal.h
@@ -27,6 +27,7 @@
 #import "WKObject.h"
 #import "_WKResourceLoadStatisticsFirstPartyInternal.h"
 #import "_WKResourceLoadStatisticsThirdParty.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<API::ResourceLoadStatisticsThirdParty> {
 
 @interface _WKResourceLoadStatisticsThirdParty () <WKObject> {
 @package
-    API::ObjectStorage<API::ResourceLoadStatisticsThirdParty> _thirdParty;
+    AlignedStorage<API::ResourceLoadStatisticsThirdParty> _thirdParty;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfoInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfoInternal.h
@@ -28,6 +28,7 @@
 #import "APITargetedElementInfo.h"
 #import "WKObject.h"
 #import "_WKTargetedElementInfo.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -39,6 +40,6 @@ template<> struct WrapperTraits<API::TargetedElementInfo> {
 
 @interface _WKTargetedElementInfo () <WKObject> {
 @package
-    API::ObjectStorage<API::TargetedElementInfo> _info;
+    AlignedStorage<API::TargetedElementInfo> _info;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequestInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequestInternal.h
@@ -28,6 +28,7 @@
 #import "APITargetedElementRequest.h"
 #import "WKObject.h"
 #import "_WKTargetedElementRequest.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -39,6 +40,6 @@ template<> struct WrapperTraits<API::TargetedElementRequest> {
 
 @interface _WKTargetedElementRequest () <WKObject> {
 @package
-    API::ObjectStorage<API::TargetedElementRequest> _request;
+    AlignedStorage<API::TargetedElementRequest> _request;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextRunInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextRunInternal.h
@@ -28,6 +28,7 @@
 #import "APITextRun.h"
 #import "WKObject.h"
 #import "_WKTextRun.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -39,6 +40,6 @@ template<> struct WrapperTraits<API::TextRun> {
 
 @interface _WKTextRun () <WKObject> {
 @package
-    API::ObjectStorage<API::TextRun> _textRun;
+    AlignedStorage<API::TextRun> _textRun;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserInitiatedActionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserInitiatedActionInternal.h
@@ -27,6 +27,7 @@
 
 #import "APIUserInitiatedAction.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<API::UserInitiatedAction> {
 
 @interface _WKUserInitiatedAction () <WKObject> {
 @package
-    API::ObjectStorage<API::UserInitiatedAction> _userInitiatedAction;
+    AlignedStorage<API::UserInitiatedAction> _userInitiatedAction;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheetInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheetInternal.h
@@ -26,6 +26,7 @@
 #import "_WKUserStyleSheet.h"
 
 #import "APIUserStyleSheet.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -54,6 +55,6 @@ inline WebCore::UserStyleLevel toWebCoreUserStyleLevel(_WKUserStyleLevel level)
 
 @interface _WKUserStyleSheet () <WKObject> {
 @package
-    API::ObjectStorage<API::UserStyleSheet> _userStyleSheet;
+    AlignedStorage<API::UserStyleSheet> _userStyleSheet;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKVisitedLinkStoreInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKVisitedLinkStoreInternal.h
@@ -27,6 +27,7 @@
 
 #import "VisitedLinkStore.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<VisitedLinkStore> {
 
 @interface _WKVisitedLinkStore () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::VisitedLinkStore> _visitedLinkStore;
+    AlignedStorage<WebKit::VisitedLinkStore> _visitedLinkStore;
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponseInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponseInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIWebAuthenticationAssertionResponse.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -40,7 +41,7 @@ template<> struct WrapperTraits<API::WebAuthenticationAssertionResponse> {
 
 @interface _WKWebAuthenticationAssertionResponse () <WKObject> {
 @package
-    API::ObjectStorage<API::WebAuthenticationAssertionResponse> _response;
+    AlignedStorage<API::WebAuthenticationAssertionResponse> _response;
 }
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelInternal.h
@@ -29,6 +29,7 @@
 
 #import "APIWebAuthenticationPanel.h"
 #import "WKObject.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -40,7 +41,7 @@ template<> struct WrapperTraits<API::WebAuthenticationPanel> {
 
 @interface _WKWebAuthenticationPanel () <WKObject> {
 @package
-    API::ObjectStorage<API::WebAuthenticationPanel> _panel;
+    AlignedStorage<API::WebAuthenticationPanel> _panel;
 }
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebarInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebarInternal.h
@@ -29,6 +29,7 @@
 
 #import "WKObject.h"
 #import "WebExtensionSidebar.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 template<> struct WrapperTraits<WebExtensionSidebar> {
@@ -38,7 +39,7 @@ template<> struct WrapperTraits<WebExtensionSidebar> {
 
 @interface _WKWebExtensionSidebar () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebExtensionSidebar> _webExtensionSidebar;
+    AlignedStorage<WebKit::WebExtensionSidebar> _webExtensionSidebar;
 }
 
 @property (nonatomic, readonly) WebKit::WebExtensionSidebar& _webExtensionSidebar;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnectionInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnectionInternal.h
@@ -26,6 +26,7 @@
 #import "APIWebPushDaemonConnection.h"
 #import "WKObject.h"
 #import "_WKWebPushDaemonConnection.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::WebPushDaemonConnection> {
 
 @interface _WKWebPushDaemonConnection () <WKObject> {
 @package
-    API::ObjectStorage<API::WebPushDaemonConnection> _connection;
+    AlignedStorage<API::WebPushDaemonConnection> _connection;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessageInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessageInternal.h
@@ -26,6 +26,7 @@
 #import "APIWebPushMessage.h"
 #import "WKObject.h"
 #import "_WKWebPushMessage.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::WebPushMessage> {
 
 @interface _WKWebPushMessage () <WKObject> {
 @package
-    API::ObjectStorage<API::WebPushMessage> _message;
+    AlignedStorage<API::WebPushMessage> _message;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionDataInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionDataInternal.h
@@ -26,6 +26,7 @@
 #import "APIWebPushSubscriptionData.h"
 #import "WKObject.h"
 #import "_WKWebPushSubscriptionData.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -37,6 +38,6 @@ template<> struct WrapperTraits<API::WebPushSubscriptionData> {
 
 @interface _WKWebPushSubscriptionData () <WKObject> {
 @package
-    API::ObjectStorage<API::WebPushSubscriptionData> _data;
+    AlignedStorage<API::WebPushSubscriptionData> _data;
 }
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfigurationInternal.h
@@ -27,6 +27,7 @@
 
 #import "WKObject.h"
 #import "WebsiteDataStoreConfiguration.h"
+#import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
@@ -38,6 +39,6 @@ template<> struct WrapperTraits<WebsiteDataStoreConfiguration> {
 
 @interface _WKWebsiteDataStoreConfiguration () <WKObject> {
 @package
-    API::ObjectStorage<WebKit::WebsiteDataStoreConfiguration> _configuration;
+    AlignedStorage<WebKit::WebsiteDataStoreConfiguration> _configuration;
 }
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm
@@ -28,9 +28,10 @@
 
 #import <WebCore/CSSStyleDeclaration.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKWebProcessPlugInCSSStyleDeclarationHandle {
-    API::ObjectStorage<WebKit::InjectedBundleCSSStyleDeclarationHandle> _cssStyleDeclarationHandle;
+    AlignedStorage<WebKit::InjectedBundleCSSStyleDeclarationHandle> _cssStyleDeclarationHandle;
 }
 
 - (void)dealloc

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -43,10 +43,11 @@
 #import <WebCore/LinkIconType.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
 @implementation WKWebProcessPlugInFrame {
-    API::ObjectStorage<WebKit::WebFrame> _frame;
+    AlignedStorage<WebKit::WebFrame> _frame;
 }
 
 + (instancetype)lookUpFrameFromHandle:(_WKFrameHandle *)handle

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm
@@ -28,9 +28,10 @@
 
 #import "WKWebProcessPlugInNodeHandleInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKWebProcessPlugInHitTestResult {
-    API::ObjectStorage<WebKit::InjectedBundleHitTestResult> _hitTestResult;
+    AlignedStorage<WebKit::InjectedBundleHitTestResult> _hitTestResult;
 }
 
 - (void)dealloc

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -34,9 +34,10 @@
 #import <WebCore/IntRect.h>
 #import <WebCore/NativeImage.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKWebProcessPlugInNodeHandle {
-    API::ObjectStorage<WebKit::InjectedBundleNodeHandle> _nodeHandle;
+    AlignedStorage<WebKit::InjectedBundleNodeHandle> _nodeHandle;
 }
 
 - (void)dealloc

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -32,9 +32,10 @@
 #import <WebCore/DataDetection.h>
 #import <WebCore/Range.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKWebProcessPlugInRangeHandle {
-    API::ObjectStorage<WebKit::InjectedBundleRangeHandle> _rangeHandle;
+    AlignedStorage<WebKit::InjectedBundleRangeHandle> _rangeHandle;
 }
 
 - (void)dealloc

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
@@ -27,9 +27,10 @@
 #import "WKWebProcessPlugInScriptWorldInternal.h"
 
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 
 @implementation WKWebProcessPlugInScriptWorld {
-    API::ObjectStorage<WebKit::InjectedBundleScriptWorld> _world;
+    AlignedStorage<WebKit::InjectedBundleScriptWorld> _world;
 }
 
 + (WKWebProcessPlugInScriptWorld *)world

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
@@ -33,11 +33,12 @@
 #import "WKStringCF.h"
 #import "WKWebProcessPlugInBrowserContextControllerInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 
 @interface WKWebProcessPlugInController () {
-    API::ObjectStorage<WebKit::InjectedBundle> _bundle;
+    AlignedStorage<WebKit::InjectedBundle> _bundle;
     RetainPtr<id <WKWebProcessPlugIn>> _principalClassInstance;
 }
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -64,6 +64,7 @@
 #import <WebCore/HTMLInputElement.h>
 #import <WebCore/LocalFrame.h>
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/AlignedStorage.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/WeakObjCPtr.h>
@@ -74,7 +75,7 @@
 @end
 
 @implementation WKWebProcessPlugInBrowserContextController {
-    API::ObjectStorage<WebKit::WebPage> _page;
+    AlignedStorage<WebKit::WebPage> _page;
     WeakObjCPtr<id <WKWebProcessPlugInLoadDelegate>> _loadDelegate;
     WeakObjCPtr<id <WKWebProcessPlugInFormDelegatePrivate>> _formDelegate;
     WeakObjCPtr<id <WKWebProcessPlugInEditingDelegate>> _editingDelegate;


### PR DESCRIPTION
#### a40f3a3fba44cd2c0d2afcde46fe1b32b1a8fe35
<pre>
Address safer C++ static analysis warnings in WKObject.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=288056">https://bugs.webkit.org/show_bug.cgi?id=288056</a>

Reviewed by Timothy Hatcher and Darin Adler.

- Replace API::ObjectStorage with a new WTF::AlignedStorage type
- WTF::AlignedStorage offers several benefits since it is strongly typed and it
  doesn&apos;t rely on std::aligned_storage which is deprecated in C++23. Instead,
  it uses `alignas(Alignment) std::byte m_storage[sizeof(T)];` which is the
  suggested replacement in the standard. WTF::AlignedStorage also has the
  benefit of hiding away the reinterpret_cast which is still required and
  requirements suppression to silence static analysis
- The PR adopts WTF::AlignedStorage instead of std::aligned_storage in several
  places too.

* Source/JavaScriptCore/dfg/DFGAbstractValue.cpp:
(JSC::DFG::AbstractValue::ensureCanInitializeWithZeros):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/AlignedStorage.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfoInternal.h.
(WTF::sizeof):
* Source/WTF/wtf/HashTable.h:
(WTF::shouldValidateKey&gt;::checkKey):
* Source/WTF/wtf/NeverDestroyed.h:
(WTF::NeverDestroyed::storagePointer const):
(WTF::LazyNeverDestroyed::storagePointerWithoutAccessCheck const):
* Source/WTF/wtf/RobinHoodHashTable.h:
(WTF::SizePolicy&gt;::checkKey):
* Source/WTF/wtf/threads/Signals.h:
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/Shared/API/Cocoa/_WKFrameHandleInternal.h:
* Source/WebKit/Shared/API/Cocoa/_WKHitTestResultInternal.h:
* Source/WebKit/Shared/Cocoa/WKNSArray.mm:
* Source/WebKit/Shared/Cocoa/WKNSData.mm:
* Source/WebKit/Shared/Cocoa/WKNSDictionary.mm:
* Source/WebKit/Shared/Cocoa/WKNSNumber.mm:
* Source/WebKit/Shared/Cocoa/WKObject.h:
(API::ObjectStorage::get): Deleted.
(API::ObjectStorage::operator*): Deleted.
(API::ObjectStorage::operator-&gt;): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardList.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStoreInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfoInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKDownloadInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStoreInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationActionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationData.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKNavigationResponseInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKOpenPanelParametersInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKSecurityOriginInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTaskInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentControllerInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKUserScriptInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionActionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionCommandInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContextInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionControllerInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionDataRecordInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPatternInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMessagePortInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferencesInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataRecordInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStoreInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWindowFeaturesInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKApplicationManifestInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAttachmentInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSessionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListActionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKContextMenuElementInfoInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFieldsInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTaskInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFeatureInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNodeInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKGeolocationPositionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorDebuggableInfoInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtensionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfigurationInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadInfoInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsFirstPartyInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKResourceLoadStatisticsThirdPartyInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfoInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequestInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextRunInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKUserInitiatedActionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheetInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKVisitedLinkStoreInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponseInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanelInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebExtensionSidebarInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushDaemonConnectionInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushMessageInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebPushSubscriptionDataInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfigurationInternal.h:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInCSSStyleDeclarationHandle.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInHitTestResult.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:

Canonical link: <a href="https://commits.webkit.org/290792@main">https://commits.webkit.org/290792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15be64f93f2a8ffc30ae437e660f2648d909976b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41856 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27535 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8420 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82556 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50334 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8191 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/125 "Found 60 new test failures: animations/font-variations/font-stretch.html fast/css/aspect-ratio-min-height-replaced.html fast/workers/worker-page-cache.html http/tests/loading/main-resource-delegates-on-back-navigation.html http/tests/loading/unfinished-load-back-to-cached-page-callbacks.html http/tests/media/hls/track-in-band-ext-x-date-range-start-time.html http/tests/security/clean-origin-css-exposed-resource-timing.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/security/contentSecurityPolicy/script-src-none-inline-event.html http/tests/security/contentSecurityPolicy/script-src-parsing-implicit-and-explicit-port-number.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40986 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83907 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78513 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98072 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89856 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18293 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79019 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18552 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78384 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78220 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22723 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/93 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14385 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18294 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23626 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112424 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18020 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32647 "Found 13 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.no-llint, microbenchmarks/memcpy-wasm.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21481 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->