### PR TITLE
[text-wrap-style:pretty] lazy hyphenation support.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.h
@@ -44,10 +44,24 @@ public:
 private:
     friend struct SlidingWidth;
 
+    struct EntryBalance {
+        float accumulatedCost { std::numeric_limits<float>::infinity() };
+        size_t previousBreakIndex { 0 };
+    };
+
+    struct EntryPretty {
+        float accumulatedCost { std::numeric_limits<float>::infinity() };
+        size_t previousBreakIndex { 0 };
+        size_t lineIndex { 0 };
+        InlineLayoutUnit lastLineWidth { 0 };
+        InlineItemPosition lineEnd { };
+        std::optional<PreviousLine> previousLine { };
+    };
+
     void initialize();
     void updateCachedWidths();
     void checkCanConstrainInlineItems();
-    std::optional<size_t> buildLineWithHyphenationFrom(size_t lastValidBreakpoint);
+    EntryPretty layoutSingleLineForPretty(InlineItemRange layoutRange, InlineLayoutUnit idealLineWidth, EntryPretty lastValidEntry);
 
     std::optional<Vector<LayoutUnit>> balanceRangeWithLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, size_t numberOfLines, bool isFirstChunk);
     std::optional<Vector<LayoutUnit>> balanceRangeWithNoLineRequirement(InlineItemRange, InlineLayoutUnit idealLineWidth, bool isFirstChunk);


### PR DESCRIPTION
#### bbce6e1c2c581add31f4c3db328cc7f06d5e9fd8
<pre>
[text-wrap-style:pretty] lazy hyphenation support.
<a href="https://bugs.webkit.org/show_bug.cgi?id=287903">https://bugs.webkit.org/show_bug.cgi?id=287903</a>
&lt;<a href="https://rdar.apple.com/145096164">rdar://145096164</a>&gt;

Reviewed by Alan Baradlay.

This PR adds basic hyphenation support to text-wrap-style:pretty.

our implementation of prettifyRange() uses dynamic programming as described in:

<a href="https://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf">https://www.eprg.org/G53DOC/pdfs/knuth-plass-breaking.pdf</a>

to layout text such that words are not hyphenated and each line is as close to its
idealLineWidth as possible, with a maximum positive deviation of:

                        textWrapPrettyStretchability * textWrapPrettyMaxShrink

and a maximum negative deviation of

                        textWrapPrettyShrinkability * textWrapPrettyMaxStretch

However, there are certain cases where it is impossible to layout text according
to these hard limits without hyphenation. This PR add the stripped down lazy
hyphenation approach described in the paper to text-wrap-style:pretty.

This approach tries to lay out as many lines as possible using Knuth-Plass DP
until we are no longer able to find a valid (line length within our min-max range)
breaking point without hyphenation. We then perform a one line layout using greedy
wrapping to fit the idealLineWidth using:

InlineContentConstrainer::buildOneLineLayout()

We then layout the rest of the text using the Knuth-Plass algorithm while performing
single-line greedy layouts as needed.

Note that this PR does not currently handle EntryPretty.lineEnd.offset, which will be
added in a follow up PR.

* Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp:
(WebCore::Layout::buildPreviousLine):
(WebCore::Layout::InlineContentConstrainer::buildOneLineLayout):

Canonical link: <a href="https://commits.webkit.org/290752@main">https://commits.webkit.org/290752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/067ad1972a71867a6a0d5283bef35d91ca97e234

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10512 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95996 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8301 "Passed tests") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50269 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8076 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78375 "Passed tests") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97969 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18171 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18431 "Built successfully") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78145 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19307 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22631 "Passed tests") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18177 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17914 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->