### PR TITLE
Change PLATFORM(IOS_SIMULATOR) to PLATFORM(IOS) in ProcessLauncher::hasExtensionsInAppBundle().

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -128,7 +128,7 @@ static void launchWithExtensionKitFallback(ProcessLauncher& processLauncher, Pro
 
 bool ProcessLauncher::hasExtensionsInAppBundle()
 {
-#if PLATFORM(IOS_SIMULATOR)
+#if PLATFORM(IOS)
     static bool hasExtensions = false;
     static dispatch_once_t flag;
     dispatch_once(&flag, ^{


### PR DESCRIPTION
#### 715167cff7e1ef8d0d84f184594c3231d630c205
<pre>
Change PLATFORM(IOS_SIMULATOR) to PLATFORM(IOS) in ProcessLauncher::hasExtensionsInAppBundle().
<a href="https://bugs.webkit.org/show_bug.cgi?id=288069">https://bugs.webkit.org/show_bug.cgi?id=288069</a>
<a href="https://rdar.apple.com/145182060">rdar://145182060</a>

Reviewed by Per Arne Vollan.

ProcessLauncher::hasExtensionsInAppBundle() currently checks if the platform is
iOS simulator (`PLATFORM(IOS_SIMULATOR)`) when determining whether to check for
extensions in the app bundle, but it should check for if the platform is iOS
(`PLATFORM(IOS)`). This PR changes IOS_SIMULATOR to IOS.

* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::hasExtensionsInAppBundle): Change to `PLATFORM(IOS)`.

Canonical link: <a href="https://commits.webkit.org/290805@main">https://commits.webkit.org/290805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e80057e40115c820b8ee375d8c7ed6fd9b407d43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95879 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41653 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18714 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69858 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27390 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93861 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8201 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50198 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7974 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18055 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13259 "Build was cancelled. Recent messages:OS: Sequoia (15.3), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 19 flakes 3 failures; Uploaded test results; 23 flakes 2 failures; compiling") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78894 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22551 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21174 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11362 "Built successfully") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/14393 "Build was cancelled. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23409 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->