### PR TITLE
[Site Isolation] Main frame history state may be incorrectly created when navigating during iframe creation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe-expected.txt
@@ -1,0 +1,10 @@
+Verifies that navigating the main frame while adding an iframe only increments history.length by one.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS history.length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that navigating the main frame while adding an iframe only increments history.length by one.");
+jsTestIsAsync = true;
+
+onmessage = () => {
+    onmessage = null;
+    setTimeout(() => {
+        sessionStorage.didNavigate = true;
+        location.href = 'data:text/html,<script> history.back(); <\/script>';
+    }, 10);
+}
+
+onload = async () => {
+    if (sessionStorage.didNavigate) {
+        delete sessionStorage.didNavigate;
+        shouldBe("history.length", "2");
+        finishJSTest();
+    } else {
+        await testRunner?.clearBackForwardList();
+        setInterval(() => {
+            const iframe = document.createElement('iframe');
+            iframe.src = 'http://localhost:8000/site-isolation/resources/green-background.html';
+            document.body.appendChild(iframe);
+        }, 1);
+    }
+}
+</script>

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9600,7 +9600,8 @@ void WebPageProxy::backForwardAddItemShared(IPC::Connection& connection, Ref<Fra
     if (RefPtr targetFrame = WebFrameProxy::webFrame(navigatedFrameState->frameID)) {
         if (RefPtr pendingChildBackForwardItem = targetFrame->takePendingChildBackForwardItem())
             return pendingChildBackForwardItem->setChild(WTFMove(navigatedFrameState));
-    }
+    } else
+        return;
 
     RefPtr provisionalPage = m_provisionalPage;
     const bool isRemoteFrameNavigation = m_legacyMainFrameProcess != *process && (!provisionalPage || provisionalPage->process() != *process);


### PR DESCRIPTION
#### edb3f0e437978ead3d1e0d358413fbc68e95cecf
<pre>
[Site Isolation] Main frame history state may be incorrectly created when navigating during iframe creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=288073">https://bugs.webkit.org/show_bug.cgi?id=288073</a>
<a href="https://rdar.apple.com/145199120">rdar://145199120</a>

Reviewed by Alex Christensen.

Site isolation introduces an unavoidable race condition where the history state committed by a web
process may have been created for a frame that the UI process has already destroyed. When this happens,
we should return early instead of adding an incorrect back/forward item.

* LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/add-iframes-and-navigate-mainframe.html: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::backForwardAddItemShared):

Canonical link: <a href="https://commits.webkit.org/290724@main">https://commits.webkit.org/290724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01202d6c598b9bc7f2179e6d3e4d98e2e035b4e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95883 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41655 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69862 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27392 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82366 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50202 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36758 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40777 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18057 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78206 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78077 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22556 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21173 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14332 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23411 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17805 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21261 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->