### PR TITLE
Use smart pointers in NetworkDataTaskCocoa.mm

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -360,8 +360,8 @@ void NetworkDataTaskCocoa::didSendData(uint64_t totalBytesSent, uint64_t totalBy
 {
     WTFEmitSignpost(m_task.get(), DataTask, "sent %llu bytes (expected %llu bytes)", totalBytesSent, totalBytesExpectedToSend);
 
-    if (m_client)
-        m_client->didSendData(totalBytesSent, totalBytesExpectedToSend);
+    if (RefPtr client = m_client.get())
+        client->didSendData(totalBytesSent, totalBytesExpectedToSend);
 }
 
 void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&& challenge, NegotiatedLegacyTLS negotiatedLegacyTLS, ChallengeCompletionHandler&& completionHandler)
@@ -371,8 +371,8 @@ void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&
     if (tryPasswordBasedAuthentication(challenge, completionHandler))
         return;
 
-    if (m_client)
-        m_client->didReceiveChallenge(WTFMove(challenge), negotiatedLegacyTLS, WTFMove(completionHandler));
+    if (RefPtr client = m_client.get())
+        client->didReceiveChallenge(WTFMove(challenge), negotiatedLegacyTLS, WTFMove(completionHandler));
     else {
         ASSERT_NOT_REACHED();
         completionHandler(AuthenticationChallengeDisposition::PerformDefaultHandling, { });
@@ -381,16 +381,16 @@ void NetworkDataTaskCocoa::didReceiveChallenge(WebCore::AuthenticationChallenge&
 
 void NetworkDataTaskCocoa::didNegotiateModernTLS(const URL& url)
 {
-    if (m_client)
-        m_client->didNegotiateModernTLS(url);
+    if (RefPtr client = m_client.get())
+        client->didNegotiateModernTLS(url);
 }
 
 void NetworkDataTaskCocoa::didCompleteWithError(const WebCore::ResourceError& error, const WebCore::NetworkLoadMetrics& networkLoadMetrics)
 {
     WTFEmitSignpost(m_task.get(), DataTask, "completed with error: %d", !error.isNull());
 
-    if (m_client)
-        m_client->didCompleteWithError(error, networkLoadMetrics);
+    if (RefPtr client = m_client.get())
+        client->didCompleteWithError(error, networkLoadMetrics);
 }
 
 void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
@@ -399,8 +399,8 @@ void NetworkDataTaskCocoa::didReceiveData(const WebCore::SharedBuffer& data)
 
     setBytesTransferredOverNetwork([m_task _countOfBytesReceivedEncoded]);
 
-    if (m_client)
-        m_client->didReceiveData(data);
+    if (RefPtr client = m_client.get())
+        client->didReceiveData(data);
 }
 
 void NetworkDataTaskCocoa::didReceiveResponse(WebCore::ResourceResponse&& response, NegotiatedLegacyTLS negotiatedLegacyTLS, PrivateRelayed privateRelayed, WebKit::ResponseCompletionHandler&& completionHandler)
@@ -488,9 +488,10 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
         auto protectedThis = weakThis.get();
         if (!protectedThis)
             return completionHandler({ });
-        if (!protectedThis->m_client)
+        RefPtr client = protectedThis->m_client.get();
+        if (!client)
             return completionHandler({ });
-        protectedThis->m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), weakThis] (WebCore::ResourceRequest&& request) mutable {
+        client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), weakThis] (WebCore::ResourceRequest&& request) mutable {
             auto protectedThis = weakThis.get();
             if (!protectedThis || !protectedThis->m_session)
                 return completionHandler({ });


### PR DESCRIPTION
#### c88e660eef7aa3cdf194198705c550b3ecfec4ea
<pre>
Use smart pointers in NetworkDataTaskCocoa.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=288077">https://bugs.webkit.org/show_bug.cgi?id=288077</a>

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::didSendData):
(WebKit::NetworkDataTaskCocoa::didReceiveChallenge):
(WebKit::NetworkDataTaskCocoa::didNegotiateModernTLS):
(WebKit::NetworkDataTaskCocoa::didCompleteWithError):
(WebKit::NetworkDataTaskCocoa::didReceiveData):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c88e660eef7aa3cdf194198705c550b3ecfec4ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69887 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27412 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93886 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8225 "Found 6 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82387 "Found 1 new API test failure: TestWebKitAPI.ContentFiltering.LoadAlternateAfterRedirectWK2 (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50227 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8027 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40800 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78326 "Found 1 new API test failure: TestWebKitAPI.ContentFiltering.LoadAlternateAfterRedirectWK2 (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37846 "Found 10 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox-redirects-cuts-opener.https.html imported/w3c/web-platform-tests/resource-timing/redirects.html imported/w3c/web-platform-tests/resource-timing/redirects.sub.html imported/w3c/web-platform-tests/xhr/access-control-and-redirects.any.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97878 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18080 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13280 "Found 15 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/security/xss-DENIED-xsl-document-securityOrigin.xml http/tests/security/xss-DENIED-xsl-external-entity-xslt-docloader.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync-double.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78908 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78093 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22574 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21196 "Found 10 new test failures: http/tests/contentfiltering/block-after-redirect.html http/tests/xmlhttprequest/access-control-and-redirects.html http/tests/xmlhttprequest/redirect-cross-origin-post-sync.html http/tests/xmlhttprequest/redirect-cross-origin-sync.html http/tests/xmlhttprequest/xmlhttprequest-unsafe-redirect.html http/wpt/html/cross-origin-embedder-policy/require-corp.https.html imported/w3c/web-platform-tests/html/cross-origin-opener-policy/coop-sandbox-redirects-cuts-opener.https.html imported/w3c/web-platform-tests/resource-timing/redirects.html imported/w3c/web-platform-tests/resource-timing/redirects.sub.html imported/w3c/web-platform-tests/xhr/access-control-and-redirects.any.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11386 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19612 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->