### PR TITLE
[JSC] Modernize logging in DFG / FTL

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp
@@ -50,8 +50,7 @@ void AdaptiveInferredPropertyValueWatchpoint::initialize(const ObjectPropertyCon
 
 void AdaptiveInferredPropertyValueWatchpoint::handleFire(VM&, const FireDetail& detail)
 {
-    if (DFG::shouldDumpDisassembly())
-        dataLog("Firing watchpoint ", RawPointer(this), " (", key(), ") on ", *m_codeBlock, "\n");
+    dataLogLnIf(DFG::shouldDumpDisassembly(), "Firing watchpoint ", RawPointer(this), " (", key(), ") on ", *m_codeBlock);
 
 
     auto lambda = scopedLambda<void(PrintStream&)>([&](PrintStream& out) {

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp
@@ -74,10 +74,7 @@ void AdaptiveStructureWatchpoint::fireInternal(VM& vm, const FireDetail& detail)
         return;
     }
     
-    if (DFG::shouldDumpDisassembly()) {
-        dataLog(
-            "Firing watchpoint ", RawPointer(this), " (", m_key, ") on ", *m_codeBlock, "\n");
-    }
+    dataLogLnIf(DFG::shouldDumpDisassembly(), "Firing watchpoint ", RawPointer(this), " (", m_key, ") on ", *m_codeBlock);
 
     auto lambda = scopedLambda<void(PrintStream&)>([&](PrintStream& out) {
         out.print("Adaptation of ", m_key, " failed: ", detail);

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -65,10 +65,7 @@ public:
         // version over LoadStore.
         DFG_ASSERT(m_graph, nullptr, m_graph.m_form == SSA);
         
-        if (DFGArgumentsEliminationPhaseInternal::verbose) {
-            dataLog("Graph before arguments elimination:\n");
-            m_graph.dump();
-        }
+        dataLogIf(DFGArgumentsEliminationPhaseInternal::verbose, "Graph before arguments elimination:\n", m_graph);
         
         identifyCandidates();
         if (m_candidates.isEmpty())

--- a/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
@@ -59,10 +59,7 @@ public:
         
         m_count = 0;
 
-        if (m_verbose && !shouldDumpGraphAtEachPhase(m_graph.m_plan.mode())) {
-            dataLog("Graph before CFA:\n");
-            m_graph.dump();
-        }
+        dataLogIf((m_verbose && !shouldDumpGraphAtEachPhase(m_graph.m_plan.mode())), "Graph before CFA:\n", m_graph);
         
         // This implements a pseudo-worklist-based forward CFA, except that the visit order
         // of blocks is the bytecode program order (which is nearly topological), and
@@ -78,8 +75,7 @@ public:
         m_state.initialize();
         
         if (m_graph.m_form != SSA) {
-            if (m_verbose)
-                dataLog("   Widening state at OSR entry block.\n");
+            dataLogLnIf(m_verbose, "   Widening state at OSR entry block.");
             
             // Widen the abstract values at the block that serves as the must-handle OSR entry.
             for (BlockIndex blockIndex = m_graph.numBlocks(); blockIndex--;) {
@@ -160,8 +156,7 @@ public:
 private:
     bool injectOSR(BasicBlock* block)
     {
-        if (m_verbose)
-            dataLog("   Found must-handle block: ", *block, "\n");
+        dataLogLnIf(m_verbose, "   Found must-handle block: ", *block);
         
         // This merges snapshot of stack values while CFA phase want to have proven types and values. This is somewhat tricky.
         // But this is OK as long as DFG OSR entry validates the inputs with *proven* AbstractValue values. And it turns out that this
@@ -173,19 +168,16 @@ private:
             Operand operand = mustHandleValues.operandForIndex(i);
             std::optional<JSValue> value = mustHandleValues[i];
             if (!value) {
-                if (m_verbose)
-                    dataLog("   Not live in bytecode: ", operand, "\n");
+                dataLogLnIf(m_verbose, "   Not live in bytecode: ", operand);
                 continue;
             }
             Node* node = block->variablesAtHead.operand(operand);
             if (!node) {
-                if (m_verbose)
-                    dataLog("   Not live: ", operand, "\n");
+                dataLogLnIf(m_verbose, "   Not live: ", operand);
                 continue;
             }
             
-            if (m_verbose)
-                dataLog("   Widening ", operand, " with ", value.value(), "\n");
+            dataLogLnIf(m_verbose, "   Widening ", operand, " with ", value.value());
             
             AbstractValue& target = block->valuesAtHead.operand(operand);
             changed |= target.mergeOSREntryValue(m_graph, value.value(), node->variableAccessData(), node);
@@ -205,33 +197,30 @@ private:
             return;
         if (!block->cfaShouldRevisit)
             return;
-        if (m_verbose)
-            dataLog("   Block ", *block, ":\n");
+        dataLogLnIf(m_verbose, "   Block ", *block, ":");
         
         if (m_blocksWithOSR.remove(block))
             injectOSR(block);
         
         m_state.beginBasicBlock(block);
-        if (m_verbose) {
-            dataLog("      head vars: ", block->valuesAtHead, "\n");
+        if (UNLIKELY(m_verbose)) {
+            dataLogLn("      head vars: ", block->valuesAtHead);
             if (m_graph.m_form == SSA)
-                dataLog("      head regs: ", nodeValuePairListDump(block->ssa->valuesAtHead), "\n");
+                dataLogLn("      head regs: ", nodeValuePairListDump(block->ssa->valuesAtHead));
         }
         for (unsigned i = 0; i < block->size(); ++i) {
             Node* node = block->at(i);
-            if (m_verbose) {
-                dataLogF("      %s @%u: ", Graph::opName(node->op()).characters(), node->index());
-                
-                if (!safeToExecute(m_state, m_graph, node))
-                    dataLog("(UNSAFE) ");
-                
-                dataLog(m_state.variablesForDebugging(), " ", m_interpreter);
-                
-                dataLogF("\n");
+            if (UNLIKELY(m_verbose)) {
+                WTF::dataFile().atomically([&](auto&) {
+                    dataLog("      ", Graph::opName(node->op()), " @", node->index(), ": ");
+                    if (!safeToExecute(m_state, m_graph, node))
+                        dataLog("(UNSAFE) ");
+                    dataLog(m_state.variablesForDebugging(), " ", m_interpreter);
+                    dataLogLn();
+                });
             }
             if (!m_interpreter.execute(i)) {
-                if (m_verbose)
-                    dataLogF("         Expect OSR exit.\n");
+                dataLogLnIf(m_verbose, "         Expect OSR exit.");
                 break;
             }
             
@@ -240,24 +229,27 @@ private:
                 DFG_CRASH(m_graph, node, toCString("AI-clobberize disagreement; AI says ", m_state.clobberState(), " while clobberize says ", writeSet(m_graph, node)).data());
         }
         if (m_verbose) {
-            dataLogF("      tail regs: ");
-            m_interpreter.dump(WTF::dataFile());
-            dataLogF("\n");
+            WTF::dataFile().atomically([&](auto&) {
+                dataLog("      tail regs: ");
+                m_interpreter.dump(WTF::dataFile());
+                dataLogLn();
+            });
         }
         m_changed |= m_state.endBasicBlock();
         
         if (m_verbose) {
-            dataLog("      tail vars: ", block->valuesAtTail, "\n");
-            if (m_graph.m_form == SSA)
-                dataLog("      head regs: ", nodeValuePairListDump(block->ssa->valuesAtTail), "\n");
+            WTF::dataFile().atomically([&](auto&) {
+                dataLogLn("      tail vars: ", block->valuesAtTail);
+                if (m_graph.m_form == SSA)
+                    dataLogLn("      head regs: ", nodeValuePairListDump(block->ssa->valuesAtTail));
+            });
         }
     }
     
     void performForwardCFA()
     {
         ++m_count;
-        if (m_verbose)
-            dataLogF("CFA [%u]\n", m_count);
+        dataLogLnIf(m_verbose, "CFA [", m_count, "]");
         
         for (BlockIndex blockIndex = 0; blockIndex < m_graph.numBlocks(); ++blockIndex)
             performBlockCFA(m_graph.block(blockIndex));

--- a/Source/JavaScriptCore/dfg/DFGCFGSimplificationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFGSimplificationPhase.cpp
@@ -71,8 +71,7 @@ public:
                     // Successor with one predecessor -> merge.
                     if (canMergeWithBlock(block->successor(0))) {
                         ASSERT(block->successor(0)->predecessors[0] == block);
-                        if (extremeLogging)
-                            m_graph.dump();
+                        dataLogLnIf(extremeLogging, m_graph);
                         m_graph.dethread();
                         mergeBlocks(block, block->successor(0), noBlocks());
                         innerChanged = outerChanged = true;
@@ -98,16 +97,14 @@ public:
                         BasicBlock* targetBlock = block->successorForCondition(condition);
                         BasicBlock* jettisonedBlock = block->successorForCondition(!condition);
                         if (canMergeWithBlock(targetBlock)) {
-                            if (extremeLogging)
-                                m_graph.dump();
+                            dataLogLnIf(extremeLogging, m_graph);
                             m_graph.dethread();
                             if (targetBlock == jettisonedBlock)
                                 mergeBlocks(block, targetBlock, noBlocks());
                             else
                                 mergeBlocks(block, targetBlock, oneBlock(jettisonedBlock));
                         } else {
-                            if (extremeLogging)
-                                m_graph.dump();
+                            dataLogLnIf(extremeLogging, m_graph);
                             m_graph.dethread();
                             
                             Node* terminal = block->terminal();
@@ -186,14 +183,12 @@ public:
                         }
                         
                         if (canMergeWithBlock(targetBlock)) {
-                            if (extremeLogging)
-                                m_graph.dump();
+                            dataLogLnIf(extremeLogging, m_graph);
                             m_graph.dethread();
                             
                             mergeBlocks(block, targetBlock, jettisonedBlocks);
                         } else {
-                            if (extremeLogging)
-                                m_graph.dump();
+                            dataLogLnIf(extremeLogging, m_graph);
                             m_graph.dethread();
                             
                             NodeOrigin boundaryNodeOrigin = terminal->origin;

--- a/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp
@@ -428,8 +428,10 @@ private:
             size_t index = entry.m_index;
             
             if (verbose) {
-                dataLog(" Iterating on phi from block ", block, " ");
-                m_graph.dump(WTF::dataFile(), "", currentPhi);
+                WTF::dataFile().atomically([&](auto&) {
+                    dataLog(" Iterating on phi from block ", block, " ");
+                    m_graph.dump(WTF::dataFile(), "", currentPhi);
+                });
             }
 
             for (size_t i = predecessors.size(); i--;) {
@@ -461,8 +463,11 @@ private:
                     || variableInPrevious->op() == SetArgumentDefinitely
                     || variableInPrevious->op() == SetArgumentMaybe);
           
-                if (verbose)
-                    m_graph.dump(WTF::dataFile(), "    Adding new variable from predecessor ", variableInPrevious);
+                if (verbose) {
+                    WTF::dataFile().atomically([&](auto& out) {
+                        m_graph.dump(out, "    Adding new variable from predecessor ", variableInPrevious);
+                    });
+                }
 
                 if (!currentPhi->child1()) {
                     currentPhi->children.setChild1(Edge(variableInPrevious));

--- a/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCapabilities.cpp
@@ -124,8 +124,7 @@ static bool verboseCapabilities()
 
 inline void debugFail(CodeBlock* codeBlock, OpcodeID opcodeID, CapabilityLevel result)
 {
-    if (verboseCapabilities() && !canCompile(result))
-        dataLog("DFG rejecting opcode in ", *codeBlock, " because of opcode ", opcodeNames[opcodeID], "\n");
+    dataLogLnIf(verboseCapabilities() && !canCompile(result), "DFG rejecting opcode in ", *codeBlock, " because of opcode ", opcodeNames[opcodeID]);
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGDriver.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDriver.cpp
@@ -75,8 +75,7 @@ static CompilationResult compileImpl(
     ASSERT(JITCode::isBaselineCode(codeBlock->alternative()->jitType()));
     ASSERT(!profiledDFGCodeBlock || profiledDFGCodeBlock->jitType() == JITType::DFGJIT);
     
-    if (logCompilationChanges(mode))
-        dataLog("DFG(Driver) compiling ", *codeBlock, " with ", mode, ", instructions size = ", codeBlock->instructionsSize(), "\n");
+    dataLogLnIf(logCompilationChanges(mode), "DFG(Driver) compiling ", *codeBlock, " with ", mode, ", instructions size = ", codeBlock->instructionsSize());
     
     if (vm.typeProfiler())
         vm.typeProfilerLog()->processLogEntries(vm, "Preparing for DFG compilation."_s);

--- a/Source/JavaScriptCore/dfg/DFGEdgeDominates.h
+++ b/Source/JavaScriptCore/dfg/DFGEdgeDominates.h
@@ -46,11 +46,7 @@ public:
     void operator()(Node*, Edge edge)
     {
         bool result = m_graph.m_ssaDominators->dominates(edge.node()->owner, m_block);
-        if (verbose) {
-            dataLog(
-                "Checking if ", edge, " in ", *edge.node()->owner,
-                " dominates ", *m_block, ": ", result, "\n");
-        }
+        dataLogLnIf(verbose, "Checking if ", edge, " in ", *edge.node()->owner, " dominates ", *m_block, ": ", result);
         m_result &= result;
     }
     

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -697,8 +697,7 @@ void Graph::dethread()
     if (m_form == LoadStore || m_form == SSA)
         return;
     
-    if (logCompilationChanges())
-        dataLog("Dethreading DFG graph.\n");
+    dataLogLnIf(logCompilationChanges(), "Dethreading DFG graph.");
     
     for (BlockIndex blockIndex = m_blocks.size(); blockIndex--;) {
         BasicBlock* block = m_blocks[blockIndex].get();
@@ -1165,8 +1164,7 @@ bool Graph::isLiveInBytecode(Operand operand, CodeOrigin codeOrigin)
 {
     static constexpr bool verbose = false;
     
-    if (verbose)
-        dataLog("Checking of operand is live: ", operand, "\n");
+    dataLogLnIf(verbose, "Checking of operand is live: ", operand);
     bool isCallerOrigin = false;
 
     CodeOrigin* codeOriginPtr = &codeOrigin;
@@ -1194,8 +1192,7 @@ bool Graph::isLiveInBytecode(Operand operand, CodeOrigin codeOrigin)
 
         VirtualRegister reg = operand.virtualRegister() - codeOriginPtr->stackOffset();
         
-        if (verbose)
-            dataLog("reg = ", reg, "\n");
+        dataLogLnIf(verbose, "reg = ", reg);
 
         if (operand.virtualRegister().offset() < codeOriginPtr->stackOffset() + CallFrame::headerSizeInRegisters) {
             if (reg.isArgument()) {
@@ -1204,23 +1201,20 @@ bool Graph::isLiveInBytecode(Operand operand, CodeOrigin codeOrigin)
 
                 if (inlineCallFrame->isClosureCall
                     && reg == CallFrameSlot::callee) {
-                    if (verbose)
-                        dataLog("Looks like a callee.\n");
+                    dataLogLnIf(verbose, "Looks like a callee.");
                     return true;
                 }
                 
                 if (inlineCallFrame->isVarargs()
                     && reg == CallFrameSlot::argumentCountIncludingThis) {
-                    if (verbose)
-                        dataLog("Looks like the argument count.\n");
+                    dataLogLnIf(verbose, "Looks like the argument count.");
                     return true;
                 }
                 
                 return false;
             }
 
-            if (verbose)
-                dataLog("Asking the bytecode liveness.\n");
+            dataLogLnIf(verbose, "Asking the bytecode liveness.");
             CodeBlock* codeBlock = baselineCodeBlockFor(inlineCallFrame);
             FullBytecodeLiveness& fullLiveness = livenessFor(codeBlock);
             BytecodeIndex bytecodeIndex = codeOriginPtr->bytecodeIndex();
@@ -1231,8 +1225,7 @@ bool Graph::isLiveInBytecode(Operand operand, CodeOrigin codeOrigin)
         // op_call_varargs inlining.
         if (inlineCallFrame && reg.isArgument()
             && static_cast<size_t>(reg.toArgument()) < inlineCallFrame->m_argumentsWithFixup.size()) {
-            if (verbose)
-                dataLog("Argument is live.\n");
+            dataLogLnIf(verbose, "Argument is live.");
             return true;
         }
 
@@ -1242,8 +1235,7 @@ bool Graph::isLiveInBytecode(Operand operand, CodeOrigin codeOrigin)
     if (operand.isTmp())
         return false;
 
-    if (verbose)
-        dataLog("Ran out of stack, returning true.\n");
+    dataLogLnIf(verbose, "Ran out of stack, returning true.");
     return true;    
 }
 
@@ -1672,15 +1664,17 @@ static void logDFGAssertionFailure(
     const char* assertion)
 {
     startCrashing();
-    dataLog("DFG ASSERTION FAILED: ", assertion, "\n");
-    dataLog(file, "(", line, ") : ", function, "\n");
-    dataLog("\n");
-    dataLog(whileText);
-    dataLog("Graph at time of failure:\n");
-    graph.dump();
-    dataLog("\n");
-    dataLog("DFG ASSERTION FAILED: ", assertion, "\n");
-    dataLog(file, "(", line, ") : ", function, "\n");
+    WTF::dataFile().atomically([&](auto&) {
+        dataLogLn("DFG ASSERTION FAILED: ", assertion);
+        dataLogLn(file, "(", line, ") : ", function);
+        dataLogLn();
+        dataLog(whileText);
+        dataLogLn("Graph at time of failure:");
+        dataLog(graph);
+        dataLogLn();
+        dataLogLn("DFG ASSERTION FAILED: ", assertion);
+        dataLogLn(file, "(", line, ") : ", function);
+    });
 }
 
 void Graph::logAssertionFailure(

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -286,7 +286,17 @@ public:
     void assertIsRegistered(Structure* structure);
     
     // CodeBlock is optional, but may allow additional information to be dumped (e.g. Identifier names).
-    void dump(PrintStream& = WTF::dataFile(), DumpContext* = nullptr);
+    void dump() const
+    {
+        const_cast<Graph&>(*this).dump(WTF::dataFile(), nullptr);
+    }
+
+    void dump(PrintStream& out) const
+    {
+        const_cast<Graph&>(*this).dump(out, nullptr);
+    }
+
+    void dump(PrintStream&, DumpContext*);
 
     bool terminalsAreValid();
     

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp
@@ -343,8 +343,7 @@ void InPlaceAbstractState::activateVariable(size_t variableIndex)
 
 bool InPlaceAbstractState::merge(BasicBlock* from, BasicBlock* to)
 {
-    if (DFGInPlaceAbstractStateInternal::verbose)
-        dataLog("   Merging from ", pointerDump(from), " to ", pointerDump(to), "\n");
+    dataLogLnIf(DFGInPlaceAbstractStateInternal::verbose, "   Merging from ", pointerDump(from), " to ", pointerDump(to));
     ASSERT(from->variablesAtTail.numberOfArguments() == to->variablesAtHead.numberOfArguments());
     ASSERT(from->variablesAtTail.numberOfLocals() == to->variablesAtHead.numberOfLocals());
     ASSERT(from->variablesAtTail.numberOfTmps() == to->variablesAtHead.numberOfTmps());
@@ -370,8 +369,7 @@ bool InPlaceAbstractState::merge(BasicBlock* from, BasicBlock* to)
 
         for (NodeAbstractValuePair& entry : to->ssa->valuesAtHead) {
             NodeFlowProjection node = entry.node;
-            if (DFGInPlaceAbstractStateInternal::verbose)
-                dataLog("      Merging for ", node, ": from ", forNode(node), " to ", entry.value, "\n");
+            dataLogLnIf(DFGInPlaceAbstractStateInternal::verbose, "      Merging for ", node, ": from ", forNode(node), " to ", entry.value);
 #ifndef NDEBUG
             unsigned valueCountInFromBlock = 0;
             for (NodeAbstractValuePair& fromBlockValueAtTail : from->ssa->valuesAtTail) {
@@ -389,8 +387,7 @@ bool InPlaceAbstractState::merge(BasicBlock* from, BasicBlock* to)
             if (!node->isTuple())
                 changed |= entry.value.merge(forNode(node));
 
-            if (DFGInPlaceAbstractStateInternal::verbose)
-                dataLog("         Result: ", entry.value, "\n");
+            dataLogLnIf(DFGInPlaceAbstractStateInternal::verbose, "         Result: ", entry.value);
         }
         break;
     }
@@ -403,8 +400,7 @@ bool InPlaceAbstractState::merge(BasicBlock* from, BasicBlock* to)
     if (!to->cfaHasVisited)
         changed = true;
     
-    if (DFGInPlaceAbstractStateInternal::verbose)
-        dataLog("      Will revisit: ", changed, "\n");
+    dataLogLnIf(DFGInPlaceAbstractStateInternal::verbose, "      Will revisit: ", changed);
     to->cfaShouldRevisit |= changed;
     
     return changed;

--- a/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp
@@ -182,14 +182,12 @@ private:
         
         for (auto* node : *block) {
             RangeKeyAndAddend data = rangeKeyAndAddend(node);
-            if (DFGIntegerCheckCombiningPhaseInternal::verbose)
-                dataLog("For ", node, ": ", data, "\n");
+            dataLogLnIf(DFGIntegerCheckCombiningPhaseInternal::verbose, "For ", node, ": ", data);
             if (!data)
                 continue;
 
             Range& range = m_map.add(data.m_key, Range { }).iterator->value;
-            if (DFGIntegerCheckCombiningPhaseInternal::verbose)
-                dataLog("    Range: ", range, "\n");
+            dataLogLnIf(DFGIntegerCheckCombiningPhaseInternal::verbose, "    Range: ", range);
             if (range.m_count) {
                 if (data.m_addend > range.m_maxBound) {
                     range.m_maxBound = data.m_addend;
@@ -205,8 +203,7 @@ private:
                 range.m_maxOrigin = node->origin.semantic;
             }
             range.m_count++;
-            if (DFGIntegerCheckCombiningPhaseInternal::verbose)
-                dataLog("    New range: ", range, "\n");
+            dataLogLnIf(DFGIntegerCheckCombiningPhaseInternal::verbose, "    New range: ", range);
         }
         
         for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1034,10 +1034,7 @@ public:
             m_insertionSet.execute(m_graph.block(0));
         }
         
-        if (DFGIntegerRangeOptimizationPhaseInternal::verbose) {
-            dataLog("Graph before integer range optimization:\n");
-            m_graph.dump();
-        }
+        dataLogIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Graph before integer range optimization:\n", m_graph);
         
         // This performs a fixpoint over the blocks in reverse post-order. Logically, we
         // maintain a list of relationships at each point in the program. The list should be
@@ -1124,8 +1121,7 @@ public:
                 m_relationships = m_relationshipsAtHead[block];
             
                 for (auto* node : *block) {
-                    if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                        dataLog("Analysis: at ", node, ": ", listDump(sortedRelationships()), "\n");
+                    dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Analysis: at ", node, ": ", listDump(sortedRelationships()));
                     executeNode(node);
                 }
                 
@@ -1210,12 +1206,10 @@ public:
                         RelationshipMap forTrue = m_relationships;
                         RelationshipMap forFalse = m_relationships;
                         
-                        if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                            dataLog("Dealing with true:\n");
+                        dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Dealing with true:");
                         setRelationship(forTrue, relationshipForTrue);
                         if (Relationship relationshipForFalse = relationshipForTrue.inverse()) {
-                            if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                                dataLog("Dealing with false:\n");
+                            dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Dealing with false:");
                             setRelationship(forFalse, relationshipForFalse);
                         }
                         
@@ -1238,8 +1232,7 @@ public:
             m_relationships = m_relationshipsAtHead[block];
             for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
                 Node* node = block->at(nodeIndex);
-                if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                    dataLog("Transformation: at ", node, ": ", listDump(sortedRelationships()), "\n");
+                dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "Transformation: at ", node, ": ", listDump(sortedRelationships()));
                 
                 // This ends up being pretty awkward to write because we need to decide if we
                 // optimize by using the relationships before the operation, but we need to
@@ -1302,15 +1295,13 @@ public:
                         maxValue = std::min(maxValue, relationship.maxValueOfLeft());
                     }
 
-                    if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                        dataLog("    minValue = ", minValue, ", maxValue = ", maxValue, "\n");
+                    dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "    minValue = ", minValue, ", maxValue = ", maxValue);
                     
                     if (sumOverflows<int>(minValue, node->child2()->asInt32()) ||
                         sumOverflows<int>(maxValue, node->child2()->asInt32()))
                         break;
 
-                    if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                        dataLog("    It's in bounds.\n");
+                    dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "    It's in bounds.");
                     
                     executeNode(block->at(nodeIndex));
                     node->setArithMode(Arith::Unchecked);
@@ -1664,7 +1655,7 @@ private:
                         && otherRelationship.right()->isInt32Constant()) {
                         Relationship newRelationship = relationship.filterConstant(otherRelationship);
                         if (DFGIntegerRangeOptimizationPhaseInternal::verbose && newRelationship != relationship)
-                            dataLog("      Refined to: ", newRelationship, " based on ", otherRelationship, "\n");
+                            dataLogLn("      Refined to: ", newRelationship, " based on ", otherRelationship);
                         relationship = newRelationship;
                     }
                 }
@@ -1678,7 +1669,7 @@ private:
                         && otherRelationship.right()->isInt32Constant()) {
                         Relationship newRelationship = otherRelationship.filterConstant(relationship);
                         if (DFGIntegerRangeOptimizationPhaseInternal::verbose && newRelationship != otherRelationship)
-                            dataLog("      Refined ", otherRelationship, " to: ", newRelationship, "\n");
+                            dataLogLn("      Refined ", otherRelationship, " to: ", newRelationship);
                         otherRelationship = newRelationship;
                     }
                 }
@@ -1702,8 +1693,7 @@ private:
             // @x == @c and @x != @d, where @d > @c, then we want to turn @x != @d into @x < @d.
             
             if (timeToLive && otherRelationship.kind() == Relationship::Equal) {
-                if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                    dataLog("      Considering (lhs): ", otherRelationship, "\n");
+                dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "      Considering (lhs): ", otherRelationship);
                 
                 // We have:
                 //     @a op @b + C
@@ -1733,8 +1723,7 @@ private:
                     || possibleEquality.offset() == std::numeric_limits<int>::min()
                     || possibleEquality.right() == relationship.left())
                     continue;
-                if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                    dataLog("      Considering (rhs): ", possibleEquality, "\n");
+                dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "      Considering (rhs): ", possibleEquality);
 
                 // We have:
                 //     @a op @b + C
@@ -1764,9 +1753,11 @@ private:
     bool mergeTo(RelationshipMap& relationshipMap, BasicBlock* target)
     {
         if (DFGIntegerRangeOptimizationPhaseInternal::verbose) {
-            dataLog("Merging to ", pointerDump(target), ":\n");
-            dataLog("    Incoming: ", listDump(sortedRelationships(relationshipMap)), "\n");
-            dataLog("    At head: ", listDump(sortedRelationships(m_relationshipsAtHead[target])), "\n");
+            WTF::dataFile().atomically([&](auto&) {
+                dataLogLn("Merging to ", pointerDump(target), ":");
+                dataLogLn("    Incoming: ", listDump(sortedRelationships(relationshipMap)));
+                dataLogLn("    At head: ", listDump(sortedRelationships(m_relationshipsAtHead[target])));
+            });
         }
         
         if (m_seenBlocks.add(target)) {
@@ -1785,8 +1776,7 @@ private:
                 for (Relationship relationship : entry.value) {
                     ASSERT(relationship.left() == entry.key);
                     if (isLive(relationship.right())) {
-                        if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                            dataLog("  Propagating ", relationship, "\n");
+                        dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "  Propagating ", relationship);
                         values.append(relationship);
                     }
                 }
@@ -1822,13 +1812,11 @@ private:
             Vector<Relationship> mergedRelationships;
             for (Relationship targetRelationship : entry.value) {
                 for (Relationship sourceRelationship : iter->value) {
-                    if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                        dataLog("  Merging ", targetRelationship, " and ", sourceRelationship, ":\n");
+                    dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "  Merging ", targetRelationship, " and ", sourceRelationship, ":");
                     targetRelationship.merge(
                         sourceRelationship,
                         [&] (Relationship newRelationship) {
-                            if (DFGIntegerRangeOptimizationPhaseInternal::verbose)
-                                dataLog("    Got ", newRelationship, "\n");
+                            dataLogLnIf(DFGIntegerRangeOptimizationPhaseInternal::verbose, "    Got ", newRelationship);
 
                             if (newRelationship.right()->isInt32Constant()) {
                                 // We can produce a relationship with a constant equivalent to

--- a/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
@@ -72,10 +72,7 @@ public:
         m_graph.ensureSSANaturalLoops();
         m_graph.ensureControlEquivalenceAnalysis();
 
-        if (verbose) {
-            dataLog("Graph before LICM:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph before LICM:\n", m_graph);
         
         m_data.resize(m_graph.m_ssaNaturalLoops->numLoops());
         
@@ -206,13 +203,14 @@ public:
             // to bias hoisting to outer loops then we need to use a reverse loop.
             
             if (verbose) {
-                dataLog(
-                    "Attempting to hoist out of block ", *block, " in loops:\n");
-                for (unsigned stackIndex = loopStack.size(); stackIndex--;) {
-                    dataLog(
-                        "        ", *loopStack[stackIndex], ", which writes ",
-                        m_data[loopStack[stackIndex]->index()].writes, "\n");
-                }
+                WTF::dataFile().atomically([&](auto&) {
+                    dataLogLn("Attempting to hoist out of block ", *block, " in loops:");
+                    for (unsigned stackIndex = loopStack.size(); stackIndex--;) {
+                        dataLogLn(
+                            "        ", *loopStack[stackIndex], ", which writes ",
+                            m_data[loopStack[stackIndex]->index()].writes);
+                    }
+                });
             }
             
             for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
@@ -241,14 +239,12 @@ private:
         LoopData& data = m_data[loop->index()];
 
         if (!data.preHeader) {
-            if (verbose)
-                dataLog("    Not hoisting ", node, " because the pre-header is invalid.\n");
+            dataLogLnIf(verbose, "    Not hoisting ", node, " because the pre-header is invalid.");
             return false;
         }
         
         if (!data.preHeader->cfaDidFinish) {
-            if (verbose)
-                dataLog("    Not hoisting ", node, " because CFA is invalid.\n");
+            dataLogLnIf(verbose, "    Not hoisting ", node, " because CFA is invalid.");
             return false;
         }
         
@@ -390,16 +386,12 @@ private:
         };
 
         if (!edgesDominate(m_graph, node, data.preHeader)) {
-            if (verbose) {
-                dataLog(
-                    "    Not hoisting ", node, " because it isn't loop invariant.\n");
-            }
+            dataLogLnIf(verbose, "    Not hoisting ", node, " because it isn't loop invariant.");
             return tryHoistChecks();
         }
 
         if (doesWrites(m_graph, node)) {
-            if (verbose)
-                dataLog("    Not hoisting ", node, " because it writes things.\n");
+            dataLogLnIf(verbose, "    Not hoisting ", node, " because it writes things.");
             return tryHoistChecks();
         }
 
@@ -410,21 +402,17 @@ private:
         addsBlindSpeculation = mayExit(m_graph, node, m_state) && !isControlEquivalent;
 
         if (readsOverlap(m_graph, node, data.writes)) {
-            if (verbose) {
-                dataLog(
-                    "    Not hoisting ", node,
-                    " because it reads things that the loop writes.\n");
-            }
+            dataLogLnIf(verbose,
+                "    Not hoisting ", node,
+                " because it reads things that the loop writes.");
             return tryHoistChecks();
         }
         
         if (addsBlindSpeculation && !canSpeculateBlindly) {
-            if (verbose) {
-                dataLog(
-                    "    Not hoisting ", node, " because it may exit and the pre-header (",
-                    *data.preHeader, ") is not control equivalent to the node's original block (",
-                    *fromBlock, ") and hoisting had previously failed.\n");
-            }
+            dataLogLnIf(verbose,
+                "    Not hoisting ", node, " because it may exit and the pre-header (",
+                *data.preHeader, ") is not control equivalent to the node's original block (",
+                *fromBlock, ") and hoisting had previously failed.");
             return tryHoistChecks();
         }
         
@@ -433,10 +421,7 @@ private:
             bool ignoreEmptyChildren = true;
             if (canSpeculateBlindly
                 && safeToExecute(m_state, m_graph, node, ignoreEmptyChildren)) {
-                if (verbose) {
-                    dataLog(
-                        "    Rescuing hoisting by inserting empty checks.\n");
-                }
+                dataLogLnIf(verbose, "    Rescuing hoisting by inserting empty checks.");
                 m_graph.doToChildren(
                     node,
                     [&] (Edge& edge) {
@@ -447,19 +432,12 @@ private:
                         insertHoistedNode(check);
                     });
             } else {
-                if (verbose) {
-                    dataLog(
-                        "    Not hoisting ", node, " because it isn't safe to execute.\n");
-                }
+                dataLogLnIf(verbose, "    Not hoisting ", node, " because it isn't safe to execute.");
                 return tryHoistChecks();
             }
         }
         
-        if (verbose) {
-            dataLog(
-                "    Hoisting ", node, " from ", *fromBlock, " to ", *data.preHeader,
-                "\n");
-        }
+        dataLogLnIf(verbose, "    Hoisting ", node, " from ", *fromBlock, " to ", *data.preHeader);
 
         insertHoistedNode(node);
         updateAbstractState();

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -88,10 +88,7 @@ public:
 
     bool run()
     {
-        if (UNLIKELY(Options::verboseLoopUnrolling())) {
-            dataLogLn("Graph before Loop Unrolling Phase:");
-            m_graph.dump();
-        }
+        dataLogIf(Options::verboseLoopUnrolling(), "Graph before Loop Unrolling Phase:\n", m_graph);
 
         uint32_t unrolledCount = 0;
         while (true) {
@@ -191,13 +188,8 @@ public:
         BasicBlock* header = data.header();
         unrollLoop(data);
 
-        if (UNLIKELY(Options::verboseLoopUnrolling())) {
-            dataLogLn("\tGraph after Loop Unrolling for loop");
-            m_graph.dump();
-        }
-
-        if (UNLIKELY(Options::printEachUnrolledLoop()))
-            dataLogLn("\tIn function ", m_graph.m_codeBlock->inferredName(), ", successfully unrolled the loop header=", *header);
+        dataLogIf(Options::verboseLoopUnrolling(), "\tGraph after Loop Unrolling for loop\n", m_graph);
+        dataLogLnIf(Options::printEachUnrolledLoop(), "\tIn function ", m_graph.m_codeBlock->inferredName(), ", successfully unrolled the loop header=", *header);
         return true;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp
@@ -57,10 +57,7 @@ public:
 
     bool run()
     {
-        if (DFGMovHintRemovalPhaseInternal::verbose) {
-            dataLog("Graph before MovHint removal:\n");
-            m_graph.dump();
-        }
+        dataLogIf(DFGMovHintRemovalPhaseInternal::verbose, "Graph before MovHint removal:\n", m_graph);
 
         for (BasicBlock* block : m_graph.blocksInNaturalOrder())
             handleBlock(block);
@@ -73,8 +70,7 @@ public:
 private:
     void handleBlock(BasicBlock* block)
     {
-        if (DFGMovHintRemovalPhaseInternal::verbose)
-            dataLog("Handing block ", pointerDump(block), "\n");
+        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "Handing block ", pointerDump(block));
 
         // A MovHint is unnecessary if the local dies before it is used. We answer this question by
         // maintaining the current exit epoch, and associating an epoch with each local. When a
@@ -91,8 +87,7 @@ private:
                 m_state.operand(reg) = currentEpoch;
             });
 
-        if (DFGMovHintRemovalPhaseInternal::verbose)
-            dataLog("    Locals at ", block->terminal()->origin.forExit, ": ", m_state, "\n");
+        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Locals at ", block->terminal()->origin.forExit, ": ", m_state);
 
         // Assume that blocks after we exit.
         currentEpoch.bump();
@@ -102,8 +97,7 @@ private:
 
             if (node->op() == MovHint) {
                 Epoch localEpoch = m_state.operand(node->unlinkedOperand());
-                if (DFGMovHintRemovalPhaseInternal::verbose)
-                    dataLog("    At ", node, " (", node->unlinkedOperand(), "): current = ", currentEpoch, ", local = ", localEpoch, "\n");
+                dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    At ", node, " (", node->unlinkedOperand(), "): current = ", currentEpoch, ", local = ", localEpoch);
                 if (!localEpoch || localEpoch == currentEpoch) {
                     // Now, MovHint will put bottom value to dead locals. This means that if you insert a new DFG node which introduce
                     // a new OSR exit, then it gets confused with the already-determined-dead locals. So this phase runs at very end of
@@ -132,8 +126,7 @@ private:
                         if (!!m_state.operand(operand))
                             return;
 
-                        if (DFGMovHintRemovalPhaseInternal::verbose)
-                            dataLog("    Killed operand at ", node, ": ", operand, "\n");
+                        dataLogLnIf(DFGMovHintRemovalPhaseInternal::verbose, "    Killed operand at ", node, ": ", operand);
                         m_state.operand(operand) = currentEpoch;
                     });
             }

--- a/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp
@@ -154,8 +154,10 @@ public:
                             case FunctionExecutablePLoc:
                             case StructurePLoc:
                                 if (heapPair.value.isDead()) {
-                                    dataLogLn("PromotedHeapLocation is dead, but should not be: ", heapPair.key);
-                                    availabilityMap.dump(WTF::dataFile());
+                                    WTF::dataFile().atomically([&](auto&) {
+                                        dataLogLn("PromotedHeapLocation is dead, but should not be: ", heapPair.key);
+                                        availabilityMap.dump(WTF::dataFile());
+                                    });
                                     CRASH();
                                 }
                                 break;

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4934,7 +4934,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationTriggerTierUpNow, void, (VM* vmPointe
     sanitizeStackForVM(vm);
 
     if (codeBlock->jitType() != JITType::DFGJIT) {
-        dataLog("Unexpected code block in DFG->FTL tier-up: ", *codeBlock, "\n");
+        dataLogLn("Unexpected code block in DFG->FTL tier-up: ", *codeBlock);
         RELEASE_ASSERT_NOT_REACHED();
     }
     
@@ -5232,7 +5232,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationTriggerOSREntryNow, char*, (VM* vmPoi
     sanitizeStackForVM(vm);
 
     if (codeBlock->jitType() != JITType::DFGJIT) {
-        dataLog("Unexpected code block in DFG->FTL tier-up: ", *codeBlock, "\n");
+        dataLogLn("Unexpected code block in DFG->FTL tier-up: ", *codeBlock);
         RELEASE_ASSERT_NOT_REACHED();
     }
 

--- a/Source/JavaScriptCore/dfg/DFGPhantomInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhantomInsertionPhase.cpp
@@ -56,20 +56,14 @@ public:
         // SetLocals execute, which is inaccurate. That causes us to insert too few Phantoms.
         DFG_ASSERT(m_graph, nullptr, m_graph.m_refCountState == ExactRefCount);
         
-        if (verbose) {
-            dataLog("Graph before Phantom insertion:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph before Phantom insertion:\n", m_graph);
         
         m_graph.clearEpochs();
         
         for (BasicBlock* block : m_graph.blocksInNaturalOrder())
             handleBlock(block);
         
-        if (verbose) {
-            dataLog("Graph after Phantom insertion:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph after Phantom insertion:\n", m_graph);
         
         return true;
     }
@@ -97,8 +91,7 @@ private:
         unsigned lastExitingIndex = 0;
         for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
             Node* node = block->at(nodeIndex);
-            if (verbose)
-                dataLog("Considering ", node, "\n");
+            dataLogLnIf(verbose, "Considering ", node);
             
             switch (node->op()) {
             case MovHint:

--- a/Source/JavaScriptCore/dfg/DFGPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPhase.cpp
@@ -46,12 +46,10 @@ void Phase::beginPhase()
         m_graphDumpBeforePhase = out.toCString();
     }
 
-    if (!shouldDumpGraphAtEachPhase(m_graph.m_plan.mode()))
-        return;
-    
-    dataLog(m_graph.prefix(), "Beginning DFG phase ", m_name, ".\n");
-    dataLog(m_graph.prefix(), "Before ", m_name, ":\n");
-    m_graph.dump();
+    dataLogIf(shouldDumpGraphAtEachPhase(m_graph.m_plan.mode()),
+        m_graph.prefix(), "Beginning DFG phase ", m_name, ".\n",
+        m_graph.prefix(), "Before ", m_name, ":\n",
+        m_graph);
 }
 
 void Phase::endPhase()

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -101,8 +101,7 @@ void dumpAndVerifyGraph(Graph& graph, const char* text, bool forceDump = false)
 {
     GraphDumpMode modeForFinalValidate = DumpGraph;
     if (verboseCompilationEnabled(graph.m_plan.mode()) || forceDump) {
-        dataLog(text, "\n");
-        graph.dump();
+        dataLog(text, "\n", graph);
         modeForFinalValidate = DontDumpGraph;
     }
     if (validationEnabled())
@@ -193,11 +192,9 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         cleanMustHandleValuesIfNecessary();
     }
 
-    if (verboseCompilationEnabled(m_mode) && m_osrEntryBytecodeIndex) {
-        dataLog("\n");
-        dataLog("Compiler must handle OSR entry from ", m_osrEntryBytecodeIndex, " with values: ", m_mustHandleValues, "\n");
-        dataLog("\n");
-    }
+    dataLogLnIf(verboseCompilationEnabled(m_mode) && m_osrEntryBytecodeIndex,
+        "\n",
+        "Compiler must handle OSR entry from ", m_osrEntryBytecodeIndex, " with values: ", m_mustHandleValues, "\n");
 
     Graph dfg(*m_vm, *this);
 
@@ -236,10 +233,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
     if (validationEnabled())
         validate(dfg);
     
-    if (Options::dumpGraphAfterParsing()) {
-        dataLog("Graph after parsing:\n");
-        dfg.dump();
-    }
+    dataLogIf(Options::dumpGraphAfterParsing(), "Graph after parsing:\n", dfg);
 
     RUN_PHASE(performCPSRethreading);
     RUN_PHASE(performUnification);

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -77,8 +77,7 @@ public:
             propagateForward();
         } while (m_changed);
 
-        if (verboseFixPointLoops)
-            dataLog("Iterated ", counter, " times in double voting fixpoint.\n");
+        dataLogLnIf(verboseFixPointLoops, "Iterated ", counter, " times in double voting fixpoint.");
         
         return true;
     }
@@ -107,8 +106,7 @@ private:
             propagateBackward();
         } while (m_changed);
 
-        if (verboseFixPointLoops)
-            dataLog("Iterated ", counter, " times in propagateToFixpoint.\n");
+        dataLogLnIf(verboseFixPointLoops, "Iterated ", counter, " times in propagateToFixpoint.");
     }
     
     bool setPrediction(SpeculatedType prediction)

--- a/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp
@@ -69,10 +69,7 @@ public:
         // the stack. It's not clear to me if this is important or not.
         // https://bugs.webkit.org/show_bug.cgi?id=145296
         
-        if (verbose) {
-            dataLog("Graph before PutStack sinking:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph before PutStack sinking:\n", m_graph);
 
         m_graph.ensureSSADominators();
         
@@ -100,16 +97,14 @@ public:
                 Operands<bool> live = liveAtTail[block];
                 for (unsigned nodeIndex = block->size(); nodeIndex--;) {
                     Node* node = block->at(nodeIndex);
-                    if (verbose)
-                        dataLog("Live at ", node, ": ", live, "\n");
+                    dataLogLnIf(verbose, "Live at ", node, ": ", live);
                     
                     Vector<Operand, 4> reads;
                     Vector<Operand, 4> writes;
                     auto escapeHandler = [&] (Operand operand) {
                         if (operand.isHeader())
                             return;
-                        if (verbose)
-                            dataLog("    ", operand, " is live at ", node, "\n");
+                        dataLogLnIf(verbose, "    ", operand, " is live at ", node);
                         reads.append(operand);
                     };
 
@@ -228,8 +223,7 @@ public:
                 Operands<FlushFormat> deferred = deferredAtHead[block];
                 
                 for (Node* node : *block) {
-                    if (verbose)
-                        dataLog("Deferred at ", node, ":", deferred, "\n");
+                    dataLogLnIf(verbose, "Deferred at ", node, ":", deferred);
                     
                     if (node->op() == GetStack) {
                         // Handle the case that the input doesn't match our requirements. This is
@@ -275,15 +269,13 @@ public:
                         continue;
                     } else if (node->op() == KillStack) {
                         // We don't want to sink a PutStack past a KillStack.
-                        if (verbose)
-                            dataLogLn("Killing stack for ", node->unlinkedOperand());
+                        dataLogLnIf(verbose, "Killing stack for ", node->unlinkedOperand());
                         deferred.operand(node->unlinkedOperand()) = ConflictingFlush;
                         continue;
                     }
                     
                     auto escapeHandler = [&] (Operand operand) {
-                        if (verbose)
-                            dataLog("For ", node, " escaping ", operand, "\n");
+                        dataLogLnIf(verbose, "For ", node, " escaping ", operand);
                         if (operand.isHeader())
                             return;
                         // We will materialize just before any reads.
@@ -312,14 +304,9 @@ public:
                 
                 for (BasicBlock* successor : block->successors()) {
                     for (size_t i = deferred.size(); i--;) {
-                        if (verbose)
-                            dataLog("Considering ", deferred.operandForIndex(i), " at ", pointerDump(block), "->", pointerDump(successor), ": ", deferred[i], " and ", deferredAtHead[successor][i], " merges to ");
-
-                        deferredAtHead[successor][i] =
-                            merge(deferredAtHead[successor][i], deferred[i]);
-                        
-                        if (verbose)
-                            dataLog(deferredAtHead[successor][i], "\n");
+                        dataLogIf(verbose, "Considering ", deferred.operandForIndex(i), " at ", pointerDump(block), "->", pointerDump(successor), ": ", deferred[i], " and ", deferredAtHead[successor][i], " merges to ");
+                        deferredAtHead[successor][i] = merge(deferredAtHead[successor][i], deferred[i]);
+                        dataLogLnIf(verbose, deferredAtHead[successor][i]);
                     }
                 }
             }
@@ -396,8 +383,7 @@ public:
                 if (!isConcrete(format))
                     return nullptr;
 
-                if (verbose)
-                    dataLog("Adding Phi for ", operand, " at ", pointerDump(block), "\n");
+                dataLogLnIf(verbose, "Adding Phi for ", operand, " at ", pointerDump(block));
                 
                 Node* phiNode = m_graph.addNode(SpecHeapTop, Phi, block->at(0)->origin.withInvalidExit());
                 phiNode->mergeFlags(resultFor(format));
@@ -420,32 +406,28 @@ public:
                 mapping.operand(operand) = def->value();
             }
             
-            if (verbose)
-                dataLog("Mapping at top of ", pointerDump(block), ": ", mapping, "\n");
+            dataLogLnIf(verbose, "Mapping at top of ", pointerDump(block), ": ", mapping);
             
             for (SSACalculator::Def* phiDef : ssaCalculator.phisForBlock(block)) {
                 Operand operand = indexToOperand[phiDef->variable()->index()];
                 
                 insertionSet.insert(0, phiDef->value());
                 
-                if (verbose)
-                    dataLog("   Mapping ", operand, " to ", phiDef->value(), "\n");
+                dataLogLnIf(verbose, "   Mapping ", operand, " to ", phiDef->value());
                 mapping.operand(operand) = phiDef->value();
             }
             
             deferred = deferredAtHead[block];
             for (unsigned nodeIndex = 0; nodeIndex < block->size(); ++nodeIndex) {
                 Node* node = block->at(nodeIndex);
-                if (verbose)
-                    dataLog("Deferred at ", node, ":", deferred, "\n");
+                dataLogLnIf(verbose, "Deferred at ", node, ":", deferred);
                 
                 switch (node->op()) {
                 case PutStack: {
                     StackAccessData* data = node->stackAccessData();
                     Operand operand = data->operand;
                     deferred.operand(operand) = data->format;
-                    if (verbose)
-                        dataLog("   Mapping ", operand, " to ", node->child1().node(), " at ", node, "\n");
+                    dataLogLnIf(verbose, "   Mapping ", operand, " to ", node->child1().node(), " at ", node);
                     mapping.operand(operand) = node->child1().node();
                     break;
                 }
@@ -484,8 +466,7 @@ public:
                 
                 default: {
                     auto escapeHandler = [&] (Operand operand) {
-                        if (verbose)
-                            dataLog("For ", node, " escaping ", operand, "\n");
+                        dataLogLnIf(verbose, "For ", node, " escaping ", operand);
 
                         if (operand.isHeader())
                             return;
@@ -498,8 +479,7 @@ public:
                         }
                     
                         // Gotta insert a PutStack.
-                        if (verbose)
-                            dataLog("Inserting a PutStack for ", operand, " at ", node, "\n");
+                        dataLogLnIf(verbose, "Inserting a PutStack for ", operand, " at ", node);
 
                         Node* incoming = mapping.operand(operand);
                         DFG_ASSERT(m_graph, node, incoming);
@@ -542,8 +522,7 @@ public:
                     Node* phiNode = phiDef->value();
                     SSACalculator::Variable* variable = phiDef->variable();
                     Operand operand = indexToOperand[variable->index()];
-                    if (verbose)
-                        dataLog("Creating Upsilon for ", operand, " at ", pointerDump(block), "->", pointerDump(successorBlock), "\n");
+                    dataLogLnIf(verbose, "Creating Upsilon for ", operand, " at ", pointerDump(block), "->", pointerDump(successorBlock));
                     FlushFormat format = deferredAtHead[successorBlock].operand(operand);
                     DFG_ASSERT(m_graph, nullptr, isConcrete(format), format);
                     UseKind useKind = uncheckedUseKindFor(format);
@@ -587,11 +566,7 @@ public:
             }
         }
         
-        if (verbose) {
-            dataLog("Graph after PutStack sinking:\n");
-            m_graph.dump();
-        }
-        
+        dataLogIf(verbose, "Graph after PutStack sinking:\n", m_graph);
         return true;
     }
 };

--- a/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp
@@ -111,10 +111,7 @@ public:
 
         m_graph.ensureSSADominators();
         
-        if (verbose) {
-            dataLog("Graph before SSA transformation:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph before SSA transformation:\n", m_graph);
 
         // Create a SSACalculator::Variable for every root VariableAccessData.
         for (VariableAccessData& variable : m_graph.m_variableAccessData) {
@@ -212,16 +209,18 @@ public:
             });
         
         if (verbose) {
-            dataLog("Computed Phis, about to transform the graph.\n");
-            dataLog("\n");
-            dataLog("Graph:\n");
-            m_graph.dump();
-            dataLog("\n");
-            dataLog("Mappings:\n");
-            for (unsigned i = 0; i < m_variableForSSAIndex.size(); ++i)
-                dataLog("    ", i, ": ", VariableAccessDataDump(m_graph, m_variableForSSAIndex[i]), "\n");
-            dataLog("\n");
-            dataLog("SSA calculator: ", calculator, "\n");
+            WTF::dataFile().atomically([&](auto&) {
+                dataLogLn("Computed Phis, about to transform the graph.");
+                dataLogLn();
+                dataLogLn("Graph:");
+                dataLog(m_graph);
+                dataLogLn();
+                dataLogLn("Mappings:");
+                for (unsigned i = 0; i < m_variableForSSAIndex.size(); ++i)
+                    dataLogLn("    ", i, ": ", VariableAccessDataDump(m_graph, m_variableForSSAIndex[i]));
+                dataLogLn();
+                dataLogLn("SSA calculator: ", calculator);
+            });
         }
         
         // Do the bulk of the SSA conversion. For each block, this tracks the operand->Node
@@ -272,8 +271,7 @@ public:
                     
                     VariableAccessData* variable = nodeAtHead->variableAccessData();
                     
-                    if (verbose)
-                        dataLog("Considering live variable ", VariableAccessDataDump(m_graph, variable), " at head of block ", *block, "\n");
+                    dataLogLnIf(verbose, "Considering live variable ", VariableAccessDataDump(m_graph, variable), " at head of block ", *block);
                     
                     SSACalculator::Variable* ssaVariable = m_ssaVariableForVariable.get(variable);
                     SSACalculator::Def* def = calculator.reachingDefAtHead(block, ssaVariable);
@@ -292,8 +290,7 @@ public:
                         node = node->replacement();
                         ASSERT(!node->replacement());
                     }
-                    if (verbose)
-                        dataLog("Mapping: ", valueForOperand.operandForIndex(i), " -> ", node, "\n");
+                    dataLogLnIf(verbose, "Mapping: ", valueForOperand.operandForIndex(i), " -> ", node);
                     valueForOperand[i] = node;
                 }
             }
@@ -324,8 +321,10 @@ public:
                 Node* node = block->at(nodeIndex);
                 
                 if (verbose) {
-                    dataLog("Processing node ", node, ":\n");
-                    m_graph.dump(WTF::dataFile(), "    ", node);
+                    WTF::dataFile().atomically([&](auto& out) {
+                        dataLogLn("Processing node ", node, ":");
+                        m_graph.dump(out, "    ", node);
+                    });
                 }
                 
                 m_graph.performSubstitution(node);
@@ -350,8 +349,7 @@ public:
                     } else
                         node->remove(m_graph);
                     
-                    if (verbose)
-                        dataLog("Mapping: ", variable->operand(), " -> ", child, "\n");
+                    dataLogLnIf(verbose, "Mapping: ", variable->operand(), " -> ", child);
                     valueForOperand.operand(variable->operand()) = child;
                     break;
                 }
@@ -367,8 +365,7 @@ public:
                     node->children.reset();
                     
                     node->remove(m_graph);
-                    if (verbose)
-                        dataLog("Replacing node ", node, " with ", valueForOperand.operand(variable->operand()), "\n");
+                    dataLogLnIf(verbose, "Replacing node ", node, " with ", valueForOperand.operand(variable->operand()));
                     node->setReplacement(valueForOperand.operand(variable->operand()));
                     break;
                 }
@@ -470,10 +467,7 @@ public:
 
         m_graph.m_form = SSA;
 
-        if (verbose) {
-            dataLog("Graph after SSA transformation:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph after SSA transformation:\n", m_graph);
 
         return true;
     }

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierClusteringPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierClusteringPhase.cpp
@@ -102,11 +102,10 @@ private:
             // would be weird because it would create a new root for OSR availability analysis. I
             // don't have evidence that it would be worth it.
             if (doesGC(m_graph, node) || mayExit(m_graph, node) != DoesNotExit) {
-                if (verbose) {
-                    dataLog("Possible GC point at ", node, "\n");
-                    dataLog("    doesGC = ", doesGC(m_graph, node), "\n");
-                    dataLog("    mayExit = ", mayExit(m_graph, node), "\n");
-                }
+                dataLogLnIf(verbose,
+                    "Possible GC point at ", node, "\n",
+                    "    doesGC = ", doesGC(m_graph, node), "\n",
+                    "    mayExit = ", mayExit(m_graph, node));
                 futureGC = true;
                 continue;
             }

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -79,10 +79,7 @@ public:
     
     bool run()
     {
-        if (DFGStoreBarrierInsertionPhaseInternal::verbose) {
-            dataLog("Starting store barrier insertion:\n");
-            m_graph.dump();
-        }
+        dataLogIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "Starting store barrier insertion:\n", m_graph);
         
         switch (mode) {
         case PhaseMode::Fast: {
@@ -172,9 +169,8 @@ private:
     bool handleBlock(BasicBlock* block)
     {
         if (DFGStoreBarrierInsertionPhaseInternal::verbose) {
-            dataLog("Dealing with block ", pointerDump(block), "\n");
-            if (reallyInsertBarriers())
-                dataLog("    Really inserting barriers.\n");
+            dataLogLn("Dealing with block ", pointerDump(block));
+            dataLogLnIf(reallyInsertBarriers(), "    Really inserting barriers.");
         }
         
         m_currentEpoch = Epoch::first();
@@ -213,15 +209,17 @@ private:
             m_node = block->at(m_nodeIndex);
             
             if (DFGStoreBarrierInsertionPhaseInternal::verbose) {
-                dataLog(
-                    "    ", m_currentEpoch, ": Looking at node ", m_node, " with children: ");
-                CommaPrinter comma;
-                m_graph.doToChildren(
-                    m_node,
-                    [&] (Edge edge) {
-                        dataLog(comma, edge, " (", edge->epoch(), ")");
-                    });
-                dataLog("\n");
+                WTF::dataFile().atomically([&](auto&) {
+                    dataLog(
+                        "    ", m_currentEpoch, ": Looking at node ", m_node, " with children: ");
+                    CommaPrinter comma;
+                    m_graph.doToChildren(
+                        m_node,
+                        [&] (Edge edge) {
+                            dataLog(comma, edge, " (", edge->epoch(), ")");
+                        });
+                    dataLogLn();
+                });
             }
             
             if (mode == PhaseMode::Global) {
@@ -524,16 +522,18 @@ private:
             }
             
             if (DFGStoreBarrierInsertionPhaseInternal::verbose) {
-                dataLog(
-                    "    ", m_currentEpoch, ": Done with node ", m_node, " (", m_node->epoch(),
-                    ") with children: ");
-                CommaPrinter comma;
-                m_graph.doToChildren(
-                    m_node,
-                    [&] (Edge edge) {
-                        dataLog(comma, edge, " (", edge->epoch(), ")");
-                    });
-                dataLog("\n");
+                WTF::dataFile().atomically([&](auto&) {
+                    dataLog(
+                        "    ", m_currentEpoch, ": Done with node ", m_node, " (", m_node->epoch(),
+                        ") with children: ");
+                    CommaPrinter comma;
+                    m_graph.doToChildren(
+                        m_node,
+                        [&] (Edge edge) {
+                            dataLog(comma, edge, " (", edge->epoch(), ")");
+                        });
+                    dataLogLn();
+                });
             }
             
             if (mode == PhaseMode::Global) {
@@ -561,8 +561,7 @@ private:
     
     void considerBarrier(Edge base, Edge child)
     {
-        if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-            dataLog("        Considering adding barrier ", base, " => ", child, "\n");
+        dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "        Considering adding barrier ", base, " => ", child);
         
         // We don't need a store barrier if the child is guaranteed to not be a cell.
         switch (mode) {
@@ -570,8 +569,7 @@ private:
             // Don't try too hard because it's too expensive to run AI.
             if (child->hasConstant()) {
                 if (!child->asJSValue().isCell()) {
-                    if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-                        dataLog("            Rejecting because of constant type.\n");
+                    dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "            Rejecting because of constant type.");
                     return;
                 }
             } else {
@@ -581,8 +579,7 @@ private:
                 case NodeResultInt32:
                 case NodeResultInt52:
                 case NodeResultBoolean:
-                    if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-                        dataLog("            Rejecting because of result type.\n");
+                    dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "            Rejecting because of result type.");
                     return;
                 default:
                     break;
@@ -595,8 +592,7 @@ private:
             // Go into rage mode to eliminate any chance of a barrier with a non-cell child. We
             // can afford to keep around AI in Global mode.
             if (!m_interpreter->needsTypeCheck(child, ~SpecCell)) {
-                if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-                    dataLog("            Rejecting because of AI type.\n");
+                dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "            Rejecting because of AI type.");
                 return;
             }
             break;
@@ -607,21 +603,18 @@ private:
     
     void considerBarrier(Edge base)
     {
-        if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-            dataLog("        Considering adding barrier on ", base, "\n");
+        dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "        Considering adding barrier on ", base);
         
         // We don't need a store barrier if the epoch of the base is identical to the current
         // epoch. That means that we either just allocated the object and so it's guaranteed to
         // be in newgen, or we just ran a barrier on it so it's guaranteed to be remembered
         // already.
         if (base->epoch() == m_currentEpoch) {
-            if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-                dataLog("            Rejecting because it's in the current epoch.\n");
+            dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "            Rejecting because it's in the current epoch.");
             return;
         }
         
-        if (DFGStoreBarrierInsertionPhaseInternal::verbose)
-            dataLog("            Inserting barrier.\n");
+        dataLogLnIf(DFGStoreBarrierInsertionPhaseInternal::verbose, "            Inserting barrier.");
         insertBarrier(m_nodeIndex + 1, base);
     }
 

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -628,8 +628,7 @@ private:
                 if (RegExpObject* regExpObject = regExpObjectNode->dynamicCastConstant<RegExpObject*>()) {
                     JSGlobalObject* globalObject = regExpObject->globalObject();
                     if (globalObject->isRegExpRecompiled()) {
-                        if (verbose)
-                            dataLog("Giving up because RegExp recompile happens.\n");
+                        dataLogLnIf(verbose, "Giving up because RegExp recompile happens.");
                         break;
                     }
                     m_graph.watchpoints().addLazily(globalObject->regExpRecompiledWatchpointSet());
@@ -638,15 +637,13 @@ private:
                 } else if (regExpObjectNode->op() == NewRegexp) {
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(regExpObjectNode->origin.semantic);
                     if (globalObject->isRegExpRecompiled()) {
-                        if (verbose)
-                            dataLog("Giving up because RegExp recompile happens.\n");
+                        dataLogLnIf(verbose, "Giving up because RegExp recompile happens.");
                         break;
                     }
                     m_graph.watchpoints().addLazily(globalObject->regExpRecompiledWatchpointSet());
                     regExp = regExpObjectNode->castOperand<RegExp*>();
                 } else {
-                    if (verbose)
-                        dataLog("Giving up because the regexp is unknown.\n");
+                    dataLogLnIf(verbose, "Giving up because the regexp is unknown.");
                     break;
                 }
             } else
@@ -756,8 +753,7 @@ private:
                 // strings in the first place.
                 String string = stringNode->tryGetString(m_graph);
                 if (!string) {
-                    if (verbose)
-                        dataLog("Giving up because the string is unknown.\n");
+                    dataLogLnIf(verbose, "Giving up because the string is unknown.");
                     return false;
                 }
 
@@ -767,8 +763,7 @@ private:
                 // subpatterns.
                 unsigned ginormousNumberOfSubPatterns = 1000;
                 if (regExp->numSubpatterns() > ginormousNumberOfSubPatterns) {
-                    if (verbose)
-                        dataLog("Giving up because of pattern limit.\n");
+                    dataLogLnIf(verbose, "Giving up because of pattern limit.");
                     return false;
                 }
 
@@ -776,16 +771,14 @@ private:
                     if (regExp->hasNamedCaptures()) {
                         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=176464
                         // Implement strength reduction optimization for named capture groups.
-                        if (verbose)
-                            dataLog("Giving up because of named capture groups.\n");
+                        dataLogLnIf(verbose, "Giving up because of named capture groups.");
                         return false;
                     }
 
                     if (regExp->hasIndices()) {
                         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=220930
                         // Implement strength reduction optimization for RegExp with match indices.
-                        if (verbose)
-                            dataLog("Giving up because of match indices.\n");
+                        dataLogLnIf(verbose, "Giving up because of match indices.");
                         return false;
                     }
                 }
@@ -795,8 +788,7 @@ private:
                 Structure* structure = globalObject->regExpMatchesArrayStructure();
                 if (structure->indexingType() != ArrayWithContiguous) {
                     // This is further protection against a race with haveABadTime.
-                    if (verbose)
-                        dataLog("Giving up because the structure has the wrong indexing type.\n");
+                    dataLogLnIf(verbose, "Giving up because the structure has the wrong indexing type.");
                     return false;
                 }
                 m_graph.registerStructure(structure);
@@ -810,16 +802,14 @@ private:
                 if (m_node->op() == RegExpExec || m_node->op() == RegExpExecNonGlobalOrSticky) {
                     int position;
                     if (!regExp->matchConcurrently(vm(), string, lastIndex, position, ovector)) {
-                        if (verbose)
-                            dataLog("Giving up because match failed.\n");
+                        dataLogLnIf(verbose, "Giving up because match failed.");
                         return false;
                     }
                     result.start = position;
                     result.end = ovector[1];
                 } else {
                     if (!regExp->matchConcurrently(vm(), string, lastIndex, result)) {
-                        if (verbose)
-                            dataLog("Giving up because match failed.\n");
+                        dataLogLnIf(verbose, "Giving up because match failed.");
                         return false;
                     }
                 }
@@ -1076,8 +1066,7 @@ private:
                 m_graph.watchpoints().addLazily(globalObject->regExpRecompiledWatchpointSet());
                 regExp = regExpObjectNode->castOperand<RegExp*>();
             } else {
-                if (verbose)
-                    dataLog("Giving up because the regexp is unknown.\n");
+                dataLogLnIf(verbose, "Giving up because the regexp is unknown.");
                 break;
             }
 

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -1092,13 +1092,15 @@ private:
     {
         if (m_graphDumpMode == DontDumpGraph)
             return;
-        dataLog("\n");
-        if (!m_graphDumpBeforePhase.isNull()) {
-            dataLog("Before phase:\n");
-            dataLog(m_graphDumpBeforePhase);
-        }
-        dataLog("At time of failure:\n");
-        m_graph.dump();
+        WTF::dataFile().atomically([&](auto&) {
+            dataLog("\n");
+            if (!m_graphDumpBeforePhase.isNull()) {
+                dataLog("Before phase:\n");
+                dataLog(m_graphDumpBeforePhase);
+            }
+            dataLog("At time of failure:\n");
+            dataLog(m_graph);
+        });
     }
 
     Graph& m_graph;

--- a/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp
@@ -198,12 +198,14 @@ private:
                 auto dumpEscape = [&](const char* description, Node* node) {
                     if constexpr (!verbose)
                         return;
-                    dataLogLn(description);
-                    dataLog("   candidate: ");
-                    m_graph.dump(WTF::dataFile(), Prefix::noString, candidate);
-                    dataLog("   reason: ");
-                    m_graph.dump(WTF::dataFile(), Prefix::noString, node);
-                    dataLogLn();
+                    WTF::dataFile().atomically([&](auto&) {
+                        dataLogLn(description);
+                        dataLog("   candidate: ");
+                        m_graph.dump(WTF::dataFile(), Prefix::noString, candidate);
+                        dataLog("   reason: ");
+                        m_graph.dump(WTF::dataFile(), Prefix::noString, node);
+                        dataLogLn();
+                    });
                 };
 
                 if (candidate->op() == Phi) {

--- a/Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp
@@ -55,10 +55,7 @@ public:
     {
         DFG_ASSERT(m_graph, nullptr, m_graph.m_form != SSA);
         
-        if (verbose) {
-            dataLog("Graph before varargs forwarding:\n");
-            m_graph.dump();
-        }
+        dataLogIf(verbose, "Graph before varargs forwarding:\n", m_graph);
         
         m_changed = false;
         for (BasicBlock* block : m_graph.blocksInNaturalOrder())
@@ -87,8 +84,7 @@ private:
         // We expect calls into this function to be rare. So, this is written in a simple O(n) manner.
         
         Node* candidate = block->at(candidateNodeIndex);
-        if (verbose)
-            dataLog("Handling candidate ", candidate, "\n");
+        dataLogLnIf(verbose, "Handling candidate ", candidate);
         
         // We eliminate GetButterfly over CreateClonedArguments if the butterfly is only
         // used by a GetByOffset  that loads the CreateClonedArguments's length. We also
@@ -104,8 +100,7 @@ private:
 
             auto defaultEscape = [&] {
                 if (m_graph.uses(node, candidate)) {
-                    if (verbose)
-                        dataLog("    Escape at ", node, "\n");
+                    dataLogLnIf(verbose, "    Escape at ", node);
                     return true;
                 }
                 return false;
@@ -140,8 +135,7 @@ private:
                         }
                     });
                 if (sawEscape) {
-                    if (verbose)
-                        dataLog("    Escape at ", node, "\n");
+                    dataLogLnIf(verbose, "    Escape at ", node);
                     return;
                 }
                 break;
@@ -158,8 +152,7 @@ private:
             case TailCallVarargs:
             case TailCallVarargsInlinedCaller:
                 if (node->child1() == candidate || node->child2() == candidate) {
-                    if (verbose)
-                        dataLog("    Escape at ", node, "\n");
+                    dataLogLnIf(verbose, "    Escape at ", node);
                     return;
                 }
                 if (node->child2() == candidate)
@@ -168,8 +161,7 @@ private:
                 
             case SetLocal:
                 if (node->child1() == candidate && node->variableAccessData()->isLoadedFrom()) {
-                    if (verbose)
-                        dataLog("    Escape at ", node, "\n");
+                    dataLogLnIf(verbose, "    Escape at ", node);
                     return;
                 }
                 break;
@@ -230,8 +222,7 @@ private:
             if (!validGetByOffset) {
                 for (Node* butterfly : candidateButterflies) {
                     if (m_graph.uses(node, butterfly)) {
-                        if (verbose)
-                            dataLog("    Butterfly escaped at ", node, "\n");
+                        dataLogLnIf(verbose, "    Butterfly escaped at ", node);
                         return;
                     }
                 }
@@ -240,8 +231,7 @@ private:
             forAllKilledOperands(
                 m_graph, node, block->tryAt(nodeIndex + 1),
                 [&] (Operand operand) {
-                    if (verbose)
-                        dataLog("    Killing ", operand, " while we are interested in ", listDump(relevantLocals), "\n");
+                    dataLogLnIf(verbose, "    Killing ", operand, " while we are interested in ", listDump(relevantLocals));
                     for (unsigned i = 0; i < relevantLocals.size(); ++i) {
                         if (operand == relevantLocals[i]) {
                             relevantLocals[i--] = relevantLocals.last();
@@ -253,8 +243,7 @@ private:
                     }
                 });
         }
-        if (verbose)
-            dataLog("Selected lastUserIndex = ", lastUserIndex, ", ", block->at(lastUserIndex), "\n");
+        dataLogLnIf(verbose, "Selected lastUserIndex = ", lastUserIndex, ", ", block->at(lastUserIndex));
 
         InlineCallFrame* startingInlineCallFrame = block->at(candidateNodeIndex)->origin.forExit.inlineCallFrame();
         UncheckedKeyHashSet<InlineCallFrame*, WTF::DefaultHash<InlineCallFrame*>, WTF::NullableHashTraits<InlineCallFrame*>> seenInlineCallFrames;
@@ -273,24 +262,21 @@ private:
             case ZombieHint:
             case KillStack:
                 if (argumentsInvolveStackSlot(candidate, node->unlinkedOperand())) {
-                    if (verbose)
-                        dataLog("    Interference at ", node, "\n");
+                    dataLogLnIf(verbose, "    Interference at ", node);
                     return;
                 }
                 break;
                 
             case PutStack:
                 if (argumentsInvolveStackSlot(candidate, node->stackAccessData()->operand)) {
-                    if (verbose)
-                        dataLog("    Interference at ", node, "\n");
+                    dataLogLnIf(verbose, "    Interference at ", node);
                     return;
                 }
                 break;
                 
             case SetLocal:
                 if (argumentsInvolveStackSlot(candidate, node->operand())) {
-                    if (verbose)
-                        dataLog("    Interference at ", node, "\n");
+                    dataLogLnIf(verbose, "    Interference at ", node);
                     return;
                 }
                 break;
@@ -310,8 +296,7 @@ private:
                     },
                     NoOpClobberize());
                 if (doesInterfere) {
-                    if (verbose)
-                        dataLog("    Interference at ", node, "\n");
+                    dataLogLnIf(verbose, "    Interference at ", node);
                     return;
                 }
             } }
@@ -336,8 +321,7 @@ private:
         }
         
         // We can make this work.
-        if (verbose)
-            dataLog("    Will do forwarding!\n");
+        dataLogLnIf(verbose, "    Will do forwarding!");
         m_changed = true;
         
         // Transform the program.

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp
@@ -40,7 +40,7 @@ namespace JSC { namespace DFG {
 
 void VariableEventStreamBuilder::logEvent(const VariableEvent& event)
 {
-    dataLogF("seq#%u:", static_cast<unsigned>(m_stream.size()));
+    dataLog("seq#", static_cast<unsigned>(m_stream.size()), ":");
     event.dump(WTF::dataFile());
     dataLogLn(" ");
 }

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp
@@ -128,7 +128,7 @@ void AbstractHeap::deepDump(PrintStream& out, unsigned indent) const
 
 void AbstractHeap::badRangeError() const
 {
-    dataLog("Heap does not have range: ", *this, "\n");
+    dataLogLn("Heap does not have range: ", *this);
     RELEASE_ASSERT_NOT_REACHED();
 }
 

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp
@@ -146,9 +146,11 @@ void AbstractHeapRepository::computeRangesAndDecorateInstructions()
     using namespace B3;
     root.compute();
 
-    if (verboseCompilationEnabled()) {
-        dataLog("Abstract Heap Repository:\n");
-        root.deepDump(WTF::dataFile());
+    if (UNLIKELY(verboseCompilationEnabled())) {
+        WTF::dataFile().atomically([&](auto&) {
+            dataLogLn("Abstract Heap Repository:");
+            root.deepDump(WTF::dataFile());
+        });
     }
     
     auto rangeFor = [&] (const AbstractHeap* heap) -> HeapRange {

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -77,19 +77,17 @@ void compile(State& state, Safepoint::Result& safepointResult)
         return;
     
     RegisterAtOffsetList registerOffsets = state.proc->calleeSaveRegisterAtOffsetList();
-    if (shouldDumpDisassembly())
-        dataLog(tierName, "Unwind info for ", CodeBlockWithJITType(codeBlock, JITType::FTLJIT), ": ", registerOffsets, "\n");
+    dataLogLnIf(shouldDumpDisassembly(), tierName, "Unwind info for ", CodeBlockWithJITType(codeBlock, JITType::FTLJIT), ": ", registerOffsets);
     state.jitCode->m_calleeSaveRegisters = RegisterAtOffsetList(WTFMove(registerOffsets));
     ASSERT(!(state.proc->frameSize() % sizeof(EncodedJSValue)));
     state.jitCode->common.frameRegisterCount = state.proc->frameSize() / sizeof(EncodedJSValue);
 
     int localsOffset =
         state.capturedValue->offsetFromFP() / sizeof(EncodedJSValue) + graph.m_nextMachineLocal;
-    if (shouldDumpDisassembly()) {
-        dataLog(tierName,
-            "localsOffset = ", localsOffset, " for stack slot: ",
-            pointerDump(state.capturedValue), " at ", RawPointer(state.capturedValue), "\n");
-    }
+    dataLogLnIf(shouldDumpDisassembly(),
+        tierName,
+        "localsOffset = ", localsOffset, " for stack slot: ",
+        pointerDump(state.capturedValue), " at ", RawPointer(state.capturedValue));
     
     for (unsigned i = graph.m_inlineVariableData.size(); i--;) {
         InlineCallFrame* inlineCallFrame = graph.m_inlineVariableData[i].inlineCallFrame;

--- a/Source/JavaScriptCore/ftl/FTLLocation.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLocation.cpp
@@ -131,7 +131,7 @@ void Location::restoreInto(MacroAssembler& jit, char* savedRegisters, GPRReg res
     switch (kind()) {
     case Register:
         // B3 used some register that we don't know about!
-        dataLog("Unrecognized location: ", *this, "\n");
+        dataLogLn("Unrecognized location: ", *this);
         RELEASE_ASSERT_NOT_REACHED();
         return;
         

--- a/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSREntry.cpp
@@ -109,9 +109,10 @@ void* prepareOSREntry(
         }
         if (reconstructedValue && valueOnStack == reconstructedValue.value())
             continue;
-        dataLog("Mismatch between reconstructed values and the value on the stack for argument arg", argument, " for ", *entryCodeBlock, " at ", bytecodeIndex, ":\n");
-        dataLog("    Value on stack: ", valueOnStack, "\n");
-        dataLog("    Reconstructed value: ", reconstructedValue, "\n");
+        dataLogLn(
+            "Mismatch between reconstructed values and the value on the stack for argument arg", argument, " for ", *entryCodeBlock, " at ", bytecodeIndex, ":\n",
+            "    Value on stack: ", valueOnStack, "\n",
+            "    Reconstructed value: ", reconstructedValue);
         RELEASE_ASSERT_NOT_REACHED();
     }
     

--- a/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp
@@ -633,8 +633,7 @@ static void compileStub(VM& vm, unsigned exitID, JITCode* jitCode, OSRExit& exit
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLOSRExit, void*, (CallFrame* callFrame, unsigned exitID))
 {
-    if (shouldDumpDisassembly() || Options::verboseOSR() || Options::verboseFTLOSRExit())
-        dataLog("Compiling OSR exit with exitID = ", exitID, "\n");
+    dataLogLnIf(shouldDumpDisassembly() || Options::verboseOSR() || Options::verboseFTLOSRExit(), "Compiling OSR exit with exitID = ", exitID);
 
     VM& vm = callFrame->deprecatedVM();
     // Don't need an ActiveScratchBufferScope here because we DeferGCForAWhile below.
@@ -661,19 +660,21 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationCompileFTLOSRExit, void*, (CallFrame*
     OSRExit& exit = jitCode->m_osrExit[exitID];
     
     if (shouldDumpDisassembly() || Options::verboseOSR() || Options::verboseFTLOSRExit()) {
-        dataLog("    Owning block: ", pointerDump(codeBlock), "\n");
-        dataLog("    Origin: ", exit.m_codeOrigin, "\n");
+        dataLogLn(
+            "    Owning block: ", pointerDump(codeBlock), "\n",
+            "    Origin: ", exit.m_codeOrigin);
         if (exit.m_codeOriginForExitProfile != exit.m_codeOrigin)
-            dataLog("    Origin for exit profile: ", exit.m_codeOriginForExitProfile, "\n");
-        dataLog("    Current call site index: ", callFrame->callSiteIndex().bits(), "\n");
-        dataLog("    Exit is exception handler: ", exit.isExceptionHandler(), "\n");
-        dataLog("    Is unwind handler: ", exit.isGenericUnwindHandler(), "\n");
-        dataLog("    Exit values: ", exit.m_descriptor->m_values, "\n");
-        dataLog("    Value reps: ", listDump(exit.m_valueReps), "\n");
+            dataLogLn("    Origin for exit profile: ", exit.m_codeOriginForExitProfile);
+        dataLogLn(
+            "    Current call site index: ", callFrame->callSiteIndex().bits(), "\n",
+            "    Exit is exception handler: ", exit.isExceptionHandler(), "\n",
+            "    Is unwind handler: ", exit.isGenericUnwindHandler(), "\n",
+            "    Exit values: ", exit.m_descriptor->m_values, "\n",
+            "    Value reps: ", listDump(exit.m_valueReps));
         if (!exit.m_descriptor->m_materializations.isEmpty()) {
-            dataLog("    Materializations:\n");
+            dataLogLn("    Materializations:");
             for (ExitTimeObjectMaterialization* materialization : exit.m_descriptor->m_materializations)
-                dataLog("        ", pointerDump(materialization), "\n");
+                dataLogLn("        ", pointerDump(materialization));
         }
     }
 


### PR DESCRIPTION
#### a976a26dafd31b2b2f03f65fad441e1f24341244
<pre>
[JSC] Modernize logging in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=288078">https://bugs.webkit.org/show_bug.cgi?id=288078</a>
<a href="https://rdar.apple.com/problem/145208559">rdar://problem/145208559</a>

Reviewed by Keith Miller.

1. Use dataLogLn / dataLogLnIf
2. Wrap block of dump with WTF::dataFile().atomically so that we can
   avoid interleaving dumps.

* Source/JavaScriptCore/dfg/DFGAdaptiveInferredPropertyValueWatchpoint.cpp:
(JSC::DFG::AdaptiveInferredPropertyValueWatchpoint::handleFire):
* Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.cpp:
(JSC::DFG::AdaptiveStructureWatchpoint::fireInternal):
* Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseCodeBlock):
* Source/JavaScriptCore/dfg/DFGCFAPhase.cpp:
(JSC::DFG::CFAPhase::run):
(JSC::DFG::CFAPhase::injectOSR):
(JSC::DFG::CFAPhase::performBlockCFA):
(JSC::DFG::CFAPhase::performForwardCFA):
* Source/JavaScriptCore/dfg/DFGCFGSimplificationPhase.cpp:
(JSC::DFG::CFGSimplificationPhase::run):
* Source/JavaScriptCore/dfg/DFGCPSRethreadingPhase.cpp:
(JSC::DFG::CPSRethreadingPhase::propagatePhis):
* Source/JavaScriptCore/dfg/DFGCSEPhase.cpp:
* Source/JavaScriptCore/dfg/DFGCapabilities.cpp:
(JSC::DFG::debugFail):
* Source/JavaScriptCore/dfg/DFGDriver.cpp:
(JSC::DFG::compileImpl):
* Source/JavaScriptCore/dfg/DFGEdgeDominates.h:
(JSC::DFG::EdgeDominates::operator()):
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::dethread):
(JSC::DFG::Graph::isLiveInBytecode):
(JSC::DFG::logDFGAssertionFailure):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.cpp:
(JSC::DFG::InPlaceAbstractState::merge):
* Source/JavaScriptCore/dfg/DFGIntegerCheckCombiningPhase.cpp:
(JSC::DFG::IntegerCheckCombiningPhase::handleBlock):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGLICMPhase.cpp:
(JSC::DFG::LICMPhase::run):
(JSC::DFG::LICMPhase::attemptHoist):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::run):
(JSC::DFG::LoopUnrollingPhase::tryUnroll):
* Source/JavaScriptCore/dfg/DFGMovHintRemovalPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp:
(JSC::DFG::OSRAvailabilityAnalysisPhase::run):
* Source/JavaScriptCore/dfg/DFGOSRExit.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGPhantomInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPhase.cpp:
(JSC::DFG::Phase::beginPhase):
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPutStackSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSSAConversionPhase.cpp:
(JSC::DFG::SSAConversionPhase::run):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::terminateSpeculativeExecution):
(JSC::DFG::SpeculativeJIT::bail):
(JSC::DFG::SpeculativeJIT::compileCurrentBlock):
(JSC::DFG::SpeculativeJIT::linkOSREntries):
* Source/JavaScriptCore/dfg/DFGStoreBarrierClusteringPhase.cpp:
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/dfg/DFGValueRepReductionPhase.cpp:
(JSC::DFG::ValueRepReductionPhase::convertValueRepsToDouble):
* Source/JavaScriptCore/dfg/DFGVarargsForwardingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGVariableEventStream.cpp:
(JSC::DFG::VariableEventStreamBuilder::logEvent):
* Source/JavaScriptCore/ftl/FTLAbstractHeap.cpp:
(JSC::FTL::AbstractHeap::badRangeError const):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.cpp:
(JSC::FTL::AbstractHeapRepository::computeRangesAndDecorateInstructions):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/ftl/FTLLocation.cpp:
(JSC::FTL::Location::restoreInto const):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::lower):
(JSC::FTL::DFG::LowerDFGToB3::compileBlock):
(JSC::FTL::DFG::LowerDFGToB3::safelyInvalidateAfterTermination):
(JSC::FTL::DFG::LowerDFGToB3::validateAIState):
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOSREntry.cpp:
(JSC::FTL::prepareOSREntry):
* Source/JavaScriptCore/ftl/FTLOSRExitCompiler.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::dumpDisassembly):

Canonical link: <a href="https://commits.webkit.org/290739@main">https://commits.webkit.org/290739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33a5ef274bcbd80860bc049f4fb94020b1fb7758

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41676 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69880 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27410 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93884 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8223 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82383 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/7996 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36776 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40798 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83707 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78291 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37842 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97876 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89663 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18078 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78223 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78091 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22572 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21185 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14349 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23432 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112152 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17826 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21282 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->