### PR TITLE
[JSC][armv7] Verify MacroAssemblerARMv7::branch32 usage in debug builds

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -2554,9 +2554,11 @@ public:
     Jump branch32(RelationalCondition cond, RegisterID left, RegisterID right)
     {
         if (left == ARMRegisters::sp) {
+            ASSERT(right != addressTempRegister);
             move(left, addressTempRegister);
             m_assembler.cmp(addressTempRegister, right);
         } else if (right == ARMRegisters::sp) {
+            ASSERT(left != addressTempRegister);
             move(right, addressTempRegister);
             m_assembler.cmp(left, addressTempRegister);
         } else

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4849,11 +4849,11 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
 
     if (ASSERT_ENABLED) {
         if (m_stubInfo.useDataIC) {
-            jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), jit.scratchRegister());
-            jit.addPtr(jit.scratchRegister(), GPRInfo::callFrameRegister, jit.scratchRegister());
+            jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
+            jit.addPtr(m_scratchGPR, GPRInfo::callFrameRegister, m_scratchGPR);
         } else
-            jit.addPtr(CCallHelpers::TrustedImm32(codeBlock->stackPointerOffset() * sizeof(Register)), GPRInfo::callFrameRegister, jit.scratchRegister());
-        auto ok = jit.branchPtr(CCallHelpers::Equal, CCallHelpers::stackPointerRegister, jit.scratchRegister());
+            jit.addPtr(CCallHelpers::TrustedImm32(codeBlock->stackPointerOffset() * sizeof(Register)), GPRInfo::callFrameRegister, m_scratchGPR);
+        auto ok = jit.branchPtr(CCallHelpers::Equal, CCallHelpers::stackPointerRegister, m_scratchGPR);
         jit.breakpoint();
         ok.link(&jit);
     }


### PR DESCRIPTION
#### 5ea7dfca425272434583b08dfa92a93428d2d09d
<pre>
[JSC][armv7] Verify MacroAssemblerARMv7::branch32 usage in debug builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=288083">https://bugs.webkit.org/show_bug.cgi?id=288083</a>

Reviewed by Yusuke Suzuki and Justin Michaud.

On armv7 certain uses of branchPtr cause it to clobber its own arguments, leading to bogus assembly.

Catch this pitfall at least in debug builds and fix instances of this bug.

* Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h:
(JSC::MacroAssemblerARMv7::branch32):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::compile):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addLoopOSREntrypoint):

Canonical link: <a href="https://commits.webkit.org/291489@main">https://commits.webkit.org/291489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f9add187bc8064e4904a65a6530e1d2e79d196d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42489 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19878 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70517 "Found 15 new test failures: http/wpt/selection-live-range/collapse-30.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html imported/w3c/web-platform-tests/dom/ranges/Range-compareBoundaryPoints.html imported/w3c/web-platform-tests/dom/ranges/Range-comparePoint.html imported/w3c/web-platform-tests/dom/ranges/Range-isPointInRange.html imported/w3c/web-platform-tests/dom/ranges/Range-mutations-dataChange.html imported/w3c/web-platform-tests/dom/ranges/Range-set.html imported/w3c/web-platform-tests/html/dom/reflection-embedded.html imported/w3c/web-platform-tests/html/dom/reflection-forms.html imported/w3c/web-platform-tests/html/dom/reflection-grouping.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27999 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8980 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50846 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8713 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/818 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41699 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84655 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98831 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90600 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14029 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79531 "Found 18 new test failures: http/wpt/selection-live-range/collapse-30.html imported/w3c/web-platform-tests/css/css-anchor-position/anchor-size-parse-valid.html imported/w3c/web-platform-tests/dom/ranges/Range-compareBoundaryPoints.html imported/w3c/web-platform-tests/dom/ranges/Range-comparePoint.html imported/w3c/web-platform-tests/dom/ranges/Range-isPointInRange.html imported/w3c/web-platform-tests/dom/ranges/Range-mutations-dataChange.html imported/w3c/web-platform-tests/dom/ranges/Range-set.html imported/w3c/web-platform-tests/html/dom/reflection-embedded.html imported/w3c/web-platform-tests/html/dom/reflection-forms.html imported/w3c/web-platform-tests/html/dom/reflection-misc.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78754 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23298 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/613 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12051 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24203 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113186 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18683 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32764 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22141 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->