### PR TITLE
[EME] Allow CDMs to report support (or lack thereof) for specific encryption schemes

### DIFF
--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp
@@ -381,6 +381,10 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
         // 3.2. Let robustness be requested media capability's robustness member.
         String robustness = requestedCapability.robustness;
 
+        // [Editor's Draft 07 August 2024]
+        // 2. Let encryption scheme be requested media capability’s encryptionScheme member.
+        auto encryptionScheme = requestedCapability.encryptionScheme;
+
         // 3.3. If content type is the empty string, return null.
         if (requestedCapability.contentType.isEmpty())
             return std::nullopt;
@@ -409,6 +413,12 @@ std::optional<Vector<CDMMediaCapability>> CDMPrivate::getSupportedCapabilitiesFo
             // ↳ Otherwise:
             notImplemented();
         }
+
+        // [Editor's Draft 07 August 2024]
+        // 3.13. If encryption scheme is non-null and is not recognized or not supported by implementation,
+        //       continue to the next iteration.
+        if (encryptionScheme && !supportsEncryptionScheme(*encryptionScheme))
+            continue;
 
         // 3.11. If content type is not strictly a audio/video type, continue to the next iteration.
         // 3.12. If robustness is not the empty string and contains an unrecognized value or a value not supported by

--- a/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
+++ b/Source/WebCore/platform/encryptedmedia/CDMPrivate.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(ENCRYPTED_MEDIA)
 
+#include "CDMEncryptionScheme.h"
 #include "CDMInstance.h"
 #include "CDMRequirement.h"
 #include "CDMSessionType.h"
@@ -84,6 +85,7 @@ public:
     virtual bool supportsConfiguration(const CDMKeySystemConfiguration&) const = 0;
     virtual bool supportsConfigurationWithRestrictions(const CDMKeySystemConfiguration&, const CDMRestrictions&) const = 0;
     virtual bool supportsSessionTypeWithConfiguration(const CDMSessionType&, const CDMKeySystemConfiguration&) const = 0;
+    virtual bool supportsEncryptionScheme(CDMEncryptionScheme) const { return true; }
     virtual Vector<AtomString> supportedRobustnesses() const = 0;
     virtual CDMRequirement distinctiveIdentifiersRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const = 0;
     virtual CDMRequirement persistentStateRequirement(const CDMKeySystemConfiguration&, const CDMRestrictions&) const = 0;


### PR DESCRIPTION
#### 7dd8061f5106bbd5a161e6353a8632db8731a697
<pre>
[EME] Allow CDMs to report support (or lack thereof) for specific encryption schemes
<a href="https://bugs.webkit.org/show_bug.cgi?id=288080">https://bugs.webkit.org/show_bug.cgi?id=288080</a>

Reviewed by NOBODY (OOPS!).

So far CDMPrivate hasn&apos;t checked .encryptionScheme parameter, optionally
passed in requestMediaKeySystemAccess() argument. This is in accordance
with 2016 draft of Encrypted Media Extensions spec. Meanwhile in 2024 a
newer draft was released (a.k.a EME v2) which introduced this parameter.

Support for .encryptionScheme was added to .idl and MockCDM back in 2018
(<a href="https://commits.webkit.org/205633@main)">https://commits.webkit.org/205633@main)</a> however non-mock CDMs still
can&apos;t easily signal if they support particular scheme or not.  This
change adds CDMPrivate::supportsEncryptionScheme() method which closes
this gap.  The new method is then leveraged in the capability checking
algorithm in CDMPrivate::getSupportedCapabilitiesForAudioVideoType(), as
per EME v2:

    3.2.2.3 Get Supported Capabilities for Audio/Video Type:

      2. Let encryption scheme be requested media capability’s
         encryptionScheme member.
      [...]
      13. If encryption scheme is non-null and is not recognized or not
          supported by implementation, continue to the next iteration.

To prevent any changes in current behavior the default implementation
will always return true for now. In due time maintainers of particular
CDMs can override this method to reflect the actual capabilities of each
module.

* Source/WebCore/platform/encryptedmedia/CDMPrivate.cpp:
(WebCore::CDMPrivate::getSupportedCapabilitiesForAudioVideoType):
* Source/WebCore/platform/encryptedmedia/CDMPrivate.h:
(WebCore::CDMPrivate::supportsEncryptionScheme const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7dd8061f5106bbd5a161e6353a8632db8731a697

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99319 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71950 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29289 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52295 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2841 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44153 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80467 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101364 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21359 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15573 "Found 2 new test failures: svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-default-context.svg svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-ltr-context.svg (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80955 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80337 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2262 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14581 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26522 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->