### PR TITLE
Use smart pointers in Path.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -977,7 +977,6 @@ platform/graphics/ImageFrame.cpp
 platform/graphics/ImageFrameWorkQueue.cpp
 platform/graphics/MediaPlayer.cpp
 platform/graphics/Path.cpp
-platform/graphics/Path.h
 platform/graphics/SourceBufferPrivate.cpp
 platform/graphics/TransparencyLayerContextSwitcher.cpp
 platform/graphics/WidthIterator.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -553,8 +553,6 @@ platform/graphics/FontCache.cpp
 platform/graphics/FontRanges.cpp
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/Image.cpp
-platform/graphics/Path.cpp
-platform/graphics/Path.h
 platform/graphics/SourceBrush.cpp
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/objc/CDMInstanceFairPlayStreamingAVFObjC.mm

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -116,6 +116,11 @@ PathImpl& Path::ensureImpl()
     return setImpl(PathStream::create());
 }
 
+Ref<PathImpl> Path::ensureProtectedImpl()
+{
+    return ensureImpl();
+}
+
 void Path::ensureImplForTesting()
 {
     if (isEmpty())
@@ -123,14 +128,14 @@ void Path::ensureImplForTesting()
     ensureImpl();
 }
 
-PathImpl* Path::asImpl()
+RefPtr<PathImpl> Path::asImpl()
 {
     if (auto ref = std::get_if<DataRef<PathImpl>>(&m_data))
         return &ref->access();
     return nullptr;
 }
 
-const PathImpl* Path::asImpl() const
+RefPtr<const PathImpl> Path::asImpl() const
 {
     if (auto ref = std::get_if<DataRef<PathImpl>>(&m_data))
         return ref->ptr();
@@ -176,7 +181,7 @@ void Path::addRoundedRect(const FloatRoundedRect& roundedRect, PathRoundedRect::
     if (isEmpty())
         m_data = PathSegment(PathRoundedRect { roundedRect, strategy });
     else
-        ensureImpl().add(PathRoundedRect { roundedRect, strategy });
+        ensureProtectedImpl()->add(PathRoundedRect { roundedRect, strategy });
 }
 
 void Path::addRoundedRect(const FloatRect& rect, const FloatSize& roundingRadii, PathRoundedRect::Strategy strategy)
@@ -187,7 +192,7 @@ void Path::addRoundedRect(const FloatRect& rect, const FloatSize& roundingRadii,
     if (isEmpty())
         m_data = PathSegment(PathRoundedRect { calculateEvenRoundedRect(rect, roundingRadii), strategy });
     else
-        ensureImpl().add(PathRoundedRect { calculateEvenRoundedRect(rect, roundingRadii), strategy });
+        ensureProtectedImpl()->add(PathRoundedRect { calculateEvenRoundedRect(rect, roundingRadii), strategy });
 }
 
 void Path::addRoundedRect(const RoundedRect& rect)
@@ -203,7 +208,7 @@ void Path::addContinuousRoundedRect(const FloatRect& rect, const float cornerWid
     if (isEmpty())
         m_data = PathSegment(PathContinuousRoundedRect { rect, cornerWidth, cornerHeight });
     else
-        ensureImpl().add(PathContinuousRoundedRect { rect, cornerWidth, cornerHeight });
+        ensureProtectedImpl()->add(PathContinuousRoundedRect { rect, cornerWidth, cornerHeight });
 }
 
 void Path::addPath(const Path& path, const AffineTransform& transform)
@@ -301,7 +306,7 @@ PlatformPathPtr Path::platformPath() const
 const Vector<PathSegment>* Path::segmentsIfExists() const
 {
     if (auto impl = asImpl()) {
-        if (auto* stream = dynamicDowncast<PathStream>(*impl))
+        if (auto* stream = dynamicDowncast<PathStream>((*impl)))
             return &stream->segments();
     }
 
@@ -382,7 +387,7 @@ bool Path::hasSubpaths() const
     if (auto* segment = asSingle())
         return PathStream::computeHasSubpaths(singleElementSpan(*segment));
 
-    if (auto* impl = asImpl())
+    if (auto impl = asImpl())
         return impl->hasSubpaths();
 
     return false;
@@ -393,7 +398,7 @@ FloatRect Path::fastBoundingRect() const
     if (auto* segment = asSingle())
         return segment->fastBoundingRect();
 
-    if (auto* impl = asImpl())
+    if (auto impl = asImpl())
         return impl->fastBoundingRect();
 
     return { };
@@ -404,7 +409,7 @@ FloatRect Path::boundingRect() const
     if (auto* segment = asSingle())
         return PathStream::computeBoundingRect(singleElementSpan(*segment));
 
-    if (auto* impl = asImpl())
+    if (auto impl = asImpl())
         return impl->boundingRect();
 
     return { };

--- a/Source/WebCore/platform/graphics/Path.h
+++ b/Source/WebCore/platform/graphics/Path.h
@@ -114,12 +114,13 @@ private:
     PlatformPathImpl& ensurePlatformPathImpl();
     PathImpl& setImpl(Ref<PathImpl>&&);
     WEBCORE_EXPORT PathImpl& ensureImpl();
+    WEBCORE_EXPORT Ref<PathImpl> ensureProtectedImpl();
 
     PathSegment* asSingle() { return std::get_if<PathSegment>(&m_data); }
     const PathSegment* asSingle() const { return std::get_if<PathSegment>(&m_data); }
 
-    PathImpl* asImpl();
-    const PathImpl* asImpl() const;
+    RefPtr<PathImpl> asImpl();
+    RefPtr<const PathImpl> asImpl() const;
 
     std::optional<FloatPoint> initialMoveToPoint() const;
 
@@ -143,7 +144,7 @@ inline void Path::moveTo(const FloatPoint& point)
     if (isEmpty())
         m_data = PathSegment(PathMoveTo { point });
     else
-        ensureImpl().add(PathMoveTo { point });
+        ensureProtectedImpl()->add(PathMoveTo { point });
 }
 
 inline void Path::addLineTo(const FloatPoint& point)
@@ -151,7 +152,7 @@ inline void Path::addLineTo(const FloatPoint& point)
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataLine { *initial, point });
     else
-        ensureImpl().add(PathLineTo { point });
+        ensureProtectedImpl()->add(PathLineTo { point });
 }
 
 inline void Path::addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoint& endPoint)
@@ -159,7 +160,7 @@ inline void Path::addQuadCurveTo(const FloatPoint& controlPoint, const FloatPoin
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataQuadCurve { *initial, controlPoint, endPoint });
     else
-        ensureImpl().add(PathQuadCurveTo { controlPoint, endPoint });
+        ensureProtectedImpl()->add(PathQuadCurveTo { controlPoint, endPoint });
 }
 
 inline void Path::addBezierCurveTo(const FloatPoint& controlPoint1, const FloatPoint& controlPoint2, const FloatPoint& endPoint)
@@ -167,7 +168,7 @@ inline void Path::addBezierCurveTo(const FloatPoint& controlPoint1, const FloatP
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataBezierCurve { *initial, controlPoint1, controlPoint2, endPoint });
     else
-        ensureImpl().add(PathBezierCurveTo { controlPoint1, controlPoint2, endPoint });
+        ensureProtectedImpl()->add(PathBezierCurveTo { controlPoint1, controlPoint2, endPoint });
 }
 
 inline void Path::addArcTo(const FloatPoint& point1, const FloatPoint& point2, float radius)
@@ -175,7 +176,7 @@ inline void Path::addArcTo(const FloatPoint& point1, const FloatPoint& point2, f
     if (auto initial = initialMoveToPoint())
         m_data = PathSegment(PathDataArc { *initial, point1, point2, radius });
     else
-        ensureImpl().add(PathArcTo { point1, point2, radius });
+        ensureProtectedImpl()->add(PathArcTo { point1, point2, radius });
 }
 
 inline void Path::addArc(const FloatPoint& point, float radius, float startAngle, float endAngle, RotationDirection direction)
@@ -189,7 +190,7 @@ inline void Path::addArc(const FloatPoint& point, float radius, float startAngle
     if (isEmpty())
         m_data = PathSegment(PathArc { point, radius, startAngle, endAngle, direction });
     else
-        ensureImpl().add(PathArc { point, radius, startAngle, endAngle, direction });
+        ensureProtectedImpl()->add(PathArc { point, radius, startAngle, endAngle, direction });
 }
 
 inline void Path::addEllipse(const FloatPoint& point, float radiusX, float radiusY, float rotation, float startAngle, float endAngle, RotationDirection direction)
@@ -197,7 +198,7 @@ inline void Path::addEllipse(const FloatPoint& point, float radiusX, float radiu
     if (isEmpty())
         m_data = PathSegment(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
     else
-        ensureImpl().add(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
+        ensureProtectedImpl()->add(PathEllipse { point, radiusX, radiusY, rotation, startAngle, endAngle, direction });
 }
 
 inline void Path::addEllipseInRect(const FloatRect& rect)
@@ -205,7 +206,7 @@ inline void Path::addEllipseInRect(const FloatRect& rect)
     if (isEmpty())
         m_data = PathSegment(PathEllipseInRect { rect });
     else
-        ensureImpl().add(PathEllipseInRect { rect });
+        ensureProtectedImpl()->add(PathEllipseInRect { rect });
 }
 
 inline void Path::addRect(const FloatRect& rect)
@@ -213,7 +214,7 @@ inline void Path::addRect(const FloatRect& rect)
     if (isEmpty())
         m_data = PathSegment(PathRect { rect });
     else
-        ensureImpl().add(PathRect { rect });
+        ensureProtectedImpl()->add(PathRect { rect });
 }
 
 inline void Path::closeSubpath()
@@ -229,10 +230,10 @@ inline void Path::closeSubpath()
         if (std::holds_alternative<PathCloseSubpath>(*data))
             return;
     }
-    auto& impl = ensureImpl();
-    if (impl.isClosed())
+    auto impl = ensureProtectedImpl();
+    if (impl->isClosed())
         return;
-    impl.add(PathCloseSubpath { });
+    impl->add(PathCloseSubpath { });
 }
 
 inline FloatPoint Path::currentPoint() const


### PR DESCRIPTION
#### 8b44517102b796486dd05a51dae00970755b5b86
<pre>
Use smart pointers in Path.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288084">https://bugs.webkit.org/show_bug.cgi?id=288084</a>

Reviewed by Ryosuke Niwa.

Use smart pointers in Path.cpp.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::ensurePlatformPathImpl):
(WebCore::Path::ensureProtectedImpl):
(WebCore::Path::asImpl):
(WebCore::Path::asImpl const):
(WebCore::Path::moveTo):
(WebCore::Path::addLineTo):
(WebCore::Path::addQuadCurveTo):
(WebCore::Path::addBezierCurveTo):
(WebCore::Path::addArcTo):
(WebCore::Path::addArc):
(WebCore::Path::addEllipse):
(WebCore::Path::addEllipseInRect):
(WebCore::Path::addRect):
(WebCore::Path::addRoundedRect):
(WebCore::Path::addContinuousRoundedRect):
(WebCore::Path::closeSubpath):
(WebCore::Path::segmentsIfExists const):
(WebCore::Path::hasSubpaths const):
(WebCore::Path::fastBoundingRect const):
(WebCore::Path::boundingRect const):
* Source/WebCore/platform/graphics/Path.h:

Canonical link: <a href="https://commits.webkit.org/295396@main">https://commits.webkit.org/295396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5aa43296cea0e1968ece7f20860dab5fc58cfd45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/15082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/110163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/25064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/33205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79684 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19496 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59991 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12791 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/55004 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112648 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/32112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88392 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/11066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27432 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/32036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37406 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31829 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/35170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->