### PR TITLE
[JSC] Add scavenger hook for scavenging external tasks

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 		0F9E9466234660D4009FAFDD /* pas_dyld_state.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F9E9464234660D3009FAFDD /* pas_dyld_state.c */; };
 		0F9E9467234660D4009FAFDD /* pas_dyld_state.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9E9465234660D3009FAFDD /* pas_dyld_state.h */; };
 		0FA18546236B3C82003609AD /* IsoHeapChaosTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA18545236B3C82003609AD /* IsoHeapChaosTests.cpp */; };
+		0FA18546236B3C82003609A7 /* ScavengerExternalWorkTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp.cpp */; };
 		0FA5E4562492D5BA00CE962A /* pas_thread_local_cache_layout_node.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FA5E4512492D5B900CE962A /* pas_thread_local_cache_layout_node.c */; };
 		0FA5E4572492D5BA00CE962A /* pas_redundant_local_allocator_node.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA5E4522492D5B900CE962A /* pas_redundant_local_allocator_node.h */; };
 		0FA5E4582492D5BA00CE962A /* pas_thread_local_cache_layout_node.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA5E4532492D5B900CE962A /* pas_thread_local_cache_layout_node.h */; };
@@ -1042,6 +1043,7 @@
 		0F9E9464234660D3009FAFDD /* pas_dyld_state.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_dyld_state.c; sourceTree = "<group>"; };
 		0F9E9465234660D3009FAFDD /* pas_dyld_state.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_dyld_state.h; sourceTree = "<group>"; };
 		0FA18545236B3C82003609AD /* IsoHeapChaosTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IsoHeapChaosTests.cpp; sourceTree = "<group>"; };
+		0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScavengerExternalWorkTests.cpp; sourceTree = "<group>"; };
 		0FA5E4512492D5B900CE962A /* pas_thread_local_cache_layout_node.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_thread_local_cache_layout_node.c; sourceTree = "<group>"; };
 		0FA5E4522492D5B900CE962A /* pas_redundant_local_allocator_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_redundant_local_allocator_node.h; sourceTree = "<group>"; };
 		0FA5E4532492D5B900CE962A /* pas_thread_local_cache_layout_node.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_thread_local_cache_layout_node.h; sourceTree = "<group>"; };
@@ -1435,6 +1437,7 @@
 				2B2A589B2742D815005EE07C /* PGMTests.cpp */,
 				0F5E483923D69F610046DA5C /* RaceTests.cpp */,
 				0FF08F3522A59DB300386575 /* RedBlackTreeTests.cpp */,
+				0FA18545236B3C82003609A7 /* ScavengerExternalWorkTests.cpp */,
 				0FDE52552342B7C400A0808F /* SuspendScavenger.h */,
 				0FC681EB21127A16003C6A13 /* TestHarness.cpp */,
 				0FC681EA210FEDB5003C6A13 /* TestHarness.h */,
@@ -2708,6 +2711,7 @@
 				2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */,
 				0F5E483A23D69F610046DA5C /* RaceTests.cpp in Sources */,
 				0FF08F3622A59DB300386575 /* RedBlackTreeTests.cpp in Sources */,
+				0FA18546236B3C82003609A7 /* ScavengerExternalWorkTests.cpp in Sources */,
 				0FC681ED21127A19003C6A13 /* TestHarness.cpp in Sources */,
 				0F8700C225B0B26A000E1ABF /* ThingyAndUtilityHeapAllocationTests.cpp in Sources */,
 				2C473162277D4C9E00B62C49 /* TLCDecommitTests.cpp in Sources */,

--- a/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_scavenger.h
@@ -52,10 +52,32 @@ PAS_BEGIN_EXTERN_C;
 struct pas_scavenger_data;
 typedef struct pas_scavenger_data pas_scavenger_data;
 
+/* Returns true if any work is still left to be done. */
+typedef bool (*pas_scavenger_foreign_work_callback)(void*);
+
+struct pas_scavenger_foreign_work_descriptor;
+typedef struct pas_scavenger_foreign_work_descriptor pas_scavenger_foreign_work_descriptor;
+struct pas_scavenger_foreign_work_data;
+typedef struct pas_scavenger_foreign_work_data pas_scavenger_foreign_work_data;
+#define PAS_SCAVENGER_MAX_FOREIGN_WORK_DESCRIPTORS 1
+
+struct pas_scavenger_foreign_work_descriptor {
+    pas_scavenger_foreign_work_callback func;
+    void* userdata;
+    uint32_t period_log2_ticks;
+};
+
+struct pas_scavenger_foreign_work_data {
+    pthread_mutex_t lock; /* Only guards writes. */
+    pas_scavenger_foreign_work_descriptor descriptors[PAS_SCAVENGER_MAX_FOREIGN_WORK_DESCRIPTORS];
+    int next_open_descriptor;
+};
+
 /* Holds data that needs to be initialized somehow. */
 struct pas_scavenger_data {
     pthread_mutex_t lock;
     pthread_cond_t cond;
+    pas_scavenger_foreign_work_data foreign_work;
 };
 
 /* This is available extern for testing and debugging only. */
@@ -91,6 +113,20 @@ PAS_API extern pas_scavenger_activity_callback pas_scavenger_completion_callback
 /* This gets called when the scavenger thread is about to shut down.  It's called from the
    scavenger thread with no locks held. */
 PAS_API extern pas_scavenger_activity_callback pas_scavenger_will_shut_down_callback;
+
+/* If successful, arranges for the scavenger to call the callback
+ * with userdata as an argument. The scavenger will try to call it
+ * approximately once per the specified period, but no faster than once every
+ * pas_scavenger_period_in_milliseconds ms.
+ * This callback will only be called from the scavenger thread with no locks
+ * held.
+ * At most PAS_SCAVENGER_MAX_FOREIGN_WORK_DESCRIPTORS can be installed.
+ * Returns false if the callback could not be installed. */
+PAS_API bool pas_scavenger_try_install_foreign_work_callback(
+    pas_scavenger_foreign_work_callback callback,
+    uint32_t period_log2_ms,
+    void* userdata);
+
 
 /* This defers an eligibility notification. */
 PAS_API bool pas_scavenger_did_create_eligible(void);

--- a/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#include "TestHarness.h"
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include "pas_scavenger.h"
+
+using namespace std;
+
+extern "C" inline bool incrementCounter(void* counter)
+{
+    auto* atomic_counter = reinterpret_cast<std::atomic<int>*>(counter);
+    (*atomic_counter)++;
+    return false;
+}
+
+inline void testCallbacksAreCalledWhenExpected(int scavenger_on_ms, int scavenger_off_ms)
+{
+    TestScope frequentScavenging(
+        "frequent-scavenging",
+        [] () {
+            pas_scavenger_period_in_milliseconds = 1.;
+            pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+        });
+
+    auto counter = 0;
+    [[maybe_unused]] void* counter_ptr = reinterpret_cast<void*>(&counter);
+    CHECK(pas_scavenger_try_install_foreign_work_callback(incrementCounter, 1, counter_ptr));
+
+    int prevCounterValue;
+    {
+        SuspendScavengerScope suspendScavenger;
+        prevCounterValue = counter;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(scavenger_off_ms));
+        CHECK_EQUAL(counter, prevCounterValue);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(scavenger_on_ms));
+    CHECK_GREATER(counter, prevCounterValue);
+}
+
+void addScavengerExternalWorkTests()
+{
+    ADD_TEST(testCallbacksAreCalledWhenExpected(50, 50));
+}

--- a/Source/bmalloc/libpas/src/test/TestHarness.cpp
+++ b/Source/bmalloc/libpas/src/test/TestHarness.cpp
@@ -373,6 +373,7 @@ void addMinHeapTests();
 void addPGMTests();
 void addRaceTests();
 void addRedBlackTreeTests();
+void addScavengerExternalWorkTests();
 void addTLCDecommitTests();
 void addTSDTests();
 void addThingyAndUtilityHeapAllocationTests();


### PR DESCRIPTION
#### c7d6142e894fc9ca22be5151076c5c3e40e99f77
<pre>
[JSC] Add scavenger hook for scavenging external tasks
<a href="https://bugs.webkit.org/show_bug.cgi?id=287984">https://bugs.webkit.org/show_bug.cgi?id=287984</a>
<a href="https://rdar.apple.com/145154078">rdar://145154078</a>

Reviewed by Yusuke Suzuki.

This patch should strike a balance between convenience and performance.
Using a fixed array of callbacks is suitable because we always
know which systems are going to hook into libpas -- it&apos;s not like
someone will decide at runtime that they need to fall back on
the scavenger.

Re.: the additional mutex, it&apos;s possible to do without it -- we would
just need two atomic integers, &quot;next_open_slot&quot; and
&quot;last_initialized_slot&quot;. However, this is a nontrivial amount of
complexity and much easier to mess up.

* Source/WTF/wtf/SequesteredAllocator.h:
* Source/WTF/wtf/SequesteredImmortalHeap.h:
(WTF::SequesteredImmortalHeap::installScavengerHook):
(WTF::SequesteredImmortalHeap::scavenge):
* Source/WTF/wtf/Threading.cpp:
(WTF::initialize):
* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/src/libpas/pas_scavenger.c:
(ensure_data_instance):
(scavenger_thread_main):
(pas_scavenger_try_install_foreign_work_callback):
* Source/bmalloc/libpas/src/libpas/pas_scavenger.h:
* Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp: Added.
(incrementCounter):
(testCallbacksAreCalledWhenExpected):
(addScavengerExternalWorkTests):
* Source/bmalloc/libpas/src/test/TestHarness.cpp:

Canonical link: <a href="https://commits.webkit.org/290978@main">https://commits.webkit.org/290978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43a9b874c8f5a16db2033f7c3946445211f23355

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91577 "21 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11108 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/642 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42259 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19538 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94578 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8773 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50681 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/557 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41430 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84376 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78856 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98551 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90325 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18736 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79357 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78806 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78583 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23080 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11862 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14521 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18730 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112909 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18440 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32730 "Found 16 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20207 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->