### PR TITLE
Remove IsoSubspace preciseOnly support

### DIFF
--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -37,7 +37,7 @@
 namespace JSC {
 
 CompleteSubspace::CompleteSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, AlignedMemoryAllocator* alignedMemoryAllocator)
-    : Subspace(name, heap)
+    : Subspace(SubspaceKind::CompleteSubspace, name, heap)
 {
     initialize(heapCellType, alignedMemoryAllocator);
 }

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -296,7 +296,7 @@ private:
     , name ISO_SUBSPACE_INIT(*this, heapCellType, type)
 
 #define INIT_SERVER_STRUCTURE_ISO_SUBSPACE(name, heapCellType, type) \
-    , name("IsoSubspace" #name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::usePreciseAllocationsOnly, type::numberOfLowerTierPreciseCells, makeUnique<StructureAlignedMemoryAllocator>("Structure"))
+    , name("IsoSubspace" #name, *this, heapCellType, WTF::roundUpToMultipleOf<type::atomSize>(sizeof(type)), type::numberOfLowerTierPreciseCells, makeUnique<StructureAlignedMemoryAllocator>("Structure"))
 
 Heap::Heap(VM& vm, HeapType heapType)
     : m_heapType(heapType)

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -36,20 +36,15 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IsoSubspace);
 
-IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, bool preciseOnly, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<IsoMemoryAllocatorBase>&& allocator)
-    : Subspace(name, heap)
+IsoSubspace::IsoSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, size_t size, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<IsoMemoryAllocatorBase>&& allocator)
+    : Subspace(SubspaceKind::IsoSubspace, name, heap)
     , m_directory(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size))
     , m_isoAlignedMemoryAllocator(allocator ? WTFMove(allocator) : makeUnique<IsoAlignedMemoryAllocator>(name))
 {
-    if (preciseOnly)
-        m_isPreciseOnly = true;
-    else {
-        m_remainingLowerTierPreciseCount = numberOfLowerTierPreciseCells;
-        ASSERT(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size) == cellSize());
-        ASSERT(m_remainingLowerTierPreciseCount <= MarkedBlock::maxNumberOfLowerTierPreciseCells);
-    }
+    m_remainingLowerTierPreciseCount = numberOfLowerTierPreciseCells;
+    ASSERT(WTF::roundUpToMultipleOf<MarkedBlock::atomSize>(size) == cellSize());
+    ASSERT(m_remainingLowerTierPreciseCount <= MarkedBlock::maxNumberOfLowerTierPreciseCells);
 
-    m_isIsoSubspace = true;
     initialize(heapCellType, m_isoAlignedMemoryAllocator.get());
 
     Locker locker { m_space.directoryLock() };
@@ -85,7 +80,7 @@ void IsoSubspace::didBeginSweepingToFreeList(MarkedBlock::Handle* block)
         });
 }
 
-void* IsoSubspace::tryAllocatePreciseOrLowerTierPrecise(size_t size)
+void* IsoSubspace::tryAllocateLowerTierPrecise(size_t size)
 {
     auto revive = [&] (PreciseAllocation* allocation, bool isNewAllocation) {
         m_space.registerPreciseAllocation(allocation, isNewAllocation);
@@ -93,11 +88,6 @@ void* IsoSubspace::tryAllocatePreciseOrLowerTierPrecise(size_t size)
         m_preciseAllocations.append(allocation);
         return allocation->cell();
     };
-
-    if (UNLIKELY(m_isPreciseOnly)) {
-        PreciseAllocation* allocation = PreciseAllocation::tryCreate(m_space.heap(), size, this, 0);
-        return allocation ? revive(allocation, true) : nullptr;
-    }
 
     ASSERT_WITH_MESSAGE(cellSize() == size, "non-preciseOnly IsoSubspaces shouldn't have variable size");
     if (!m_lowerTierPreciseFreeList.isEmpty()) {
@@ -117,7 +107,6 @@ void* IsoSubspace::tryAllocatePreciseOrLowerTierPrecise(size_t size)
 
 void IsoSubspace::sweepLowerTierPreciseCell(PreciseAllocation* preciseAllocation)
 {
-    ASSERT(!m_isPreciseOnly);
     preciseAllocation = preciseAllocation->reuseForLowerTierPrecise();
     m_lowerTierPreciseFreeList.append(preciseAllocation);
 }

--- a/Source/JavaScriptCore/heap/IsoSubspace.h
+++ b/Source/JavaScriptCore/heap/IsoSubspace.h
@@ -43,7 +43,7 @@ class IsoSubspace;
 class IsoSubspace final : public Subspace {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IsoSubspace, JS_EXPORT_PRIVATE);
 public:
-    JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t size, bool preciseOnly, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<IsoMemoryAllocatorBase>&& = nullptr);
+    JS_EXPORT_PRIVATE IsoSubspace(CString name, Heap&, const HeapCellType&, size_t size, uint8_t numberOfLowerTierPreciseCells, std::unique_ptr<IsoMemoryAllocatorBase>&& = nullptr);
     JS_EXPORT_PRIVATE ~IsoSubspace() final;
 
     size_t cellSize() { return m_directory.cellSize(); }
@@ -51,7 +51,7 @@ public:
     void sweepLowerTierPreciseCell(PreciseAllocation*);
     void clearIsoCellSetBit(PreciseAllocation*);
 
-    void* tryAllocatePreciseOrLowerTierPrecise(size_t cellSize);
+    void* tryAllocateLowerTierPrecise(size_t cellSize);
     void destroyLowerTierPreciseFreeList();
 
     void sweep();
@@ -100,7 +100,7 @@ ALWAYS_INLINE Allocator IsoSubspace::allocatorFor(size_t size, AllocatorForMode)
 
 } // namespace GCClient
 
-#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type ""_s, (heap), (heapCellType), sizeof(type), type::usePreciseAllocationsOnly, type::numberOfLowerTierPreciseCells)
+#define ISO_SUBSPACE_INIT(heap, heapCellType, type) ("IsoSpace " #type ""_s, (heap), (heapCellType), sizeof(type), type::numberOfLowerTierPreciseCells)
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/heap/LocalAllocator.cpp
+++ b/Source/JavaScriptCore/heap/LocalAllocator.cpp
@@ -138,7 +138,7 @@ void* LocalAllocator::allocateSlowCase(JSC::Heap& heap, size_t cellSize, GCDefer
 
     Subspace* subspace = m_directory->m_subspace;
     if (subspace->isIsoSubspace()) {
-        if (void* result = static_cast<IsoSubspace*>(subspace)->tryAllocatePreciseOrLowerTierPrecise(cellSize))
+        if (void* result = static_cast<IsoSubspace*>(subspace)->tryAllocateLowerTierPrecise(cellSize))
             return result;
     }
 

--- a/Source/JavaScriptCore/heap/PreciseSubspace.cpp
+++ b/Source/JavaScriptCore/heap/PreciseSubspace.cpp
@@ -38,9 +38,8 @@ namespace JSC {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PreciseSubspace);
 
 PreciseSubspace::PreciseSubspace(CString name, JSC::Heap& heap, const HeapCellType& heapCellType, AlignedMemoryAllocator* allocator)
-    : Subspace(name, heap)
+    : Subspace(SubspaceKind::PreciseSubspace, name, heap)
 {
-    m_isPreciseOnly = true;
     initialize(heapCellType, allocator);
 }
 

--- a/Source/JavaScriptCore/heap/Subspace.cpp
+++ b/Source/JavaScriptCore/heap/Subspace.cpp
@@ -37,8 +37,9 @@ namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Subspace);
 
-Subspace::Subspace(CString name, JSC::Heap& heap)
+Subspace::Subspace(SubspaceKind kind, CString name, JSC::Heap& heap)
     : m_space(heap.objectSpace())
+    , m_kind(kind)
     , m_name(name)
 {
 }

--- a/Source/JavaScriptCore/heap/Subspace.h
+++ b/Source/JavaScriptCore/heap/Subspace.h
@@ -38,6 +38,12 @@ namespace JSC {
 class AlignedMemoryAllocator;
 class HeapCellType;
 
+enum class SubspaceKind {
+    CompleteSubspace,
+    IsoSubspace,
+    PreciseSubspace,
+};
+
 // The idea of subspaces is that you can provide some custom behavior for your objects if you
 // allocate them from a custom Subspace in which you override some of the virtual methods. This
 // class is the baseclass of all subspaces e.g. CompleteSubspace, IsoSubspace.
@@ -99,11 +105,12 @@ public:
     virtual void didRemoveBlock(unsigned blockIndex);
     virtual void didBeginSweepingToFreeList(MarkedBlock::Handle*);
 
-    bool isIsoSubspace() const { return m_isIsoSubspace; }
-    bool isPreciseOnly() const { return m_isPreciseOnly; }
+    SubspaceKind kind() const { return m_kind; }
+    bool isIsoSubspace() const { return kind() == SubspaceKind::IsoSubspace; }
+    bool isPreciseOnly() const { return kind() == SubspaceKind::PreciseSubspace; }
 
 protected:
-    Subspace(CString name, Heap&);
+    Subspace(SubspaceKind, CString name, Heap&);
 
     void initialize(const HeapCellType&, AlignedMemoryAllocator*);
     
@@ -116,8 +123,7 @@ protected:
     BlockDirectory* m_directoryForEmptyAllocation { nullptr }; // Uses the MarkedSpace linked list of blocks.
     SentinelLinkedList<PreciseAllocation, BasicRawSentinelNode<PreciseAllocation>> m_preciseAllocations;
 
-    bool m_isIsoSubspace { false };
-    bool m_isPreciseOnly { false };
+    SubspaceKind m_kind;
     uint8_t m_remainingLowerTierPreciseCount { 0 }; // Lower tier is a precise allocation but we use the term lower to avoid confusion with precise-only.
 
     Subspace* m_nextSubspaceInAlignedMemoryAllocator { nullptr };

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -102,7 +102,6 @@ public:
 
     static constexpr DestructionMode needsDestruction = DoesNotNeedDestruction;
 
-    static constexpr bool usePreciseAllocationsOnly = false;
     static constexpr uint8_t numberOfLowerTierPreciseCells = 8;
 
     static constexpr size_t atomSize = 16; // This needs to be larger or equal to 16.


### PR DESCRIPTION
#### c27dcacfd5d293f12856b13b45f5c181dfa13101
<pre>
Remove IsoSubspace preciseOnly support
<a href="https://bugs.webkit.org/show_bug.cgi?id=288101">https://bugs.webkit.org/show_bug.cgi?id=288101</a>
<a href="https://rdar.apple.com/145220913">rdar://145220913</a>

Reviewed by Yusuke Suzuki.

It&apos;s no longer used and subsumed by PreciseSubspace. Also, add a SubspaceKind enum
rather than have a bunch of bools.

* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::CompleteSubspace):
* Source/JavaScriptCore/heap/Heap.cpp:
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::IsoSubspace):
(JSC::IsoSubspace::tryAllocateLowerTierPrecise):
(JSC::IsoSubspace::sweepLowerTierPreciseCell):
(JSC::IsoSubspace::tryAllocatePreciseOrLowerTierPrecise): Deleted.
* Source/JavaScriptCore/heap/IsoSubspace.h:
* Source/JavaScriptCore/heap/LocalAllocator.cpp:
(JSC::LocalAllocator::allocateSlowCase):
* Source/JavaScriptCore/heap/PreciseSubspace.cpp:
(JSC::PreciseSubspace::PreciseSubspace):
* Source/JavaScriptCore/heap/Subspace.cpp:
(JSC::Subspace::Subspace):
* Source/JavaScriptCore/heap/Subspace.h:
(JSC::Subspace::kind const):
(JSC::Subspace::isIsoSubspace const):
(JSC::Subspace::isPreciseOnly const):
* Source/JavaScriptCore/runtime/JSCell.h:

Canonical link: <a href="https://commits.webkit.org/290743@main">https://commits.webkit.org/290743@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50799eecfac874b4a7f51a04c1a03545f0c55ff9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90908 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10446 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41709 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27433 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93909 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82421 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50241 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8036 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36814 "Found 1 new test failure: http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40831 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83736 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78342 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97913 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89690 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18103 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78121 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19302 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/119/builds/21213 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18112 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23470 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112254 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17856 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19635 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->