### PR TITLE
Simplify 3d transform if statements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-verify-reftests-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-verify-reftests-expected.txt
@@ -75,10 +75,10 @@ PASS CSS Transitions: property <transform> from [rotateX(90deg)] to [rotate(0deg
 PASS CSS Transitions with transition: all: property <transform> from [rotateX(90deg)] to [rotate(0deg)] at (0.5) should be [rotateX(45deg)]
 PASS CSS Animations: property <transform> from [rotateX(90deg)] to [rotate(0deg)] at (0.5) should be [rotateX(45deg)]
 PASS Web Animations: property <transform> from [rotateX(90deg)] to [rotate(0deg)] at (0.5) should be [rotateX(45deg)]
-FAIL CSS Transitions: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)] assert_equals: expected "matrix ( 0.71 , 0.71 , - 0.71 , 0.71 , 0 , 0 ) " but got "matrix3d ( 0.71 , 0.71 , 0 , 0 , - 0.71 , 0.71 , 0 , 0 , 0 , 0 , 1 , 0 , 0 , 0 , 0 , 1 ) "
-FAIL CSS Transitions with transition: all: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)] assert_equals: expected "matrix ( 0.71 , 0.71 , - 0.71 , 0.71 , 0 , 0 ) " but got "matrix3d ( 0.71 , 0.71 , 0 , 0 , - 0.71 , 0.71 , 0 , 0 , 0 , 0 , 1 , 0 , 0 , 0 , 0 , 1 ) "
-FAIL CSS Animations: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)] assert_equals: expected "matrix ( 0.71 , 0.71 , - 0.71 , 0.71 , 0 , 0 ) " but got "matrix3d ( 0.71 , 0.71 , 0 , 0 , - 0.71 , 0.71 , 0 , 0 , 0 , 0 , 1 , 0 , 0 , 0 , 0 , 1 ) "
-FAIL Web Animations: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)] assert_equals: expected "matrix ( 0.71 , 0.71 , - 0.71 , 0.71 , 0 , 0 ) " but got "matrix3d ( 0.71 , 0.71 , 0 , 0 , - 0.71 , 0.71 , 0 , 0 , 0 , 0 , 1 , 0 , 0 , 0 , 0 , 1 ) "
+PASS CSS Transitions: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)]
+PASS CSS Transitions with transition: all: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)]
+PASS CSS Animations: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)]
+PASS Web Animations: property <transform> from [rotateX(360deg)] to [rotateZ(90deg)] at (0.5) should be [rotateZ(45deg)]
 PASS CSS Transitions: property <transform> from [rotate(45deg)] to [rotate3d(0, 0, -1, 45deg)] at (0.5) should be [rotate(0deg)]
 PASS CSS Transitions with transition: all: property <transform> from [rotate(45deg)] to [rotate3d(0, 0, -1, 45deg)] at (0.5) should be [rotate(0deg)]
 PASS CSS Animations: property <transform> from [rotate(45deg)] to [rotate3d(0, 0, -1, 45deg)] at (0.5) should be [rotate(0deg)]

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2005, 2006, 2013 Apple Inc.  All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc.  All rights reserved.
+ * Copyright (C) 2020 Google Inc.  All rights reserved.
  * Copyright (C) 2009 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -918,7 +919,9 @@ TransformationMatrix& TransformationMatrix::rotate3d(double x, double y, double 
     TransformationMatrix mat;
 
     // Optimize cases where the axis is along a major axis
-    if (x == 1.0 && y == 0.0 && z == 0.0) {
+    // Since we've already normalized the vector we don't need to check that the
+    // other two dimensions are zero
+    if (x == 1.0) {
         mat.m_matrix[0][0] = 1.0;
         mat.m_matrix[0][1] = 0.0;
         mat.m_matrix[0][2] = 0.0;
@@ -931,7 +934,7 @@ TransformationMatrix& TransformationMatrix::rotate3d(double x, double y, double 
         mat.m_matrix[0][3] = mat.m_matrix[1][3] = mat.m_matrix[2][3] = 0.0;
         mat.m_matrix[3][0] = mat.m_matrix[3][1] = mat.m_matrix[3][2] = 0.0;
         mat.m_matrix[3][3] = 1.0;
-    } else if (x == 0.0 && y == 1.0 && z == 0.0) {
+    } else if (y == 1.0) {
         mat.m_matrix[0][0] = cosTheta;
         mat.m_matrix[0][1] = 0.0;
         mat.m_matrix[0][2] = -sinTheta;
@@ -944,7 +947,7 @@ TransformationMatrix& TransformationMatrix::rotate3d(double x, double y, double 
         mat.m_matrix[0][3] = mat.m_matrix[1][3] = mat.m_matrix[2][3] = 0.0;
         mat.m_matrix[3][0] = mat.m_matrix[3][1] = mat.m_matrix[3][2] = 0.0;
         mat.m_matrix[3][3] = 1.0;
-    } else if (x == 0.0 && y == 0.0 && z == 1.0) {
+    } else if (z == 1.0) {
         mat.m_matrix[0][0] = cosTheta;
         mat.m_matrix[0][1] = sinTheta;
         mat.m_matrix[0][2] = 0.0;


### PR DESCRIPTION
#### e117494d3054af226c3947fdd3cdb19e62282f31
<pre>
Simplify 3d transform if statements

<a href="https://bugs.webkit.org/show_bug.cgi?id=288113">https://bugs.webkit.org/show_bug.cgi?id=288113</a>
<a href="https://rdar.apple.com/145224943">rdar://145224943</a>

Reviewed by Brent Fulgham.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/5cf508ceb9a6e00b2e378c9e1f2d445de4fea98c">https://chromium.googlesource.com/chromium/src/+/5cf508ceb9a6e00b2e378c9e1f2d445de4fea98c</a>

This patch removes unneeded `AND` conditions from `if` statements since
the vectors are already normalized.

Test: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-verify-reftests.html

* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::TransformationMatrix::rotate3d):
* LayoutTests/imported/w3c/web-platform-tests/css/css-transforms/animation/transform-interpolation-verify-reftests-expected.txt: WPT progression

Canonical link: <a href="https://commits.webkit.org/290796@main">https://commits.webkit.org/290796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bdb71b9f887dfe761c11f3c11f418b1aadf99fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10515 "Built successfully") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41771 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18830 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69945 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27466 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8304 "Passed tests") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8078 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40892 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78378 "Passed tests") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97972 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13360 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79007 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18434 "Built successfully") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78147 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19337 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22633 "Passed tests") | [⏳ 🧪 mac-intel-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-Build-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11446 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18180 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23533 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17917 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->