### PR TITLE
[scroll-animations] "In & Out" demos of https://nerdy.dev/notebook/scroll-driven-animations.html mostly do not work

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt
@@ -1,6 +1,7 @@
 
 PASS Report specified timeline offsets
 PASS Computed offsets can be outside [0,1] for keyframes with timeline offsets
+PASS Offsets can be outside [0%,100%] for keyframes with timeline range names
 PASS Retain specified ordering of keyframes with timeline offsets
 PASS Include unreachable keyframes
 PASS Mix of computed and timeline offsets.

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html
@@ -87,6 +87,23 @@
 
     promise_test(async t => {
       let anim = createAnimation(t, [
+        { offset: "cover -100%", opacity: "0" },
+        { offset: "cover 200%", opacity: "1" },
+      ]);
+      let frames = anim.effect.getKeyframes();
+      let expected = [
+        { offset: { rangeName: 'cover', offset: CSS.percent(-100) },
+          computedOffset: -4, easing: "linear", composite: "auto",
+          opacity: "0" },
+        { offset: { rangeName: 'cover', offset: CSS.percent(200) },
+          computedOffset: 5, easing: "linear", composite: "auto",
+          opacity: "1" }
+      ];
+      assert_frame_lists_equal(frames, expected);
+    }, 'Offsets can be outside [0%,100%] for keyframes with timeline range names');
+
+    promise_test(async t => {
+      let anim = createAnimation(t, [
         { offset: "contain 75%", marginLeft: "0px", opacity: "0" },
         { offset: "contain 25%", marginRight: "0px", opacity: "1" }
       ]);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -101,11 +101,11 @@ struct StyleRuleKeyframeKeyHash {
     static const bool safeToCompareToEmptyOrDeleted = true;
 };
 template<> struct HashTraits<WebCore::StyleRuleKeyframe::Key> : GenericHashTraits<WebCore::StyleRuleKeyframe::Key> {
-    static WebCore::StyleRuleKeyframe::Key emptyValue() { return { WebCore::CSSValueNormal, -1 }; }
-    static bool isEmptyValue(const WebCore::StyleRuleKeyframe::Key& value) { return value.offset == -1; }
+    static WebCore::StyleRuleKeyframe::Key emptyValue() { return { WebCore::CSSValueDefault, 0 }; }
+    static bool isEmptyValue(const WebCore::StyleRuleKeyframe::Key& value) { return value.rangeName == WebCore::CSSValueDefault; }
 
-    static void constructDeletedValue(WebCore::StyleRuleKeyframe::Key& slot) { slot.offset = -2; }
-    static bool isDeletedValue(const WebCore::StyleRuleKeyframe::Key& slot) { return slot.offset == -2; }
+    static void constructDeletedValue(WebCore::StyleRuleKeyframe::Key& slot) { slot.rangeName = WebCore::CSSValueNone; }
+    static bool isDeletedValue(const WebCore::StyleRuleKeyframe::Key& slot) { return slot.rangeName == WebCore::CSSValueNone; }
 };
 template<> struct DefaultHash<WebCore::StyleRuleKeyframe::Key> : StyleRuleKeyframeKeyHash { };
 


### PR DESCRIPTION
#### c7ec9d7ff067dd19d84994162e6778d7cb1bb10b
<pre>
[scroll-animations] &quot;In &amp; Out&quot; demos of <a href="https://nerdy.dev/notebook/scroll-driven-animations.html">https://nerdy.dev/notebook/scroll-driven-animations.html</a> mostly do not work
<a href="https://bugs.webkit.org/show_bug.cgi?id=287789">https://bugs.webkit.org/show_bug.cgi?id=287789</a>
<a href="https://rdar.apple.com/144974803">rdar://144974803</a>

Reviewed by Antti Koivisto and Anne van Kesteren.

The &quot;In &amp; Out&quot; section of this page uses @keyframes rules that look something like:

```
@keyframes candycane {
    entry 0% { translate: -100% }
    entry 200% { translate: 0% }
    exit -100% { translate: 0% }
    exit 100% { translate: 100% }
}
```

When we added support for timeline ranges in keyframes in 289948@main we incorrectly handled percentages the
same way we do for keyframes specified without a timeline range which restrict their values to the [0%-100%]
range. But the percentage can actually be negative values and values above 100%, so we adjust our parsing
code to allow those and change how we construct the empty and deleted values for the `StyleRuleKeyframe::Key`
struct which represents such values in our CSS parsing code.

Since this wasn&apos;t part of the existing battery of WPT tests, we add such a case.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/get-keyframes-with-timeline-offset.html:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
(WebCore::CSSPropertyParserHelpers::consumeKeyframeKeyList):
* Source/WebCore/style/StyleResolver.cpp:
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::emptyValue):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::isEmptyValue):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::StyleRuleKeyframe::Key&gt;::isDeletedValue):

Canonical link: <a href="https://commits.webkit.org/290776@main">https://commits.webkit.org/290776@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3815e0f9e2be8a220c17d04c0dfba4b9344454c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10651 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/144 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18969 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94109 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/122 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41003 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18310 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78226 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22734 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/92 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14375 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18313 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18037 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21498 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->