### PR TITLE
[JSC][armv7] Set callee tag in wasm_to_js_wrapper_entry

### DIFF
--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -1010,7 +1010,9 @@ elsif JSVALUE64
     storeq ws1, CalleeScratch[cfr]
     storeq wasmInstance, WasmInstanceScratch[cfr]
 else
-    storep ws1, CalleeScratch[cfr]
+    storep ws1, CalleeScratch+PayloadOffset[cfr]
+    move constexpr JSValue::NativeCalleeTag, ws1
+    storep ws1, CalleeScratch+TagOffset[cfr]
     storep wasmInstance, WasmInstanceScratch[cfr]
 end
     storep ws0, WasmCallableFunctionScratch[cfr]


### PR DESCRIPTION
#### 7c2a5bafb9e54dbb9bb75f2025acedb1ca245437
<pre>
[JSC][armv7] Set callee tag in wasm_to_js_wrapper_entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=288126">https://bugs.webkit.org/show_bug.cgi?id=288126</a>

Reviewed by Yusuke Suzuki.

Set callee tag in wasm_to_js_wrapper_entry on armv7, like
its JITed counterpart  WasmToJS.cpp:wasmToJS

* Source/JavaScriptCore/llint/WebAssembly.asm:

Canonical link: <a href="https://commits.webkit.org/291057@main">https://commits.webkit.org/291057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de16db0ed0c8877e127f356ed592b9cd2fc04312

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/55/builds/45908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/95972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41744 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69928 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27457 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/64/builds/36839 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40865 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83772 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78368 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/63/builds/37907 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97945 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89725 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78946 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22625 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23509 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112290 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17890 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32703 "Found 8 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.mini-mode, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21348 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->