### PR TITLE
Refine the construction of WKWebExtension in Swift.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
@@ -82,7 +82,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion The app extension bundle must contain a `manifest.json` file in its resources directory. If the manifest is invalid or missing,
  or the bundle is otherwise improperly configured, an error will be returned.
  */
-+ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
++ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL, which can point to either a directory or a ZIP archive.
@@ -91,7 +91,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion The URL must be a file URL that points to either a directory with a `manifest.json` file or a ZIP archive containing a `manifest.json` file.
  If the manifest is invalid or missing, or the URL points to an unsupported format or invalid archive, an error will be returned.
  */
-+ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
++ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract An array of all errors that occurred during the processing of the extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -86,29 +86,47 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     });
 }
 
-// FIXME: Remove after Safari has adopted new methods.
-- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
-{
-    return [self _initWithAppExtensionBundle:appExtensionBundle error:error];
-}
-
 - (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
 {
-    return [self _initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
-}
-
-// FIXME: Remove after Safari has adopted new methods.
-- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
-{
-    return [self _initWithResourceBaseURL:resourceBaseURL error:error];
+    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
 }
 
 - (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
-    return [self _initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
 }
 
-- (instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
+- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle resourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
+{
+    return [self initWithManifestDictionary:manifest resources:nil];
+}
+
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+{
+    return [self initWithManifestDictionary:manifest resources:resources];
+}
+
+- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
+{
+    return [self initWithResources:resources];
+}
+
+- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
+{
+    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
+}
+
+- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
 {
     NSParameterAssert(appExtensionBundle || resourceBaseURL);
 
@@ -138,14 +156,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     return self;
 }
 
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
+- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
 {
     NSParameterAssert([manifest isKindOfClass:NSDictionary.class]);
 
-    return [self _initWithManifestDictionary:manifest resources:nil];
+    return [self initWithManifestDictionary:manifest resources:nil];
 }
 
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
 {
     NSParameterAssert([manifest isKindOfClass:NSDictionary.class]);
 
@@ -157,7 +175,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     return self;
 }
 
-- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)initWithResources:(NSDictionary<NSString *, id> *)resources
 {
     NSParameterAssert([resources isKindOfClass:NSDictionary.class]);
 
@@ -349,44 +367,64 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     completionHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
 }
 
-- (instancetype)initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
+- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
 {
-    return [self _initWithAppExtensionBundle:bundle error:error];
-}
-
-- (instancetype)_initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
-{
-    return [self _initWithAppExtensionBundle:bundle resourceBaseURL:nil error:error];
-}
-
-- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
-{
-    return [self _initWithResourceBaseURL:resourceBaseURL error:error];
+    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
 }
 
 - (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
-    return [self _initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
 }
 
-- (instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)bundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
+- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle resourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
+{
+    return [self initWithManifestDictionary:manifest resources:nil];
+}
+
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+{
+    return [self initWithManifestDictionary:manifest resources:resources];
+}
+
+- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
+{
+    return [self initWithResources:resources];
+}
+
+- (instancetype)initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
+{
+    return [self initWithAppExtensionBundle:bundle resourceBaseURL:nil error:error];
+}
+
+- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)initWithAppExtensionBundle:(nullable NSBundle *)bundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
 {
     if (error)
         *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return nil;
 }
 
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
+- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
 {
-    return [self _initWithManifestDictionary:manifest resources:nil];
+    return [self initWithManifestDictionary:manifest resources:nil];
 }
 
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
 {
     return nil;
 }
 
-- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)initWithResources:(NSDictionary<NSString *, id> *)resources
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
@@ -29,9 +29,12 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface WKWebExtension ()
 
-// FIXME: Remove after Safari has adopted new methods.
-- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error;
-- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error;
+- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_SWIFT_UNAVAILABLE("Use init(appExtensionBundle:).");
+- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_SWIFT_UNAVAILABLE("Use init(resourceBaseURL:).");
+- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle resourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_SWIFT_UNAVAILABLE("Use init(appExtensionBundle:resourceBaseURL:).");
+- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest NS_SWIFT_UNAVAILABLE("Use init(manifestDictionary:).");
+- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_SWIFT_UNAVAILABLE("Use init(manifestDictionary:resources:).");
+- (nullable instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_SWIFT_UNAVAILABLE("Use init(resources:).");
 
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
@@ -39,7 +42,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @param error Set to \c nil or an error instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  */
-- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error;
+- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
@@ -48,7 +51,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @discussion The URL must be a file URL that points to either a directory containing a `manifest.json` file or a valid ZIP archive.
  */
-- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error;
+- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_REFINED_FOR_SWIFT;
 
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle and resource base URL.
@@ -59,14 +62,14 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion Either the app extension bundle or the resource base URL (which can point to a directory or a valid ZIP archive) must be provided.
  This initializer is useful when the extension resources are in a different location from the app extension bundle used for native messaging.
  */
-- (nullable instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Returns a web extension initialized with a specified manifest dictionary.
  @param manifest The dictionary containing the manifest data for the web extension.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  */
-- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest;
+- (nullable instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest;
 
 /*!
  @abstract Returns a web extension initialized with a specified manifest dictionary and resources.
@@ -76,7 +79,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion The resources dictionary provides additional data required for the web extension. Paths in resources can
  have subdirectories, such as `_locales/en/messages.json`.
  */
-- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Returns a web extension initialized with specified resources.
@@ -85,7 +88,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion The resources dictionary must provide at least the `manifest.json` resource.  Paths in resources can
  have subdirectories, such as `_locales/en/messages.json`.
  */
-- (nullable instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
 /*! @abstract A Boolean value indicating whether the extension background content is a service worker. */
 @property (readonly, nonatomic) BOOL _hasServiceWorkerBackgroundContent;

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -25,6 +25,10 @@
 
 #if !os(tvOS) && !os(watchOS)
 
+#if compiler(>=6.0)
+internal import WebKit_Private
+#endif
+
 #if USE_APPLE_INTERNAL_SDK
 @_spi(CTypeConversion) import Network
 #endif
@@ -85,7 +89,25 @@ extension WKWebView {
 }
 #endif
 
+#if compiler(>=6.0)
 @available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+extension WKWebExtension {
+    public convenience init(appExtensionBundle: Bundle) async throws {
+        // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
+        try self.init(appExtensionBundle: appExtensionBundle, resourceBaseURL: nil)
+    }
+
+    public convenience init(resourceBaseURL: URL) async throws {
+        // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
+        try self.init(appExtensionBundle: nil, resourceBaseURL: resourceBaseURL)
+    }
+}
+
+@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 extension WKWebExtensionController {
     public func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
         __didClose(closedTab, windowIsClosing: windowIsClosing)
@@ -101,6 +123,8 @@ extension WKWebExtensionController {
 }
 
 @available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 extension WKWebExtensionContext {
     public func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
         __didClose(closedTab, windowIsClosing: windowIsClosing)
@@ -114,6 +138,7 @@ extension WKWebExtensionContext {
         __didMove(movedTab, from: index, in: oldWindow)
     }
 }
+#endif
 
 // FIXME: Need to declare ProxyConfiguration SPI in order to build and test
 // this with public SDKs (https://bugs.webkit.org/show_bug.cgi?id=280911).


### PR DESCRIPTION
#### 67d7e1c8fe788397d94bd9ece229ca4ee8ba58e0
<pre>
Refine the construction of WKWebExtension in Swift.
<a href="https://webkit.org/b/288129">https://webkit.org/b/288129</a>
<a href="https://rdar.apple.com/problem/145235810">rdar://problem/145235810</a>

Reviewed by Brian Weinstein.

Introduce a Swift overlay for WKWebExtension to define two async init() methods
that are more idiomatic in Swift.

Swift really does not like _init methods, so unprefix the existing private init
methods to keep the compiler happy when building the overlay. Retain prefixed
versions for ObjC compatability with existing clients.

* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm:
(-[WKWebExtension _initWithAppExtensionBundle:error:]):
(-[WKWebExtension _initWithResourceBaseURL:error:]):
(-[WKWebExtension _initWithAppExtensionBundle:resourceBaseURL:error:]):
(-[WKWebExtension _initWithManifestDictionary:]):
(-[WKWebExtension _initWithManifestDictionary:resources:]):
(-[WKWebExtension _initWithResources:]):
(-[WKWebExtension initWithAppExtensionBundle:error:]):
(-[WKWebExtension initWithResourceBaseURL:error:]):
(-[WKWebExtension initWithAppExtensionBundle:resourceBaseURL:error:]):
(-[WKWebExtension initWithManifestDictionary:]):
(-[WKWebExtension initWithManifestDictionary:resources:]):
(-[WKWebExtension initWithResources:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift:

Canonical link: <a href="https://commits.webkit.org/290825@main">https://commits.webkit.org/290825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2f864dab2a96ce8948f62af3873c809690af8f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/236 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96198 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19056 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70073 "Failure limit exceed. At least found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94200 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82625 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50399 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78578 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98182 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18394 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78456 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78286 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14407 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18394 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->