### PR TITLE
[HDR] Disable HDR display for CSS images

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2494,7 +2494,9 @@ fast/images/animated-jpegxl-loop-count.html [ Skip ]
 # Only applicable on platforms with HDR support
 compositing/hdr/hdr-basic-canvas.html [ Skip ]
 compositing/hdr/hdr-basic-image.html [ Skip ]
+compositing/hdr/hdr-css-image.html [ Skip ]
 fast/images/hdr-basic-image.html [ Skip ]
+fast/images/hdr-css-image.html [ Skip ]
 
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]

--- a/LayoutTests/compositing/hdr/hdr-css-image.html
+++ b/LayoutTests/compositing/hdr/hdr-css-image.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+    .element {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <img class="container">
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container">
+            <img class="element">
+        </div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 440px;">
+        <div class="container">
+            <img class="element">
+        </div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        let images = [];
+        let imageSources = ["../../fast/images/resources/green-400x400.png", "../../fast/images/resources/red-100x100.png"];
+
+        function loadImages() {
+            return imageSources.map((imageSource) => {
+                return new Promise((resolve) => {
+                    let image = new Image;
+                    image.onload = (e) => {
+                        if (window.internals)
+                            internals.setHeadroomForTesting(image, 5);
+
+                        resolve({ width: image.width, height: image.height });
+                    };
+                    image.src = imageSource;
+                    images.push(image);             
+                });
+            });
+        }
+ 
+        (async () => {
+            await Promise.all(loadImages());
+
+            const imageElements = document.querySelectorAll("img");
+
+            imageElements[0].src = images[0].src;
+            imageElements[1].src = images[1].src;
+            imageElements[2].src = images[1].src;
+
+            const containerElements = document.querySelectorAll("div.container");
+
+            containerElements[0].style.backgroundImage = 'url(' + images[0].src + ')';
+            containerElements[1].style.borderImage = 'url(' + images[0].src + ') 30 fill';
+
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
+                testRunner.notifyDone();
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-basic-image.html
+++ b/LayoutTests/fast/images/hdr-basic-image.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
 <style>
     .image-box {
         width: 200px;
@@ -17,9 +18,10 @@
     <script>
         if (window.internals && window.testRunner) {
             internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
             testRunner.waitUntilDone();
         }
- 
+
         var image = new Image;
         image.onload = (() => {
             if (window.internals)

--- a/LayoutTests/fast/images/hdr-css-image-expected.html
+++ b/LayoutTests/fast/images/hdr-css-image-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+    }
+    .box {
+        width: 100px;
+        height: 100px;
+        display: inline-block;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="container" style="background-color: rgb(255 215 0);">
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container" style="background-color: green;">
+            <div class="box" style="background-color: rgb(255 215 0);">
+        </div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 440px;">
+        <div class="container" style="background-color: green;">
+            <div class="box" style="background-color: rgb(255 215 0);">
+        </div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-css-image.html
+++ b/LayoutTests/fast/images/hdr-css-image.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+<meta name="fuzzy" content="maxDifference=0-14; totalPixels=0-120000" />
+<style>
+    .container {
+        width: 200px;
+        height: 200px;
+        will-change: transform;
+    }
+    .element {
+        width: 100px;
+        height: 100px;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <img class="container">
+    </div>
+    <div style="position: fixed; top: 10px; left: 220px;">
+        <div class="container">
+            <img class="element">
+        </div>
+    </div>
+    <div style="position: fixed; top: 10px; left: 440px;">
+        <div class="container">
+            <img class="element">
+        </div>
+    </div>
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.waitUntilDone();
+        }
+
+        let images = [];
+        let imageSources = ["resources/green-400x400.png", "resources/red-100x100.png"];
+
+        function loadImages() {
+            return imageSources.map((imageSource) => {
+                return new Promise((resolve) => {
+                    let image = new Image;
+                    image.onload = (e) => {
+                        if (window.internals)
+                            internals.setHeadroomForTesting(image, 5);
+
+                        resolve({ width: image.width, height: image.height });
+                    };
+                    image.src = imageSource;
+                    images.push(image);             
+                });
+            });
+        }
+ 
+        (async () => {
+            await Promise.all(loadImages());
+
+            const imageElements = document.querySelectorAll("img");
+
+            imageElements[0].src = images[0].src;
+            imageElements[1].src = images[1].src;
+            imageElements[2].src = images[1].src;
+
+            const containerElements = document.querySelectorAll("div.container");
+
+            containerElements[0].style.backgroundImage = 'url(' + images[0].src + ')';
+            containerElements[1].style.borderImage = 'url(' + images[0].src + ') 30 fill';
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        })();
+    </script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4511,7 +4511,9 @@ fast/images/pagewide-play-pause-offscreen-animations.html [ Pass ]
 # Only applicable on platforms with HDR support
 compositing/hdr/hdr-basic-canvas.html [ Pass ]
 compositing/hdr/hdr-basic-image.html [ Pass ]
-webkit.org/b/287985 fast/images/hdr-basic-image.html [ ImageOnlyFailure ]
+compositing/hdr/hdr-css-image.html [ Pass ]
+fast/images/hdr-basic-image.html [ Pass ]
+fast/images/hdr-css-image.html [ Pass ]
 
 # Re-enabling tests fixed by DocumentManager in iOS16+ rdar://102159271
 fast/forms/ios/file-upload-panel-capture.html [ Pass Crash ] # remove crash after this is resolved: webkit.org/b/268568

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-css-image-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-css-image-expected.txt
@@ -1,0 +1,63 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 205.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 220.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 440.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1520,7 +1520,9 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 # Only applicable on platforms with HDR support
 [ Sequoia+ ] compositing/hdr/hdr-basic-canvas.html [ Pass ]
 [ Sequoia+ ] compositing/hdr/hdr-basic-image.html [ Pass ]
-webkit.org/b/287985 [ Sequoia+ ] fast/images/hdr-basic-image.html [ ImageOnlyFailure ]
+[ Sequoia+ ] compositing/hdr/hdr-css-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-basic-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-css-image.html [ Pass ]
 
 # The direct image codepath is not used with the remote layer tree.
 [ Sonoma+ ] compositing/images/direct-image-object-fit.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-css-image-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-css-image-expected.txt
@@ -1,0 +1,63 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 3
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 204.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 220.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+        (GraphicsLayer
+          (position 440.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 200.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+
+

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4231,7 +4231,7 @@ void Page::setFullscreenAutoHideDuration(Seconds duration)
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-bool Page::canDrawHDRContents() const
+bool Page::canDrawHDRContent() const
 {
     if (!(m_settings->supportHDRDisplayEnabled() || m_settings->canvasPixelFormatEnabled()))
         return false;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -664,7 +664,7 @@ public:
     Document* outermostFullscreenDocument() const;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    bool canDrawHDRContents() const;
+    bool canDrawHDRContent() const;
 #endif
 
     bool shouldSuppressScrollbarAnimations() const { return m_suppressScrollbarAnimations; }

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -122,15 +122,14 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             orientation = currentFrameOrientation();
 
         auto headroom = options.headroom();
-        if (headroom == Headroom::FromImage)
-            headroom = currentFrameHeadroom();
+        if (headroom == Headroom::FromImage && headroomForTesting().value_or(Headroom::None) > Headroom::None)
+            fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
+        else {
+            if (headroom == Headroom::FromImage)
+                headroom = currentFrameHeadroom();
 
-        constexpr static auto goldenColor = SRGBA<uint8_t> { 255, 215, 0 };
-
-        if (headroomForTesting().value_or(Headroom::None) > Headroom::None)
-            fillWithSolidColor(context, destinationRect, goldenColor, options.compositeOperator());
-        else
             context.drawNativeImage(*nativeImage, destinationRect, adjustedSourceRect, { options, orientation, headroom });
+        }
     }
 
     if (auto observer = imageObserver())

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -191,6 +191,7 @@ public:
     static constexpr auto darkGreen = SRGBA<uint8_t> { 0, 128, 0 };
     static constexpr auto orange = SRGBA<uint8_t> { 255, 128, 0 };
     static constexpr auto purple = SRGBA<uint8_t> { 128, 0, 255 };
+    static constexpr auto gold = SRGBA<uint8_t> { 255, 215, 0 };
 
     static bool isBlackColor(const Color&);
     static bool isWhiteColor(const Color&);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -376,7 +376,12 @@ void GraphicsContextCG::drawNativeImageInternal(NativeImage& nativeImage, const 
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
     auto oldHeadroom = CGContextGetEDRTargetHeadroom(context);
-    if (auto headroom = options.headroom(); headroom > 1)
+
+    auto headroom = options.headroom();
+    if (headroom == Headroom::FromImage)
+        headroom = nativeImage.headroom();
+
+    if (headroom > Headroom::None)
         CGContextSetEDRTargetHeadroom(context, headroom);
 #endif
 

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -485,6 +485,9 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         if (!geometry.destinationRect.isEmpty() && (image = bgImage->image(backgroundObject ? backgroundObject : &m_renderer, geometry.tileSize, isFirstLine))) {
             context.setDrawLuminanceMask(bgLayer.maskMode() == MaskMode::Luminance);
 
+            // FIXME: <http://webkit.org/b/288163> Allow HDR display for background images when CSS HDR images are able to set GraphicsLayer::drawHDRContent.
+            auto headroom = Headroom::None;
+
             ImagePaintingOptions options = {
                 op == CompositeOperator::SourceOver ? bgLayer.compositeForPainting() : op,
                 bgLayer.blendMode(),
@@ -492,7 +495,8 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
                 ImageOrientation::Orientation::FromImage,
                 m_renderer.chooseInterpolationQuality(context, *image, &bgLayer, geometry.tileSize),
                 document().settings().imageSubsamplingEnabled() ? AllowImageSubsampling::Yes : AllowImageSubsampling::No,
-                document().settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No
+                document().settings().showDebugBorders() ? ShowDebugBackground::Yes : ShowDebugBackground::No,
+                headroom
             };
 
             auto drawResult = context.drawTiledImage(*image, geometry.destinationRect, toLayoutPoint(geometry.relativePhase()), geometry.tileSize, geometry.spaceSize, options);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -406,7 +406,7 @@ RenderLayer::~RenderLayer()
 RenderLayer::PaintedContentRequest::PaintedContentRequest(const RenderLayer& owningLayer)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (owningLayer.page().canDrawHDRContents())
+    if (owningLayer.page().canDrawHDRContent())
         makePaintedHDRContentUnknown();
 #else
     UNUSED_PARAM(owningLayer);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -151,7 +151,7 @@ public:
         : m_backing(inBacking)
     {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        if (m_backing.renderer().page().canDrawHDRContents()) {
+        if (m_backing.renderer().page().canDrawHDRContent()) {
             m_hdrContent = RequestState::Unknown;
             m_isReplacedElementWithHDR = RequestState::Unknown;
         }

--- a/Source/WebCore/rendering/style/NinePieceImage.cpp
+++ b/Source/WebCore/rendering/style/NinePieceImage.cpp
@@ -218,6 +218,9 @@ void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement
     if (!image)
         return;
 
+    // FIXME: <http://webkit.org/b/288163> Allow HDR display for background images when CSS HDR images are able to set GraphicsLayer::drawHDRContent.
+    auto headroom = Headroom::None;
+
     InterpolationQualityMaintainer interpolationMaintainer(graphicsContext, ImageQualityController::interpolationQualityFromStyle(style));
     for (ImagePiece piece = MinPiece; piece < MaxPiece; ++piece) {
         if ((piece == MiddlePiece && !fill()) || isEmptyPieceRect(piece, destinationRects, sourceRects))
@@ -230,7 +233,7 @@ void NinePieceImage::paint(GraphicsContext& graphicsContext, const RenderElement
 
         Image::TileRule hRule = isHorizontalPiece(piece) ? static_cast<Image::TileRule>(horizontalRule()) : Image::StretchTile;
         Image::TileRule vRule = isVerticalPiece(piece) ? static_cast<Image::TileRule>(verticalRule()) : Image::StretchTile;
-        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::Orientation::FromImage });
+        graphicsContext.drawTiledImage(*image, destinationRects[piece], sourceRects[piece], tileScales[piece], hRule, vRule, { op, ImageOrientation::Orientation::FromImage, headroom });
     }
 }
 


### PR DESCRIPTION
#### 9d522eb64cf21c3efa3513a850797e5a9718586c
<pre>
[HDR] Disable HDR display for CSS images
<a href="https://bugs.webkit.org/show_bug.cgi?id=287985#">https://bugs.webkit.org/show_bug.cgi?id=287985#</a>
<a href="https://rdar.apple.com/145154746">rdar://145154746</a>

Reviewed by Simon Fraser.

Currently only the headroom of HTMLImageElements are checked for setting the
GraphicsLayer::drawsHDRContent(). So a layer with an HDR &lt;img&gt; element, has to
show the CSS HDR image the same way if is displayed in a layer with no HDR &lt;img&gt;
element.

For now and to be consistent with HDR CSS images, the HDR display will be
disabled for CSS images.

* LayoutTests/TestExpectations:
* LayoutTests/compositing/hdr/hdr-css-image.html: Added.
* LayoutTests/fast/images/hdr-basic-image.html:
* LayoutTests/fast/images/hdr-css-image-expected.html: Added.
* LayoutTests/fast/images/hdr-css-image.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/compositing/hdr/hdr-css-image-expected.txt: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-css-image-expected.txt: Added.
* Source/WebCore/page/Page.cpp:
(WebCore::Page::canDrawHDRContent const):
(WebCore::Page::canDrawHDRContents const): Deleted.
* Source/WebCore/page/Page.h:
Rename the method canDrawHDRContents() to canDrawHDRContent() to be consistent
with  GraphicsLayer::drawsHDRContent().

* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
-- BitmapImage::headroomForTesting() will be respected first if it is set and
   ImagePaintingOptions::headroom is equal to Headroom::FromImage.
-- BitmapImage::headroom() will be respected second if ImagePaintingOptions::headroom
   is equal to Headroom::FromImage.
-- Otherwise ImagePaintingOptions::headroom will be used.

* Source/WebCore/platform/graphics/Color.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::drawNativeImageInternal):
This part was missing. NativeImage can be drawn from places other than BitmapImage.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::PaintedContentsInfo):
* Source/WebCore/rendering/style/NinePieceImage.cpp:
(WebCore::NinePieceImage::paint const):

Canonical link: <a href="https://commits.webkit.org/290804@main">https://commits.webkit.org/290804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9248293597496c48784cec1a6f7e152c7e9d71bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96132 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41890 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93180 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18991 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70031 "Failure limit exceed. At least found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50357 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/140 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41025 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78536 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98115 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18332 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79043 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78246 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19343 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22755 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18335 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->