### PR TITLE
Make objectIsRelayoutBoundary detect all new formatting contexts as a boundary instead of just hidden overflow.

### DIFF
--- a/LayoutTests/fast/repaint/align-self-overflow-change-expected.txt
+++ b/LayoutTests/fast/repaint/align-self-overflow-change-expected.txt
@@ -6,6 +6,5 @@ Tests invalidation on align-self style change (just overflow). Passes if there i
   (rect 0 52 200 200)
   (rect 0 252 200 100)
   (rect 0 2 200 50)
-  (rect 0 2 800 14)
 )
 

--- a/LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt
+++ b/LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt
@@ -6,7 +6,6 @@ Tests invalidation on justify-self style change. Passes if there is no red.
   (rect 0 52 150 300)
   (rect 150 52 50 300)
   (rect -50 52 50 300)
-  (rect -50 16 50 336)
   (rect -50 0 50 352)
 )
 

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -919,11 +919,13 @@ void RenderBlockFlow::simplifiedNormalFlowLayout()
     bool shouldUpdateOverflow = false;
     for (InlineWalker walker(*this); !walker.atEnd(); walker.advance()) {
         RenderObject& renderer = *walker.current();
-        if (!renderer.isOutOfFlowPositioned() && (renderer.isReplacedOrAtomicInline() || renderer.isFloating())) {
-            RenderBox& box = downcast<RenderBox>(renderer);
-            box.layoutIfNeeded();
-            shouldUpdateOverflow = true;
-        } else if (is<RenderText>(renderer) || is<RenderInline>(renderer))
+        if (!renderer.isOutOfFlowPositioned()) {
+            if (CheckedPtr element = dynamicDowncast<RenderBox>(renderer)) {
+                element->layoutIfNeeded();
+                shouldUpdateOverflow = true;
+            }
+        }
+        if (is<RenderText>(renderer) || is<RenderInline>(renderer))
             renderer.clearNeedsLayout();
     }
 


### PR DESCRIPTION
#### ce15de8768af93d1dbd3b4437db3517221b0bc9f
<pre>
Make objectIsRelayoutBoundary detect all new formatting contexts as a boundary instead of just hidden overflow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288139">https://bugs.webkit.org/show_bug.cgi?id=288139</a>
&lt;<a href="https://rdar.apple.com/145515971">rdar://145515971</a>&gt;

Reviewed by Alan Baradlay.

Allow objectIsRelayoutBoundary to return true for any objects that creates a new
formatting context, instead of only ones created by hidden overflow.

Since this sometimes that overflow can still change on ancestors, return a
tri-state enum about whether overflow changes are possible.

When reaching an ancestor in markContainingBlocksForLayout that is a boundary
for normal layout but not overflow, switch to simplified layout requests.

* LayoutTests/fast/repaint/align-self-overflow-change-expected.txt:
* LayoutTests/fast/repaint/justify-self-overflow-change-expected.txt:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::simplifiedNormalFlowLayout):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::objectIsRelayoutBoundary):
(WebCore::RenderObject::markContainingBlocksForLayout):

Canonical link: <a href="https://commits.webkit.org/292724@main">https://commits.webkit.org/292724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56ac17876b4def482525d2b6422438ee7a581b3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/96752 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/101825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47272 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/98797 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/24806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73734 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30950 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/99755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87512 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54069 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46600 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82402 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/103848 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/23820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/17376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82782 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83578 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82169 "Found 3 new API test failures: /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print-errors, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/print, /WebKitGTK/TestPrinting:/webkit/WebKitPrintOperation/close-after-print (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20677 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/26827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17298 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/23782 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/28937 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23441 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/26921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25182 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->