### PR TITLE
[GLib] Ensure WebKitCookieManager APIs keep cookie cache up to date

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp
@@ -859,6 +859,56 @@ static void testCookieManagerLongExpires(CookieManagerTest* test, gconstpointer)
     g_assert_cmpint(g_strv_length(test->getDomains()), ==, 0);
 }
 
+static void testCookieSyncWithWebView(CookiePersistentStorageTest* test, gconstpointer)
+{
+    g_unlink(test->m_cookiesTextFile.get());
+    g_unlink(test->m_cookiesSQLiteFile.get());
+    test->m_cookiesTextFile.reset(g_build_filename(Test::dataDirectory(), "cookies.txt", nullptr));
+
+    // When COOKIE_CHANGE_LISTENER_API is defined the WebCookieCache is enabled which requires
+    // on every change NetworkStorageSessionSoup sends messages to the WebProcess to keep it updated.
+    // So here we are testing webkit_cookie_manager_replace_cookies() and webkit_cookie_manager_set_persistent_storage() removes everything from the cache.
+    // Some waits have been added just to be more reliable as there is a lot of IPC (UI -> Network -> WebProcess).
+
+    test->initializeWebView();
+    test->setPersistentStorage(WEBKIT_COOKIE_PERSISTENT_STORAGE_SQLITE);
+
+    GUniquePtr<SoupCookie> cookie(soup_cookie_new(kCookieName, kCookieValue, kFirstPartyDomain, kCookiePath, SOUP_COOKIE_MAX_AGE_ONE_DAY));
+    test->addCookie(cookie.get());
+
+    test->loadURI(kServer->getURIForPath("/index.html").data());
+    test->waitUntilLoadFinished();
+
+    auto* value = test->runJavaScriptAndWaitUntilFinished("document.cookie", nullptr);
+    GUniquePtr<char> cookieString(jsc_value_to_string(value));
+    g_assert_cmpstr(cookieString.get(), ==, "foo=bar");
+
+    GUniquePtr<SoupCookie> newCookie(soup_cookie_new(kCookieName, kCookieValueNew, kFirstPartyDomain, kCookiePath, SOUP_COOKIE_MAX_AGE_ONE_DAY));
+    GUniquePtr<SoupCookie> thirdPartyCookie(soup_cookie_new(kCookiePathNew, kCookieName, kThirdPartyDomain, kCookiePath, SOUP_COOKIE_MAX_AGE_ONE_DAY));
+    GUniquePtr<GList> cookies(g_list_append(g_list_append(nullptr, newCookie.get()), thirdPartyCookie.get()));
+
+    bool callbackDone = false;
+    webkit_cookie_manager_replace_cookies(test->m_cookieManager, cookies.get(), nullptr, (GAsyncReadyCallback)+[](WebKitCookieManager* manager, GAsyncResult* result, bool* done) {
+        g_assert_true(webkit_cookie_manager_replace_cookies_finish(manager, result, nullptr));
+        *done = true;
+    }, &callbackDone);
+    while (!callbackDone)
+        g_main_context_iteration(g_main_loop_get_context(test->m_mainLoop), TRUE);
+
+    test->wait(1.0);
+    value = test->runJavaScriptAndWaitUntilFinished("document.cookie", nullptr);
+    cookieString.reset(jsc_value_to_string(value));
+    g_assert_cmpstr(cookieString.get(), ==, "foo=new-value");
+
+    g_assert_true(g_file_set_contents(test->m_cookiesTextFile.get(), "127.0.0.1\tFALSE\t/\tFALSE\t-1\tbaz\tvalue\n", -1, nullptr));
+    test->setPersistentStorage(WEBKIT_COOKIE_PERSISTENT_STORAGE_TEXT);
+
+    test->wait(1.0);
+    value = test->runJavaScriptAndWaitUntilFinished("document.cookie", nullptr);
+    cookieString.reset(jsc_value_to_string(value));
+    g_assert_cmpstr(cookieString.get(), ==, "baz=value");
+}
+
 #if USE(SOUP2)
 static void serverCallback(SoupServer* server, SoupMessage* message, const char* path, GHashTable*, SoupClientContext*, gpointer)
 #else
@@ -903,6 +953,7 @@ void beforeAll()
     CookieManagerTest::add("WebKitCookieManager", "persistent-storage-delete-all", testCookieManagerPersistentStorageDeleteAll);
     CookieManagerTest::add("WebKitCookieManager", "ephemeral", testCookieManagerEphemeral);
     CookieManagerTest::add("WebKitCookieManager", "long-expires", testCookieManagerLongExpires);
+    CookiePersistentStorageTest::add("WebKitCookieManager", "sync-with-webview", testCookieSyncWithWebView);
 }
 
 void afterAll()


### PR DESCRIPTION
#### e25e1c371d81d00aa1c7905372e05b4936378b7d
<pre>
[GLib] Ensure WebKitCookieManager APIs keep cookie cache up to date
<a href="https://bugs.webkit.org/show_bug.cgi?id=288142">https://bugs.webkit.org/show_bug.cgi?id=288142</a>

Reviewed by Carlos Garcia Campos.

Every time the cookie manager replaces the cookie list or cookie jar we
now inform the webprocess cache that everything was removed.

* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::setCookieStorage):
(WebCore::NetworkStorageSession::deleteAllCookies):
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestCookieManager.cpp:
(testCookieSyncWithWebView):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/290871@main">https://commits.webkit.org/290871@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89ebea1d1feb87cfcd06e76b04b31343358e77d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/326 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41919 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70055 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27578 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8471 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82684 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50381 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/265 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41061 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78562 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98171 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79075 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78278 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19381 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22779 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/199 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11551 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23679 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18088 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21549 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->