### PR TITLE
[UnifiedPDF] [iOS] Hook up accessibility for Unified PDF

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -60,9 +60,7 @@ OBJC_CLASS NSString;
 OBJC_CLASS PDFAnnotation;
 OBJC_CLASS PDFDocument;
 OBJC_CLASS PDFSelection;
-#if PLATFORM(MAC)
 OBJC_CLASS WKAccessibilityPDFDocumentObject;
-#endif
 
 namespace WebCore {
 class Color;
@@ -473,9 +471,8 @@ protected:
     RangeSet<WTF::Range<uint64_t>> m_validRanges WTF_GUARDED_BY_LOCK(m_streamedDataLock);
 
     RetainPtr<PDFDocument> m_pdfDocument;
-#if PLATFORM(MAC)
+
     RetainPtr<WKAccessibilityPDFDocumentObject> m_accessibilityDocumentObject;
-#endif
 
     String m_suggestedFilename;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -160,9 +160,12 @@ public:
 
     bool shouldCachePagePreviews() const;
 
-#if PLATFORM(MAC)
     WebCore::FloatRect convertFromPDFPageToScreenForAccessibility(const WebCore::FloatRect&, PDFDocumentLayout::PageIndex) const;
+#if PLATFORM(MAC)
     void accessibilityScrollToPage(PDFDocumentLayout::PageIndex);
+#endif
+#if !PLATFORM(MAC)
+    id accessibilityHitTestInPageForIOS(WebCore::FloatPoint);
 #endif
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(UNIFIED_PDF) && PLATFORM(MAC)
+#if ENABLE(UNIFIED_PDF)
 
 #include "PDFDocumentLayout.h"
 #include "PDFPluginBase.h"
@@ -44,6 +44,7 @@ class WeakPtrImplWithEventTargetData;
     RetainPtr<PDFDocument> _pdfDocument;
     WeakObjCPtr<NSObject> _parent;
     ThreadSafeWeakPtr<WebKit::UnifiedPDFPlugin> _pdfPlugin;
+    RetainPtr<NSMutableArray> _axElements;
 }
 
 @property (assign) WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> pluginElement;
@@ -53,13 +54,16 @@ class WeakPtrImplWithEventTargetData;
 - (void)setPDFDocument:(RetainPtr<PDFDocument>)document;
 - (void)setPDFPlugin:(WebKit::UnifiedPDFPlugin*)plugin;
 - (PDFDocument *)document;
+- (NSRect)convertFromPDFPageToScreenForAccessibility:(NSRect)rectInPageCoordinates pageIndex:(WebKit::PDFDocumentLayout::PageIndex)pageIndex;
+
+#if PLATFORM(MAC)
 - (NSObject *)accessibilityParent;
 - (id)accessibilityHitTest:(NSPoint)point;
 - (void)gotoDestination:(PDFDestination *)destination;
-- (NSRect)convertFromPDFPageToScreenForAccessibility:(NSRect)rectInPageCoordinate pageIndex:(WebKit::PDFDocumentLayout::PageIndex)pageIndex;
 - (id)accessibilityAssociatedControlForAnnotation:(PDFAnnotation *)annotation;
 - (void)setActiveAnnotation:(PDFAnnotation *)annotation;
+#endif // PLATFORM(MAC)
 
 @end
 
-#endif
+#endif // ENABLE(UNIFIED_PDF)

--- a/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm
@@ -75,10 +75,16 @@
     if (!m_page)
         return nil;
 
+    RefPtr focusedLocalFrame = [self focusedLocalFrame];
+
+#if ENABLE(PDF_PLUGIN)
+    if (m_hasMainFramePlugin)
+        return [[self accessibilityRootObjectWrapper:focusedLocalFrame.get()] accessibilityHitTest:WebCore::IntPoint(point)];
+#endif // ENABLE(PDF_PLUGIN)
+
     WebCore::IntPoint convertedPoint = m_page->accessibilityScreenToRootView(WebCore::IntPoint(point));
 
     // If we are hit-testing a remote element, offset the hit test by the scroll of the web page.
-    RefPtr focusedLocalFrame = [self focusedLocalFrame];
     if (CheckedPtr frameView = focusedLocalFrame ? focusedLocalFrame->view() : nullptr)
         convertedPoint.moveBy(frameView->scrollPosition());
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -695,6 +695,11 @@ void WebPage::getSelectionContext(CompletionHandler<void(const String&, const St
 
 NSObject *WebPage::accessibilityObjectForMainFramePlugin()
 {
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = mainFramePlugIn())
+        return pluginView->accessibilityObject();
+#endif
+
     return nil;
 }
     


### PR DESCRIPTION
#### a29783762efc4e2780f77187cd78a58ec3205c26
<pre>
[UnifiedPDF] [iOS] Hook up accessibility for Unified PDF
<a href="https://bugs.webkit.org/show_bug.cgi?id=288135">https://bugs.webkit.org/show_bug.cgi?id=288135</a>
<a href="https://rdar.apple.com/145235024">rdar://145235024</a>

Reviewed by Abrar Rahman Protyasha.

Add accessibility support for Unified PDF on iOS

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::convertFromPDFPageToScreenForAccessibility const):
(WebKit::UnifiedPDFPlugin::accessibilityObject const):
(WebKit::UnifiedPDFPlugin::accessibilityHitTestInPage):
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.h:
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject initWithPDFDocument:andElement:]):
(-[WKAccessibilityPDFDocumentObject setParent:]):
(-[WKAccessibilityPDFDocumentObject document]):
(-[WKAccessibilityPDFDocumentObject convertFromPDFPageToScreenForAccessibility:pageIndex:]):
(-[WKAccessibilityPDFDocumentObject setAXElements]):
(-[WKAccessibilityPDFDocumentObject accessibilityHitTest:]):
(-[WKAccessibilityPDFDocumentObject accessibilityElements]):
(-[WKAccessibilityPDFDocumentObject accessibilityScroll:]):
* Source/WebKit/WebProcess/WebPage/WKAccessibilityWebPageObjectIOS.mm:
(-[WKAccessibilityWebPageObject accessibilityHitTest:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::accessibilityObjectForMainFramePlugin):

Canonical link: <a href="https://commits.webkit.org/291103@main">https://commits.webkit.org/291103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eebbd1ed0aa7b7383bf2718387e978c185efa959

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91941 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42546 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19957 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70550 "Found 1 new test failure: imported/w3c/web-platform-tests/mixed-content/gen/top.http-rp/opt-in/video-tag.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28036 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9010 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50878 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8740 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/869 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19063 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79575 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78801 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23344 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/650 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12101 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24253 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18741 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->