### PR TITLE
Unreviewed, fix the tvOS engineering build

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig
@@ -80,6 +80,8 @@ WK_PDFKIT_LDFLAGS_iphoneos = -framework PDFKit;
 WK_PDFKIT_LDFLAGS_iphonesimulator = -framework PDFKit;
 WK_PDFKIT_LDFLAGS_xros = -framework PDFKit;
 WK_PDFKIT_LDFLAGS_xrsimulator = -framework PDFKit;
+WK_PDFKIT_LDFLAGS_appletvos = -weak_framework PDFKit;
+WK_PDFKIT_LDFLAGS_appletvsimulator = -weak_framework PDFKit;
 
 WK_SYSTEM_LDFLAGS = $(WK_SYSTEM_LDFLAGS_$(WK_PLATFORM_NAME));
 WK_SYSTEM_LDFLAGS_macosx = -framework System;

--- a/Tools/TestWebKitAPI/config.h
+++ b/Tools/TestWebKitAPI/config.h
@@ -126,7 +126,6 @@
 #define HAVE_TLS_VERSION_DURING_CHALLENGE 1
 #endif
 
-// FIXME (rdar://133488399): Weak link PDFKit on tvOS and use HAVE(PDFKit) in TestWebKitAPI.
-#if HAVE(PDFKIT) && !PLATFORM(APPLETV)
+#if HAVE(PDFKIT)
 #define USE_PDFKIT_FOR_TESTING 1
 #endif


### PR DESCRIPTION
#### 462f461d225e7d406133ff4829f5b288f8c40dfb
<pre>
Unreviewed, fix the tvOS engineering build

Enable `USE_PDFKIT_FOR_TESTING` on tvOS, so that API tests build after enabling unified PDF support.
Additionally (weak) link against PDFKit in API tests.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPIBase.xcconfig:
* Tools/TestWebKitAPI/config.h:

Canonical link: <a href="https://commits.webkit.org/290750@main">https://commits.webkit.org/290750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e48e4c7b7849f008ca4bafc01bbb9b65dd74492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/7 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96025 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41793 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18856 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93997 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50285 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/11 "Failed to checkout and rebase branch from PR 41008") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40917 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78391 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/11 "Failed to checkout and rebase branch from PR 41008") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18199 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18459 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78292 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78162 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22648 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/11 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14356 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18206 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17942 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19727 "Failed to checkout and rebase branch from PR 41008") | | | 
<!--EWS-Status-Bubble-End-->