### PR TITLE
[UnifiedPDF] [iPadOS] Previewing link by clicking-and-holding with trackpad incorrectly navigates

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1716,6 +1716,11 @@ public:
     void handleContextMenuKeyEvent();
 #endif
 
+#if USE(UICONTEXTMENU)
+    void willBeginContextMenuInteraction();
+    void didEndContextMenuInteraction();
+#endif
+
 #if ENABLE(CONTEXT_MENU_EVENT)
     void dispatchAfterCurrentContextMenuEvent(CompletionHandler<void(bool)>&&);
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -14976,6 +14976,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_webView)
         return;
 
+    _page->willBeginContextMenuInteraction();
     _isDisplayingContextMenuWithAnimation = YES;
     [animator addCompletion:[weakSelf = WeakObjCPtr<WKContentView>(self)] {
         if (auto strongSelf = weakSelf.get()) {
@@ -15117,6 +15118,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!_webView)
         return;
 
+    _page->didEndContextMenuInteraction();
     // FIXME: This delegate is being called more than once by UIKit. <rdar://problem/51550291>
     // This conditional avoids the WKUIDelegate being called twice too.
     if (_contextMenuElementInfo) {

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1795,6 +1795,26 @@ RefPtr<ModelPresentationManagerProxy> WebPageProxy::modelPresentationManagerProx
 }
 #endif
 
+#if USE(UICONTEXTMENU)
+
+void WebPageProxy::willBeginContextMenuInteraction()
+{
+    if (!hasRunningProcess())
+        return;
+
+    legacyMainFrameProcess().send(Messages::WebPage::WillBeginContextMenuInteraction(), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::didEndContextMenuInteraction()
+{
+    if (!hasRunningProcess())
+        return;
+
+    legacyMainFrameProcess().send(Messages::WebPage::DidEndContextMenuInteraction(), webPageIDInMainFrameProcess());
+}
+
+#endif // USE(UICONTEXTMENU)
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1988,6 +1988,10 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
                 bool shouldFollowLinkAnnotation = [frame = m_frame] {
                     if (!frame || !frame->coreLocalFrame())
                         return true;
+#if USE(UICONTEXTMENU)
+                    if (RefPtr webPage = frame->page(); webPage->hasActiveContextMenuInteraction())
+                        return false;
+#endif
                     auto immediateActionStage = frame->protectedCoreLocalFrame()->checkedEventHandler()->immediateActionStage();
                     return !immediateActionBeganOrWasCompleted(immediateActionStage);
                 }();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7908,6 +7908,10 @@ void WebPage::didCommitLoad(WebFrame* frame)
     m_elementsToExcludeFromRemoveBackground.clear();
 #endif
 
+#if USE(UICONTEXTMENU)
+    m_hasActiveContextMenuInteraction = false;
+#endif
+
     flushDeferredDidReceiveMouseEvent();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1949,6 +1949,12 @@ public:
 
     void didProgrammaticallyClearTextFormControl(const WebCore::HTMLTextFormControlElement&);
 
+#if USE(UICONTEXTMENU)
+    void willBeginContextMenuInteraction();
+    void didEndContextMenuInteraction();
+    bool hasActiveContextMenuInteraction() const { return m_hasActiveContextMenuInteraction; }
+#endif
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
@@ -2850,6 +2856,10 @@ private:
     OptionSet<TextInteractionSource> m_activeTextInteractionSources;
     std::optional<WebCore::FloatPoint> m_lastTouchLocationBeforeTap;
 #endif // PLATFORM(IOS_FAMILY)
+
+#if USE(UICONTEXTMENU)
+    bool m_hasActiveContextMenuInteraction { false };
+#endif
 
     WebCore::Timer m_layerVolatilityTimer;
     Seconds m_layerVolatilityTimerInterval;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -869,4 +869,9 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #if HAVE(AUDIT_TOKEN)
     SetPresentingApplicationAuditTokenAndBundleIdentifier(struct WebKit::CoreIPCAuditToken auditToken, String bundleIdentifier)
 #endif
+
+#if USE(UICONTEXTMENU)
+    WillBeginContextMenuInteraction()
+    DidEndContextMenuInteraction()
+#endif
 }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -6132,6 +6132,20 @@ void WebPage::didDispatchClickEvent(const PlatformMouseEvent& event, Node& node)
 
 #endif // ENABLE(IOS_TOUCH_EVENTS)
 
+#if USE(UICONTEXTMENU)
+
+void WebPage::willBeginContextMenuInteraction()
+{
+    m_hasActiveContextMenuInteraction = true;
+}
+
+void WebPage::didEndContextMenuInteraction()
+{
+    m_hasActiveContextMenuInteraction = false;
+}
+
+#endif // USE(UICONTEXTMENU)
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG


### PR DESCRIPTION
#### b5438c176a46e82983f6b6f0b806351d759b9d95
<pre>
[UnifiedPDF] [iPadOS] Previewing link by clicking-and-holding with trackpad incorrectly navigates
<a href="https://bugs.webkit.org/show_bug.cgi?id=288145">https://bugs.webkit.org/show_bug.cgi?id=288145</a>
<a href="https://rdar.apple.com/142476781">rdar://142476781</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

Currently, clicking and holding on a link in a PDF (with unified PDF enabled) using a trackpad
incorrectly navigates to the link, shortly after presenting a context menu. On macOS, we consult the
immediate action state to avoid following the link upon handling a click, but this mechanism doesn&apos;t
exist on iOS.

To address this, we add some plumbing to update `WebPage` when the UI-side context menu interaction
is presented and dismissed, and consult this state in the same place where we currently bail when
handling an immediate action on macOS.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[WKContentView contextMenuInteraction:willEndForConfiguration:animator:]):

Add IPC calls to the web process, so that `WebPage` can track context menu interaction lifecycle.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willBeginContextMenuInteraction):
(WebKit::WebPageProxy::didEndContextMenuInteraction):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::handleMouseEvent):

If the context menu is presented, avoid following the link annotation under the mouse.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didCommitLoad):

Reset the new flag (`m_hasActiveContextMenuInteraction`).

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::willBeginContextMenuInteraction):
(WebKit::WebPage::didEndContextMenuInteraction):

Canonical link: <a href="https://commits.webkit.org/290754@main">https://commits.webkit.org/290754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b586ab0a4074e7db3680869c47744cc0f3bd4d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/90995 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41792 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10935 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18855 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/69960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/93996 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50286 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78389 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/6 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/97997 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78163 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19309 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22649 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/6 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18205 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17941 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->