### PR TITLE
[Screen Time Refactoring] Previously opened website won’t be blocked after relaunching Chrome

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -134,7 +134,6 @@ public:
 #endif
 
 #if ENABLE(SCREEN_TIME)
-    void installScreenTimeWebpageController() final;
     void didChangeScreenTimeWebpageControllerURL() final;
     void setURLIsPictureInPictureForScreenTime(bool) final;
     void setURLIsPlayingVideoForScreenTime(bool) final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -325,11 +325,6 @@ void PageClientImplCocoa::removeTextAnimationForAnimationID(const WTF::UUID& uui
 #endif
 
 #if ENABLE(SCREEN_TIME)
-void PageClientImplCocoa::installScreenTimeWebpageController()
-{
-    [m_webView _installScreenTimeWebpageController];
-}
-
 void PageClientImplCocoa::didChangeScreenTimeWebpageControllerURL()
 {
     updateScreenTimeWebpageControllerURL(webView().get());
@@ -340,9 +335,10 @@ void PageClientImplCocoa::updateScreenTimeWebpageControllerURL(WKWebView *webVie
     if (!PAL::isScreenTimeFrameworkAvailable())
         return;
 
+    if (![webView _screenTimeWebpageController])
+        [webView _installScreenTimeWebpageController];
+
     RetainPtr screenTimeWebpageController = [webView _screenTimeWebpageController];
-    if (!screenTimeWebpageController)
-        return;
 
     RefPtr pageProxy = [webView _page].get();
     if (pageProxy && !pageProxy->preferences().screenTimeEnabled()) {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -817,7 +817,6 @@ public:
     virtual void scheduleVisibleContentRectUpdate() { }
 
 #if ENABLE(SCREEN_TIME)
-    virtual void installScreenTimeWebpageController() { }
     virtual void didChangeScreenTimeWebpageControllerURL() { };
     virtual void setURLIsPictureInPictureForScreenTime(bool) { };
     virtual void setURLIsPlayingVideoForScreenTime(bool) { };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1983,10 +1983,6 @@ void WebPageProxy::prepareToLoadWebPage(WebProcessProxy& process, LoadParameters
     if (NetworkIssueReporter::isEnabled())
         m_networkIssueReporter = makeUnique<NetworkIssueReporter>();
 #endif
-
-#if ENABLE(SCREEN_TIME)
-    m_pageClient->installScreenTimeWebpageController();
-#endif
 }
 
 #if !PLATFORM(COCOA)
@@ -9286,7 +9282,7 @@ void WebPageProxy::hasVideoInPictureInPictureDidChange(bool value)
 {
     uiClient().hasVideoInPictureInPictureDidChange(this, value);
 #if ENABLE(SCREEN_TIME)
-    m_pageClient->setURLIsPictureInPictureForScreenTime(value);
+    protectedPageClient()->setURLIsPictureInPictureForScreenTime(value);
 #endif
 }
 
@@ -13639,7 +13635,7 @@ void WebPageProxy::updatePlayingMediaDidChange(CanDelayNotification canDelayNoti
 
 #if ENABLE(SCREEN_TIME)
     if (oldState.contains(MediaProducerMediaState::IsPlayingVideo) != newState.contains(MediaProducerMediaState::IsPlayingVideo))
-        m_pageClient->setURLIsPlayingVideoForScreenTime(newState.contains(MediaProducerMediaState::IsPlayingVideo));
+        protectedPageClient()->setURLIsPlayingVideoForScreenTime(newState.contains(MediaProducerMediaState::IsPlayingVideo));
 #endif
 }
 


### PR DESCRIPTION
#### 5bf1140d588362632333f571f622a2ed9862b9ea
<pre>
[Screen Time Refactoring] Previously opened website won’t be blocked after relaunching Chrome
<a href="https://bugs.webkit.org/show_bug.cgi?id=288148">https://bugs.webkit.org/show_bug.cgi?id=288148</a>
<a href="https://rdar.apple.com/145095487">rdar://145095487</a>

Reviewed by Aditya Keerthi.

Currently, we only install STWebpageController in `WebPageProxy::prepareToLoadWebPage`.
This is an issue for webpages or tabs that were already loaded.
When we&apos;ve navigated to a page, then quit Chrome and relaunch, the function
`WebPageProxy::prepareToLoadWebPage` does not get called again.
Chrome sets their session state and the webview&apos;s interaction state
which then calls into our WKWebView&apos;s `setInteractionState`that then calls
`WebPageProxy::restoreFromSessionState`.

Thus, we need to change where we call install STWebpageController. Instead, we will
create a controller if it does not exist when `didChangeScreenTimeWebpageControllerURL`
is called.

Also, we changed some API tests to wait until a controller is created as we do not
create a controller upon `WebPageProxy::prepareToLoadWebPage` but in
`WebPageProxy::didCommitLayerTree` which calls `didChangeScreenTimeWebpageControllerURL`.

Additionally, add an API test that mimics the state that Chrome is in.

* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::updateScreenTimeWebpageControllerURL):
(WebKit::PageClientImplCocoa::installScreenTimeWebpageController): Deleted.
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::installScreenTimeWebpageController): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::prepareToLoadWebPage):
(WebKit::WebPageProxy::hasVideoInPictureInPictureDidChange):
(WebKit::WebPageProxy::updatePlayingMediaDidChange):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(testShowsSystemScreenTimeBlockingView):
(TEST(ScreenTime, IsBlockedByScreenTimeTrue)):
(TEST(ScreenTime, IsBlockedByScreenTimeFalse)):
(TEST(ScreenTime, IsBlockedByScreenTimeMultiple)):
(TEST(ScreenTime, IsBlockedByScreenTimeKVO)):
(TEST(ScreenTime, IdentifierString)):
(TEST(ScreenTime, OffscreenSystemScreenTimeBlockingView)):
(TEST(ScreenTime, OffscreenBlurredScreenTimeBlockingView)):
(TEST(ScreenTime, DoNotDonateURLsInOffscreenWebView)):
(TEST(ScreenTime, ScreenTimeControllerInstalledAfterRestoreFromSessionState)):

Canonical link: <a href="https://commits.webkit.org/291022@main">https://commits.webkit.org/291022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c670bb09ad859e8b810f95ed49e4ec91783d0d05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91687 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93737 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70389 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27893 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/652 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41533 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98658 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18833 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79417 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78632 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11935 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14546 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18531 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20288 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->