### PR TITLE
Address unexpected static analyzer warnings

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -84,6 +84,7 @@ platform/mediastream/AudioMediaStreamTrackRenderer.h
 platform/mediastream/MediaStreamPrivate.h
 platform/mediastream/mac/CoreAudioCaptureSource.h
 platform/mock/ScrollbarsControllerMock.h
+platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.h
 plugins/PluginData.h
 rendering/RenderQuote.cpp
 rendering/RenderVTTCue.h

--- a/Source/WebCore/bridge/objc/WebScriptObjectPrivate.h
+++ b/Source/WebCore/bridge/objc/WebScriptObjectPrivate.h
@@ -76,8 +76,8 @@ WEBCORE_EXPORT @interface WebScriptObjectPrivate : NSObject
 {
 @public
     JSC::JSObject* imp;
-    JSC::Bindings::RootObject* rootObject;
-    JSC::Bindings::RootObject* originRootObject;
+    SUPPRESS_UNCOUNTED_MEMBER JSC::Bindings::RootObject* rootObject;
+    SUPPRESS_UNCOUNTED_MEMBER JSC::Bindings::RootObject* originRootObject;
     BOOL isCreatedByDOMWrapper;
 }
 @end

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -47,7 +47,7 @@
 using WebCore::ResourceUsageOverlay;
 
 @interface WebResourceUsageOverlayLayer : CALayer {
-    ResourceUsageOverlay* m_overlay;
+    WeakPtr<ResourceUsageOverlay> m_overlay;
 }
 @end
 
@@ -64,7 +64,8 @@ using WebCore::ResourceUsageOverlay;
 
 - (void)drawInContext:(CGContextRef)context
 {
-    m_overlay->platformDraw(context);
+    if (RefPtr overlay = m_overlay.get())
+        overlay->platformDraw(context);
 }
 
 @end
@@ -460,6 +461,7 @@ void ResourceUsageOverlay::platformDraw(CGContextRef context)
     CGContextSetShouldAntialias(context, false);
     CGContextSetShouldSmoothFonts(context, false);
 
+    RefPtr overlay = m_overlay.get();
     CGRect viewBounds = m_overlay->bounds();
     CGContextClearRect(context, viewBounds);
 

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -33,8 +33,8 @@
 #include "PlatformImage.h"
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
-#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
@@ -46,7 +46,7 @@ struct ImageDecoderFrameInfo {
     Seconds duration;
 };
 
-class ImageDecoder : public ThreadSafeRefCounted<ImageDecoder> {
+class ImageDecoder : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ImageDecoder> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ImageDecoder, WEBCORE_EXPORT);
 public:
     static RefPtr<ImageDecoder> create(FragmentedSharedBuffer&, const String& mimeType, AlphaOption, GammaAndColorProfileOption);

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -46,11 +46,6 @@ namespace WebCore {
 class CDMSessionAVContentKeySession;
 }
 
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CDMSessionAVContentKeySession> : std::true_type { };
-}
-
 namespace WebCore {
 
 class CDMPrivateMediaSourceAVFObjC;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm
@@ -65,7 +65,7 @@
 #pragma mark -
 
 @interface WebCoreSharedBufferResourceLoaderDelegate : NSObject<AVAssetResourceLoaderDelegate> {
-    WebCore::ImageDecoderAVFObjC* _parent;
+    ThreadSafeWeakPtr<WebCore::ImageDecoderAVFObjC> _parent;
     long long _expectedContentSize;
     RetainPtr<NSData> _data;
     bool _complete;
@@ -157,7 +157,9 @@
 - (void)fulfillRequest:(AVAssetResourceLoadingRequest *)request
 {
     if (auto infoRequest = request.contentInformationRequest) {
-        infoRequest.contentType = _parent->uti();
+        RefPtr parent = _parent.get();
+        RELEASE_ASSERT(parent);
+        infoRequest.contentType = parent->uti();
         infoRequest.byteRangeAccessSupported = YES;
         infoRequest.contentLength = _complete ? _data.get().length : _expectedContentSize;
     }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm
@@ -317,9 +317,10 @@ void SourceBufferParserAVFObjC::didParseStreamDataAsAsset(AVAsset* asset)
                 segment.audioTracks.append(WTFMove(info));
             } else if ([mediaType isEqualToString:AVMediaTypeText] && m_configuration.textTracksEnabled) {
                 SourceBufferPrivateClient::InitializationSegment::TextTrackInformation info;
-                info.description = MediaDescriptionAVFObjC::create(track);
-                if (info.description->codec().toString() != "wvtt"_s) {
-                    ALWAYS_LOG_IF_POSSIBLE(identifier, "Ignoring text track of type ", info.description->codec());
+                Ref description = MediaDescriptionAVFObjC::create(track);
+                info.description = description.copyRef();
+                if (description->codec().toString() != "wvtt"_s) {
+                    ALWAYS_LOG_IF_POSSIBLE(identifier, "Ignoring text track of type ", description->codec());
                     break;
                 }
                 info.track = TextTrackPrivateMediaSourceAVFObjC::create(track, InbandTextTrackPrivate::CueFormat::WebVTT);

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -28,7 +28,7 @@
 #include "FloatRoundedRect.h"
 #include "GraphicsLayer.h"
 #include <wtf/RetainPtr.h>
-#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 
@@ -95,7 +95,7 @@ enum class PlatformCALayerLayerType : uint8_t {
         LayerTypeHost,
 };
 
-class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCounted<PlatformCALayer, WTF::DestructionThread::Main> {
+class WEBCORE_EXPORT PlatformCALayer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<PlatformCALayer, WTF::DestructionThread::Main> {
     friend class PlatformCALayerCocoa;
 public:
     static CFTimeInterval currentTimeToMediaTime(MonotonicTime);

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -193,7 +193,7 @@ using WebCore::LogOverlayScrollbars;
 #endif
 
 @interface WebScrollbarPartAnimation : NSObject {
-    WebCore::Scrollbar* _scrollbar;
+    SingleThreadWeakPtr<WebCore::Scrollbar> _scrollbar;
     RetainPtr<NSScrollerImp> _scrollerImp;
     FeatureToAnimate _featureToAnimate;
     CGFloat _startValue;
@@ -234,9 +234,10 @@ using WebCore::LogOverlayScrollbars;
 
 - (void)startAnimation
 {
-    ASSERT(_scrollbar);
+    RefPtr scrollbar = _scrollbar.get();
+    RELEASE_ASSERT(scrollbar);
 
-    _scrollerImp = scrollerImpForScrollbar(*_scrollbar);
+    _scrollerImp = scrollerImpForScrollbar(*scrollbar);
 
     LOG_WITH_STREAM(OverlayScrollbars, stream << "-[WebScrollbarPartAnimation " << self << "startAnimation] for " << _featureToAnimate);
 
@@ -268,7 +269,8 @@ using WebCore::LogOverlayScrollbars;
             t = elapsed / _duration;
         progress = _timingFunction->transformProgress(t, _duration);
     }
-    ASSERT(_scrollbar);
+    RefPtr scrollbar = _scrollbar.get();
+    RELEASE_ASSERT(scrollbar);
 
     LOG_WITH_STREAM(OverlayScrollbars, stream << "-[" << self << " setCurrentProgress: " << progress << "] for " << _featureToAnimate);
 
@@ -293,8 +295,8 @@ using WebCore::LogOverlayScrollbars;
         break;
     }
 
-    if (_scrollbar && !_scrollbar->supportsUpdateOnSecondaryThread())
-        _scrollbar->invalidate();
+    if (scrollbar && !scrollbar->supportsUpdateOnSecondaryThread())
+        scrollbar->invalidate();
 }
 
 - (void)invalidate

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -30,8 +30,9 @@
 #include "StoredCredentialsPolicy.h"
 #include <wtf/Box.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 
 #if PLATFORM(COCOA)
@@ -78,7 +79,7 @@ class FragmentedSharedBuffer;
 class SynchronousLoaderMessageQueue;
 class Timer;
 
-class ResourceHandle : public RefCounted<ResourceHandle>, public AuthenticationClient {
+class ResourceHandle : public RefCountedAndCanMakeWeakPtr<ResourceHandle>, public AuthenticationClient {
 public:
     WEBCORE_EXPORT static RefPtr<ResourceHandle> create(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
     WEBCORE_EXPORT static void loadResourceSynchronously(NetworkingContext*, const ResourceRequest&, StoredCredentialsPolicy, SecurityOrigin*, ResourceError&, ResourceResponse&, Vector<uint8_t>& data);

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -60,7 +60,7 @@ struct WGPURenderBundleEncoderImpl {
 @property (readonly, nonatomic) float depthBiasSlopeScale;
 @property (readonly, nonatomic) float depthBiasClamp;
 @property (readonly, nonatomic) id<MTLBuffer> fragmentDynamicOffsetsBuffer;
-@property (readonly, nonatomic) const WebGPU::RenderPipeline* pipeline;
+@property (readonly, nonatomic) WeakPtr<WebGPU::RenderPipeline> pipeline;
 
 - (Vector<WebGPU::BindableResources>*)resources;
 - (WebGPU::RenderBundle::MinVertexCountsContainer*)minVertexCountForDrawCommand;

--- a/Source/WebKit/UIProcess/WebColorPicker.h
+++ b/Source/WebKit/UIProcess/WebColorPicker.h
@@ -27,7 +27,7 @@
 
 #include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
-#include <wtf/RefCounted.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
 class Color;
@@ -48,7 +48,7 @@ protected:
     virtual ~WebColorPickerClient() = default;
 };
 
-class WebColorPicker : public RefCounted<WebColorPicker> {
+class WebColorPicker : public RefCountedAndCanMakeWeakPtr<WebColorPicker> {
 public:
     using Client = WebColorPickerClient;
 

--- a/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
+++ b/Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h
@@ -35,7 +35,7 @@ class WebContextMenuProxyMac;
 @class NSSharingServicePicker;
 
 @interface WKSharingServicePickerDelegate : NSObject <NSSharingServiceDelegate, NSSharingServicePickerDelegate> {
-    WebKit::WebContextMenuProxyMac* _menuProxy;
+    WeakPtr<WebKit::WebContextMenuProxyMac> _menuProxy;
     RetainPtr<NSSharingServicePicker> _picker;
     BOOL _filterEditingServices;
     BOOL _handleEditingReplacement;

--- a/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebColorPickerMac.mm
@@ -65,7 +65,7 @@ static const CGFloat colorPickerMatrixSwatchWidth = 13.0;
 @interface WKColorPopoverMac : NSObject<WKColorPickerUIMac, WKPopoverColorWellDelegate, NSWindowDelegate> {
 @private
     BOOL _lastChangedByUser;
-    WebKit::WebColorPickerMac *_picker;
+    WeakPtr<WebKit::WebColorPickerMac> _picker;
     RetainPtr<WKPopoverColorWell> _popoverWell;
 }
 - (id)initWithFrame:(const WebCore::IntRect &)rect inView:(NSView *)view;
@@ -267,12 +267,13 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
 
 - (void)windowWillClose:(NSNotification *)notification
 {
-    if (!_picker)
+    RefPtr picker = _picker.get();
+    if (!picker)
         return;
 
     if (notification.object == [NSColorPanel sharedColorPanel]) {
         _lastChangedByUser = YES;
-        _picker->endPicker();
+        picker->endPicker();
     }
 }
 
@@ -287,7 +288,8 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
         return;
     }
 
-    _picker->didChooseColor(WebCore::colorFromCocoaColor([_popoverWell color]));
+    if (RefPtr picker = _picker.get())
+        picker->didChooseColor(WebCore::colorFromCocoaColor([_popoverWell color]));
 }
 
 - (void)setColor:(NSColor *)color
@@ -298,11 +300,12 @@ void WebColorPickerMac::showColorPicker(const WebCore::Color& color)
 
 - (void)didClosePopover
 {
-    if (!_picker)
+    RefPtr picker = _picker.get();
+    if (!picker)
         return;
 
     if (![NSColorPanel sharedColorPanel].isVisible)
-        _picker->endPicker();
+        picker->endPicker();
 }
 
 @end

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -376,7 +376,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
         RemoteLayerTreeTransaction layerTransaction(transactionID);
         layerTransaction.setCallbackIDs(WTFMove(m_pendingCallbackIDs));
 
-        m_remoteLayerTreeContext->buildTransaction(layerTransaction, *downcast<GraphicsLayerCARemote>(rootLayer.layer.get()).protectedPlatformCALayer(), rootLayer.frameID);
+        RefPtr layer = downcast<GraphicsLayerCARemote>(rootLayer.layer.get()).platformCALayer();
+        m_remoteLayerTreeContext->buildTransaction(layerTransaction, *layer, rootLayer.frameID);
 
         // FIXME: Investigate whether this needs to be done multiple times in a page with multiple root frames. <rdar://116202678>
         webPage->willCommitLayerTree(layerTransaction, rootLayer.frameID);


### PR DESCRIPTION
#### 3a900416e44772133da0c2dba539f00f6fb77065
<pre>
Address unexpected static analyzer warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=288157">https://bugs.webkit.org/show_bug.cgi?id=288157</a>

Reviewed by Chris Dumez.

Address the static analyzer warnings found after enabling ivar checks.

* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/bridge/objc/WebScriptObjectPrivate.h:
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(-[WebResourceUsageOverlayLayer drawInContext:]):
(WebCore::ResourceUsageOverlay::platformDraw):
* Source/WebCore/platform/graphics/ImageDecoder.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(-[WebCDMSessionAVContentKeySessionDelegate contentKeySession:didProvideContentKeyRequest:]):
(-[WebCDMSessionAVContentKeySessionDelegate contentKeySessionContentProtectionSessionIdentifierDidChange:]):
* Source/WebCore/platform/graphics/avfoundation/objc/ImageDecoderAVFObjC.mm:
(-[WebCoreSharedBufferResourceLoaderDelegate fulfillRequest:]):
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferParserAVFObjC.mm:
(WebCore::SourceBufferParserAVFObjC::didParseStreamDataAsAsset):
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(-[WebAnimationDelegate animationDidStart:]):
(-[WebAnimationDelegate animationDidStop:finished:]):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(-[WebScrollbarPartAnimation startAnimation]):
(-[WebScrollbarPartAnimation setCurrentProgress:]):
* Source/WebCore/platform/network/ResourceHandle.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::executePreDrawCommands):
(WebGPU::RenderBundleEncoder::errorValidatingDraw const):
(WebGPU::RenderBundleEncoder::errorValidatingDrawIndexed const):
(WebGPU::RenderBundleEncoder::runIndexBufferValidation):
(WebGPU::RenderBundleEncoder::runVertexBufferValidation):
(WebGPU::RenderBundleEncoder::computeMininumVertexInstanceCount const):
* Source/WebKit/UIProcess/WebColorPicker.h:
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.h:
* Source/WebKit/UIProcess/mac/WKSharingServicePickerDelegate.mm:
(-[WKSharingServicePickerDelegate menuProxy]):
(-[WKSharingServicePickerDelegate sharingService:willShareItems:]):
(-[WKSharingServicePickerDelegate sharingService:didShareItems:]):
(-[WKSharingServicePickerDelegate sharingService:sourceWindowForShareItems:sharingContentScope:]):
(-[WKSharingServicePickerDelegate removeBackground]):
* Source/WebKit/UIProcess/mac/WebColorPickerMac.mm:
(-[WKColorPopoverMac windowWillClose:]):
(-[WKColorPopoverMac didChooseColor:]):
(-[WKColorPopoverMac didClosePopover]):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):

Canonical link: <a href="https://commits.webkit.org/290766@main">https://commits.webkit.org/290766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ab077e9f821739f86ad43beaf48b01b718b656d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91013 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/24 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96040 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41807 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18874 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96040 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27489 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94014 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82470 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96040 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/19 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40931 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/18 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98014 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18214 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78183 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22662 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/33 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14368 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18221 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17956 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->