### PR TITLE
Generating scroll to text fragments around text that contains newlines fails.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt
@@ -1,0 +1,1 @@
+:~:text=This%20is%20the%20text%20without%20a%20space%20fakecode.h%20and%20the%20end%20of%20the%20selecton.

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we generate working directives when there is a newline inside of the directive. </title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>
+Select some code that doesn't have a space before it.
+<span id="test">This is the text without a space
+<code>fakecode.h</code>
+and the end of the selecton.</span>
+</html>
+

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -102,7 +102,7 @@ static String previousWordsFromPositionInSameBlock(unsigned numberOfWords, Visib
     RefPtr endNode = startPosition.deepEquivalent().containerNode();
     range->setEnd(endNode.releaseNonNull(), startPosition.deepEquivalent().computeOffsetInContainerNode());
 
-    return range->toString().trim(isHTMLSpaceButNotLineBreak);
+    return range->toString().trim(isHTMLSpaceButNotLineBreak).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 static String nextWordsFromPositionInSameBlock(unsigned numberOfWords, VisiblePosition& startPosition)
@@ -125,7 +125,7 @@ static String nextWordsFromPositionInSameBlock(unsigned numberOfWords, VisiblePo
     RefPtr endNode = nextPosition.deepEquivalent().containerNode();
     range->setEnd(endNode.releaseNonNull(), nextPosition.deepEquivalent().computeOffsetInContainerNode());
 
-    return range->toString().trim(isHTMLSpaceButNotLineBreak);
+    return range->toString().trim(isHTMLSpaceButNotLineBreak).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 // https://wicg.github.io/scroll-to-text-fragment/#generating-text-fragment-directives
@@ -137,7 +137,7 @@ void FragmentDirectiveGenerator::generateFragmentDirective(const SimpleRange& te
     document->updateLayoutIgnorePendingStylesheets();
 
     auto url = document->url();
-    auto textFromRange = createLiveRange(textFragmentRange)->toString();
+    auto textFromRange = createLiveRange(textFragmentRange)->toString().simplifyWhiteSpace(isASCIIWhitespace);
 
     VisiblePosition visibleStartPosition = VisiblePosition(Position(textFragmentRange.protectedStartContainer(), textFragmentRange.startOffset(), Position::PositionIsOffsetInAnchor));
     VisiblePosition visibleEndPosition = VisiblePosition(Position(textFragmentRange.protectedEndContainer(), textFragmentRange.endOffset(), Position::PositionIsOffsetInAnchor));


### PR DESCRIPTION
#### fecae51ab97156332c1faf6c5e42c7a6e41841d9
<pre>
Generating scroll to text fragments around text that contains newlines fails.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288156">https://bugs.webkit.org/show_bug.cgi?id=288156</a>
<a href="https://rdar.apple.com/137109344">rdar://137109344</a>

Reviewed by Wenson Hsieh.

When generating text fragments from text that includes a new line character
we would send that text that included the newline to the URL parser when we added
the fragment to the URL that we would then paste to the clipboard. The URL spec
says to remove all newlines and tabs so the two words that were separated by a
newline are now squished together and the fragment is incorrect. We need to
simplify the white space that is extracted from the range and then the words
will not be squished together and the permissive white space matching in the
fragment find code will find the correct text.

We encode newlines as spaces when generating text fragments, so that they are
ingested correctly in both Chrome and Safari.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt: Added.
* LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html: Added.
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::previousWordsFromPositionInSameBlock):
(WebCore::nextWordsFromPositionInSameBlock):
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):

Canonical link: <a href="https://commits.webkit.org/290761@main">https://commits.webkit.org/290761@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d6a54d69ec6dbcd250a7a8fef7eead1c40eb1c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91016 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/27 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18877 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94017 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/18 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/40934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/17 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18217 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13382 "Build is in progress. Recent messages:") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78178 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19313 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22666 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/17 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18224 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17959 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->