### PR TITLE
[JSC] Rename DisallowGC to AssertNoGC

### DIFF
--- a/Source/JavaScriptCore/bytecode/RepatchInlines.h
+++ b/Source/JavaScriptCore/bytecode/RepatchInlines.h
@@ -91,7 +91,7 @@ inline void* handleHostCall(VM& vm, JSCell* owner, CallFrame* calleeFrame, JSVal
             NativeCallFrameTracer tracer(vm, calleeFrame);
             calleeFrame->setCallee(asObject(callee));
             vm.encodedHostCallReturnValue = callData.native.function(asObject(callee)->globalObject(), calleeFrame);
-            DisallowGC disallowGC;
+            AssertNoGC assertNoGC;
             if (UNLIKELY(scope.exception()))
                 return nullptr;
             return LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr();
@@ -112,7 +112,7 @@ inline void* handleHostCall(VM& vm, JSCell* owner, CallFrame* calleeFrame, JSVal
         NativeCallFrameTracer tracer(vm, calleeFrame);
         calleeFrame->setCallee(asObject(callee));
         vm.encodedHostCallReturnValue = constructData.native.function(asObject(callee)->globalObject(), calleeFrame);
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         if (UNLIKELY(scope.exception()))
             return nullptr;
         return LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr();

--- a/Source/JavaScriptCore/bytecode/StructureStubInfo.h
+++ b/Source/JavaScriptCore/bytecode/StructureStubInfo.h
@@ -240,7 +240,7 @@ private:
 
     ALWAYS_INLINE bool considerRepatchingCacheImpl(VM& vm, CodeBlock* codeBlock, Structure* structure, CacheableIdentifier impl)
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
 
         
         // This method is called from the Optimize variants of IC slow paths. The first part of this

--- a/Source/JavaScriptCore/heap/DeferGC.cpp
+++ b/Source/JavaScriptCore/heap/DeferGC.cpp
@@ -29,7 +29,7 @@
 namespace JSC {
 
 #if ASSERT_ENABLED
-LazyNeverDestroyed<ThreadSpecific<unsigned, WTF::CanBeGCThread::True>> DisallowGC::s_scopeReentryCount;
+LazyNeverDestroyed<ThreadSpecific<unsigned, WTF::CanBeGCThread::True>> AssertNoGC::s_scopeReentryCount;
 #endif
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/DeferGC.h
+++ b/Source/JavaScriptCore/heap/DeferGC.h
@@ -56,13 +56,13 @@ private:
     JSC::Heap& m_heap;
 };
 
-class DisallowGC : public DisallowScope<DisallowGC> {
-    WTF_MAKE_NONCOPYABLE(DisallowGC);
+class AssertNoGC : public DisallowScope<AssertNoGC> {
+    WTF_MAKE_NONCOPYABLE(AssertNoGC);
     WTF_FORBID_HEAP_ALLOCATION;
-    typedef DisallowScope<DisallowGC> Base;
+    typedef DisallowScope<AssertNoGC> Base;
 public:
 #if ASSERT_ENABLED
-    DisallowGC() = default;
+    AssertNoGC() = default;
 
     static void initialize()
     {
@@ -82,11 +82,11 @@ private:
     JS_EXPORT_PRIVATE static LazyNeverDestroyed<ThreadSpecific<unsigned, WTF::CanBeGCThread::True>> s_scopeReentryCount;
 
 #else
-    ALWAYS_INLINE DisallowGC() { } // We need this to placate Clang due to unused warnings.
+    ALWAYS_INLINE AssertNoGC() { } // We need this to placate Clang due to unused warnings.
     ALWAYS_INLINE static void initialize() { }
 #endif // ASSERT_ENABLED
     
-    friend class DisallowScope<DisallowGC>;
+    friend class DisallowScope<AssertNoGC>;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2788,7 +2788,7 @@ void Heap::reportExternalMemoryVisited(size_t size)
 
 void Heap::collectIfNecessaryOrDefer(GCDeferralContext* deferralContext)
 {
-    ASSERT(deferralContext || isDeferred() || !DisallowGC::isInEffectOnCurrentThread());
+    ASSERT(deferralContext || isDeferred() || !AssertNoGC::isInEffectOnCurrentThread());
     if constexpr (validateDFGDoesGC)
         vm().verifyCanGC();
 

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -491,7 +491,7 @@ private:
 
 void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size_t framesToSkip, size_t maxStackSize, JSCell* caller, JSCell* ownerOfCallLinkInfo, CallLinkInfo* callLinkInfo)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     VM& vm = this->vm();
     CallFrame* callFrame = vm.topCallFrame;
     if (!callFrame || !maxStackSize)
@@ -506,7 +506,7 @@ void Interpreter::getStackTrace(JSCell* owner, Vector<StackFrame>& results, size
         return false;
     };
 
-    // This is OK since we never cause GC inside it (see DisallowGC).
+    // This is OK since we never cause GC inside it (see AssertNoGC).
     Vector<std::tuple<CodeBlock*, BytecodeIndex>, 16> reconstructedFrames;
     auto countFrame = [&](CodeBlock* codeBlock, BytecodeIndex bytecodeIndex) {
         if (skippedFrames < framesToSkip) {
@@ -1177,7 +1177,7 @@ failedJSONP:
         }
 
         {
-            DisallowGC disallowGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
+            AssertNoGC assertNoGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             jitCode = program->generatedJITCode();
             protoCallFrame.init(codeBlock, globalObject, globalCallee, thisObj, 1);
         }
@@ -1272,7 +1272,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCallImpl(VM& vm, JSObject* function, c
         }
 
         {
-            DisallowGC disallowGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
+            AssertNoGC assertNoGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             if (isJSCall)
                 jitCode = functionExecutable->generatedJITCodeForCall();
             protoCallFrame.init(newCodeBlock, globalObject, function, thisValue, argsCount, args.data());
@@ -1371,7 +1371,7 @@ JSObject* Interpreter::executeConstruct(JSObject* constructor, const CallData& c
         }
 
         {
-            DisallowGC disallowGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
+            AssertNoGC assertNoGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             if (isJSConstruct)
                 jitCode = constructData.js.functionExecutable->generatedJITCodeForConstruct();
             protoCallFrame.init(newCodeBlock, globalObject, constructor, newTarget, argsCount, args.data());
@@ -1590,7 +1590,7 @@ JSValue Interpreter::executeEval(EvalExecutable* eval, JSValue thisValue, JSScop
         }
 
         {
-            DisallowGC disallowGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
+            AssertNoGC assertNoGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             jitCode = eval->generatedJITCode();
             protoCallFrame.init(codeBlock, globalObject, callee, thisValue, 1);
         }
@@ -1658,7 +1658,7 @@ JSValue Interpreter::executeModuleProgram(JSModuleRecord* record, ModuleProgramE
         }
 
         {
-            DisallowGC disallowGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
+            AssertNoGC assertNoGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             jitCode = executable->generatedJITCode();
 
             // The |this| of the module is always `undefined`.

--- a/Source/JavaScriptCore/jit/JITThunks.cpp
+++ b/Source/JavaScriptCore/jit/JITThunks.cpp
@@ -230,7 +230,7 @@ void JITThunks::finalize(Handle<Unknown> handle, void*)
     auto* nativeExecutable = static_cast<NativeExecutable*>(handle.get().asCell());
     auto hostFunctionKey = std::make_tuple(nativeExecutable->function(), nativeExecutable->constructor(), nativeExecutable->implementationVisibility(), nativeExecutable->name());
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         auto iterator = m_nativeExecutableSet.find<HostKeySearcher>(hostFunctionKey);
         // Because this finalizer is called, this means that we still have dead Weak<> in m_nativeExecutableSet.
         ASSERT(iterator != m_nativeExecutableSet.end());
@@ -251,7 +251,7 @@ NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction funct
 
     auto hostFunctionKey = std::make_tuple(function, constructor, implementationVisibility, name);
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         auto iterator = m_nativeExecutableSet.find<HostKeySearcher>(hostFunctionKey);
         if (iterator != m_nativeExecutableSet.end()) {
             // It is possible that this returns Weak<> which is Dead, but not finalized.
@@ -274,7 +274,7 @@ NativeExecutable* JITThunks::hostFunctionStub(VM& vm, TaggedNativeFunction funct
     
     NativeExecutable* nativeExecutable = NativeExecutable::create(vm, forCall.releaseNonNull(), function, WTFMove(forConstruct), constructor, implementationVisibility, name);
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         auto addResult = m_nativeExecutableSet.add<NativeExecutableTranslator>(nativeExecutable);
         if (!addResult.isNewEntry) {
             // Override the existing Weak<NativeExecutable> with the new one since it is dead.

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2040,7 +2040,7 @@ static UGPRPair handleHostCall(CallFrame* calleeFrame, JSValue callee, CodeSpeci
             SlowPathFrameTracer tracer(vm, calleeFrame);
             calleeFrame->setCallee(asObject(callee));
             vm.encodedHostCallReturnValue = callData.native.function(asObject(callee)->globalObject(), calleeFrame);
-            DisallowGC disallowGC;
+            AssertNoGC assertNoGC;
             auto* callerSP = calleeFrame + CallerFrameAndPC::sizeInRegisters;
             LLINT_CALL_RETURN(globalObject, callerSP, LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr(), JSEntryPtrTag);
         }
@@ -2060,7 +2060,7 @@ static UGPRPair handleHostCall(CallFrame* calleeFrame, JSValue callee, CodeSpeci
         SlowPathFrameTracer tracer(vm, calleeFrame);
         calleeFrame->setCallee(asObject(callee));
         vm.encodedHostCallReturnValue = constructData.native.function(asObject(callee)->globalObject(), calleeFrame);
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         auto* callerSP = calleeFrame + CallerFrameAndPC::sizeInRegisters;
         LLINT_CALL_RETURN(globalObject, callerSP, LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr(), JSEntryPtrTag);
     }
@@ -2284,7 +2284,7 @@ static inline UGPRPair commonCallDirectEval(CallFrame* callFrame, const JSInstru
         RELEASE_AND_RETURN(throwScope, setUpCall(calleeFrame, CodeForCall, calleeAsValue));
 
     vm.encodedHostCallReturnValue = JSValue::encode(result);
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     auto* callerSP = calleeFrame + CallerFrameAndPC::sizeInRegisters;
     LLINT_CALL_RETURN(globalObject, callerSP, LLInt::getHostCallReturnValueEntrypoint().code().taggedPtr(), JSEntryPtrTag);
 }

--- a/Source/JavaScriptCore/runtime/ConcurrentJSLock.h
+++ b/Source/JavaScriptCore/runtime/ConcurrentJSLock.h
@@ -99,7 +99,7 @@ public:
     ConcurrentJSLocker(ConcurrentJSLock& lockable)
         : ConcurrentJSLockerBase(lockable)
 #if !defined(NDEBUG)
-        , m_disallowGC(std::in_place)
+        , m_assertNoGC(std::in_place)
 #endif
     {
     }
@@ -107,7 +107,7 @@ public:
     ConcurrentJSLocker(ConcurrentJSLock* lockable)
         : ConcurrentJSLockerBase(lockable)
 #if !defined(NDEBUG)
-        , m_disallowGC(std::in_place)
+        , m_assertNoGC(std::in_place)
 #endif
     {
     }
@@ -115,7 +115,7 @@ public:
     ConcurrentJSLocker(NoLockingNecessaryTag)
         : ConcurrentJSLockerBase(NoLockingNecessary)
 #if !defined(NDEBUG)
-        , m_disallowGC(std::nullopt)
+        , m_assertNoGC(std::nullopt)
 #endif
     {
     }
@@ -124,7 +124,7 @@ public:
 
 #if !defined(NDEBUG)
 private:
-    std::optional<DisallowGC> m_disallowGC;
+    std::optional<AssertNoGC> m_assertNoGC;
 #endif
 };
 

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -116,7 +116,7 @@ void initialize()
             IPInt::initialize();
 #endif
         LLInt::initialize();
-        DisallowGC::initialize();
+        AssertNoGC::initialize();
 
         initializeSuperSampler();
         Thread& thread = Thread::current();

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -1176,7 +1176,7 @@ bool JSArray::shiftCountWithArrayStorage(VM& vm, unsigned startIndex, unsigned c
     if (startIndex >= vectorLength)
         return true;
     
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     Locker locker { cellLock() };
     
     if (startIndex + count > vectorLength)

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.cpp
@@ -319,7 +319,7 @@ JSString* JSBoundFunction::nameSlow(VM& vm)
 
 String JSBoundFunction::nameStringWithoutGCSlow(VM& vm)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     unsigned nestingCount = 0;
     JSObject* cursor = m_targetFunction.get();
     String terminal;

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -190,7 +190,7 @@ inline Allocator allocatorForConcurrently(VM& vm, size_t allocationSize, Allocat
 template<typename T, AllocationFailureMode failureMode>
 ALWAYS_INLINE void* tryAllocateCellHelper(VM& vm, size_t size, GCDeferralContext* deferralContext)
 {
-    ASSERT(deferralContext || vm.heap.isDeferred() || !DisallowGC::isInEffectOnCurrentThread());
+    ASSERT(deferralContext || vm.heap.isDeferred() || !AssertNoGC::isInEffectOnCurrentThread());
     ASSERT(size >= sizeof(T));
     JSCell* result = static_cast<JSCell*>(subspaceFor<T>(vm)->allocate(vm, WTF::roundUpToMultipleOf<T::atomSize>(size), deferralContext, failureMode));
     if constexpr (failureMode == AllocationFailureMode::ReturnNull) {

--- a/Source/JavaScriptCore/runtime/JSFunction.cpp
+++ b/Source/JavaScriptCore/runtime/JSFunction.cpp
@@ -226,7 +226,7 @@ String JSFunction::name(VM& vm)
 
 String JSFunction::nameWithoutGC(VM& vm)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     if (isHostFunction()) {
         if (this->inherits<JSBoundFunction>())
             return jsCast<JSBoundFunction*>(this)->nameStringWithoutGC(vm);

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -3785,7 +3785,7 @@ bool JSObject::ensureLengthSlow(VM& vm, unsigned length)
     unsigned propertyCapacity = structure->outOfLineCapacity();
     
     GCDeferralContext deferralContext(vm);
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     unsigned availableOldLength =
         Butterfly::availableContiguousVectorLength(propertyCapacity, oldVectorLength);
     Butterfly* newButterfly = nullptr;

--- a/Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp
@@ -53,9 +53,9 @@ ObjectInitializationScope::~ObjectInitializationScope()
 
 void ObjectInitializationScope::notifyAllocated(JSObject* object)
 {
-    ASSERT(!m_disallowGC);
+    ASSERT(!m_assertNoGC);
     ASSERT(!m_disallowVMEntry);
-    m_disallowGC.emplace();
+    m_assertNoGC.emplace();
     m_disallowVMEntry.emplace(m_vm);
     m_object = object;
 }
@@ -63,7 +63,7 @@ void ObjectInitializationScope::notifyAllocated(JSObject* object)
 void ObjectInitializationScope::notifyInitialized(JSObject* object)
 {
     if (m_object) {
-        m_disallowGC.reset();
+        m_assertNoGC.reset();
         m_disallowVMEntry.reset();
         m_object = nullptr;
     }

--- a/Source/JavaScriptCore/runtime/ObjectInitializationScope.h
+++ b/Source/JavaScriptCore/runtime/ObjectInitializationScope.h
@@ -49,7 +49,7 @@ private:
     void verifyPropertiesAreInitialized(JSObject*);
 
     VM& m_vm;
-    std::optional<DisallowGC> m_disallowGC;
+    std::optional<AssertNoGC> m_assertNoGC;
     std::optional<DisallowVMEntry> m_disallowVMEntry;
     JSObject* m_object { nullptr };
 };

--- a/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h
@@ -32,7 +32,7 @@ namespace JSC {
 
 inline StringReplaceCache::Entry* StringReplaceCache::get(const String& subject, RegExp* regExp)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
         return nullptr;
     ASSERT(regExp->global());
@@ -55,7 +55,7 @@ inline StringReplaceCache::Entry* StringReplaceCache::get(const String& subject,
 
 inline void StringReplaceCache::set(const String& subject, RegExp* regExp, JSImmutableButterfly* result, MatchResult matchResult, const Vector<int>& lastMatch)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
         return;
 

--- a/Source/JavaScriptCore/runtime/StringSplitCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/StringSplitCacheInlines.h
@@ -32,7 +32,7 @@ namespace JSC {
 
 inline JSImmutableButterfly* StringSplitCache::get(const String& subject, const String& separator)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
         return nullptr;
     if (!separator.impl() || !separator.impl()->isAtom())
@@ -56,7 +56,7 @@ inline JSImmutableButterfly* StringSplitCache::get(const String& subject, const 
 
 inline void StringSplitCache::set(const String& subject, const String& separator, JSImmutableButterfly* butterfly)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     if (!subject.impl() || !subject.impl()->isAtom())
         return;
     if (!separator.impl() || !separator.impl()->isAtom())

--- a/Source/JavaScriptCore/runtime/WeakGCMap.h
+++ b/Source/JavaScriptCore/runtime/WeakGCMap.h
@@ -64,7 +64,7 @@ public:
     {
         // If functor invokes GC, GC can prune WeakGCMap, and manipulate UncheckedKeyHashMap while we are touching it in ensure function.
         // The functor must not invoke GC.
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         AddResult result = m_map.ensure(key, std::forward<Functor>(functor));
         ValueArg* value = result.iterator->value.get();
         if (!result.isNewEntry && !value) {

--- a/Source/JavaScriptCore/runtime/WeakGCSet.h
+++ b/Source/JavaScriptCore/runtime/WeakGCSet.h
@@ -79,7 +79,7 @@ public:
     AddResult add(ValueArg* key)
     {
         // Constructing a Weak shouldn't trigger a GC but add this ASSERT for good measure.
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         return m_set.add(key);
     }
 
@@ -88,7 +88,7 @@ public:
     {
         // If functor invokes GC, GC can prune WeakGCSet, and manipulate HashSet while we are touching it in the ensure function.
         // The functor must not invoke GC.
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         
         auto result = m_set.template ensure<HashTranslator>(std::forward<T>(key), functor);
         return result.iterator->get();

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.cpp
@@ -100,7 +100,7 @@ template <typename WeakMapBucket>
 template<typename Appender>
 void WeakMapImpl<WeakMapBucket>::takeSnapshotInternal(unsigned limit, Appender appender)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     unsigned fetched = 0;
     forEach([&](JSCell* key, JSValue value) {
         appender(key, value);

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -213,12 +213,12 @@ public:
     }
 
     // WeakMap operations must not cause GC. We model operations in DFG based on this guarantee.
-    // This guarantee is ensured by DisallowGC.
+    // This guarantee is ensured by AssertNoGC.
 
     template <typename T = WeakMapBucketType>
     ALWAYS_INLINE typename std::enable_if<std::is_same<T, WeakMapBucket<WeakMapBucketDataKeyValue>>::value, JSValue>::type get(JSCell* key)
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         if (WeakMapBucketType* bucket = findBucket(key))
             return bucket->value();
         return jsUndefined();
@@ -252,7 +252,7 @@ public:
 
     ALWAYS_INLINE bool has(JSCell* key)
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         return !!findBucket(key);
     }
 
@@ -262,7 +262,7 @@ public:
 
     ALWAYS_INLINE bool remove(JSCell* key)
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
         WeakMapBucketType* bucket = findBucket(key);
         if (!bucket)
             return false;

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -57,14 +57,14 @@ static ALWAYS_INLINE bool canBeHeldWeakly(JSValue value)
 template <typename WeakMapBucket>
 ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::add(VM& vm, JSCell* key, JSValue value)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     add(vm, key, value, jsWeakMapHash(key));
 }
 
 template <typename WeakMapBucket>
 ALWAYS_INLINE void WeakMapImpl<WeakMapBucket>::add(VM& vm, JSCell* key, JSValue value, uint32_t hash)
 {
-    DisallowGC disallowGC;
+    AssertNoGC assertNoGC;
     ASSERT_WITH_MESSAGE(jsWeakMapHash(key) == hash, "We expect hash value is what we expect.");
 
     addInternal(vm, key, value, hash);

--- a/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/WeakMapPrototype.cpp
@@ -150,7 +150,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsert, (JSGlobalObject* globalObj
     JSValue value;
 
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
 
         auto [index, exists] = map->findBucketIndex(keyCell, hash);
         if (exists)
@@ -189,7 +189,7 @@ JSC_DEFINE_HOST_FUNCTION(protoFuncWeakMapGetOrInsertComputed, (JSGlobalObject* g
     JSValue value;
 
     {
-        DisallowGC disallowGC;
+        AssertNoGC assertNoGC;
 
         auto [index, exists] = map->findBucketIndex(keyCell, hash);
         if (exists)


### PR DESCRIPTION
#### 362f9fb7940ba6207a56bc172c2c1cc054964da2
<pre>
[JSC] Rename DisallowGC to AssertNoGC
<a href="https://bugs.webkit.org/show_bug.cgi?id=288160">https://bugs.webkit.org/show_bug.cgi?id=288160</a>
<a href="https://rdar.apple.com/145254502">rdar://145254502</a>

Reviewed by Yijia Huang.

Saying &quot;Assert&quot; is more clear naming.

* Source/JavaScriptCore/bytecode/RepatchInlines.h:
(JSC::handleHostCall):
* Source/JavaScriptCore/bytecode/StructureStubInfo.h:
(JSC::StructureStubInfo::considerRepatchingCacheImpl):
* Source/JavaScriptCore/heap/DeferGC.cpp:
* Source/JavaScriptCore/heap/DeferGC.h:
(JSC::AssertNoGC::AssertNoGC):
(JSC::DisallowGC::initialize): Deleted.
(JSC::DisallowGC::scopeReentryCount): Deleted.
(JSC::DisallowGC::setScopeReentryCount): Deleted.
(JSC::DisallowGC::DisallowGC): Deleted.
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::collectIfNecessaryOrDefer):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getStackTrace):
(JSC::Interpreter::executeProgram):
(JSC::Interpreter::executeCallImpl):
(JSC::Interpreter::executeConstruct):
(JSC::Interpreter::executeEval):
(JSC::Interpreter::executeModuleProgram):
* Source/JavaScriptCore/jit/JITThunks.cpp:
(JSC::JITThunks::finalize):
(JSC::JITThunks::hostFunctionStub):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::handleHostCall):
(JSC::LLInt::commonCallDirectEval):
* Source/JavaScriptCore/runtime/ConcurrentJSLock.h:
(JSC::ConcurrentJSLocker::ConcurrentJSLocker):
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::shiftCountWithArrayStorage):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSBoundFunction::nameStringWithoutGCSlow):
* Source/JavaScriptCore/runtime/JSCellInlines.h:
(JSC::tryAllocateCellHelper):
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::nameWithoutGC):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::ensureLengthSlow):
* Source/JavaScriptCore/runtime/ObjectInitializationScope.cpp:
(JSC::ObjectInitializationScope::notifyAllocated):
(JSC::ObjectInitializationScope::notifyInitialized):
* Source/JavaScriptCore/runtime/ObjectInitializationScope.h:
* Source/JavaScriptCore/runtime/StringReplaceCacheInlines.h:
(JSC::StringReplaceCache::get):
(JSC::StringReplaceCache::set):
* Source/JavaScriptCore/runtime/StringSplitCacheInlines.h:
(JSC::StringSplitCache::get):
(JSC::StringSplitCache::set):
* Source/JavaScriptCore/runtime/WeakGCMap.h:
* Source/JavaScriptCore/runtime/WeakGCSet.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.cpp:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::takeSnapshotInternal):
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
(JSC::WeakMapImpl::get):
(JSC::WeakMapImpl::has):
(JSC::WeakMapImpl::remove):
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::WeakMapImpl&lt;WeakMapBucket&gt;::add):
* Source/JavaScriptCore/runtime/WeakMapPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/290764@main">https://commits.webkit.org/290764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92006a3b60f6467ee9233e0606fdcf12bf9d376c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/31 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18881 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94021 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/28 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40938 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83842 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/27 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98021 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89794 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18221 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/78988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78308 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/78188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22673 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/45 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14366 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18228 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112367 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17963 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19748 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->