### PR TITLE
CSSFontSelector: stop bumping generation when build starts

### DIFF
--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -132,7 +132,6 @@ void CSSFontSelector::buildStarted()
 {
     m_buildIsUnderway = true;
     m_cssFontFaceSet->purge();
-    ++m_version;
 
     ASSERT(m_cssConnectionsPossiblyToRemove.isEmpty());
     ASSERT(m_cssConnectionsEncounteredDuringBuild.isEmpty());


### PR DESCRIPTION
#### 0efd4a541a862ba20eb6abddb30f5cc06cea830d
<pre>
CSSFontSelector: stop bumping generation when build starts
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::buildStarted):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0efd4a541a862ba20eb6abddb30f5cc06cea830d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/36 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96051 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41818 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93077 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18886 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96051 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94026 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8378 "Found 2 new test failures: fast/css/font-face-default-font.html imported/blink/fast/text/update-sans-serif-and-recalc-style.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82506 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96051 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8114 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/32 "Found 4 new test failures: fast/css/font-face-default-font.html fast/text/capitalize-boundaries.html fast/text/midword-break-after-breakable-char.html imported/blink/fast/text/update-sans-serif-and-recalc-style.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78484 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/30 "Found 4 new test failures: fast/css/font-face-default-font.html fast/text/capitalize-boundaries.html fast/text/midword-break-after-breakable-char.html imported/blink/fast/text/update-sans-serif-and-recalc-style.html (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98026 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18226 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13387 "Found 12 new test failures: editing/deleting/5144139-2.html fast/borders/rtl-border-05.html fast/css/font-face-default-font.html fast/css/text-security.html fast/text/capitalize-boundaries.html fast/text/international/bidi-european-terminators.html fast/text/international/bidi-listbox.html fast/text/international/bidi-menulist.html fast/text/international/rtl-caret.html fast/text/midword-break-after-breakable-char.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/98026 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78312 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/98026 "") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22671 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/48 "Found 15 new test failures: fast/css/font-face-default-font.html fast/text/capitalize-boundaries.html fast/text/midword-break-after-breakable-char.html imported/blink/fast/text/update-sans-serif-and-recalc-style.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-additive-symbols-setter.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-fallback-setter.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-name-setter.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-negative-setter.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-pad-setter.html imported/w3c/web-platform-tests/css/css-counter-styles/cssom/cssom-prefix-suffix-setter.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11479 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18232 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23598 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19752 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->