### PR TITLE
REGRESSSION(288610@main) Auto-pip results in black pip window

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
@@ -83,6 +83,7 @@ private:
     void setAllowsPictureInPicturePlayback(bool) final;
     bool isExternalPlaybackActive() const final;
     bool willRenderToLayer() const final;
+    void transferVideoViewToFullscreen() final;
     void returnVideoView() final;
 
     RetainPtr<WebAVPlayerViewControllerDelegate> m_playerViewControllerDelegate;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -864,7 +864,7 @@ void VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController()
 
     if (!m_currentMode.hasPictureInPicture() && !m_changingStandbyOnly) {
         ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Moving videoView to fullscreen WebAVPlayerLayerView");
-        [playerLayerView() transferVideoViewTo:[m_playerViewController playerLayerView]];
+        transferVideoViewToFullscreen();
     }
 
 #if PLATFORM(WATCHOS)
@@ -929,6 +929,11 @@ bool VideoPresentationInterfaceAVKitLegacy::isExternalPlaybackActive() const
 bool VideoPresentationInterfaceAVKitLegacy::willRenderToLayer() const
 {
     return true;
+}
+
+void VideoPresentationInterfaceAVKitLegacy::transferVideoViewToFullscreen()
+{
+    [playerLayerView() transferVideoViewTo:[m_playerViewController playerLayerView]];
 }
 
 void VideoPresentationInterfaceAVKitLegacy::returnVideoView()

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -240,6 +240,7 @@ protected:
     virtual void setAllowsPictureInPicturePlayback(bool) = 0;
     virtual bool isExternalPlaybackActive() const = 0;
     virtual bool willRenderToLayer() const = 0;
+    virtual void transferVideoViewToFullscreen() { }
     WEBCORE_EXPORT virtual void returnVideoView();
 
 #if PLATFORM(WATCHOS)

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -678,8 +678,12 @@ void VideoPresentationInterfaceIOS::willStartPictureInPicture()
     m_enteringPictureInPicture = true;
 
     if (m_standby && !m_currentMode.hasVideo()) {
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
         [m_window setHidden:NO];
         playerViewController().view.hidden = NO;
+        transferVideoViewToFullscreen();
+        [CATransaction commit];
     }
 
     if (auto model = videoPresentationModel()) {


### PR DESCRIPTION
#### 5d50b8fe60635fc57f087ab1c1f42859e25cd06d
<pre>
REGRESSSION(288610@main) Auto-pip results in black pip window
<a href="https://rdar.apple.com/145099773">rdar://145099773</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288165">https://bugs.webkit.org/show_bug.cgi?id=288165</a>

Reviewed by Eric Carlson.

In the 288610@main, the state machine for some re-entrant code which previously
ensured that video content was moved into fullscreen (on the way to pip) during
an auto-pip transition was cleaned up, which had the unfortunate side effect of
breaking the auto-pip transition.

Restore the behavior of moving video content into fullscreen during an auto-pip
transition, but do so in a way that is much more straightforward, and doesn&apos;t
depend upon the doSetup() state machine.

* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(WebCore::VideoPresentationInterfaceAVKitLegacy::setupPlayerViewController):
(WebCore::VideoPresentationInterfaceAVKitLegacy::transferVideoViewToFullscreen):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::transferVideoViewToFullscreen):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::willStartPictureInPicture):

Canonical link: <a href="https://commits.webkit.org/290799@main">https://commits.webkit.org/290799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1acb350a601db17bd9f2b6325e16e3b587926c9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/65 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41821 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93083 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/10971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69975 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27499 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94032 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8379 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82524 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50301 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8152 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/81 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40945 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/99 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98031 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18232 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13392 "Found 1 new test failure: accessibility/mac/iframe-relative-frame.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78987 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18491 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78187 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19339 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/61 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11482 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23601 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/17971 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->