### PR TITLE
[IndexedDB] Generate index keys for newly created index on client side

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.cpp
@@ -488,4 +488,12 @@ void IDBDatabase::didDeleteIndexInfo(const IDBIndexInfo& info)
     objectStore->deleteIndex(info.name());
 }
 
+std::optional<ScriptExecutionContextIdentifier> IDBDatabase::scriptExecutionContextIdentifier() const
+{
+    if (RefPtr context = scriptExecutionContext())
+        return context->identifier();
+
+    return std::nullopt;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/IDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabase.h
@@ -87,6 +87,7 @@ public:
 
     IDBDatabaseInfo& info() { return m_info; }
     IDBDatabaseConnectionIdentifier databaseConnectionIdentifier() const { return m_databaseConnectionIdentifier; }
+    std::optional<ScriptExecutionContextIdentifier> scriptExecutionContextIdentifier() const;
 
     Ref<IDBTransaction> startVersionChangeTransaction(const IDBTransactionInfo&, IDBOpenDBRequest&);
     void didStartTransaction(IDBTransaction&);

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -96,6 +96,7 @@ public:
     const IDBTransactionInfo& info() const { return m_info; }
     IDBDatabase& database() { return m_database.get(); }
     const IDBDatabase& database() const { return m_database.get(); }
+    Ref<IDBDatabase> protectedDatabase() const;
     IDBDatabaseInfo* originalDatabaseInfo() const { return m_info.originalDatabaseInfo().get(); }
 
     void didStart(const IDBError&);
@@ -146,8 +147,8 @@ public:
     bool didDispatchAbortOrCommit() const { return m_didDispatchAbortOrCommit; }
 
     IDBClient::IDBConnectionProxy& connectionProxy();
-
     void connectionClosedFromServer(const IDBError&);
+    void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
 
     template<typename Visitor> void visitReferencedObjectStores(Visitor&) const;
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -90,6 +90,8 @@ public:
 
     void fireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion);
     void didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IndexedDB::ConnectionClosedOnBehalfOfServer = IndexedDB::ConnectionClosedOnBehalfOfServer::No);
+    void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
+    void didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID);
 
     void notifyOpenDBRequestBlocked(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion);
     void openDBRequestCancelled(const IDBOpenRequestData&);

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -429,6 +429,21 @@ void IDBConnectionToServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdent
         m_delegate->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
 }
 
+void IDBConnectionToServer::generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const std::optional<IDBKeyPath>& keyPath, const IDBKeyData& key, const IDBValue& value, std::optional<int64_t> recordID)
+{
+    ASSERT(isMainThread());
+
+    m_proxy->generateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID);
+}
+
+void IDBConnectionToServer::didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const IDBKeyData& key, const IndexKey& indexKey, std::optional<int64_t> recordID)
+{
+    ASSERT(isMainThread());
+
+    if (m_serverConnectionIsValid)
+        m_delegate->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
+}
+
 void IDBConnectionToServer::didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
 {
     LOG(IndexedDB, "IDBConnectionToServer::didStartTransaction");

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -29,6 +29,7 @@
 #include "IDBConnectionToServerDelegate.h"
 #include "IDBDatabaseConnectionIdentifier.h"
 #include "IDBIndexIdentifier.h"
+#include "IDBKeyPath.h"
 #include "IDBObjectStoreIdentifier.h"
 #include "IDBResourceIdentifier.h"
 #include "IndexKey.h"
@@ -127,6 +128,9 @@ public:
 
     WEBCORE_EXPORT void fireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion);
     void didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer);
+
+    WEBCORE_EXPORT void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
+    void didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID);
 
     WEBCORE_EXPORT void didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError&);
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h
@@ -100,6 +100,7 @@ public:
     virtual void databaseConnectionClosed(IDBDatabaseConnectionIdentifier) = 0;
     virtual void abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier) = 0;
     virtual void didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IndexedDB::ConnectionClosedOnBehalfOfServer) = 0;
+    virtual void didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID) = 0;
     virtual void openDBRequestCancelled(const IDBOpenRequestData&) = 0;
 
     virtual void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) = 0;

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp
@@ -27,6 +27,7 @@
 #include "TransactionOperation.h"
 
 #include "IDBCursor.h"
+#include "IDBDatabase.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -35,6 +36,14 @@ namespace IDBClient {
 
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(TransactionOperation);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(TransactionOperationImpl);
+
+TransactionOperation::TransactionOperation(IDBTransaction& transaction)
+    : m_transaction(transaction)
+    , m_identifier(transaction.connectionProxy())
+    , m_operationID(transaction.generateOperationID())
+    , m_scriptExecutionContextIdentifier(transaction.protectedDatabase()->scriptExecutionContextIdentifier())
+{
+}
 
 TransactionOperation::TransactionOperation(IDBTransaction& transaction, IDBRequest& request)
     : TransactionOperation(transaction)

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
@@ -111,20 +111,16 @@ public:
     Thread& originThread() const { return m_originThread.get(); }
 
     IDBRequest* idbRequest() { return m_idbRequest.get(); }
+    IDBTransaction& transaction() const { return m_transaction.get(); }
 
     bool nextRequestCanGoToServer() const { return m_nextRequestCanGoToServer && m_idbRequest; }
     void setNextRequestCanGoToServer(bool nextRequestCanGoToServer) { m_nextRequestCanGoToServer = nextRequestCanGoToServer; }
 
     uint64_t operationID() const { return m_operationID; }
+    std::optional<ScriptExecutionContextIdentifier> scriptExecutionContextIdentifier() const { return m_scriptExecutionContextIdentifier; }
 
 protected:
-    TransactionOperation(IDBTransaction& transaction)
-        : m_transaction(transaction)
-        , m_identifier(transaction.connectionProxy())
-        , m_operationID(transaction.generateOperationID())
-    {
-    }
-
+    TransactionOperation(IDBTransaction&);
     TransactionOperation(IDBTransaction&, IDBRequest&);
 
     Ref<IDBTransaction> m_transaction;
@@ -141,7 +137,6 @@ private:
     std::optional<IDBObjectStoreIdentifier> objectStoreIdentifier() const { return m_objectStoreIdentifier; }
     std::optional<IDBIndexIdentifier> indexIdentifier() const { return m_indexIdentifier; }
     std::optional<IDBResourceIdentifier> cursorIdentifier() const { return m_cursorIdentifier; }
-    IDBTransaction& transaction() { return m_transaction.get(); }
     IndexedDB::IndexRecordType indexRecordType() const { return m_indexRecordType; }
 
     Ref<Thread> m_originThread { Thread::current() };
@@ -150,6 +145,7 @@ private:
     bool m_didComplete { false };
 
     uint64_t m_operationID { 0 };
+    std::optional<ScriptExecutionContextIdentifier> m_scriptExecutionContextIdentifier;
 };
 
 class TransactionOperationImpl final : public TransactionOperation {

--- a/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h
@@ -29,6 +29,7 @@
 #include "IDBError.h"
 #include "IDBIndexIdentifier.h"
 #include "IDBObjectStoreIdentifier.h"
+#include "IDBValue.h"
 #include "IndexKey.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/MainThread.h>
@@ -44,7 +45,6 @@ class IDBKeyData;
 class IDBObjectStoreInfo;
 class IDBResourceIdentifier;
 class IDBTransactionInfo;
-class IDBValue;
 class ThreadSafeDataBuffer;
 
 enum class IDBGetRecordDataType : bool;
@@ -76,7 +76,6 @@ public:
     virtual IDBError deleteObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier) = 0;
     virtual IDBError renameObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const String& newName) = 0;
     virtual IDBError clearObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier) = 0;
-    virtual IDBError createIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&) = 0;
     virtual IDBError deleteIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier) = 0;
     virtual IDBError renameIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName) = 0;
     virtual IDBError keyExistsInObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyData&, bool& keyExists) = 0;
@@ -91,6 +90,17 @@ public:
     virtual IDBError maybeUpdateKeyGeneratorNumber(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, double newKeyNumber) = 0;
     virtual IDBError openCursor(const IDBResourceIdentifier& transactionIdentifier, const IDBCursorInfo&, IDBGetResult& outResult) = 0;
     virtual IDBError iterateCursor(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& cursorIdentifier, const IDBIterateCursorData&, IDBGetResult& outResult) = 0;
+
+    virtual IDBError addIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&) = 0;
+    virtual void revertAddIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier) = 0;
+    virtual IDBError updateIndexRecordsWithIndexKey(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID) = 0;
+    struct ObjectStoreRecord {
+        IDBKeyData key;
+        IDBValue value;
+        std::optional<int64_t> recordID;
+    };
+    using RecordOrError = Expected<ObjectStoreRecord, IDBError>;
+    virtual void forEachObjectStoreRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, Function<void(RecordOrError&&)>&&) = 0;
 
     virtual IDBObjectStoreInfo* infoForObjectStore(IDBObjectStoreIdentifier) = 0;
     virtual void deleteBackingStore() = 0;

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp
@@ -162,6 +162,12 @@ void IDBConnectionToClient::fireVersionChangeEvent(UniqueIDBDatabaseConnection& 
         m_delegate->fireVersionChangeEvent(connection, requestIdentifier, requestedVersion);
 }
 
+void IDBConnectionToClient::generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const std::optional<IDBKeyPath>& keyPath, const IDBKeyData& key, const IDBValue& value, std::optional<int64_t> recordID)
+{
+    if (m_delegate)
+        m_delegate->generateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID);
+}
+
 void IDBConnectionToClient::didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
 {
     if (m_delegate)

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
@@ -69,6 +69,7 @@ public:
     void didIterateCursor(const IDBResultData&);
 
     void fireVersionChangeEvent(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion);
+    void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
     void didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError&);
     void didCloseFromServer(UniqueIDBDatabaseConnection&, const IDBError&);
 

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClientDelegate.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClientDelegate.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "IDBKeyPath.h"
 #include "IDBResourceIdentifier.h"
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
@@ -33,6 +34,9 @@
 namespace WebCore {
 
 class IDBError;
+class IDBIndexInfo;
+class IDBKeyData;
+class IDBValue;
 class IDBResultData;
 
 struct IDBDatabaseNameAndVersion;
@@ -69,6 +73,7 @@ public:
     virtual void didIterateCursor(const IDBResultData&) = 0;
 
     virtual void fireVersionChangeEvent(UniqueIDBDatabaseConnection&, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion) = 0;
+    virtual void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID) = 0;
     virtual void didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError&) = 0;
     virtual void didCloseFromServer(UniqueIDBDatabaseConnection&, const IDBError&) = 0;
     virtual void notifyOpenDBRequestBlocked(const IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion) = 0;

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -494,6 +494,12 @@ void IDBServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier databa
         databaseConnection->didFireVersionChangeEvent(requestIdentifier, connectionClosed);
 }
 
+void IDBServer::didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const IDBKeyData& key, const IndexKey& indexKey, std::optional<int64_t> recordID)
+{
+    if (RefPtr transaction = m_transactions.get(transactionIdentifier))
+        transaction->didGenerateIndexKeyForRecord(requestIdentifier, indexInfo, key, indexKey, recordID);
+}
+
 void IDBServer::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     LOG(IndexedDB, "IDBServer::openDBRequestCancelled");

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.h
@@ -85,6 +85,7 @@ public:
     WEBCORE_EXPORT void databaseConnectionClosed(IDBDatabaseConnectionIdentifier);
     WEBCORE_EXPORT void abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>& transactionIdentifier);
     WEBCORE_EXPORT void didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, IndexedDB::ConnectionClosedOnBehalfOfServer);
+    WEBCORE_EXPORT void didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID);
     WEBCORE_EXPORT void openDBRequestCancelled(const IDBOpenRequestData&);
 
     WEBCORE_EXPORT void getAllDatabaseNamesAndVersions(IDBConnectionIdentifier, const IDBResourceIdentifier&, const ClientOrigin&);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
@@ -82,6 +82,16 @@ void MemoryBackingStoreTransaction::addNewIndex(MemoryIndex& index)
     addExistingIndex(index);
 }
 
+void MemoryBackingStoreTransaction::removeNewIndex(MemoryIndex& index)
+{
+    LOG(IndexedDB, "MemoryBackingStoreTransaction::removeNewIndex()");
+
+    ASSERT(isVersionChange());
+
+    m_versionChangeAddedIndexes.remove(&index);
+    m_indexes.remove(&index);
+}
+
 void MemoryBackingStoreTransaction::addExistingIndex(MemoryIndex& index)
 {
     LOG(IndexedDB, "MemoryBackingStoreTransaction::addExistingIndex");

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -70,6 +70,7 @@ public:
     void indexCleared(MemoryIndex&, std::unique_ptr<IndexValueStore>&&);
 
     void addNewIndex(MemoryIndex&);
+    void removeNewIndex(MemoryIndex&);
     void addExistingIndex(MemoryIndex&);
     void indexDeleted(Ref<MemoryIndex>&&);
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h
@@ -65,7 +65,6 @@ private:
     IDBError deleteObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier) final;
     IDBError renameObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const String& newName) final;
     IDBError clearObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier) final;
-    IDBError createIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&) final;
     IDBError deleteIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier) final;
     IDBError renameIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName) final;
     IDBError keyExistsInObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyData&, bool& keyExists) final;
@@ -89,6 +88,11 @@ private:
     String fullDatabasePath() const final { return nullString(); }
 
     bool hasTransaction(const IDBResourceIdentifier& identifier) const final { return m_transactions.contains(identifier); }
+
+    IDBError addIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&) final;
+    void revertAddIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier) final;
+    IDBError updateIndexRecordsWithIndexKey(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID) final;
+    void forEachObjectStoreRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, Function<void(RecordOrError&&)>&&) final;
 
     RefPtr<MemoryObjectStore> takeObjectStoreByIdentifier(IDBObjectStoreIdentifier);
 

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -66,8 +66,11 @@ public:
     void writeTransactionFinished(MemoryBackingStoreTransaction&);
     MemoryBackingStoreTransaction* writeTransaction();
 
-    IDBError createIndex(MemoryBackingStoreTransaction&, const IDBIndexInfo&);
+    IDBError addIndex(MemoryBackingStoreTransaction&, const IDBIndexInfo&);
+    void revertAddIndex(MemoryBackingStoreTransaction&, IDBIndexIdentifier);
+    IDBError updateIndexRecordsWithIndexKey(MemoryBackingStoreTransaction&, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&);
     IDBError deleteIndex(MemoryBackingStoreTransaction&, IDBIndexIdentifier);
+    void forEachRecord(Function<void(const IDBKeyData&, const IDBValue&)>&&);
     void deleteAllIndexes(MemoryBackingStoreTransaction&);
     void registerIndex(Ref<MemoryIndex>&&);
 

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -1237,94 +1237,6 @@ IDBError SQLiteIDBBackingStore::clearObjectStore(const IDBResourceIdentifier& tr
     return IDBError { };
 }
 
-IDBError SQLiteIDBBackingStore::createIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo& info)
-{
-    LOG(IndexedDB, "SQLiteIDBBackingStore::createIndex - ObjectStore %" PRIu64 ", Index %" PRIu64, info.objectStoreIdentifier().toRawValue(), info.identifier().toRawValue());
-    ASSERT(m_sqliteDB);
-    ASSERT(m_sqliteDB->isOpen());
-
-    auto* transaction = m_transactions.get(transactionIdentifier);
-    if (!transaction || !transaction->inProgress())
-        return IDBError { ExceptionCode::UnknownError, "Attempt to create an index without an in-progress transaction"_s };
-
-    if (transaction->mode() != IDBTransactionMode::Versionchange) {
-        LOG_ERROR("Attempt to create an index in a non-version-change transaction");
-        return IDBError { ExceptionCode::UnknownError, "Attempt to create an index in a non-version-change transaction"_s };
-    }
-
-    auto keyPathBlob = serializeIDBKeyPath(info.keyPath());
-    if (!keyPathBlob) {
-        LOG_ERROR("Unable to serialize IDBKeyPath to save in database");
-        return IDBError { ExceptionCode::UnknownError, "Unable to serialize IDBKeyPath to create index in database"_s };
-    }
-
-    {
-        auto sql = cachedStatement(SQL::CreateIndexInfo, "INSERT INTO IndexInfo VALUES (?, ?, ?, ?, ?, ?);"_s);
-        if (!sql
-            || sql->bindInt64(1, info.identifier().toRawValue()) != SQLITE_OK
-            || sql->bindText(2, info.name()) != SQLITE_OK
-            || sql->bindInt64(3, info.objectStoreIdentifier().toRawValue()) != SQLITE_OK
-            || sql->bindBlob(4, keyPathBlob->span()) != SQLITE_OK
-            || sql->bindInt(5, info.unique()) != SQLITE_OK
-            || sql->bindInt(6, info.multiEntry()) != SQLITE_OK
-            || sql->step() != SQLITE_DONE) {
-            LOG_ERROR("Could not add index '%s' to IndexInfo table (%i) - %s", info.name().utf8().data(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
-            return IDBError { ExceptionCode::UnknownError, "Unable to create index in database"_s };
-        }
-    }
-
-    // Write index records for any records that already exist in this object store.
-
-    auto cursor = transaction->maybeOpenBackingStoreCursor(info.objectStoreIdentifier(), std::nullopt, IDBKeyRangeData::allKeys());
-
-    if (!cursor) {
-        LOG_ERROR("Cannot open cursor to populate indexes in database");
-        return IDBError { ExceptionCode::UnknownError, "Unable to populate indexes in database"_s };
-    }
-
-    while (!cursor->currentKey().isNull()) {
-        auto& key = cursor->currentKey();
-        auto value = cursor->currentValue();
-        ThreadSafeDataBuffer valueBuffer = value.data();
-
-        ASSERT(cursor->currentRecordRowID());
-
-        auto* objectStoreInfo = infoForObjectStore(info.objectStoreIdentifier());
-        ASSERT(objectStoreInfo);
-        IDBError error = updateOneIndexForAddRecord(*objectStoreInfo, info, key, valueBuffer, cursor->currentRecordRowID());
-        if (!error.isNull()) {
-            auto sql = cachedStatement(SQL::DeleteIndexInfo, "DELETE FROM IndexInfo WHERE id = ? AND objectStoreID = ?;"_s);
-            if (!sql
-                || sql->bindInt64(1, info.identifier().toRawValue()) != SQLITE_OK
-                || sql->bindInt64(2, info.objectStoreIdentifier().toRawValue()) != SQLITE_OK
-                || sql->step() != SQLITE_DONE) {
-                LOG_ERROR("Index creation failed due to uniqueness constraint failure, but there was an error deleting the Index record from the database");
-                return IDBError { ExceptionCode::UnknownError, "Index creation failed due to uniqueness constraint failure, but there was an error deleting the Index record from the database"_s };
-            }
-
-            return error;
-        }
-
-        if (!cursor->advance(1)) {
-            LOG_ERROR("Error advancing cursor while indexing existing records for new index.");
-            return IDBError { ExceptionCode::UnknownError, "Error advancing cursor while indexing existing records for new index"_s };
-        }
-    }
-
-    ASSERT(m_databaseInfo);
-    if (!m_databaseInfo) {
-        RELEASE_LOG_ERROR(IndexedDB, "%p - SQLiteIDBBackingStore::clearObjectStore: m_databaseInfo is null", this);
-        return IDBError { ExceptionCode::UnknownError, "Database info is invalid"_s };
-    }
-
-    auto* objectStore = m_databaseInfo->infoForExistingObjectStore(info.objectStoreIdentifier());
-    ASSERT(objectStore);
-    objectStore->addExistingIndex(info);
-    m_databaseInfo->setMaxIndexID(info.identifier().toRawValue());
-
-    return IDBError { };
-}
-
 IDBError SQLiteIDBBackingStore::uncheckedHasIndexRecord(const IDBIndexInfo& info, const IDBKeyData& indexKey, bool& hasRecord)
 {
     hasRecord = false;
@@ -1377,7 +1289,7 @@ IDBError SQLiteIDBBackingStore::uncheckedPutIndexKey(const IDBIndexInfo& info, c
             if (!error.isNull())
                 return error;
             if (hasRecord)
-                return IDBError(ExceptionCode::ConstraintError);
+                return IDBError { ExceptionCode::ConstraintError, "Index key is not unique"_s };
         }
     }
 
@@ -1749,28 +1661,6 @@ IDBError SQLiteIDBBackingStore::deleteRange(const IDBResourceIdentifier& transac
     transaction->notifyCursorsOfChanges(objectStoreID);
 
     return error;
-}
-
-IDBError SQLiteIDBBackingStore::updateOneIndexForAddRecord(IDBObjectStoreInfo& objectStoreInfo, const IDBIndexInfo& info, const IDBKeyData& key, const ThreadSafeDataBuffer& value, int64_t recordID)
-{
-    std::optional<IndexKey> resultIndexKey;
-    callOnIDBSerializationThreadAndWait([objectStoreInfo = objectStoreInfo.isolatedCopy(), info = info.isolatedCopy(), key = key.isolatedCopy(), value, &resultIndexKey](auto& globalObject) {
-        auto jsValue = deserializeIDBValueToJSValue(globalObject, value);
-        if (jsValue.isUndefinedOrNull())
-            return;
-
-        IndexKey indexKey;
-        generateIndexKeyForValue(globalObject, info, jsValue, indexKey, objectStoreInfo.keyPath(), key);
-        resultIndexKey = WTFMove(indexKey).isolatedCopy();
-    });
-
-    if (!resultIndexKey)
-        return IDBError { };
-
-    if (resultIndexKey->isNull())
-        return IDBError { };
-
-    return uncheckedPutIndexKey(info, key, *resultIndexKey, recordID);
 }
 
 IDBError SQLiteIDBBackingStore::updateAllIndexesForAddRecord(const IDBObjectStoreInfo& info, const IDBKeyData& key, const IndexIDToIndexKeyMap& indexKeys, int64_t recordID)
@@ -2721,6 +2611,99 @@ void SQLiteIDBBackingStore::handleLowMemoryWarning()
 {
     if (m_sqliteDB)
         m_sqliteDB->releaseMemory();
+}
+
+IDBError SQLiteIDBBackingStore::addIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo& indexInfo)
+{
+    if (!m_sqliteDB || !m_sqliteDB->isOpen())
+        return IDBError { ExceptionCode::UnknownError, "Database connection is closed."_s };
+
+    auto* transaction = m_transactions.get(transactionIdentifier);
+    if (!transaction || !transaction->inProgress())
+        return IDBError { ExceptionCode::UnknownError, "Transaction is not in progress."_s };
+
+    if (transaction->mode() != IDBTransactionMode::Versionchange)
+        return IDBError { ExceptionCode::UnknownError, "Transaction is not in versionchange mode."_s };
+
+    if (!m_databaseInfo) {
+        RELEASE_LOG_ERROR(IndexedDB, "%p - SQLiteIDBBackingStore::addIndex: m_databaseInfo is null", this);
+        return IDBError { ExceptionCode::UnknownError, "Database info is invalid."_s };
+    }
+
+    auto keyPathBlob = serializeIDBKeyPath(indexInfo.keyPath());
+    if (!keyPathBlob)
+        return IDBError { ExceptionCode::UnknownError, "Failed to serialize IDBKeyPath to create index in database."_s };
+
+    {
+        auto sql = cachedStatement(SQL::CreateIndexInfo, "INSERT INTO IndexInfo VALUES (?, ?, ?, ?, ?, ?);"_s);
+        if (!sql
+            || sql->bindInt64(1, indexInfo.identifier().toRawValue()) != SQLITE_OK
+            || sql->bindText(2, indexInfo.name()) != SQLITE_OK
+            || sql->bindInt64(3, indexInfo.objectStoreIdentifier().toRawValue()) != SQLITE_OK
+            || sql->bindBlob(4, keyPathBlob->span()) != SQLITE_OK
+            || sql->bindInt(5, indexInfo.unique()) != SQLITE_OK
+            || sql->bindInt(6, indexInfo.multiEntry()) != SQLITE_OK
+            || sql->step() != SQLITE_DONE)
+            return IDBError { ExceptionCode::UnknownError, "Failed to create index in database."_s };
+    }
+
+    auto* objectStore = m_databaseInfo->infoForExistingObjectStore(indexInfo.objectStoreIdentifier());
+    ASSERT(objectStore);
+    objectStore->addExistingIndex(indexInfo);
+    m_databaseInfo->setMaxIndexID(indexInfo.identifier().toRawValue());
+
+    return IDBError { };
+}
+
+void SQLiteIDBBackingStore::revertAddIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier objectStoreIdentifier, IDBIndexIdentifier indexIdentifier)
+{
+    deleteIndex(transactionIdentifier, objectStoreIdentifier, indexIdentifier);
+}
+
+IDBError SQLiteIDBBackingStore::updateIndexRecordsWithIndexKey(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo& indexInfo, const IDBKeyData& key, const IndexKey& indexKey, std::optional<int64_t> recordID)
+{
+    if (!m_sqliteDB || !m_sqliteDB->isOpen())
+        return IDBError { ExceptionCode::UnknownError, "Database connection is closed."_s };
+
+    auto* transaction = m_transactions.get(transactionIdentifier);
+    if (!transaction || !transaction->inProgress())
+        return IDBError { ExceptionCode::UnknownError, "Transaction is not in progress."_s };
+
+    if (!recordID)
+        return IDBError { ExceptionCode::UnknownError, "Record ID is invalid."_s };
+
+    if (indexKey.isNull())
+        return IDBError { };
+
+    return uncheckedPutIndexKey(indexInfo, key, indexKey, *recordID);
+}
+
+void SQLiteIDBBackingStore::forEachObjectStoreRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier objectStoreIdentifier, Function<void(RecordOrError&&)>&& apply)
+{
+    auto* transaction = m_transactions.get(transactionIdentifier);
+    if (!transaction || !transaction->inProgress()) {
+        IDBError error { ExceptionCode::UnknownError, "Cannot iterate object store records without in-progress transaction"_s };
+        apply(makeUnexpected(WTFMove(error)));
+        return;
+    }
+
+    auto cursor = transaction->maybeOpenBackingStoreCursor(objectStoreIdentifier, std::nullopt, IDBKeyRangeData::allKeys());
+    if (!cursor) {
+        IDBError error { ExceptionCode::UnknownError, "Failed to create object store cursor"_s };
+        apply(makeUnexpected(WTFMove(error)));
+        return;
+    }
+
+    while (!cursor->currentKey().isNull()) {
+        ASSERT(cursor->currentRecordRowID());
+        apply(ObjectStoreRecord { cursor->currentKey(), cursor->currentValue(), cursor->currentRecordRowID() });
+        if (cursor->advance(1))
+            continue;
+
+        IDBError error { ExceptionCode::UnknownError, "Error advancing cursor when iterating object store records"_s };
+        apply(makeUnexpected(WTFMove(error)));
+        return;
+    }
 }
 
 #undef TABLE_SCHEMA_PREFIX

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -68,7 +68,6 @@ public:
     IDBError deleteObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier) final;
     IDBError renameObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const String& newName) final;
     IDBError clearObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier) final;
-    IDBError createIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&) final;
     IDBError deleteIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier) final;
     IDBError renameIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName) final;
     IDBError keyExistsInObjectStore(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, const IDBKeyData&, bool& keyExists) final;
@@ -92,6 +91,11 @@ public:
     String fullDatabasePath() const final;
 
     bool hasTransaction(const IDBResourceIdentifier&) const final;
+
+    IDBError addIndex(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&) final;
+    void revertAddIndex(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, IDBIndexIdentifier) final;
+    IDBError updateIndexRecordsWithIndexKey(const IDBResourceIdentifier& transactionIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID) final;
+    void forEachObjectStoreRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier, Function<void(RecordOrError&&)>&&) final;
 
     void unregisterCursor(SQLiteIDBCursor&);
 
@@ -121,7 +125,6 @@ private:
     IDBError uncheckedSetKeyGeneratorValue(IDBObjectStoreIdentifier, uint64_t value);
 
     IDBError updateAllIndexesForAddRecord(const IDBObjectStoreInfo&, const IDBKeyData&, const IndexIDToIndexKeyMap&, int64_t recordID);
-    IDBError updateOneIndexForAddRecord(IDBObjectStoreInfo&, const IDBIndexInfo&, const IDBKeyData&, const ThreadSafeDataBuffer& value, int64_t recordID);
     IDBError uncheckedPutIndexKey(const IDBIndexInfo&, const IDBKeyData& keyValue, const IndexKey&, int64_t recordID);
     IDBError uncheckedPutIndexRecord(IDBObjectStoreIdentifier, IDBIndexIdentifier, const IDBKeyData& keyValue, const IDBKeyData& indexKey, int64_t recordID);
     IDBError uncheckedHasIndexRecord(const IDBIndexInfo&, const IDBKeyData&, bool& hasRecord);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -101,7 +101,8 @@ public:
     void deleteObjectStore(UniqueIDBDatabaseTransaction&, const String& objectStoreName, ErrorCallback&&, SpaceCheckResult = SpaceCheckResult::Unknown);
     void renameObjectStore(UniqueIDBDatabaseTransaction&, IDBObjectStoreIdentifier, const String& newName, ErrorCallback&&, SpaceCheckResult = SpaceCheckResult::Unknown);
     void clearObjectStore(UniqueIDBDatabaseTransaction&, IDBObjectStoreIdentifier, ErrorCallback&&, SpaceCheckResult = SpaceCheckResult::Unknown);
-    void createIndex(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&, ErrorCallback&&, SpaceCheckResult = SpaceCheckResult::Unknown);
+    void createIndexAsync(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&);
+    void didGenerateIndexKeyForRecord(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID);
     void deleteIndex(UniqueIDBDatabaseTransaction&, IDBObjectStoreIdentifier, const String& indexName, ErrorCallback&&, SpaceCheckResult = SpaceCheckResult::Unknown);
     void renameIndex(UniqueIDBDatabaseTransaction&, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String& newName, ErrorCallback&&, SpaceCheckResult = SpaceCheckResult::Unknown);
     void putOrAdd(const IDBRequestData&, const IDBKeyData&, const IDBValue&, const IndexIDToIndexKeyMap&, IndexedDB::ObjectStoreOverwriteMode, KeyDataCallback&&);
@@ -161,8 +162,9 @@ private:
     void close();
 
     void clearStalePendingOpenDBRequests();
-
     void clearTransactionsOnConnection(UniqueIDBDatabaseConnection&);
+    void createIndexAsyncAfterQuotaCheck(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&, SpaceCheckResult);
+    void didCreateIndexAsyncForTransaction(UniqueIDBDatabaseTransaction&, const IDBIndexInfo&, const IDBError&);
 
     WeakPtr<UniqueIDBDatabaseManager> m_manager;
     IDBDatabaseIdentifier m_identifier;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -96,6 +96,11 @@ public:
     void setSuspensionAbortResult(const IDBError& error) { m_suspensionAbortResult = { error }; }
     const std::optional<IDBError>& suspensionAbortResult() const { return m_suspensionAbortResult; }
 
+    uint64_t pendingGenerateIndexKeyRequests() const { return m_pendingGenerateIndexKeyRequests; }
+    WEBCORE_EXPORT void didCreateIndexAsync(const IDBError&);
+    bool generateIndexKeyForRecord(const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
+    WEBCORE_EXPORT void didGenerateIndexKeyForRecord(IDBResourceIdentifier createIndexRequestIdentifier, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t> recordID);
+
 private:
     UniqueIDBDatabaseTransaction(UniqueIDBDatabaseConnection&, const IDBTransactionInfo&);
 
@@ -108,6 +113,9 @@ private:
 
     std::optional<IDBError> m_suspensionAbortResult;
     Vector<IDBError> m_requestResults;
+
+    uint64_t m_pendingGenerateIndexKeyRequests { 0 };
+    IDBResourceIdentifier m_createIndexRequestIdentifier;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp
@@ -77,13 +77,9 @@ IDBResourceIdentifier IDBResourceIdentifier::isolatedCopy() const
     return IDBResourceIdentifier(m_idbConnectionIdentifier, m_resourceNumber);
 }
 
-#if !LOG_DISABLED
-
 String IDBResourceIdentifier::loggingString() const
 {
     return makeString('<', m_idbConnectionIdentifier ? m_idbConnectionIdentifier->toUInt64() : 0, ", "_s, m_resourceNumber, '>');
 }
-
-#endif
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h
@@ -61,9 +61,7 @@ public:
 
     WEBCORE_EXPORT IDBResourceIdentifier isolatedCopy() const;
 
-#if !LOG_DISABLED
     String loggingString() const;
-#endif
 
     WEBCORE_EXPORT IDBResourceIdentifier();
 private:

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -234,6 +234,7 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
         void didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&, const IndexedDB::ConnectionClosedOnBehalfOfServer) final { }
         void openDBRequestCancelled(const IDBOpenRequestData&) final { }
         void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) final { }
+        void didGenerateIndexKeyForRecord(const IDBResourceIdentifier&, const IDBResourceIdentifier&, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t>) { }
         ~EmptyIDBConnectionToServerDeletegate() { }
     };
 

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
@@ -159,6 +159,11 @@ void IDBStorageConnectionToClient::fireVersionChangeEvent(WebCore::IDBServer::Un
     IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::FireVersionChangeEvent(connection.identifier(), requestIdentifier, requestedVersion), 0);
 }
 
+void IDBStorageConnectionToClient::generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const std::optional<WebCore::IDBKeyPath>& keyPath, const WebCore::IDBKeyData& key, const WebCore::IDBValue& value, std::optional<int64_t> recordID)
+{
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::GenerateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID), 0);
+}
+
 void IDBStorageConnectionToClient::didCloseFromServer(WebCore::IDBServer::UniqueIDBDatabaseConnection& connection, const WebCore::IDBError& error)
 {
     IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidCloseFromServer(connection.identifier(), error), 0);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -67,6 +67,7 @@ private:
     void didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, Vector<WebCore::IDBDatabaseNameAndVersion>&&) final;
     void notifyOpenDBRequestBlocked(const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion) final;
     void fireVersionChangeEvent(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion) final;
+    void generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const std::optional<WebCore::IDBKeyPath>&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, std::optional<int64_t> recordID);
     void didCloseFromServer(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBError&) final;
 
     IPC::Connection::UniqueID m_connection;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1765,6 +1765,12 @@ void NetworkStorageManager::didFireVersionChangeEvent(WebCore::IDBDatabaseConnec
         connection->didFireVersionChangeEvent(requestIdentifier, connectionClosed);
 }
 
+void NetworkStorageManager::didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const WebCore::IDBKeyData& key, const WebCore::IndexKey& indexKey, std::optional<int64_t> recordID)
+{
+    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier))
+        transaction->didGenerateIndexKeyForRecord(requestIdentifier, indexInfo, key, indexKey, recordID);
+}
+
 void NetworkStorageManager::abortTransaction(const WebCore::IDBResourceIdentifier& transactionIdentifier)
 {
     if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier))
@@ -1821,8 +1827,9 @@ void NetworkStorageManager::clearObjectStore(const WebCore::IDBRequestData& requ
         transaction->clearObjectStore(requestData, objectStoreIdentifier);
 }
 
-void NetworkStorageManager::createIndex(const WebCore::IDBRequestData& requestData, const WebCore::IDBIndexInfo& indexInfo)
+void NetworkStorageManager::createIndex(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBIndexInfo& indexInfo)
 {
+    MESSAGE_CHECK(!requestData.requestIdentifier().isEmpty(), connection);
     if (RefPtr transaction = idbTransaction(requestData))
         transaction->createIndex(requestData, indexInfo);
 }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -216,6 +216,7 @@ private:
     void databaseConnectionClosed(WebCore::IDBDatabaseConnectionIdentifier);
     void abortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier);
     void didFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer);
+    void didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const WebCore::IDBKeyData&, const WebCore::IndexKey&, std::optional<int64_t> recordID);
     void abortTransaction(const WebCore::IDBResourceIdentifier&);
     void commitTransaction(const WebCore::IDBResourceIdentifier&, uint64_t handledRequestResultsCount);
     void didFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&);
@@ -223,7 +224,7 @@ private:
     void deleteObjectStore(const WebCore::IDBRequestData&, const String& objectStoreName);
     void renameObjectStore(const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier, const String& newName);
     void clearObjectStore(const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier);
-    void createIndex(const WebCore::IDBRequestData&, const WebCore::IDBIndexInfo&);
+    void createIndex(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBIndexInfo&);
     void deleteIndex(const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier, const String& indexName);
     void renameIndex(const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier, WebCore::IDBIndexIdentifier, const String& newName);
     void putOrAdd(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, const WebCore::IndexIDToIndexKeyMap&, WebCore::IndexedDB::ObjectStoreOverwriteMode);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -67,6 +67,7 @@
     DatabaseConnectionClosed(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
     AbortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, std::optional<WebCore::IDBResourceIdentifier> transactionIdentifier)
     DidFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, WebCore::IDBResourceIdentifier requestIdentifier, WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosedOnBehalfOfServer)
+    DidGenerateIndexKeyForRecord(WebCore::IDBResourceIdentifier transactionIdentifier, WebCore::IDBResourceIdentifier requestIdentifier, WebCore::IDBIndexInfo indexInfo, WebCore::IDBKeyData key, WebCore::IndexKey indexKey, std::optional<int64_t> recordID)
     DidFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, WebCore::IDBResourceIdentifier transactionIdentifier)
     AbortTransaction(WebCore::IDBResourceIdentifier transactionIdentifier)
     CommitTransaction(WebCore::IDBResourceIdentifier transactionIdentifier, uint64_t handledRequestResultsCount)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -197,6 +197,11 @@ void WebIDBConnectionToServer::didFireVersionChangeEvent(IDBDatabaseConnectionId
     send(Messages::NetworkStorageManager::DidFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed));
 }
 
+void WebIDBConnectionToServer::didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const WebCore::IDBKeyData& key, const WebCore::IndexKey& indexKey, std::optional<int64_t> recordID)
+{
+    send(Messages::NetworkStorageManager::DidGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID));
+}
+
 void WebIDBConnectionToServer::openDBRequestCancelled(const IDBOpenRequestData& requestData)
 {
     send(Messages::NetworkStorageManager::OpenDBRequestCancelled(requestData));
@@ -300,6 +305,11 @@ void WebIDBConnectionToServer::didIterateCursor(const WebIDBResult& result)
 void WebIDBConnectionToServer::fireVersionChangeEvent(IDBDatabaseConnectionIdentifier uniqueDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion)
 {
     m_connectionToServer->fireVersionChangeEvent(uniqueDatabaseConnectionIdentifier, requestIdentifier, requestedVersion);
+}
+
+void WebIDBConnectionToServer::generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const std::optional<WebCore::IDBKeyPath>& keyPath, const WebCore::IDBKeyData& key, const WebCore::IDBValue& value, std::optional<int64_t> recordID)
+{
+    m_connectionToServer->generateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID);
 }
 
 void WebIDBConnectionToServer::didStartTransaction(const IDBResourceIdentifier& transactionIdentifier, const IDBError& error)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -79,6 +79,7 @@ private:
     void databaseConnectionClosed(WebCore::IDBDatabaseConnectionIdentifier) final;
     void abortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier) final;
     void didFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer) final;
+    void didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const WebCore::IDBKeyData&, const WebCore::IndexKey&, std::optional<int64_t> recordID) final;
     void openDBRequestCancelled(const WebCore::IDBOpenRequestData&) final;
 
     void getAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&) final;
@@ -103,6 +104,7 @@ private:
     void didOpenCursor(const WebIDBResult&);
     void didIterateCursor(const WebIDBResult&);
     void fireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier uniqueDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion);
+    void generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const std::optional<WebCore::IDBKeyPath>&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, std::optional<int64_t> recordID);
     void didStartTransaction(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBError&);
     void didCloseFromServer(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBError&);
     void notifyOpenDBRequestBlocked(const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion);

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in
@@ -45,6 +45,7 @@ messages -> WebIDBConnectionToServer {
     DidIterateCursor(WebKit::WebIDBResult result)
 
     FireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, WebCore::IDBResourceIdentifier requestIdentifier, uint64_t requestedVersion)
+    GenerateIndexKeyForRecord(WebCore::IDBResourceIdentifier requestIdentifier, WebCore::IDBIndexInfo indexInfo, std::optional<WebCore::IDBKeyPath> keyPath, WebCore::IDBKeyData key, WebCore::IDBValue value, std::optional<int64_t> recordID)
     DidStartTransaction(WebCore::IDBResourceIdentifier transactionIdentifier, WebCore::IDBError error)
     DidCloseFromServer(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, WebCore::IDBError error) final;
     NotifyOpenDBRequestBlocked(WebCore::IDBResourceIdentifier requestIdentifier, uint64_t oldVersion, uint64_t newVersion)

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.cpp
@@ -397,6 +397,13 @@ void InProcessIDBServer::fireVersionChangeEvent(IDBServer::UniqueIDBDatabaseConn
     });
 }
 
+void InProcessIDBServer::generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const std::optional<WebCore::IDBKeyPath>& keyPath, const WebCore::IDBKeyData& key, const WebCore::IDBValue& value, std::optional<int64_t> recordID)
+{
+    dispatchTaskReply([this, protectedThis = Ref { *this }, requestIdentifier = crossThreadCopy(requestIdentifier), indexInfo = crossThreadCopy(indexInfo), keyPath = crossThreadCopy(keyPath), key = crossThreadCopy(key), value = crossThreadCopy(value), recordID] {
+        m_connectionToServer->generateIndexKeyForRecord(requestIdentifier, indexInfo, keyPath, key, value, recordID);
+    });
+}
+
 void InProcessIDBServer::didStartTransaction(const WebCore::IDBResourceIdentifier& transactionIdentifier, const IDBError& error)
 {
     dispatchTaskReply([this, protectedThis = Ref { *this }, transactionIdentifier = transactionIdentifier.isolatedCopy(), error = error.isolatedCopy()] {
@@ -450,6 +457,14 @@ void InProcessIDBServer::didFireVersionChangeEvent(IDBDatabaseConnectionIdentifi
     dispatchTask([this, protectedThis = Ref { *this }, databaseConnectionIdentifier, requestIdentifier = crossThreadCopy(requestIdentifier), connectionClosed] {
         Locker locker { m_serverLock };
         m_server->didFireVersionChangeEvent(databaseConnectionIdentifier, requestIdentifier, connectionClosed);
+    });
+}
+
+void InProcessIDBServer::didGenerateIndexKeyForRecord(const IDBResourceIdentifier& transactionIdentifier, const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo& indexInfo, const IDBKeyData& key, const IndexKey& indexKey, std::optional<int64_t> recordID)
+{
+    dispatchTask([this, protectedThis = Ref { *this }, transactionIdentifier = crossThreadCopy(transactionIdentifier), requestIdentifier = crossThreadCopy(requestIdentifier), indexInfo = crossThreadCopy(indexInfo), key = crossThreadCopy(key), indexKey = crossThreadCopy(indexKey), recordID] {
+        Locker locker { m_serverLock };
+        m_server->didGenerateIndexKeyForRecord(transactionIdentifier, requestIdentifier, indexInfo, key, indexKey, recordID);
     });
 }
 

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -28,6 +28,7 @@
 #include <WebCore/IDBConnectionToClient.h>
 #include <WebCore/IDBConnectionToServer.h>
 #include <WebCore/IDBIndexIdentifier.h>
+#include <WebCore/IDBIndexInfo.h>
 #include <WebCore/IDBObjectStoreIdentifier.h>
 #include <WebCore/IDBServer.h>
 #include <wtf/RefCounted.h>
@@ -92,6 +93,7 @@ public:
     void databaseConnectionClosed(WebCore::IDBDatabaseConnectionIdentifier) final;
     void abortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier) final;
     void didFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer) final;
+    void didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const  WebCore::IDBIndexInfo&, const WebCore::IDBKeyData&, const WebCore::IndexKey&, std::optional<int64_t> recordID) final;
     void openDBRequestCancelled(const WebCore::IDBOpenRequestData&) final;
     void getAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&) final;
 
@@ -116,6 +118,7 @@ public:
     void didOpenCursor(const WebCore::IDBResultData&) final;
     void didIterateCursor(const WebCore::IDBResultData&) final;
     void fireVersionChangeEvent(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion) final;
+    void generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const std::optional<WebCore::IDBKeyPath>&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, std::optional<int64_t> recordID) final;
     void didStartTransaction(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBError&) final;
     void didCloseFromServer(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBError&) final;
     void notifyOpenDBRequestBlocked(const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion) final;


### PR DESCRIPTION
#### 2421aec95337294207e263a9e0cfa61003c28016
<pre>
[IndexedDB] Generate index keys for newly created index on client side
<a href="https://bugs.webkit.org/show_bug.cgi?id=288167">https://bugs.webkit.org/show_bug.cgi?id=288167</a>
<a href="https://rdar.apple.com/145258114">rdar://145258114</a>

Reviewed by Brady Eidson.

When handling a index creation request, server now iterates all existing records of object store and asks requested
client to generate index keys. Server will wait until all index keys to be generated before replying client with the
result of the index creation request.

No new test as there should be no user-visible behavior change.

* Source/WebCore/Modules/indexeddb/IDBDatabase.cpp:
(WebCore::IDBDatabase::scriptExecutionContextIdentifier const):
* Source/WebCore/Modules/indexeddb/IDBDatabase.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::createIndexOnServer):
(WebCore::IDBTransaction::protectedDatabase const):
(WebCore::IDBTransaction::generateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::generateIndexKeyForRecord):
(WebCore::IDBClient::IDBConnectionProxy::didGenerateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::generateIndexKeyForRecord):
(WebCore::IDBClient::IDBConnectionToServer::didGenerateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServerDelegate.h:
* Source/WebCore/Modules/indexeddb/client/TransactionOperation.cpp:
(WebCore::IDBClient::TransactionOperation::TransactionOperation):
* Source/WebCore/Modules/indexeddb/client/TransactionOperation.h:
(WebCore::IDBClient::TransactionOperation::transaction const):
(WebCore::IDBClient::TransactionOperation::scriptExecutionContextIdentifier const):
(WebCore::IDBClient::TransactionOperation::cursorIdentifier const):
(WebCore::IDBClient::TransactionOperation::TransactionOperation): Deleted.
(WebCore::IDBClient::TransactionOperation::transaction): Deleted.
* Source/WebCore/Modules/indexeddb/server/IDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.cpp:
(WebCore::IDBServer::IDBConnectionToClient::generateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h:
* Source/WebCore/Modules/indexeddb/server/IDBConnectionToClientDelegate.h:
* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
(WebCore::IDBServer::IDBServer::didGenerateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/server/IDBServer.h:
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::removeNewIndex):
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::addIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::revertAddIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::updateIndexRecordsWithIndexKey):
(WebCore::IDBServer::MemoryIDBBackingStore::forEachObjectStoreRecord):
(WebCore::IDBServer::MemoryIDBBackingStore::createIndex): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::addIndex):
(WebCore::IDBServer::MemoryObjectStore::revertAddIndex):
(WebCore::IDBServer::MemoryObjectStore::updateIndexRecordsWithIndexKey):
(WebCore::IDBServer::MemoryObjectStore::forEachRecord):
(WebCore::IDBServer::MemoryObjectStore::createIndex): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::uncheckedPutIndexKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::addIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::revertAddIndex):
(WebCore::IDBServer::SQLiteIDBBackingStore::updateIndexRecordsWithIndexKey):
(WebCore::IDBServer::SQLiteIDBBackingStore::forEachObjectStoreRecord):
(WebCore::IDBServer::SQLiteIDBBackingStore::createIndex): Deleted.
(WebCore::IDBServer::SQLiteIDBBackingStore::updateOneIndexForAddRecord): Deleted.
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.cpp:
(WebCore::IDBServer::UniqueIDBDatabase::createIndexAsync):
(WebCore::IDBServer::UniqueIDBDatabase::createIndexAsyncAfterQuotaCheck):
(WebCore::IDBServer::UniqueIDBDatabase::didGenerateIndexKeyForRecord):
(WebCore::IDBServer::UniqueIDBDatabase::didCreateIndexAsyncForTransaction):
(WebCore::IDBServer::UniqueIDBDatabase::createIndex): Deleted.
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::createIndex):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::didCreateIndexAsync):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::generateIndexKeyForRecord):
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::didGenerateIndexKeyForRecord):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
(WebCore::IDBServer::UniqueIDBDatabaseTransaction::pendingGenerateIndexKeyRequests const):
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.cpp:
* Source/WebCore/Modules/indexeddb/shared/IDBResourceIdentifier.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp:
(WebKit::IDBStorageConnectionToClient::generateIndexKeyForRecord):
* Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::didGenerateIndexKeyForRecord):
(WebKit::NetworkStorageManager::createIndex):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp:
(WebKit::WebIDBConnectionToServer::didGenerateIndexKeyForRecord):
(WebKit::WebIDBConnectionToServer::generateIndexKeyForRecord):
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.messages.in:
* Source/WebKitLegacy/Storage/InProcessIDBServer.cpp:
(InProcessIDBServer::generateIndexKeyForRecord):
(InProcessIDBServer::didGenerateIndexKeyForRecord):
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/291051@main">https://commits.webkit.org/291051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbfe684b0ca6700a7268c284e06d62d07915fcc3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70091 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27608 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50417 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/216 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41103 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98206 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18414 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13494 "Found 1 new test failure: accessibility/mac/iframe-relative-frame.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79101 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78304 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22812 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11588 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18414 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23718 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->