### PR TITLE
Fix size of aggregates indexed by CSSPropertyID

### DIFF
--- a/Source/WebCore/animation/WebAnimationTypes.h
+++ b/Source/WebCore/animation/WebAnimationTypes.h
@@ -110,7 +110,7 @@ constexpr OptionSet<AcceleratedEffectProperty> transformRelatedAcceleratedProper
 };
 
 struct CSSPropertiesBitSet {
-    WTF::BitSet<numCSSProperties> m_properties { };
+    WTF::BitSet<cssPropertyIDEnumValueCount> m_properties { };
 };
 
 using TimelineRangeValue = std::variant<TimelineRangeOffset, RefPtr<CSSNumericValue>, RefPtr<CSSKeywordValue>, String>;

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -117,8 +117,8 @@ public:
         return colorProperties.get(propertyId);
     }
 
-    static const WEBCORE_EXPORT WTF::BitSet<numCSSProperties> colorProperties;
-    static const WEBCORE_EXPORT WTF::BitSet<numCSSProperties> physicalProperties;
+    static const WEBCORE_EXPORT WTF::BitSet<cssPropertyIDEnumValueCount> colorProperties;
+    static const WEBCORE_EXPORT WTF::BitSet<cssPropertyIDEnumValueCount> physicalProperties;
 
     bool operator==(const CSSProperty& other) const
     {

--- a/Source/WebCore/rendering/style/WillChangeData.h
+++ b/Source/WebCore/rendering/style/WillChangeData.h
@@ -77,7 +77,7 @@ private:
 
     struct AnimatableFeature {
         static const int numCSSPropertyIDBits = 14;
-        static_assert(numCSSProperties < (1 << numCSSPropertyIDBits), "CSSPropertyID should fit in 14_bits");
+        static_assert(cssPropertyIDEnumValueCount <= (1 << numCSSPropertyIDBits), "CSSPropertyID should fit in 14 bits");
 
         Feature m_feature { Feature::Property };
         unsigned m_cssPropertyID : numCSSPropertyIDBits { CSSPropertyInvalid };

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -161,8 +161,8 @@ private:
     UncheckedKeyHashSet<AtomString> m_appliedCustomProperties;
     UncheckedKeyHashSet<AtomString> m_inProgressCustomProperties;
     UncheckedKeyHashSet<AtomString> m_inCycleCustomProperties;
-    WTF::BitSet<numCSSProperties> m_inProgressProperties;
-    WTF::BitSet<numCSSProperties> m_invalidAtComputedValueTimeProperties;
+    WTF::BitSet<cssPropertyIDEnumValueCount> m_inProgressProperties;
+    WTF::BitSet<cssPropertyIDEnumValueCount> m_invalidAtComputedValueTimeProperties;
 
     const PropertyCascade::Property* m_currentProperty { nullptr };
     SelectorChecker::LinkMatchMask m_linkMatch { };


### PR DESCRIPTION
#### 7ce1585cdfca3841ed6fe9935c731f014423e621
<pre>
Fix size of aggregates indexed by CSSPropertyID
<a href="https://bugs.webkit.org/show_bug.cgi?id=288168">https://bugs.webkit.org/show_bug.cgi?id=288168</a>
<a href="https://rdar.apple.com/145259581">rdar://145259581</a>

Reviewed by Yusuke Suzuki.

CSSProperty::numCSSProperties (generated by process-css-properties.py)
is not the *total* number of CSS properties defined in the CSSPropertyID
enum. It&apos;s rather the number of *real* CSS properties, which excludes
CSSPropertyInvalid and CSSPropertyCustom. Hence numCSSProperties is
always *smaller* than the largest value in CSSPropertyID enum.

Because of the confusing name though, some aggregates (arrays and
WTF::BitSet) in the codebase use this value as the size, and index into
the aggregate using CSSPropertyID values. Therefore, it&apos;s possible to
cause an OOB by indexing using a value in CSSPropertyID that&apos;s larger
than numCSSProperties. This is done in e.g CSSProperty::isColorProperty.

Fix this by introducing a new variable, cssPropertyIDEnumValueCount,
that accurately describes the number of values defined in
CSSPropertyID (which is also the largest value in the enum, plus 1)
Then change aggregates to use cssPropertyIDEnumValueCount as the size
instead.

* Source/WebCore/animation/WebAnimationTypes.h:
* Source/WebCore/css/CSSProperty.h:
* Source/WebCore/css/process-css-properties.py:
(GenerationContext.generate_property_id_bit_set):
(GenerateCSSPropertyNames._generate_css_property_names_gperf_prelude):
(GenerateCSSPropertyNames):
* Source/WebCore/rendering/style/WillChangeData.h:
* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/290897@main">https://commits.webkit.org/290897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b57dd182a77ae8ab1eaaedc8be53a3907450c389

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96368 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70180 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27699 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94401 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8617 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50506 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8383 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/371 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98371 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18562 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13607 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79200 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78404 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19394 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22924 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11698 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23839 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18273 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21731 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20039 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->