### PR TITLE
[ResourceMonitor] Add more meaningful release log information part 1.

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
 Test unloaded HTML supports dark mode correctly.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
 Test resource monitor.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
 Test iframe with huge resource usage is unloaded.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt
@@ -5,8 +5,8 @@ CONSOLE MESSAGE: Launched shared worker
 CONSOLE MESSAGE: iframe is ready
 CONSOLE MESSAGE: Get message from parent window
 CONSOLE MESSAGE: Send fetch request to worker
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/shared-worker.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/shared-worker.html
 Test iframes using same shared worker are unloaded.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/throttler-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/throttler-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit.
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
 CONSOLE MESSAGE: Frame's network usage exceeded the limit.
 Test throttler prevents unloaded.
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -413,7 +413,7 @@
 #include "HTMLVideoElement.h"
 #endif
 
-#define DOCUMENT_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, pageID() ? pageID()->toUInt64() : 0, frameID() ? frameID()->object().toUInt64() : 0, this == &topDocument(), ##__VA_ARGS__)
+#define DOCUMENT_RELEASE_LOG(channel, fmt, ...) RELEASE_LOG(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, pageID() ? pageID()->toUInt64() : 0, frameID() ? frameID()->object().toUInt64() : 0, this->isTopDocument(), ##__VA_ARGS__)
 #define DOCUMENT_RELEASE_LOG_ERROR(channel, fmt, ...) RELEASE_LOG_ERROR(channel, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] Document::" fmt, this, pageID() ? pageID()->toUInt64() : 0, frameID() ? frameID()->object().toUInt64() : 0, this->isTopDocument(), ##__VA_ARGS__)
 
 namespace WebCore {
@@ -11331,8 +11331,10 @@ ResourceMonitor& Document::resourceMonitor()
 {
     ASSERT(!frame()->isMainFrame());
 
-    if (!m_resourceMonitor)
+    if (!m_resourceMonitor) {
         m_resourceMonitor = ResourceMonitor::create(*frame());
+        DOCUMENT_RELEASE_LOG(ResourceMonitoring, "ResourceMonitor is created for the document.");
+    }
     return *m_resourceMonitor.get();
 }
 

--- a/Source/WebCore/loader/ResourceLoadInfo.cpp
+++ b/Source/WebCore/loader/ResourceLoadInfo.cpp
@@ -159,6 +159,40 @@ ResourceFlags ResourceLoadInfo::getResourceFlags() const
     return flags;
 }
 
+ASCIILiteral resourceTypeToString(OptionSet<ResourceType> resourceTypes)
+{
+    switch (*resourceTypes.begin()) {
+    case ResourceType::Document:
+        return "document"_s;
+    case ResourceType::Image:
+        return "image"_s;
+    case ResourceType::StyleSheet:
+        return "style-sheet"_s;
+    case ResourceType::Script:
+        return "script"_s;
+    case ResourceType::Font:
+        return "font"_s;
+    case ResourceType::WebSocket:
+        return "websocket"_s;
+    case ResourceType::Fetch:
+        return "fetch"_s;
+    case ResourceType::SVGDocument:
+        return "svg-document"_s;
+    case ResourceType::Media:
+        return "media"_s;
+    case ResourceType::Popup:
+        return "popup"_s;
+    case ResourceType::Ping:
+        return "ping"_s;
+    case ResourceType::CSPReport:
+        return "csp-report"_s;
+    case ResourceType::Other:
+        return "other"_s;
+    default:
+        return "raw"_s;
+    }
+}
+
 } // namespace WebCore::ContentExtensions
 
 #endif // ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/loader/ResourceLoadInfo.h
+++ b/Source/WebCore/loader/ResourceLoadInfo.h
@@ -85,6 +85,8 @@ std::optional<OptionSet<ResourceType>> readResourceType(StringView);
 std::optional<OptionSet<LoadType>> readLoadType(StringView);
 std::optional<OptionSet<LoadContext>> readLoadContext(StringView);
 
+ASCIILiteral resourceTypeToString(OptionSet<ResourceType>);
+
 struct ResourceLoadInfo {
     URL resourceURL;
     URL mainDocumentURL;

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -46,12 +46,13 @@ public:
     bool isEligible() const { return eligibility() == Eligibility::Eligible; }
 
     void setDocumentURL(URL&&);
-    void didReceiveResponse(const URL&, OptionSet<ContentExtensions::ResourceType>);
     WEBCORE_EXPORT void addNetworkUsage(size_t);
 
 private:
     explicit ResourceMonitor(LocalFrame&);
 
+    void didReceiveResponse(const URL&, OptionSet<ContentExtensions::ResourceType>);
+    void continueAfterDidReceiveEligibility(Eligibility, const URL&, OptionSet<ContentExtensions::ResourceType>);
     void checkNetworkUsageExcessIfNecessary();
     ResourceMonitor* parentResourceMonitorIfExists() const;
 

--- a/Source/WebCore/loader/ResourceMonitorChecker.cpp
+++ b/Source/WebCore/loader/ResourceMonitorChecker.cpp
@@ -33,7 +33,7 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-#define RESOURCEMONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ResourceLoading, "%p - ResourceMonitorChecker::" fmt, this, ##__VA_ARGS__)
+#define RESOURCEMONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ResourceMonitoring, "ResourceMonitorChecker::" fmt, ##__VA_ARGS__)
 
 namespace WebCore {
 
@@ -95,7 +95,7 @@ ResourceMonitorChecker::Eligibility ResourceMonitorChecker::checkEligibility(con
     ASSERT(m_ruleList);
 
     auto matched = m_ruleList->processContentRuleListsForResourceMonitoring(info.resourceURL, info.mainDocumentURL, info.frameURL, info.type);
-    RESOURCEMONITOR_RELEASE_LOG("The url is %" PUBLIC_LOG_STRING ": %" SENSITIVE_LOG_STRING, (matched ? "eligible" : "not eligible"), info.resourceURL.string().utf8().data());
+    RESOURCEMONITOR_RELEASE_LOG("The url is %" PUBLIC_LOG_STRING ": %" SENSITIVE_LOG_STRING " (%" PUBLIC_LOG_STRING ")", (matched ? "eligible" : "not eligible"), info.resourceURL.string().utf8().data(), ContentExtensions::resourceTypeToString(info.type).characters());
 
     return matched ? Eligibility::Eligible : Eligibility::NotEligible;
 }

--- a/Source/WebCore/loader/ResourceMonitorPersistence.cpp
+++ b/Source/WebCore/loader/ResourceMonitorPersistence.cpp
@@ -35,7 +35,7 @@
 
 #if ENABLE(CONTENT_EXTENSIONS)
 
-#define RESOURCEMONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ResourceLoading, "%p - ResourceMonitorPersistence::" fmt, this, ##__VA_ARGS__)
+#define RESOURCEMONITOR_RELEASE_LOG(fmt, ...) RELEASE_LOG(ResourceMonitoring, "ResourceMonitorPersistence::" fmt, ##__VA_ARGS__)
 
 namespace WebCore {
 
@@ -78,7 +78,7 @@ static ContinuousApproximateTime doubleToContinuousApproximateTime(double timest
 
 void ResourceMonitorPersistence::reportSQLError(ASCIILiteral method, ASCIILiteral action)
 {
-    RESOURCEMONITOR_RELEASE_LOG("%" PUBLIC_LOG_STRING ": Failed to %" PUBLIC_LOG_STRING " (%d) - %" PUBLIC_LOG_STRING, method.characters(), action.characters(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
+    RELEASE_LOG_ERROR(ResourceMonitoring, "ResourceMonitorPersistence::%" PUBLIC_LOG_STRING ": Failed to %" PUBLIC_LOG_STRING " (%d) - %" PUBLIC_LOG_STRING, method.characters(), action.characters(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
 }
 
 bool ResourceMonitorPersistence::openDatabase(String&& path)
@@ -90,7 +90,7 @@ bool ResourceMonitorPersistence::openDatabase(String&& path)
     m_sqliteDB = makeUnique<SQLiteDatabase>();
 
     auto reportErrorAndCloseDatabase = [&](ASCIILiteral action) {
-        RESOURCEMONITOR_RELEASE_LOG("openDatabase: Failed to %" PUBLIC_LOG_STRING " at path '%" PUBLIC_LOG_STRING "' (%d) - %" PUBLIC_LOG_STRING, action.characters(), path.utf8().data(), m_sqliteDB->lastError(), m_sqliteDB->lastErrorMsg());
+        reportSQLError("openDatabase"_s, action);
         closeDatabase();
         return false;
     };

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1463,9 +1463,9 @@ void LocalFrame::showResourceMonitoringError()
     if (RefPtr page = protectedPage())
         mainFrameURL = page->mainFrameURL();
 
-    FRAME_RELEASE_LOG(ResourceLoading, "Detected excessive network usage in frame at %" SENSITIVE_LOG_STRING " and main frame at %" SENSITIVE_LOG_STRING ": unloading", url.isValid() ? url.string().utf8().data() : "invalid", mainFrameURL.isValid() ? mainFrameURL.string().utf8().data() : "invalid");
+    FRAME_RELEASE_LOG(ResourceMonitoring, "Detected excessive network usage in frame at %" SENSITIVE_LOG_STRING " and main frame at %" SENSITIVE_LOG_STRING ": unloading", url.isValid() ? url.string().utf8().data() : "invalid", mainFrameURL.isValid() ? mainFrameURL.string().utf8().data() : "invalid");
 
-    document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Error, "Frame was unloaded because its network usage exceeded the limit."_s);
+    document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Error, makeString("Frame was unloaded because its network usage exceeded the limit: "_s, ResourceMonitorChecker::networkUsageThreshold, " bytes, url="_s, url.string()));
 
     for (RefPtr<Frame> frame = this; frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame)) {
@@ -1493,7 +1493,7 @@ void LocalFrame::reportResourceMonitoringWarning()
     if (RefPtr page = protectedPage())
         mainFrameURL = page->mainFrameURL();
 
-    FRAME_RELEASE_LOG(ResourceLoading, "Detected excessive network usage in frame at %" SENSITIVE_LOG_STRING " and main frame at %" SENSITIVE_LOG_STRING ": not unloading due to global limits", url.isValid() ? url.string().utf8().data() : "invalid", mainFrameURL.isValid() ? mainFrameURL.string().utf8().data() : "invalid");
+    FRAME_RELEASE_LOG(ResourceMonitoring, "Detected excessive network usage in frame at %" SENSITIVE_LOG_STRING " and main frame at %" SENSITIVE_LOG_STRING ": not unloading due to global limits", url.isValid() ? url.string().utf8().data() : "invalid", mainFrameURL.isValid() ? mainFrameURL.string().utf8().data() : "invalid");
 
     if (RefPtr document = this->document())
         document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Warning, "Frame's network usage exceeded the limit."_s);

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -157,6 +157,7 @@ namespace WebCore {
     M(ResourceLoading) \
     M(ResourceLoadObserver) \
     M(ResourceLoadStatistics) \
+    M(ResourceMonitoring) \
     M(ScrollAnimations) \
     M(ScrollAnchoring) \
     M(ScrollSnap) \

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -200,8 +200,10 @@ void SharedWorker::reportNetworkUsage(size_t bytesTransferredOverNetwork)
     ASSERT(!delta.hasOverflowed());
 
     if (delta) {
-        if (RefPtr resourceMonitor = m_resourceMonitor)
+        if (RefPtr resourceMonitor = m_resourceMonitor) {
+            RELEASE_LOG(ResourceMonitoring, "[identifier=%" PUBLIC_LOG_STRING "] SharedWorker::reportNetworkUsage to ResourceMonitor: %zu bytes", identifier().toString().utf8().data(), delta.value());
             resourceMonitor->addNetworkUsage(delta);
+        }
     }
 #endif
 


### PR DESCRIPTION
#### b47957d7891a2b461cf18eb5e627f8e368626905
<pre>
[ResourceMonitor] Add more meaningful release log information part 1.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288171">https://bugs.webkit.org/show_bug.cgi?id=288171</a>
<a href="https://rdar.apple.com/145259890">rdar://145259890</a>

Reviewed by Per Arne Vollan and Chris Dumez.

Adding new log category and move current release logs to that category. And also add more meaningful information
for the record.

This is part 1, targeting WebCore.

In this change, chances are:
- URL checks are most of two times per each iframe.
- One check generates several logs.
- When it hits the network limits, some extra logs is produced.
- If unloading happens, ~10 more logs.

One exception is for shared worker, which logs all network usage and this will be rare case. In case it causes an issue,
this will be removed. For now, it is required to observe the usage during development.

* LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt:
* LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt:
* LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt:
* LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt:
* LayoutTests/http/tests/iframe-monitor/throttler-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resourceMonitor):
* Source/WebCore/loader/ResourceLoadInfo.cpp:
(WebCore::ContentExtensions::resourceTypeToString):
* Source/WebCore/loader/ResourceLoadInfo.h:
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::setEligibility):
(WebCore::ResourceMonitor::didReceiveResponse):
(WebCore::eligibilityToString):
(WebCore::ResourceMonitor::continueAfterDidReceiveEligibility):
* Source/WebCore/loader/ResourceMonitor.h:
* Source/WebCore/loader/ResourceMonitorChecker.cpp:
(WebCore::ResourceMonitorChecker::checkEligibility):
* Source/WebCore/loader/ResourceMonitorPersistence.cpp:
(WebCore::ResourceMonitorPersistence::reportSQLError):
(WebCore::ResourceMonitorPersistence::openDatabase):
* Source/WebCore/loader/ResourceMonitorThrottler.cpp:
(WebCore::ResourceMonitorThrottler::~ResourceMonitorThrottler):
(WebCore::ResourceMonitorThrottler::tryAccess):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::showResourceMonitoringError):
(WebCore::LocalFrame::reportResourceMonitoringWarning):
* Source/WebCore/platform/Logging.h:
* Source/WebCore/workers/shared/SharedWorker.cpp:
(WebCore::SharedWorker::reportNetworkUsage):

Canonical link: <a href="https://commits.webkit.org/290850@main">https://commits.webkit.org/290850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f177bb3b04dedce9ae9c8ed0fd37bf50dd8b0b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/317 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96268 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19139 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96268 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27630 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94288 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82689 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96268 "") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/270 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41150 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/280 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98260 "") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18460 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/98260 "") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78524 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/98260 "") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19371 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22844 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18459 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21639 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->