### PR TITLE
[visionOS] Some HLS immersive videos fail to play.

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h
@@ -61,7 +61,7 @@ class MediaSelectionOptionAVFObjC;
 struct PlatformVideoTrackConfiguration;
 struct PlatformAudioTrackConfiguration;
 
-class AVTrackPrivateAVFObjCImpl : public CanMakeWeakPtr<AVTrackPrivateAVFObjCImpl> {
+class AVTrackPrivateAVFObjCImpl final : public CanMakeWeakPtr<AVTrackPrivateAVFObjCImpl> {
     WTF_MAKE_TZONE_ALLOCATED(AVTrackPrivateAVFObjCImpl);
 public:
     explicit AVTrackPrivateAVFObjCImpl(AVPlayerItemTrack*);
@@ -113,10 +113,9 @@ private:
     uint32_t sampleRate() const;
     uint32_t numberOfChannels() const;
 
-    RetainPtr<AVPlayerItemTrack> m_playerItemTrack;
-    RetainPtr<AVPlayerItem> m_playerItem;
-    RefPtr<MediaSelectionOptionAVFObjC> m_mediaSelectionOption;
-    RetainPtr<AVAssetTrack> m_assetTrack;
+    const RetainPtr<AVPlayerItemTrack> m_playerItemTrack;
+    const RefPtr<MediaSelectionOptionAVFObjC> m_mediaSelectionOption;
+    const RetainPtr<AVAssetTrack> m_assetTrack;
     WeakPtr<VideoTrackConfigurationObserver> m_videoTrackConfigurationObserver;
     WeakPtr<AudioTrackConfigurationObserver> m_audioTrackConfigurationObserver;
 };

--- a/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
@@ -68,7 +68,7 @@ static AVAssetTrack* assetTrackFor(const AVTrackPrivateAVFObjCImpl& impl)
         return impl.playerItemTrack().assetTrack;
     if (impl.assetTrack())
         return impl.assetTrack();
-    if (RefPtr mediaSelectionOption = impl.mediaSelectionOption(); mediaSelectionOption && mediaSelectionOption->assetTrack())
+    if (RefPtr mediaSelectionOption = impl.mediaSelectionOption())
         return mediaSelectionOption->assetTrack();
     return nil;
 }
@@ -93,9 +93,7 @@ AVTrackPrivateAVFObjCImpl::AVTrackPrivateAVFObjCImpl(MediaSelectionOptionAVFObjC
     initializeAssetTrack();
 }
 
-AVTrackPrivateAVFObjCImpl::~AVTrackPrivateAVFObjCImpl()
-{
-}
+AVTrackPrivateAVFObjCImpl::~AVTrackPrivateAVFObjCImpl() = default;
 
 void AVTrackPrivateAVFObjCImpl::initializeAssetTrack()
 {
@@ -259,7 +257,7 @@ int AVTrackPrivateAVFObjCImpl::index() const
     if (m_assetTrack)
         return [[[m_assetTrack asset] tracks] indexOfObject:m_assetTrack.get()];
     if (RefPtr mediaSelectionOption = m_mediaSelectionOption)
-        return [[[m_playerItem asset] tracks] count] + mediaSelectionOption->index();
+        return mediaSelectionOption->index();
     ASSERT_NOT_REACHED();
     return 0;
 }

--- a/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp
@@ -249,7 +249,7 @@ std::optional<VideoMetadata> videoMetadataFromFormatDescription(CMFormatDescript
             return false;
         auto projectionKind = dynamic_cf_cast<CFStringRef>(PAL::CMFormatDescriptionGetExtension(formatDescription, PAL::kCMFormatDescriptionExtension_ProjectionKind));
 
-        return projectionKind && (CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_Equirectangular, 0) == kCFCompareEqualTo || CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_HalfEquirectangular, 0) == kCFCompareEqualTo || (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_ParametricImmersive() && CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_ParametricImmersive, 0) == kCFCompareEqualTo));
+        return projectionKind && (CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_Equirectangular, 0) == kCFCompareEqualTo || CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_HalfEquirectangular, 0) == kCFCompareEqualTo || (PAL::canLoad_CoreMedia_kCMFormatDescriptionProjectionKind_ParametricImmersive() && CFStringCompare(projectionKind, PAL::kCMFormatDescriptionProjectionKind_ParametricImmersive, 0) == kCFCompareEqualTo) || CFStringCompare(projectionKind, CFSTR("Fisheye"), 0) == kCFCompareEqualTo);
     };
     if (auto isImmersive = checkForImmersiveData())
         return isImmersive;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h
@@ -56,6 +56,7 @@ public:
 
     AVMediaSelectionOption *avMediaSelectionOption() const { return m_mediaSelectionOption.get(); }
     AVAssetTrack *assetTrack() const;
+    AVPlayerItem *playerItem() const;
 
 private:
     friend class MediaSelectionGroupAVFObjC;
@@ -81,6 +82,7 @@ public:
     typename OptionContainer::ValuesIteratorRange options() { return m_options.values(); }
 
     AVMediaSelectionGroup *avMediaSelectionGroup() const { return m_mediaSelectionGroup.get(); }
+    AVPlayerItem *playerItem() const { return m_playerItem.get(); }
 
 private:
     MediaSelectionGroupAVFObjC(AVPlayerItem*, AVMediaSelectionGroup*, const Vector<String>& characteristics);

--- a/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm
@@ -84,9 +84,27 @@ int MediaSelectionOptionAVFObjC::index() const
 
 AVAssetTrack* MediaSelectionOptionAVFObjC::assetTrack() const
 {
-    if ([m_mediaSelectionOption respondsToSelector:@selector(track)])
+    if ([m_mediaSelectionOption respondsToSelector:@selector(track)] && [m_mediaSelectionOption track])
         return [m_mediaSelectionOption track];
+    if (selected()) {
+        for (AVPlayerItemTrack* track in [playerItem() tracks]) {
+            if (!track.enabled)
+                continue;
+            if (!track.assetTrack)
+                continue;
+            if ([track.assetTrack mediaType] == [m_mediaSelectionOption mediaType] && [track.assetTrack isPlayable] == [m_mediaSelectionOption isPlayable])
+                return track.assetTrack;
+        }
+    }
+
     return nil;
+}
+
+AVPlayerItem *MediaSelectionOptionAVFObjC::playerItem() const
+{
+    if (!m_group)
+        return nil;
+    return m_group->playerItem();
 }
 
 Ref<MediaSelectionGroupAVFObjC> MediaSelectionGroupAVFObjC::create(AVPlayerItem *item, AVMediaSelectionGroup *group, const Vector<String>& characteristics)

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h
@@ -66,13 +66,10 @@ public:
 
     virtual void setEnabled(bool);
 
-    void setPlayerItemTrack(AVPlayerItemTrack*);
     AVPlayerItemTrack* playerItemTrack();
 
-    void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack();
 
-    void setMediaSelectionOption(MediaSelectionOptionAVFObjC&);
     MediaSelectionOptionAVFObjC* mediaSelectionOption();
 
 private:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm
@@ -79,32 +79,14 @@ void AudioTrackPrivateAVFObjC::audioTrackConfigurationChanged()
     setConfiguration(m_impl->audioTrackConfiguration());
 }
 
-void AudioTrackPrivateAVFObjC::setPlayerItemTrack(AVPlayerItemTrack *track)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(track);
-    resetPropertiesFromTrack();
-}
-
 AVPlayerItemTrack* AudioTrackPrivateAVFObjC::playerItemTrack()
 {
     return m_impl->playerItemTrack();
 }
 
-void AudioTrackPrivateAVFObjC::setAssetTrack(AVAssetTrack *track)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(track);
-    resetPropertiesFromTrack();
-}
-
 AVAssetTrack* AudioTrackPrivateAVFObjC::assetTrack()
 {
     return m_impl->assetTrack();
-}
-
-void AudioTrackPrivateAVFObjC::setMediaSelectionOption(MediaSelectionOptionAVFObjC& option)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(option);
-    resetPropertiesFromTrack();
 }
 
 MediaSelectionOptionAVFObjC* AudioTrackPrivateAVFObjC::mediaSelectionOption()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp
@@ -51,12 +51,6 @@ void AudioTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
     setLanguage(m_impl->language());
 }
 
-void AudioTrackPrivateMediaSourceAVFObjC::setAssetTrack(AVAssetTrack *track)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(track);
-    resetPropertiesFromTrack();
-}
-
 AVAssetTrack* AudioTrackPrivateMediaSourceAVFObjC::assetTrack()
 {
     return m_impl->assetTrack();

--- a/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h
@@ -50,7 +50,6 @@ public:
 
     void setEnabled(bool) final;
 
-    void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack();
 
 private:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp
@@ -79,32 +79,14 @@ void VideoTrackPrivateAVFObjC::videoTrackConfigurationChanged()
     setConfiguration(m_impl->videoTrackConfiguration());
 }
 
-void VideoTrackPrivateAVFObjC::setPlayerItemTrack(AVPlayerItemTrack *track)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(track);
-    resetPropertiesFromTrack();
-}
-
 AVPlayerItemTrack* VideoTrackPrivateAVFObjC::playerItemTrack()
 {
     return m_impl->playerItemTrack();
 }
 
-void VideoTrackPrivateAVFObjC::setAssetTrack(AVAssetTrack *track)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(track);
-    resetPropertiesFromTrack();
-}
-
 AVAssetTrack* VideoTrackPrivateAVFObjC::assetTrack()
 {
     return m_impl->assetTrack();
-}
-
-void VideoTrackPrivateAVFObjC::setMediaSelectonOption(MediaSelectionOptionAVFObjC& option)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(option);
-    resetPropertiesFromTrack();
 }
 
 MediaSelectionOptionAVFObjC* VideoTrackPrivateAVFObjC::mediaSelectionOption()

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h
@@ -64,13 +64,10 @@ public:
 
     void setSelected(bool) override;
 
-    void setPlayerItemTrack(AVPlayerItemTrack*);
     AVPlayerItemTrack* playerItemTrack();
 
-    void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack();
 
-    void setMediaSelectonOption(MediaSelectionOptionAVFObjC&);
     MediaSelectionOptionAVFObjC* mediaSelectionOption();
 
 private:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h
@@ -51,7 +51,6 @@ public:
 
     virtual ~VideoTrackPrivateMediaSourceAVFObjC();
 
-    void setAssetTrack(AVAssetTrack*);
     AVAssetTrack* assetTrack() const;
 
     FloatSize naturalSize() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm
@@ -55,12 +55,6 @@ void VideoTrackPrivateMediaSourceAVFObjC::resetPropertiesFromTrack()
     setConfiguration(m_impl->videoTrackConfiguration());
 }
 
-void VideoTrackPrivateMediaSourceAVFObjC::setAssetTrack(AVAssetTrack *track)
-{
-    m_impl = makeUnique<AVTrackPrivateAVFObjCImpl>(track);
-    resetPropertiesFromTrack();
-}
-
 AVAssetTrack* VideoTrackPrivateMediaSourceAVFObjC::assetTrack() const
 {
     return m_impl->assetTrack();


### PR DESCRIPTION
#### 207f807363e00bca5462257a94433b484014ae6c
<pre>
[visionOS] Some HLS immersive videos fail to play.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288175">https://bugs.webkit.org/show_bug.cgi?id=288175</a>
<a href="https://rdar.apple.com/145266138">rdar://145266138</a>

Reviewed by Eric Carlson.

When we use an AVPlayer to play an HLS video, we create a VideoTrackPrivateAVFObjC
backed by a MediaSelectionOptionAVFObjC.
Those particular videos create an AVMediaSelectionKeyValueOption not a
AVMediaSelectionTrackOption and as such have no AVAssetTrack object attached.
The retrieval of an AVAssetTrack is essential to be able to retrieve the CMFormatDescription
object which contains information such as the video&apos;s width/height/colorspace,
spatial metadata or if the video has immersive content or not.

To get around this issue, should we fail to extract the AVAssetTrack object
from the AVMediaSelectionOption, we will instead try to find the corresponding
AVAssetTrack found in the AVPlayerItem&apos;s tracks instead.

Additionally, we add support for video&apos;s with projectionType set to &quot;Fisheye&quot;
and mark them as being immersive.

Fly-By: remove unused methods in AVTrackPrivateAVFObjCImpl and related
(AudioTrackPrivateAVFObjC, VideoTrackPrivateAVFObjC).

Manually tested as the HLS content exposing the problem is not publishable.

* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.h: Make members const,
make class final as destructor isn&apos;t virtual.
* Source/WebCore/platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm:
(WebCore::assetTrackFor): Remove unnecessary test.
(WebCore::AVTrackPrivateAVFObjCImpl::index const): Method used [[[m_playerItem asset] tracks] count]
as the offset, but m_playerItem was never set, so the above was always 0. Remove
(WebCore::AVTrackPrivateAVFObjCImpl::~AVTrackPrivateAVFObjCImpl): Deleted.
* Source/WebCore/platform/graphics/avfoundation/FormatDescriptionUtilities.cpp:
(WebCore::videoMetadataFromFormatDescription):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.h:
(WebCore::MediaSelectionGroupAVFObjC::playerItem const):
* Source/WebCore/platform/graphics/avfoundation/MediaSelectionGroupAVFObjC.mm:
(WebCore::MediaSelectionOptionAVFObjC::assetTrack const):
(WebCore::MediaSelectionOptionAVFObjC::playerItem const):
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateAVFObjC.mm:
(WebCore::AudioTrackPrivateAVFObjC::setPlayerItemTrack): Deleted.
(WebCore::AudioTrackPrivateAVFObjC::setAssetTrack): Deleted.
(WebCore::AudioTrackPrivateAVFObjC::setMediaSelectionOption): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.cpp:
(WebCore::AudioTrackPrivateMediaSourceAVFObjC::setAssetTrack): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/AudioTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::setPlayerItemTrack): Deleted.
(WebCore::VideoTrackPrivateAVFObjC::setAssetTrack): Deleted.
(WebCore::VideoTrackPrivateAVFObjC::setMediaSelectonOption): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateMediaSourceAVFObjC.mm:
(WebCore::VideoTrackPrivateMediaSourceAVFObjC::setAssetTrack): Deleted.

Canonical link: <a href="https://commits.webkit.org/290813@main">https://commits.webkit.org/290813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd2d210c16f4dc833327a2b7c78f8ba75a1e8816

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/69992 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27516 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50318 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8168 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/91 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78491 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98060 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/78999 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78199 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19348 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22706 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/64 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11493 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23614 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18008 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->