### PR TITLE
[UnifiedPDF] [iOS] Possible for per-site zoom to get applied if it was previously set on a document

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5212,8 +5212,9 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
     _impl->setViewScale(viewScale);
 #else
     if (_page->mainFramePluginOverridesViewScale()) {
-        if (_page->layoutSizeScaleFactorFromClient() != 1)
-            _page->setViewportConfigurationViewLayoutSize(_page->viewLayoutSize(), 1, _page->minimumEffectiveDeviceWidth());
+#if ENABLE(PDF_PLUGIN)
+        _page->resetViewportConfigurationForPDFPluginIfNeeded();
+#endif
         return;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -16204,6 +16204,23 @@ bool WebPageProxy::canStartNavigationSwipeAtLastInteractionLocation() const
     return !client || client->canStartNavigationSwipeAtLastInteractionLocation();
 }
 
+#if ENABLE(PDF_PLUGIN)
+void WebPageProxy::pluginDidInstallPDFDocument()
+{
+    resetViewportConfigurationForPDFPluginIfNeeded();
+}
+
+void WebPageProxy::resetViewportConfigurationForPDFPluginIfNeeded()
+{
+#if PLATFORM(IOS_FAMILY)
+    if (mainFramePluginOverridesViewScale()) {
+        if (layoutSizeScaleFactorFromClient() != 1)
+            setViewportConfigurationViewLayoutSize(viewLayoutSize(), 1, minimumEffectiveDeviceWidth());
+    }
+#endif
+}
+#endif
+
 } // namespace WebKit
 
 #undef WEBPAGEPROXY_RELEASE_LOG

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1787,9 +1787,18 @@ public:
     void saveDataToFileInDownloadsFolder(String&& suggestedFilename, String&& mimeType, URL&& originatingURL, API::Data&);
     void savePDFToFileInDownloadsFolder(String&& suggestedFilename, URL&& originatingURL, std::span<const uint8_t>);
 
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN)
+    void pluginDidInstallPDFDocument();
+    void resetViewportConfigurationForPDFPluginIfNeeded();
+#if PLATFORM(MAC)
     void savePDFToTemporaryFolderAndOpenWithNativeApplication(const String& suggestedFilename, FrameInfoData&&, std::span<const uint8_t>, const String& pdfUUID);
     void showPDFContextMenu(const PDFContextMenu&, PDFPluginIdentifier, CompletionHandler<void(std::optional<int32_t>&&)>&&);
+
+    void pdfZoomIn(PDFPluginIdentifier);
+    void pdfZoomOut(PDFPluginIdentifier);
+    void pdfSaveToPDF(PDFPluginIdentifier);
+    void pdfOpenWithPreview(PDFPluginIdentifier);
+#endif
 #endif
 
     WebCore::IntRect visibleScrollerThumbRect() const;
@@ -2317,13 +2326,6 @@ public:
     void createPDFHUD(PDFPluginIdentifier, const WebCore::IntRect&);
     void updatePDFHUDLocation(PDFPluginIdentifier, const WebCore::IntRect&);
     void removePDFHUD(PDFPluginIdentifier);
-#endif
-
-#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
-    void pdfZoomIn(PDFPluginIdentifier);
-    void pdfZoomOut(PDFPluginIdentifier);
-    void pdfSaveToPDF(PDFPluginIdentifier);
-    void pdfOpenWithPreview(PDFPluginIdentifier);
 #endif
 
     Seconds mediaCaptureReportingDelay() const { return m_mediaCaptureReportingDelay; }

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -554,7 +554,7 @@ messages -> WebPageProxy {
 #endif
 
 #if ENABLE(PDF_PLUGIN)
-
+    PluginDidInstallPDFDocument()
 #if PLATFORM(MAC)
     ShowPDFContextMenu(struct WebKit::PDFContextMenu contextMenu, WebKit::PDFPluginIdentifier identifier) -> (std::optional<int32_t> selectedItem)
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -333,6 +333,11 @@ void UnifiedPDFPlugin::installPDFDocument()
     }
 
     sizeToFitContentsIfNeeded();
+
+    RefPtr frame = m_frame.get();
+    if (!frame || !frame->page())
+        return;
+    frame->protectedPage()->send(Messages::WebPageProxy::PluginDidInstallPDFDocument());
 }
 
 bool UnifiedPDFPlugin::shouldSizeToFitContent() const


### PR DESCRIPTION
#### 1b250632dd10ccbd858ea80f492228ce35148e8a
<pre>
[UnifiedPDF] [iOS] Possible for per-site zoom to get applied if it was previously set on a document
<a href="https://bugs.webkit.org/show_bug.cgi?id=288176">https://bugs.webkit.org/show_bug.cgi?id=288176</a>
<a href="https://rdar.apple.com/145099940">rdar://145099940</a>

Reviewed by Abrar Rahman Protyasha.

The expected behavior is that PDFs are always loaded with a view scale of 1x.
But there is a case where this isn&apos;t happening:

Safari does view scale adjustments. If we set the scale to be 2x on one tab
and then load a PDF in another tab, Safari will attempt to use the same scale
on the PDF. Currently it (wrongly) succeeds because we don&apos;t know that we what
we&apos;re loading is a PDF. If we did know, we would have rejected this adjustment
and kept the scale at 1x.

To fix this, as the last step of loading the PDF, the WebProcess will notify
the UIProcess that it&apos;s loading a PDF and the UIProcess will ensure that the
viewing scale is 1x.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setViewScale:]):

_setViewScale is the function Safari calls to make a view scale adjument.
The current implementation of this function checks if what we&apos;re loading
should override the view scale (like a PDF) and do so if needed (PDFs
override to 1x). But if we don&apos;t know that we&apos;re loading a PDF, we won&apos;t
do this (hence our bug).

We move the overriding logic from here to it&apos;s own encapsulated function
and have _setViewScale call that function.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::pluginDidInstallPDFDocument):
(WebKit::WebPageProxy::resetViewportConfigurationForPDFPluginIfNeeded):

This is the new function that is called by both _setViewScale and
UnifiedPDFPlugin::installPDFDocument() to reset the view scale if needed.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):

Canonical link: <a href="https://commits.webkit.org/290826@main">https://commits.webkit.org/290826@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ea6f18865682d5cd07a7cc801897f4151ec33b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/127 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41861 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70004 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27533 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8411 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50330 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8182 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40991 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98079 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18298 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13419 "Found 1 new test failure: fast/dom/crash-with-bad-url.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79014 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78214 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/77 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11507 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14408 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23631 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->