### PR TITLE
Address safer C++ static analysis warnings in WebLocalFrameLoaderClient

### DIFF
--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -117,6 +117,8 @@ public:
     void ref() const;
     void deref() const;
 
+    virtual bool isWebLocalFrameLoaderClient() const { return false; }
+
     // An inline function cannot be the first non-abstract virtual function declared
     // in the class as it results in the vtable being generated as a weak symbol.
     // This hurts performance (in Mac OS X at least, when loading frameworks), so we

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1076,6 +1076,11 @@ PluginData& Page::pluginData()
     return *m_pluginData;
 }
 
+Ref<PluginData> Page::protectedPluginData()
+{
+    return pluginData();
+}
+
 void Page::clearPluginData()
 {
     m_pluginData = nullptr;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -367,6 +367,7 @@ public:
 
     static void refreshPlugins(bool reload);
     WEBCORE_EXPORT PluginData& pluginData();
+    WEBCORE_EXPORT Ref<PluginData> protectedPluginData();
     void clearPluginData();
 
     OpportunisticTaskScheduler& opportunisticTaskScheduler() const { return m_opportunisticTaskScheduler.get(); }

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -199,6 +199,8 @@ public:
     WEBCORE_EXPORT virtual FloatPoint convertToContainingView(const FloatPoint&) const;
     WEBCORE_EXPORT virtual FloatPoint convertFromContainingView(const FloatPoint&) const;
 
+    virtual bool isPluginView() const { return false; }
+
 private:
     void init(PlatformWidget); // Must be called by all Widget constructors to initialize cross-platform data.
 

--- a/Source/WebCore/plugins/PluginViewBase.h
+++ b/Source/WebCore/plugins/PluginViewBase.h
@@ -82,8 +82,6 @@ public:
 
     virtual void releaseMemory() { }
 
-    virtual bool isPluginView() const { return false; }
-
 protected:
     explicit PluginViewBase(PlatformWidget widget = 0) : Widget(widget) { }
 

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -24,8 +24,6 @@ WebProcess/Network/NetworkProcessConnection.cpp
 WebProcess/Network/webrtc/LibWebRTCNetworkManager.cpp
 WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
 WebProcess/Plugins/PluginView.cpp
-WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
-WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
 WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
 WebProcess/WebPage/ViewGestureGeometryCollector.cpp
 WebProcess/WebPage/WebFrame.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -366,7 +366,6 @@ WebProcess/WebCoreSupport/WebDragClient.cpp
 WebProcess/WebCoreSupport/WebEditorClient.cpp
 WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
 WebProcess/WebCoreSupport/WebGeolocationClient.cpp
-WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
 WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
 WebProcess/WebCoreSupport/WebNotificationClient.cpp
 WebProcess/WebCoreSupport/WebPlatformStrategies.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -93,7 +93,6 @@ WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
 WebProcess/WebCoreSupport/WebChromeClient.cpp
 WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
 WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
-WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
 WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
 WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
 WebProcess/WebCoreSupport/WebSpeechSynthesisClient.cpp

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -204,7 +204,7 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
         .frameID = frameLoader->frameID(),
         .resourceID = identifier
     };
-    if (auto* webFrameLoaderClient = toWebLocalFrameLoaderClient(frameLoaderClient))
+    if (auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frameLoaderClient))
         trackingParameters.webPageProxyID = webFrameLoaderClient->webPageProxyID();
     else if (auto* workerFrameLoaderClient = dynamicDowncast<RemoteWorkerFrameLoaderClient>(frameLoaderClient))
         trackingParameters.webPageProxyID = workerFrameLoaderClient->webPageProxyID();
@@ -276,7 +276,7 @@ bool WebLoaderStrategy::tryLoadingUsingURLSchemeHandler(ResourceLoader& resource
     if (!resourceLoader.frameLoader())
         return false;
 
-    if (auto* webFrameLoaderClient = toWebLocalFrameLoaderClient(resourceLoader.frameLoader()->client())) {
+    if (auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(resourceLoader.frameLoader()->client())) {
         webFrame = &webFrameLoaderClient->webFrame();
         webPage = webFrame->page();
     } else if (auto* workerFrameLoaderClient = dynamicDowncast<RemoteWorkerFrameLoaderClient>(resourceLoader.frameLoader()->client())) {
@@ -451,7 +451,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     if (resourceLoader.options().crossOriginEmbedderPolicy)
         loadParameters.crossOriginEmbedderPolicy = *resourceLoader.options().crossOriginEmbedderPolicy;
     
-    auto* webFrameLoaderClient = frame ? toWebLocalFrameLoaderClient(frame->loader().client()) : nullptr;
+    auto* webFrameLoaderClient = frame ? dynamicDowncast<WebLocalFrameLoaderClient>(frame->loader().client()) : nullptr;
     RefPtr webFrame = webFrameLoaderClient ? &webFrameLoaderClient->webFrame() : nullptr;
 
 #if ENABLE(APP_BOUND_DOMAINS)
@@ -702,7 +702,7 @@ WebLoaderStrategy::SyncLoadResult WebLoaderStrategy::loadDataURLSynchronously(co
 
 std::optional<WebLoaderStrategy::SyncLoadResult> WebLoaderStrategy::tryLoadingSynchronouslyUsingURLSchemeHandler(FrameLoader& frameLoader, WebCore::ResourceLoaderIdentifier identifier, const ResourceRequest& request)
 {
-    auto* webFrameLoaderClient = toWebLocalFrameLoaderClient(frameLoader.client());
+    auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frameLoader.client());
     auto* webFrame = webFrameLoaderClient ? &webFrameLoaderClient->webFrame() : nullptr;
     auto* webPage = webFrame ? webFrame->page() : nullptr;
     if (!webPage)
@@ -722,7 +722,7 @@ std::optional<WebLoaderStrategy::SyncLoadResult> WebLoaderStrategy::tryLoadingSy
 
 void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, const ResourceRequest& request, ClientCredentialPolicy clientCredentialPolicy,  const FetchOptions& options, const HTTPHeaderMap& originalRequestHeaders, ResourceError& error, ResourceResponse& response, Vector<uint8_t>& data)
 {
-    auto* webFrameLoaderClient = toWebLocalFrameLoaderClient(frameLoader.client());
+    auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frameLoader.client());
     auto* webFrame = webFrameLoaderClient ? &webFrameLoaderClient->webFrame() : nullptr;
     auto* webPage = webFrame ? webFrame->page() : nullptr;
     auto* page = webPage ? webPage->corePage() : nullptr;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -263,7 +263,7 @@ private:
 } // namespace WebKit
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::PluginView) \
-    static bool isType(const WebCore::PluginViewBase& view) { return view.isPluginView(); } \
+    static bool isType(const WebCore::Widget& widget) { return widget.isPluginView(); } \
 SPECIALIZE_TYPE_TRAITS_END()
 
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -242,6 +242,7 @@ private:
 #endif
 
     void didChangeScrollOffset() final;
+    bool isWebLocalFrameLoaderClient() const final { return true; }
 
     bool allowScript(bool enabledPerSettings) final;
 
@@ -317,15 +318,8 @@ private:
     RefPtr<WebCore::HistoryItem> createHistoryItemTree(bool clipAtTarget, WebCore::BackForwardItemIdentifier) const final;
 };
 
-// As long as EmptyFrameLoaderClient exists in WebCore, this can return nullptr.
-inline WebLocalFrameLoaderClient* toWebLocalFrameLoaderClient(WebCore::LocalFrameLoaderClient& client)
-{
-    return client.isEmptyFrameLoaderClient() ? nullptr : static_cast<WebLocalFrameLoaderClient*>(&client);
-}
-
-inline const WebLocalFrameLoaderClient* toWebLocalFrameLoaderClient(const WebCore::LocalFrameLoaderClient& client)
-{
-    return client.isEmptyFrameLoaderClient() ? nullptr : static_cast<const WebLocalFrameLoaderClient*>(&client);
-}
-
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebLocalFrameLoaderClient)
+    static bool isType(const WebCore::LocalFrameLoaderClient& client) { return client.isWebLocalFrameLoaderClient(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
@@ -52,7 +52,7 @@ WebLocalFrameLoaderClient* WebFrameNetworkingContext::webFrameLoaderClient() con
     if (!frame())
         return nullptr;
 
-    return toWebLocalFrameLoaderClient(frame()->loader().client());
+    return dynamicDowncast<WebLocalFrameLoaderClient>(frame()->loader().client());
 }
 
 #if PLATFORM(WIN)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm
@@ -75,7 +75,7 @@ WebLocalFrameLoaderClient* WebFrameNetworkingContext::webFrameLoaderClient() con
     if (!frame())
         return nullptr;
 
-    return toWebLocalFrameLoaderClient(frame()->loader().client());
+    return dynamicDowncast<WebLocalFrameLoaderClient>(frame()->loader().client());
 }
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
@@ -55,7 +55,7 @@ WebLocalFrameLoaderClient* WebFrameNetworkingContext::webFrameLoaderClient() con
     if (!frame())
         return nullptr;
 
-    return toWebLocalFrameLoaderClient(frame()->loader().client());
+    return dynamicDowncast<WebLocalFrameLoaderClient>(frame()->loader().client());
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -187,7 +187,7 @@ WebFrame::WebFrame(WebPage& page, WebCore::FrameIdentifier frameID)
 WebLocalFrameLoaderClient* WebFrame::localFrameLoaderClient() const
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get()))
-        return toWebLocalFrameLoaderClient(localFrame->loader().client());
+        return dynamicDowncast<WebLocalFrameLoaderClient>(localFrame->loader().client());
     return nullptr;
 }
 
@@ -206,7 +206,7 @@ WebRemoteFrameClient* WebFrame::remoteFrameClient() const
 WebFrameLoaderClient* WebFrame::frameLoaderClient() const
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get()))
-        return toWebLocalFrameLoaderClient(localFrame->loader().client());
+        return dynamicDowncast<WebLocalFrameLoaderClient>(localFrame->loader().client());
     if (auto* remoteFrame = dynamicDowncast<RemoteFrame>(m_coreFrame.get()))
         return static_cast<WebRemoteFrameClient*>(&remoteFrame->client());
     return nullptr;
@@ -240,7 +240,7 @@ RefPtr<WebPage> WebFrame::protectedPage() const
 RefPtr<WebFrame> WebFrame::fromCoreFrame(const Frame& frame)
 {
     if (auto* localFrame = dynamicDowncast<LocalFrame>(frame)) {
-        auto* webLocalFrameLoaderClient = toWebLocalFrameLoaderClient(localFrame->loader().client());
+        auto* webLocalFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(localFrame->loader().client());
         if (!webLocalFrameLoaderClient)
             return nullptr;
         return &webLocalFrameLoaderClient->webFrame();
@@ -451,7 +451,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
 void WebFrame::destroyProvisionalFrame()
 {
     if (RefPtr frame = std::exchange(m_provisionalFrame, nullptr)) {
-        if (auto* client = toWebLocalFrameLoaderClient(frame->loader().client()))
+        if (auto* client = dynamicDowncast<WebLocalFrameLoaderClient>(frame->loader().client()))
             client->takeFrameInvalidator().release();
         if (RefPtr parent = frame->tree().parent())
             parent->tree().removeChild(*frame);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -6123,7 +6123,7 @@ void WebPage::restoreSelectionInFocusedEditableElement()
 bool WebPage::mainFrameHasCustomContentProvider() const
 {
     if (RefPtr frame = localMainFrame()) {
-        auto* webFrameLoaderClient = toWebLocalFrameLoaderClient(frame->loader().client());
+        auto* webFrameLoaderClient = dynamicDowncast<WebLocalFrameLoaderClient>(frame->loader().client());
         ASSERT(webFrameLoaderClient);
         return webFrameLoaderClient->frameHasCustomContentProvider();
     }
@@ -8464,7 +8464,7 @@ void WebPage::setUseIconLoadingClient(bool useIconLoadingClient)
     RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame());
     if (!localMainFrame)
         return;
-    if (auto* client = toWebLocalFrameLoaderClient(localMainFrame->loader().client()))
+    if (auto* client = dynamicDowncast<WebLocalFrameLoaderClient>(localMainFrame->loader().client()))
         client->setUseIconLoadingClient(useIconLoadingClient);
 }
 


### PR DESCRIPTION
#### cd30f3e2865d144bc855c91d6f77984e492d79f1
<pre>
Address safer C++ static analysis warnings in WebLocalFrameLoaderClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=288179">https://bugs.webkit.org/show_bug.cgi?id=288179</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::protectedPluginData):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/Widget.h:
(WebCore::Widget::isPluginView const):
* Source/WebCore/plugins/PluginViewBase.h:
(WebCore::PluginViewBase::isPluginView const): Deleted.
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoad):
(WebKit::WebLoaderStrategy::tryLoadingUsingURLSchemeHandler):
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
(WebKit::WebLoaderStrategy::tryLoadingSynchronouslyUsingURLSchemeHandler):
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
(isType):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchWillSendSubmitEvent):
(WebKit::WebLocalFrameLoaderClient::setMainDocumentError):
(WebKit::WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks):
(WebKit::WebLocalFrameLoaderClient::loadStorageAccessQuirksIfNeeded):
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
(WebKit::WebLocalFrameLoaderClient::updateCachedDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedFromCachedFrame):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedForNewPage):
(WebKit::WebLocalFrameLoaderClient::createFrame):
(WebKit::WebLocalFrameLoaderClient::redirectDataToPlugin):
(WebKit::WebLocalFrameLoaderClient::objectContentType):
(WebKit::WebLocalFrameLoaderClient::overrideMediaType const):
(WebKit::WebLocalFrameLoaderClient::dispatchDidClearWindowObjectInWorld):
(WebKit::WebLocalFrameLoaderClient::contentFilterDidBlockLoad):
(WebKit::WebLocalFrameLoaderClient::shouldUsePDFPlugin const):
(WebKit::WebLocalFrameLoaderClient::isParentProcessAFullWebBrowser const):
(WebKit::WebLocalFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
(isType):
(WebKit::toWebLocalFrameLoaderClient): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp:
(WebKit::WebFrameNetworkingContext::webFrameLoaderClient const):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.mm:
(WebKit::WebFrameNetworkingContext::webFrameLoaderClient const):
* Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp:
(WebKit::WebFrameNetworkingContext::webFrameLoaderClient const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::localFrameLoaderClient const):
(WebKit::WebFrame::frameLoaderClient const):
(WebKit::WebFrame::fromCoreFrame):
(WebKit::WebFrame::destroyProvisionalFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::mainFrameHasCustomContentProvider const):
(WebKit::WebPage::setUseIconLoadingClient):

Canonical link: <a href="https://commits.webkit.org/290817@main">https://commits.webkit.org/290817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0caea06759f81a9428293dedb6efb3493c7c1e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91139 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10682 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41898 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70042 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27565 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94140 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82578 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50368 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8223 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41035 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98124 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18341 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79052 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78255 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/113 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18344 "Built successfully") | [💥 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23665 "An unexpected error occured. Recent messages:OS: Sequoia (15.3.1), Xcode: 16.2; Checked out pull request; Found 42697 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18068 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19844 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->