### PR TITLE
[Materials] Add dark mode support

### DIFF
--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark-expected.txt
@@ -12,7 +12,7 @@ bar
           (bounds 800.00 600.00)
           (contentsOpaque 1)
           (drawsContent 1)
-          (backgroundColor #FFFFFF)
+          (backgroundColor #1E1E1E)
         )
         (GraphicsLayer
           (bounds 800.00 600.00)
@@ -22,9 +22,9 @@ bar
               (bounds 200.00 200.00)
               (drawsContent 1)
               (appleVisualEffectData
-              (effect blur-material-thick)
-              (contextEffect blur-material-thick)
-              (colorScheme light))
+              (effect blur-material-chrome)
+              (contextEffect blur-material-chrome)
+              (colorScheme dark))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the chrome material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-chrome;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+    }
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt
@@ -23,7 +23,8 @@ bar
               (drawsContent 1)
               (appleVisualEffectData
               (effect blur-material-chrome)
-              (contextEffect blur-material-chrome))
+              (contextEffect blur-material-chrome)
+              (colorScheme light))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-dark-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-dark-expected.txt
@@ -12,7 +12,7 @@ bar
           (bounds 800.00 600.00)
           (contentsOpaque 1)
           (drawsContent 1)
-          (backgroundColor #FFFFFF)
+          (backgroundColor #1E1E1E)
         )
         (GraphicsLayer
           (bounds 800.00 600.00)
@@ -22,9 +22,9 @@ bar
               (bounds 200.00 200.00)
               (drawsContent 1)
               (appleVisualEffectData
-              (effect blur-material-thick)
-              (contextEffect blur-material-thick)
-              (colorScheme light))
+              (effect blur-material)
+              (contextEffect blur-material)
+              (colorScheme dark))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-dark.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-dark.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the default material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+    }
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
@@ -23,7 +23,8 @@ bar
               (drawsContent 1)
               (appleVisualEffectData
               (effect blur-material)
-              (contextEffect blur-material))
+              (contextEffect blur-material)
+              (colorScheme light))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-dark-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-dark-expected.txt
@@ -12,7 +12,7 @@ bar
           (bounds 800.00 600.00)
           (contentsOpaque 1)
           (drawsContent 1)
-          (backgroundColor #FFFFFF)
+          (backgroundColor #1E1E1E)
         )
         (GraphicsLayer
           (bounds 800.00 600.00)
@@ -24,7 +24,7 @@ bar
               (appleVisualEffectData
               (effect blur-material-thick)
               (contextEffect blur-material-thick)
-              (colorScheme light))
+              (colorScheme dark))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-dark.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-dark.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the thick material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-thick;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+    }
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-dark-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-dark-expected.txt
@@ -12,7 +12,7 @@ bar
           (bounds 800.00 600.00)
           (contentsOpaque 1)
           (drawsContent 1)
-          (backgroundColor #FFFFFF)
+          (backgroundColor #1E1E1E)
         )
         (GraphicsLayer
           (bounds 800.00 600.00)
@@ -22,9 +22,9 @@ bar
               (bounds 200.00 200.00)
               (drawsContent 1)
               (appleVisualEffectData
-              (effect blur-material-thick)
-              (contextEffect blur-material-thick)
-              (colorScheme light))
+              (effect blur-material-thin)
+              (contextEffect blur-material-thin)
+              (colorScheme dark))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-dark.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-dark.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the thin material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-thin;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+    }
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
@@ -23,7 +23,8 @@ bar
               (drawsContent 1)
               (appleVisualEffectData
               (effect blur-material-thin)
-              (contextEffect blur-material-thin))
+              (contextEffect blur-material-thin)
+              (colorScheme light))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark-expected.txt
@@ -12,7 +12,7 @@ bar
           (bounds 800.00 600.00)
           (contentsOpaque 1)
           (drawsContent 1)
-          (backgroundColor #FFFFFF)
+          (backgroundColor #1E1E1E)
         )
         (GraphicsLayer
           (bounds 800.00 600.00)
@@ -22,9 +22,9 @@ bar
               (bounds 200.00 200.00)
               (drawsContent 1)
               (appleVisualEffectData
-              (effect blur-material-thick)
-              (contextEffect blur-material-thick)
-              (colorScheme light))
+              (effect blur-material-ultra-thin)
+              (contextEffect blur-material-ultra-thin)
+              (colorScheme dark))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the ultra thin material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material-ultra-thin;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+    }
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
@@ -23,7 +23,8 @@ bar
               (drawsContent 1)
               (appleVisualEffectData
               (effect blur-material-ultra-thin)
-              (contextEffect blur-material-ultra-thin))
+              (contextEffect blur-material-ultra-thin)
+              (colorScheme light))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-dark-mode-expected-mismatch.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-dark-mode-expected-mismatch.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that light and dark materials look different.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function load() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(false);
+        testRunner.notifyDone();
+    }
+}
+window.addEventListener('load', load, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-dark-mode.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-dark-mode.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that light and dark materials look different.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+function load() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        testRunner.notifyDone();
+    }
+}
+window.addEventListener('load', load, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar</div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark-expected.txt
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark-expected.txt
@@ -15,7 +15,7 @@ four
           (bounds 800.00 600.00)
           (contentsOpaque 1)
           (drawsContent 1)
-          (backgroundColor #FFFFFF)
+          (backgroundColor #1E1E1E)
         )
         (GraphicsLayer
           (bounds 800.00 600.00)
@@ -27,7 +27,7 @@ four
               (appleVisualEffectData
               (effect blur-material)
               (contextEffect blur-material)
-              (colorScheme light))
+              (colorScheme dark))
               (structural layer
                 (position 108.00 126.00)
                 (bounds 200.00 200.00)
@@ -44,7 +44,7 @@ four
                   (appleVisualEffectData
                   (effect vibrancy-secondary-label)
                   (contextEffect blur-material)
-                  (colorScheme light))
+                  (colorScheme dark))
                 )
                 (GraphicsLayer
                   (position 0.00 36.00)
@@ -53,7 +53,7 @@ four
                   (appleVisualEffectData
                   (effect vibrancy-tertiary-label)
                   (contextEffect blur-material)
-                  (colorScheme light))
+                  (colorScheme dark))
                 )
                 (GraphicsLayer
                   (position 0.00 54.00)
@@ -62,7 +62,7 @@ four
                   (appleVisualEffectData
                   (effect vibrancy-quaternary-label)
                   (contextEffect blur-material)
-                  (colorScheme light))
+                  (colorScheme dark))
                 )
               )
             )

--- a/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark.html
+++ b/LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html><!-- webkit-test-runner [ UseSystemAppearance=true ] -->
+<html>
+<head>
+<title>This tests that the default material works properly.</title>
+<style>
+
+body {
+    background: linear-gradient(red, blue) fixed;
+}
+
+.container {
+    width: 300px;
+    height: 300px;
+}
+
+.inner {
+    -apple-visual-effect: -apple-system-blur-material;
+    width: 200px;
+    height: 200px;
+}
+
+.vibrant2 {
+    -apple-visual-effect: -apple-system-vibrancy-secondary-label;
+}
+
+.vibrant3 {
+    -apple-visual-effect: -apple-system-vibrancy-tertiary-label;
+}
+
+.vibrant4 {
+    -apple-visual-effect: -apple-system-vibrancy-quaternary-label;
+}
+
+</style>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+function dumpLayers() {
+    if (window.internals) {
+        internals.settings.setUseDarkAppearance(true);
+        document.getElementById('result').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_CONTENT_LAYERS);
+    }
+}
+window.addEventListener('load', dumpLayers, false);
+
+</script>
+</head>
+<body>
+<div class=container>foo<div class=inner>bar<div class=vibrant2>two</div><div class=vibrant3>three</div><div class=vibrant4>four</div></div></div>
+<pre id=result></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark-expected.txt
@@ -7,6 +7,7 @@ bar
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #000000)
       (children 1
         (GraphicsLayer
           (position 8.00 28.00)
@@ -15,7 +16,7 @@ bar
           (appleVisualEffectData
           (effect blur-material-chrome)
           (contextEffect blur-material-chrome)
-          (colorScheme light))
+          (colorScheme dark))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-dark-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-dark-expected.txt
@@ -7,15 +7,16 @@ bar
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #000000)
       (children 1
         (GraphicsLayer
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
           (appleVisualEffectData
-          (effect blur-material-chrome)
-          (contextEffect blur-material-chrome)
-          (colorScheme light))
+          (effect blur-material)
+          (contextEffect blur-material)
+          (colorScheme dark))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt
@@ -14,7 +14,8 @@ bar
           (drawsContent 1)
           (appleVisualEffectData
           (effect blur-material)
-          (contextEffect blur-material))
+          (contextEffect blur-material)
+          (colorScheme light))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-dark-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-dark-expected.txt
@@ -7,15 +7,16 @@ bar
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #000000)
       (children 1
         (GraphicsLayer
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
           (appleVisualEffectData
-          (effect blur-material-chrome)
-          (contextEffect blur-material-chrome)
-          (colorScheme light))
+          (effect blur-material-thick)
+          (contextEffect blur-material-thick)
+          (colorScheme dark))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt
@@ -14,7 +14,8 @@ bar
           (drawsContent 1)
           (appleVisualEffectData
           (effect blur-material-thick)
-          (contextEffect blur-material-thick))
+          (contextEffect blur-material-thick)
+          (colorScheme light))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-dark-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-dark-expected.txt
@@ -7,15 +7,16 @@ bar
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #000000)
       (children 1
         (GraphicsLayer
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
           (appleVisualEffectData
-          (effect blur-material-chrome)
-          (contextEffect blur-material-chrome)
-          (colorScheme light))
+          (effect blur-material-thin)
+          (contextEffect blur-material-thin)
+          (colorScheme dark))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt
@@ -14,7 +14,8 @@ bar
           (drawsContent 1)
           (appleVisualEffectData
           (effect blur-material-thin)
-          (contextEffect blur-material-thin))
+          (contextEffect blur-material-thin)
+          (colorScheme light))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark-expected.txt
@@ -7,15 +7,16 @@ bar
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #000000)
       (children 1
         (GraphicsLayer
           (position 8.00 28.00)
           (bounds 200.00 200.00)
           (drawsContent 1)
           (appleVisualEffectData
-          (effect blur-material-chrome)
-          (contextEffect blur-material-chrome)
-          (colorScheme light))
+          (effect blur-material-ultra-thin)
+          (contextEffect blur-material-ultra-thin)
+          (colorScheme dark))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt
@@ -14,7 +14,8 @@ bar
           (drawsContent 1)
           (appleVisualEffectData
           (effect blur-material-ultra-thin)
-          (contextEffect blur-material-ultra-thin))
+          (contextEffect blur-material-ultra-thin)
+          (colorScheme light))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)

--- a/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark-expected.txt
+++ b/LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark-expected.txt
@@ -10,6 +10,7 @@ four
     (GraphicsLayer
       (bounds 800.00 600.00)
       (contentsOpaque 1)
+      (backgroundColor #000000)
       (children 1
         (GraphicsLayer
           (position 8.00 28.00)
@@ -18,7 +19,7 @@ four
           (appleVisualEffectData
           (effect blur-material)
           (contextEffect blur-material)
-          (colorScheme light))
+          (colorScheme dark))
           (structural layer
             (position 108.00 128.00)
             (bounds 200.00 200.00)
@@ -35,7 +36,7 @@ four
               (appleVisualEffectData
               (effect vibrancy-secondary-label)
               (contextEffect blur-material)
-              (colorScheme light))
+              (colorScheme dark))
             )
             (GraphicsLayer
               (position 0.00 40.00)
@@ -44,7 +45,7 @@ four
               (appleVisualEffectData
               (effect vibrancy-tertiary-label)
               (contextEffect blur-material)
-              (colorScheme light))
+              (colorScheme dark))
             )
             (GraphicsLayer
               (position 0.00 60.00)
@@ -53,7 +54,7 @@ four
               (appleVisualEffectData
               (effect vibrancy-quaternary-label)
               (contextEffect blur-material)
-              (colorScheme light))
+              (colorScheme dark))
             )
           )
         )

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h
@@ -35,11 +35,18 @@ SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, CoreMaterial)
 SOFT_LINK_CLASS_FOR_HEADER(PAL, MTMaterialLayer)
 
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipeNone, NSString *)
+
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *)
+
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentDark, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeDark, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickDark, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinDark, NSString *)
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinDark, NSString *)
 
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryStroke, NSString *)
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryFill, NSString *)

--- a/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm
@@ -35,11 +35,18 @@ SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, PAL_EXPORT
 SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTMaterialLayer, PAL_EXPORT)
 
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipeNone, NSString *, PAL_EXPORT)
+
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinLight, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinLight, NSString *, PAL_EXPORT)
+
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentDark, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformChromeDark, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThickDark, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentThinDark, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialRecipePlatformContentUltraThinDark, NSString *, PAL_EXPORT)
 
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryStroke, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMaterial, MTCoreMaterialVisualStyleCategoryFill, NSString *, PAL_EXPORT)

--- a/Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h
@@ -53,11 +53,18 @@ extern MTCoreMaterialVisualStyle const MTCoreMaterialVisualStyleSeparator;
 typedef NSString * MTCoreMaterialRecipe NS_STRING_ENUM;
 
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipeNone;
+
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformChromeLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentUltraThinLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThinLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentLight;
 extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThickLight;
+
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformChromeDark;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentUltraThinDark;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThinDark;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentDark;
+extern MTCoreMaterialRecipe const MTCoreMaterialRecipePlatformContentThickDark;
 
 extern NSDictionary <NSString *, id> *MTVisualStylingCreateDictionaryRepresentation(MTCoreMaterialRecipe, MTCoreMaterialVisualStyleCategory, MTCoreMaterialVisualStyle, NSDictionary <NSString *, id> *);
 

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.cpp
@@ -176,10 +176,24 @@ TextStream& operator<<(TextStream& ts, AppleVisualEffect effect)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, AppleVisualEffectData::ColorScheme colorScheme)
+{
+    switch (colorScheme) {
+    case AppleVisualEffectData::ColorScheme::Light:
+        ts << "light";
+        break;
+    case AppleVisualEffectData::ColorScheme::Dark:
+        ts << "dark";
+        break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, AppleVisualEffectData effectData)
 {
     ts.dumpProperty("effect", effectData.effect);
     ts.dumpProperty("contextEffect", effectData.contextEffect);
+    ts.dumpProperty("colorScheme", effectData.colorScheme);
     return ts;
 }
 

--- a/Source/WebCore/platform/cocoa/AppleVisualEffect.h
+++ b/Source/WebCore/platform/cocoa/AppleVisualEffect.h
@@ -68,11 +68,15 @@ struct AppleVisualEffectData {
     AppleVisualEffect effect { AppleVisualEffect::None };
     AppleVisualEffect contextEffect { AppleVisualEffect::None };
 
+    enum class ColorScheme : uint8_t { Light, Dark };
+    ColorScheme colorScheme { ColorScheme::Light };
+
     std::optional<FloatRoundedRect> borderRect;
 
     bool operator==(const AppleVisualEffectData&) const = default;
 };
 
+WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffectData::ColorScheme);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, AppleVisualEffectData);
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -954,6 +954,7 @@ void RenderLayerBacking::updateAppleVisualEffect(const RenderStyle& style)
 
     visualEffectData.effect = style.appleVisualEffect();
     visualEffectData.contextEffect = style.usedAppleVisualEffectForSubtree();
+    visualEffectData.colorScheme = renderer().document().useDarkAppearance(&style) ? AppleVisualEffectData::ColorScheme::Dark : AppleVisualEffectData::ColorScheme::Light;
 
 #if HAVE(MATERIAL_HOSTING)
     if (appleVisualEffectIsHostedMaterial(style.appleVisualEffect())) {

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h
@@ -41,6 +41,11 @@ typedef NS_ENUM(NSInteger, WKHostedMaterialEffectType) {
     WKHostedMaterialEffectTypeThinBlur,
 };
 
+typedef NS_ENUM(NSInteger, WKHostedMaterialColorScheme) {
+    WKHostedMaterialColorSchemeLight,
+    WKHostedMaterialColorSchemeDark,
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_UI_ACTOR
@@ -49,12 +54,12 @@ NS_SWIFT_UI_ACTOR
 + (BOOL)isMaterialHostingAvailable;
 
 + (CALayer *)createHostingLayer;
-+ (void)updateHostingLayer:(CALayer *)hostingLayer materialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius;
++ (void)updateHostingLayer:(CALayer *)hostingLayer materialEffectType:(WKHostedMaterialEffectType)materialEffectType colorScheme:(WKHostedMaterialColorScheme) colorScheme cornerRadius:(CGFloat)cornerRadius;
 + (nullable CALayer *)contentLayerForMaterialHostingLayer:(CALayer *)hostingLayer;
 
 #if PLATFORM(IOS_FAMILY)
 + (UIView *)createHostingView:(UIView *)contentView;
-+ (void)updateHostingView:(UIView *)hostingView contentView:(UIView *)contentView materialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius;
++ (void)updateHostingView:(UIView *)hostingView contentView:(UIView *)contentView materialEffectType:(WKHostedMaterialEffectType)materialEffectType colorScheme:(WKHostedMaterialColorScheme) colorScheme cornerRadius:(CGFloat)cornerRadius;
 #endif
 
 @end

--- a/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
+++ b/Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift
@@ -76,6 +76,7 @@ private struct ViewBackedMaterialHostingProvider: MaterialHostingProvider {
 private struct MaterialHostingView<P: MaterialHostingProvider>: View {
     private let content: P.Source
     private let materialEffectType: WKHostedMaterialEffectType
+    private let colorScheme: WKHostedMaterialColorScheme
     private let cornerRadius: CGFloat
 
     static func resolvedMaterialEffect(for type: WKHostedMaterialEffectType) -> Material? {
@@ -91,9 +92,10 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
         }
     }
 
-    init(content: P.Source, materialEffectType: WKHostedMaterialEffectType = .none, cornerRadius: CGFloat = 0) {
+    init(content: P.Source, materialEffectType: WKHostedMaterialEffectType = .none, colorScheme: WKHostedMaterialColorScheme = .light, cornerRadius: CGFloat = 0) {
         self.content = content
         self.materialEffectType = materialEffectType
+        self.colorScheme = colorScheme
         self.cornerRadius = cornerRadius
     }
 
@@ -101,7 +103,8 @@ private struct MaterialHostingView<P: MaterialHostingProvider>: View {
         let view = P.view(for: content)
 
         if let effect = MaterialHostingView<P>.resolvedMaterialEffect(for: materialEffectType) {
-            view.materialEffect(effect, in: .rect(cornerRadius: cornerRadius))
+            AnyView(view.materialEffect(effect, in: .rect(cornerRadius: cornerRadius)))
+                .environment(\.colorScheme, colorScheme == .light ? .light : .dark)
         } else {
             view
         }
@@ -140,7 +143,7 @@ private extension CALayer {
         return hostingLayer
     }
 
-    class func updateHostingLayer(_ layer: CALayer, materialEffectType: WKHostedMaterialEffectType, cornerRadius: CGFloat) {
+    class func updateHostingLayer(_ layer: CALayer, materialEffectType: WKHostedMaterialEffectType, colorScheme: WKHostedMaterialColorScheme, cornerRadius: CGFloat) {
         guard let hostingLayer = layer as? CAHostingLayer<MaterialHostingView<LayerBackedMaterialHostingProvider>> else {
             assertionFailure("updateHostingLayer should only be called with a hosting layer.")
             return
@@ -151,7 +154,7 @@ private extension CALayer {
             return
         }
 
-        hostingLayer.rootView = MaterialHostingView<LayerBackedMaterialHostingProvider>(content: contentLayer, materialEffectType: materialEffectType, cornerRadius: cornerRadius)
+        hostingLayer.rootView = MaterialHostingView<LayerBackedMaterialHostingProvider>(content: contentLayer, materialEffectType: materialEffectType, colorScheme: colorScheme, cornerRadius: cornerRadius)
     }
 
     class func contentLayer(forMaterialHostingLayer layer: CALayer) -> CALayer? {
@@ -164,12 +167,12 @@ private extension CALayer {
         _UIHostingView(rootView: MaterialHostingView<ViewBackedMaterialHostingProvider>(content: contentView))
     }
 
-    class func updateHostingView(_ view: UIView, contentView: UIView, materialEffectType: WKHostedMaterialEffectType, cornerRadius: CGFloat) {
+    class func updateHostingView(_ view: UIView, contentView: UIView, materialEffectType: WKHostedMaterialEffectType, colorScheme: WKHostedMaterialColorScheme, cornerRadius: CGFloat) {
         guard let hostingView = view as? _UIHostingView<MaterialHostingView<ViewBackedMaterialHostingProvider>> else {
             return;
         }
 
-        hostingView.rootView = MaterialHostingView<ViewBackedMaterialHostingProvider>(content: contentView, materialEffectType: materialEffectType, cornerRadius: cornerRadius)
+        hostingView.rootView = MaterialHostingView<ViewBackedMaterialHostingProvider>(content: contentView, materialEffectType: materialEffectType, colorScheme: colorScheme, cornerRadius: cornerRadius)
     }
 
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8057,9 +8057,16 @@ enum class WebCore::AppleVisualEffect : uint8_t {
 };
 
 header: <WebCore/AppleVisualEffect.h>
+[Nested] enum class WebCore::AppleVisualEffectData::ColorScheme : uint8_t {
+    Light,
+    Dark
+};
+
+header: <WebCore/AppleVisualEffect.h>
 [CustomHeader] struct WebCore::AppleVisualEffectData {
     WebCore::AppleVisualEffect effect;
     WebCore::AppleVisualEffect contextEffect;
+    WebCore::AppleVisualEffectData::ColorScheme colorScheme;
     std::optional<WebCore::FloatRoundedRect> borderRect;
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h
@@ -77,7 +77,7 @@ class WebPageProxy;
 @property (nonatomic, readonly) UIView *contentView;
 
 - (void)updateHostingSize:(WebCore::FloatSize)size;
-- (void)updateMaterialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius;
+- (void)updateMaterialEffectType:(WKHostedMaterialEffectType)materialEffectType colorScheme:(WKHostedMaterialColorScheme)colorScheme cornerRadius:(CGFloat)cornerRadius;
 
 @end
 #endif

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -423,9 +423,9 @@ static Class scrollViewScrollIndicatorClass()
     [_hostingView setFrame:CGRectMake(0, 0, size.width(), size.height())];
 }
 
-- (void)updateMaterialEffectType:(WKHostedMaterialEffectType)materialEffectType cornerRadius:(CGFloat)cornerRadius
+- (void)updateMaterialEffectType:(WKHostedMaterialEffectType)materialEffectType colorScheme:(WKHostedMaterialColorScheme)colorScheme cornerRadius:(CGFloat)cornerRadius
 {
-    [WKMaterialHostingSupport updateHostingView:_hostingView.get() contentView:_contentView.get() materialEffectType:materialEffectType cornerRadius:cornerRadius];
+    [WKMaterialHostingSupport updateHostingView:_hostingView.get() contentView:_contentView.get() materialEffectType:materialEffectType colorScheme:colorScheme cornerRadius:cornerRadius];
 }
 
 @end


### PR DESCRIPTION
#### 0e26af9fa9a5720aa1be96a47aade5e82361e12e
<pre>
[Materials] Add dark mode support
<a href="https://bugs.webkit.org/show_bug.cgi?id=288152">https://bugs.webkit.org/show_bug.cgi?id=288152</a>
<a href="https://rdar.apple.com/145091546">rdar://145091546</a>

Reviewed by Abrar Rahman Protyasha.

Materials and vibrancy should adapt to dark mode. This patch implements that
functionality for CoreMaterial backed visual effects, as well as SwiftUI-based
effects.

The color scheme of an effect is determined as part of creating
`AppleVisualEffectData`, and then applied by `RemoteLayerTreePropertyApplier`.

* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-dark-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-dark.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-dark-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-dark.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-dark-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-dark.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt:
* LayoutTests/apple-visual-effects/apple-visual-effect-dark-mode-expected-mismatch.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-dark-mode.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark-expected.txt: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark.html: Added.
* LayoutTests/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-dark-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-chrome-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-dark-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-dark-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thick-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-dark-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-thin-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-dark-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-blur-material-ultra-thin-expected.txt:
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-dark-expected.txt: Added.
* LayoutTests/platform/ios/apple-visual-effects/apple-visual-effect-vibrancy-effects-expected.txt:
* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.h:

Add dark mode material constants.

* Source/WebCore/PAL/pal/cocoa/CoreMaterialSoftLink.mm:
* Source/WebCore/PAL/pal/spi/cocoa/CoreMaterialSPI.h:
* Source/WebCore/platform/cocoa/AppleVisualEffect.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/cocoa/AppleVisualEffect.h:

Introduce a `colorScheme` field to `AppleVisualEffectData`. This will be used to
select the appropriate material on the UI-side.

* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAppleVisualEffect):

Use the used color scheme of the renderer to determine the color scheme of the
visual effect.

* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.h:
* Source/WebKit/Platform/cocoa/WKMaterialHostingSupport.swift:
(MaterialHostingView.body):

`materialEffect` uses the environment of the parent view. For this reason, the
environment modifier is applied to an `AnyView` which wraps the view with the
material effect applied. The environment&apos;s color scheme is set to achieve the
desired appearance.

(WKMaterialHostingSupport.updateHostingLayer(_:materialEffectType:colorScheme:cornerRadius:)):
(WKMaterialHostingSupport.updateHostingView(_:contentView:materialEffectType:colorScheme:cornerRadius:)):
(WKMaterialHostingSupport.updateHostingLayer(_:materialEffectType:cornerRadius:)): Deleted.
(WKMaterialHostingSupport.updateHostingView(_:contentView:materialEffectType:cornerRadius:)): Deleted.
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::materialRecipeForAppleVisualEffect):
(WebKit::hostedMaterialColorSchemeForAppleVisualEffectData):
(WebKit::applyVisualStylingToLayer):
(WebKit::updateAppleVisualEffect):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(-[WKMaterialHostingView updateMaterialEffectType:colorScheme:cornerRadius:]):
(-[WKMaterialHostingView updateMaterialEffectType:cornerRadius:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/290803@main">https://commits.webkit.org/290803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd00d4c5ac4d7646a8ee815c72da317f7ada436c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96099 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41860 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70005 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27532 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8417 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82541 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50331 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40990 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78510 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98078 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18297 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79015 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78215 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/78 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14392 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23630 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->