### PR TITLE
[JSC] Move some inline functions from AirTmpWidth.h to AirTmpWidthInlines.h

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -38,7 +38,7 @@
 #include "AirPhaseScope.h"
 #include "AirRegLiveness.h"
 #include "AirTmpMap.h"
-#include "AirTmpWidth.h"
+#include "AirTmpWidthInlines.h"
 #include "AirUseCounts.h"
 #include <wtf/IterationStatus.h>
 #include <wtf/ListDump.h>

--- a/Source/JavaScriptCore/b3/air/AirTmpWidth.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidth.h
@@ -52,18 +52,10 @@ public:
     //
     // This doesn't tell you which of those properties holds, but you can query that using the other
     // methods.
-    Width width(Tmp tmp) const
-    {
-        Widths tmpWidths = widths(tmp);
-        return std::min(tmpWidths.use, tmpWidths.def);
-    }
+    inline Width width(Tmp) const;
 
     // Return the minimum required width for all defs/uses of this Tmp.
-    Width requiredWidth(Tmp tmp)
-    {
-        Widths tmpWidths = widths(tmp);
-        return std::max(tmpWidths.use, tmpWidths.def);
-    }
+    inline Width requiredWidth(Tmp);
 
     // This indirectly tells you how much of the tmp's high bits are guaranteed to be zero. The number of
     // high bits that are zero are:
@@ -71,16 +63,10 @@ public:
     //     TotalBits - defWidth(tmp)
     //
     // Where TotalBits are the total number of bits in the register, so 64 on a 64-bit system.
-    Width defWidth(Tmp tmp) const
-    {
-        return widths(tmp).def;
-    }
+    inline Width defWidth(Tmp) const;
 
     // This tells you how much of Tmp is going to be read.
-    Width useWidth(Tmp tmp) const
-    {
-        return widths(tmp).use;
-    }
+    inline Width useWidth(Tmp) const;
 
     void setWidths(Tmp, Width useWidth, Width defWidth);
 
@@ -107,16 +93,8 @@ private:
     };
 
     inline Widths& widths(Tmp);
-
-    const Widths& widths(Tmp tmp) const
-    {
-        return const_cast<TmpWidth*>(this)->widths(tmp);
-    }
-
-    void addWidths(Tmp tmp, Widths tmpWidths)
-    {
-        widths(tmp) = tmpWidths;
-    }
+    inline const Widths& widths(Tmp) const;
+    inline void addWidths(Tmp, Widths);
 
     Vector<Widths>& widthsVector(Bank bank)
     {

--- a/Source/JavaScriptCore/b3/air/AirTmpWidthInlines.h
+++ b/Source/JavaScriptCore/b3/air/AirTmpWidthInlines.h
@@ -44,6 +44,38 @@ inline TmpWidth::Widths& TmpWidth::widths(Tmp tmp)
     return m_widthFP[index];
 }
 
+const TmpWidth::Widths& TmpWidth::widths(Tmp tmp) const
+{
+    return const_cast<TmpWidth*>(this)->widths(tmp);
+}
+
+Width TmpWidth::width(Tmp tmp) const
+{
+    Widths tmpWidths = widths(tmp);
+    return std::min(tmpWidths.use, tmpWidths.def);
+}
+
+void TmpWidth::addWidths(Tmp tmp, Widths tmpWidths)
+{
+    widths(tmp) = tmpWidths;
+}
+
+Width TmpWidth::requiredWidth(Tmp tmp)
+{
+    Widths tmpWidths = widths(tmp);
+    return std::max(tmpWidths.use, tmpWidths.def);
+}
+
+Width TmpWidth::defWidth(Tmp tmp) const
+{
+    return widths(tmp).def;
+}
+
+Width TmpWidth::useWidth(Tmp tmp) const
+{
+    return widths(tmp).use;
+}
+
 } } } // namespace JSC::B3::Air
 
 #endif // ENABLE(B3_JIT)


### PR DESCRIPTION
#### 9eb2c98a7cee3c25cd96369b3826360394f86100
<pre>
[JSC] Move some inline functions from AirTmpWidth.h to AirTmpWidthInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=288181">https://bugs.webkit.org/show_bug.cgi?id=288181</a>

Reviewed by Yusuke Suzuki.

Non-unified source build couldn&apos;t compile:

&gt; JavaScriptCore/b3/air/AirTmpWidth.h(109,20): error: inline function &apos;JSC::B3::Air::TmpWidth::widths&apos; is not defined
&gt; JavaScriptCore/b3/air/AirTmpWidth.h(64,28): note: used here
&gt;    64 |         Widths tmpWidths = widths(tmp);
&gt;       |                            ^

An inline function `requiredWidth` was using an inline function
`widths` which was defined in AirTmpWidthInlines.h.

Inline functions which use inline functions in *Inlines.h should move
into *Inlines.h.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
* Source/JavaScriptCore/b3/air/AirTmpWidth.h:
(JSC::B3::Air::TmpWidth::width const): Deleted.
(JSC::B3::Air::TmpWidth::requiredWidth): Deleted.
(JSC::B3::Air::TmpWidth::defWidth const): Deleted.
(JSC::B3::Air::TmpWidth::useWidth const): Deleted.
(JSC::B3::Air::TmpWidth::widths const): Deleted.
(JSC::B3::Air::TmpWidth::addWidths): Deleted.
* Source/JavaScriptCore/b3/air/AirTmpWidthInlines.h:
(JSC::B3::Air::TmpWidth::widths const):
(JSC::B3::Air::TmpWidth::width const):
(JSC::B3::Air::TmpWidth::addWidths):
(JSC::B3::Air::TmpWidth::requiredWidth):
(JSC::B3::Air::TmpWidth::defWidth const):
(JSC::B3::Air::TmpWidth::useWidth const):

Canonical link: <a href="https://commits.webkit.org/290830@main">https://commits.webkit.org/290830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae230e2ad99dde0fd41a1ebacd5c65c9058319df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10790 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/19107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94255 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/84064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/90010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/18436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/19107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/98232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14411 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/18435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112589 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->