### PR TITLE
Deploy more smart pointers in ScrollbarsControllerMac.mm and AuthenticationMac.mm

### DIFF
--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -64,7 +64,7 @@ static NSScrollerImp *scrollerImpForScrollbar(Scrollbar& scrollbar)
 } // namespace WebCore
 
 @interface WebScrollerImpPairDelegate : NSObject <NSScrollerImpPairDelegate> {
-    WebCore::ScrollableArea* _scrollableArea;
+    WeakPtr<WebCore::ScrollableArea> _scrollableArea;
 }
 - (id)initWithScrollableArea:(WebCore::ScrollableArea*)scrollableArea;
 
@@ -90,45 +90,49 @@ static NSScrollerImp *scrollerImpForScrollbar(Scrollbar& scrollbar)
 - (NSRect)contentAreaRectForScrollerImpPair:(NSScrollerImpPair *)scrollerImpPair
 {
     UNUSED_PARAM(scrollerImpPair);
-    if (!_scrollableArea)
+    CheckedPtr scrollableArea = _scrollableArea.get();
+    if (!scrollableArea)
         return NSZeroRect;
 
-    WebCore::IntSize contentsSize = _scrollableArea->contentsSize();
+    WebCore::IntSize contentsSize = scrollableArea->contentsSize();
     return NSMakeRect(0, 0, contentsSize.width(), contentsSize.height());
 }
 
 - (BOOL)inLiveResizeForScrollerImpPair:(NSScrollerImpPair *)scrollerImpPair
 {
     UNUSED_PARAM(scrollerImpPair);
-    if (!_scrollableArea)
+    CheckedPtr scrollableArea = _scrollableArea.get();
+    if (!scrollableArea)
         return NO;
 
-    return _scrollableArea->inLiveResize();
+    return scrollableArea->inLiveResize();
 }
 
 - (NSPoint)mouseLocationInContentAreaForScrollerImpPair:(NSScrollerImpPair *)scrollerImpPair
 {
     UNUSED_PARAM(scrollerImpPair);
-    if (!_scrollableArea)
+    CheckedPtr scrollableArea = _scrollableArea.get();
+    if (!scrollableArea)
         return NSZeroPoint;
 
     // It's OK that this position isn't relative to this scroller (which might be an overflow scroller).
     // AppKit just takes the result and passes it back to -scrollerImpPair:convertContentPoint:toScrollerImp:.
-    return _scrollableArea->lastKnownMousePositionInView();
+    return scrollableArea->lastKnownMousePositionInView();
 }
 
 - (NSPoint)scrollerImpPair:(NSScrollerImpPair *)scrollerImpPair convertContentPoint:(NSPoint)pointInContentArea toScrollerImp:(NSScrollerImp *)scrollerImp
 {
     UNUSED_PARAM(scrollerImpPair);
 
-    if (!_scrollableArea || !scrollerImp)
+    CheckedPtr scrollableArea = _scrollableArea.get();
+    if (!scrollableArea || !scrollerImp)
         return NSZeroPoint;
 
     WebCore::Scrollbar* scrollbar = 0;
     if ([scrollerImp isHorizontal])
-        scrollbar = _scrollableArea->horizontalScrollbar();
+        scrollbar = scrollableArea->horizontalScrollbar();
     else
-        scrollbar = _scrollableArea->verticalScrollbar();
+        scrollbar = scrollableArea->verticalScrollbar();
 
     // It is possible to have a null scrollbar here since it is possible for this delegate
     // method to be called between the moment when a scrollbar has been set to 0 and the
@@ -148,23 +152,25 @@ static NSScrollerImp *scrollerImpForScrollbar(Scrollbar& scrollbar)
     UNUSED_PARAM(scrollerImpPair);
     UNUSED_PARAM(rect);
 
-    if (!_scrollableArea)
+    CheckedPtr scrollableArea = _scrollableArea.get();
+    if (!scrollableArea)
         return;
 
     if ([scrollerImpPair overlayScrollerStateIsLocked])
         return;
 
-    _scrollableArea->scrollbarsController().contentAreaWillPaint();
+    scrollableArea->scrollbarsController().contentAreaWillPaint();
 }
 
 - (void)scrollerImpPair:(NSScrollerImpPair *)scrollerImpPair updateScrollerStyleForNewRecommendedScrollerStyle:(NSScrollerStyle)newRecommendedScrollerStyle
 {
-    if (!_scrollableArea)
+    CheckedPtr scrollableArea = _scrollableArea.get();
+    if (!scrollableArea)
         return;
 
     [scrollerImpPair setScrollerStyle:newRecommendedScrollerStyle];
 
-    static_cast<WebCore::ScrollbarsControllerMac&>(_scrollableArea->scrollbarsController()).updateScrollerStyle();
+    static_cast<WebCore::ScrollbarsControllerMac&>(scrollableArea->scrollbarsController()).updateScrollerStyle();
 }
 
 @end

--- a/Source/WebCore/platform/network/AuthenticationClient.h
+++ b/Source/WebCore/platform/network/AuthenticationClient.h
@@ -26,12 +26,14 @@
 #ifndef AuthenticationClient_h
 #define AuthenticationClient_h
 
+#include <wtf/WeakPtr.h>
+
 namespace WebCore {
 
 class AuthenticationChallenge;
 class Credential;
 
-class AuthenticationClient {
+class AuthenticationClient : public CanMakeWeakPtr<AuthenticationClient> {
 public:
     virtual void receivedCredential(const AuthenticationChallenge&, const Credential&) = 0;
     virtual void receivedRequestToContinueWithoutCredential(const AuthenticationChallenge&) = 0;

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -30,7 +30,7 @@
 #include "StoredCredentialsPolicy.h"
 #include <wtf/Box.h>
 #include <wtf/MonotonicTime.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
@@ -79,7 +79,7 @@ class FragmentedSharedBuffer;
 class SynchronousLoaderMessageQueue;
 class Timer;
 
-class ResourceHandle : public RefCountedAndCanMakeWeakPtr<ResourceHandle>, public AuthenticationClient {
+class ResourceHandle : public RefCounted<ResourceHandle>, public AuthenticationClient {
 public:
     WEBCORE_EXPORT static RefPtr<ResourceHandle> create(NetworkingContext*, const ResourceRequest&, ResourceHandleClient*, bool defersLoading, bool shouldContentSniff, ContentEncodingSniffingPolicy, RefPtr<SecurityOrigin>&& sourceOrigin, bool isMainFrameNavigation);
     WEBCORE_EXPORT static void loadResourceSynchronously(NetworkingContext*, const ResourceRequest&, StoredCredentialsPolicy, SecurityOrigin*, ResourceError&, ResourceResponse&, Vector<uint8_t>& data);

--- a/Source/WebCore/platform/network/mac/AuthenticationMac.mm
+++ b/Source/WebCore/platform/network/mac/AuthenticationMac.mm
@@ -35,7 +35,7 @@ using namespace WebCore;
 
 @interface WebCoreAuthenticationClientAsChallengeSender : NSObject <NSURLAuthenticationChallengeSender>
 {
-    AuthenticationClient* m_client;
+    WeakPtr<AuthenticationClient> m_client;
 }
 - (id)initWithAuthenticationClient:(AuthenticationClient*)client;
 - (AuthenticationClient*)client;
@@ -55,42 +55,42 @@ using namespace WebCore;
 
 - (AuthenticationClient*)client
 {
-    return m_client;
+    return m_client.get();
 }
 
 - (void)detachClient
 {
-    m_client = 0;
+    m_client = nullptr;
 }
 
 - (void)performDefaultHandlingForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    if (m_client)
-        m_client->receivedRequestToPerformDefaultHandling(core(challenge));
+    if (RefPtr client = m_client.get())
+        client->receivedRequestToPerformDefaultHandling(core(challenge));
 }
 
 - (void)rejectProtectionSpaceAndContinueWithChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    if (m_client)
-        m_client->receivedChallengeRejection(core(challenge));
+    if (RefPtr client = m_client.get())
+        client->receivedChallengeRejection(core(challenge));
 }
 
 - (void)useCredential:(NSURLCredential *)credential forAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    if (m_client)
-        m_client->receivedCredential(core(challenge), Credential(credential));
+    if (RefPtr client = m_client.get())
+        client->receivedCredential(core(challenge), Credential(credential));
 }
 
 - (void)continueWithoutCredentialForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    if (m_client)
-        m_client->receivedRequestToContinueWithoutCredential(core(challenge));
+    if (RefPtr client = m_client.get())
+        client->receivedRequestToContinueWithoutCredential(core(challenge));
 }
 
 - (void)cancelAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    if (m_client)
-        m_client->receivedCancellation(core(challenge));
+    if (RefPtr client = m_client.get())
+        client->receivedCancellation(core(challenge));
 }
 
 @end


### PR DESCRIPTION
#### b5abd929a9f9f43a07167a5c0435e0b5def28d4d
<pre>
Deploy more smart pointers in ScrollbarsControllerMac.mm and AuthenticationMac.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=288182">https://bugs.webkit.org/show_bug.cgi?id=288182</a>

Reviewed by Alan Baradlay.

Addressed static analyzer warnings by using WeakPtr.

* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(-[WebScrollerImpPairDelegate contentAreaRectForScrollerImpPair:]):
(-[WebScrollerImpPairDelegate inLiveResizeForScrollerImpPair:]):
(-[WebScrollerImpPairDelegate mouseLocationInContentAreaForScrollerImpPair:]):
(-[WebScrollerImpPairDelegate scrollerImpPair:convertContentPoint:toScrollerImp:]):
(-[WebScrollerImpPairDelegate scrollerImpPair:setContentAreaNeedsDisplayInRect:]):
(-[WebScrollerImpPairDelegate scrollerImpPair:updateScrollerStyleForNewRecommendedScrollerStyle:]):
* Source/WebCore/platform/network/AuthenticationClient.h:
* Source/WebCore/platform/network/ResourceHandle.h:
* Source/WebCore/platform/network/mac/AuthenticationMac.mm:
(-[WebCoreAuthenticationClientAsChallengeSender client]):
(-[WebCoreAuthenticationClientAsChallengeSender detachClient]):
(-[WebCoreAuthenticationClientAsChallengeSender performDefaultHandlingForAuthenticationChallenge:]):
(-[WebCoreAuthenticationClientAsChallengeSender rejectProtectionSpaceAndContinueWithChallenge:]):
(-[WebCoreAuthenticationClientAsChallengeSender useCredential:forAuthenticationChallenge:]):
(-[WebCoreAuthenticationClientAsChallengeSender continueWithoutCredentialForAuthenticationChallenge:]):
(-[WebCoreAuthenticationClientAsChallengeSender cancelAuthenticationChallenge:]):

Canonical link: <a href="https://commits.webkit.org/290800@main">https://commits.webkit.org/290800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b86fd9652e9c0630ff34ce4f8f78c1fd30a7c5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96106 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41867 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70010 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27537 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94101 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8418 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98087 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18304 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79024 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78224 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22728 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/84 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14390 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23637 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18031 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19810 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->