### PR TITLE
Allow run-benchmark to collect PGO profiles for other platforms.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py
@@ -70,3 +70,13 @@ class BrowserDriver:
     @property
     def webdriver_binary_path(self):
         return get_driver_binary_path(self.browser_name)
+
+    @property
+    def pgo_profile_output_directory(self):
+        raise NotImplementedError()
+
+    def prepare_pgo_profile_collection(self):
+        raise NotImplementedError()
+
+    def collect_pgo_profile(self, destination):
+        raise NotImplementedError()

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py
@@ -164,3 +164,11 @@ class OSXBrowserDriver(BrowserDriver):
         temp_args = args[:]
         temp_args.insert(pos, url)
         return temp_args
+
+    def prepare_pgo_profile_collection(self):
+        shutil.rmtree(self.pgo_profile_output_directory, ignore_errors=True)
+        os.mkdir(self.pgo_profile_output_directory)
+
+    def collect_pgo_profile(self, destination):
+        _log.info(f'Copying PGO profiles from {self.pgo_profile_output_directory} to {destination}')
+        shutil.copytree(self.pgo_profile_output_directory, destination, dirs_exist_ok=True)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py
@@ -110,3 +110,7 @@ class OSXSafariDriver(OSXBrowserDriver):
             subprocess.check_call(['/usr/bin/defaults', 'write', 'com.apple.Safari', 'NSWindow Frame BrowserWindowFrame', ' '.join(['0', '0', str(cls._screen_size().width), str(cls._screen_size().height)] * 2)])
         except Exception as error:
             _log.error('Reset safari window size failed - Error: {}'.format(error))
+
+    @property
+    def pgo_profile_output_directory(self):
+        return '/private/tmp/WebKitPGO'

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -19,8 +19,6 @@ benchmark_runner_subclasses = {
     WebServerBenchmarkRunner.name: WebServerBenchmarkRunner,
 }
 
-WEBKIT_PGO_DIR = '/private/tmp/WebKitPGO'
-
 def default_platform():
     if sys.platform.startswith('linux'):
         return 'linux'
@@ -90,9 +88,6 @@ def parse_args(parser=None):
     if (args.generate_pgo_profiles or args.trace_type) and not args.diagnose_dir:
         raise Exception('Collecting profiles requires a diagnostic directory (--diagnose-directory) to be set.')
 
-    if args.generate_pgo_profiles and args.platform != 'osx':
-        raise Exception('PGO Profile generation is currently only supported on macOS.')
-
     return args
 
 
@@ -102,7 +97,7 @@ def run_benchmark_plan(args, plan):
                                     args.local_copy, args.count, args.timeout, args.build_dir, args.output_file,
                                     args.platform, args.browser, args.browser_path, args.subtests, args.scale_unit,
                                     args.show_iteration_values, args.device_id, args.diagnose_dir,
-                                    WEBKIT_PGO_DIR if args.generate_pgo_profiles else None,
+                                    args.generate_pgo_profiles,
                                     args.diagnose_dir if args.trace_type else None,
                                     args.trace_type, args.profiling_interval,
                                     args.browser_args, args.http_server_type)


### PR DESCRIPTION
#### 67556ed539e7987c71c7d6eff0457b7ea7e41172
<pre>
Allow run-benchmark to collect PGO profiles for other platforms.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288183">https://bugs.webkit.org/show_bug.cgi?id=288183</a>
<a href="https://rdar.apple.com/138666783">rdar://138666783</a>

Reviewed by Alexey Proskuryakov.

Refactor run-benchmark script to allow collecting PGO profiles on different
platforms and browsers.

* Tools/Scripts/webkitpy/benchmark_runner/benchmark_runner.py:
(BenchmarkRunner.__init__):
(BenchmarkRunner._run_benchmark):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/browser_driver.py:
(BrowserDriver.webdriver_binary_path):
(BrowserDriver):
(BrowserDriver.pgo_profile_output_directory):
(BrowserDriver.prepare_pgo_profile_collection):
(BrowserDriver.collect_pgo_profile):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_browser_driver.py:
(OSXBrowserDriver._insert_url):
(OSXBrowserDriver):
(OSXBrowserDriver.prepare_pgo_profile_collection):
(OSXBrowserDriver.collect_pgo_profile):
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/osx_safari_driver.py:
(OSXSafariDriver._maximize_window):
(OSXSafariDriver):
(OSXSafariDriver.pgo_profile_output_directory):
* Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py:
(parse_args):
(run_benchmark_plan):

Canonical link: <a href="https://commits.webkit.org/290829@main">https://commits.webkit.org/290829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59facc87011fc18ddbbab15a77e73cb3c140cb0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91228 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96225 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93278 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19085 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70093 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94229 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50419 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/90723 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/237 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98211 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18418 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78307 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19362 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18418 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->