### PR TITLE
[JSC] Remove already enabled & shipped feature flags

### DIFF
--- a/JSTests/microbenchmarks/from-hex.js
+++ b/JSTests/microbenchmarks/from-hex.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function test(string)
 {
     return Uint8Array.fromHex(string);

--- a/JSTests/microbenchmarks/to-base64.js
+++ b/JSTests/microbenchmarks/to-base64.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function test(buffer)
 {
     return buffer.toBase64();

--- a/JSTests/microbenchmarks/to-hex.js
+++ b/JSTests/microbenchmarks/to-hex.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function test(buffer)
 {
     return buffer.toHex();

--- a/JSTests/stress/error-isError.js
+++ b/JSTests/stress/error-isError.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useErrorIsError=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);

--- a/JSTests/stress/promise-try.js
+++ b/JSTests/stress/promise-try.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--usePromiseTryMethod=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`expected ${expected} but got ${actual}`);

--- a/JSTests/stress/regexp-escape.js
+++ b/JSTests/stress/regexp-escape.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useRegExpEscape=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-fromBase64.js
+++ b/JSTests/stress/uint8array-fromBase64.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-fromHex.js
+++ b/JSTests/stress/uint8array-fromHex.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-setFromBase64-write-up-to-error.js
+++ b/JSTests/stress/uint8array-setFromBase64-write-up-to-error.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-setFromBase64.js
+++ b/JSTests/stress/uint8array-setFromBase64.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-setFromHex.js
+++ b/JSTests/stress/uint8array-setFromHex.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-toBase64.js
+++ b/JSTests/stress/uint8array-toBase64.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/stress/uint8array-toHex.js
+++ b/JSTests/stress/uint8array-toHex.js
@@ -1,5 +1,3 @@
-//@ requireOptions("--useUint8ArrayBase64Methods=1")
-
 function shouldBe(actual, expected) {
     if (actual !== expected)
         throw new Error(`FAIL: expected '${expected}' actual '${actual}'`);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -3,15 +3,10 @@
 flags:
   SharedArrayBuffer: useSharedArrayBuffer
   Atomics: useSharedArrayBuffer
-  Atomics.pause: useAtomicsPause
   iterator-helpers: useIteratorHelpers
   Temporal: useTemporal
   ShadowRealm: useShadowRealm
-  promise-try: usePromiseTryMethod
-  uint8array-base64: useUint8ArrayBase64Methods
-  RegExp.escape: useRegExpEscape
   Math.sumPrecise: useMathSumPreciseMethod
-  Error.isError: useErrorIsError
   json-parse-with-source: useJSONSourceTextAccess
   iterator-sequencing: useIteratorSequencing
 skip:

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -91,8 +91,7 @@ void AtomicsObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     FOR_EACH_ATOMICS_FUNC(PUT_DIRECT_NATIVE_FUNC)
 #undef PUT_DIRECT_NATIVE_FUNC
 
-    if (Options::useAtomicsPause())
-        JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("pause"_s, atomicsFuncPause, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, AtomicsPauseIntrinsic);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("pause"_s, atomicsFuncPause, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, AtomicsPauseIntrinsic);
 
     if (vm.vmType == VM::VMType::Default)
         JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("waitAsync"_s, atomicsFuncWaitAsync, static_cast<unsigned>(PropertyAttribute::DontEnum), 4, ImplementationVisibility::Public, AtomicsWaitAsyncIntrinsic);

--- a/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorConstructor.cpp
@@ -50,9 +50,7 @@ void ErrorConstructor::finishCreation(VM& vm, ErrorPrototype* errorPrototype)
     putDirectWithoutTransition(vm, vm.propertyNames->stackTraceLimit, jsNumber(globalObject->stackTraceLimit().value_or(Options::defaultErrorStackTraceLimit())), static_cast<unsigned>(PropertyAttribute::None));
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->captureStackTrace, errorConstructorCaptureStackTrace, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-
-    if (Options::useErrorIsError())
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isError"_s, errorConstructorIsError, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isError"_s, errorConstructorIsError, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
 }
 
 // ECMA 15.9.3

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -54,10 +54,8 @@ void JSGenericTypedArrayViewConstructor<ViewClass>::finishCreation(VM& vm, JSGlo
     putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
 
     if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
-        if (Options::useUint8ArrayBase64Methods()) {
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromBase64"_s, uint8ArrayConstructorFromBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromHex"_s, uint8ArrayConstructorFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-        }
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromBase64"_s, uint8ArrayConstructorFromBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("fromHex"_s, uint8ArrayConstructorFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
@@ -48,12 +48,10 @@ void JSGenericTypedArrayViewPrototype<ViewClass>::finishCreation(
     putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
 
     if constexpr (std::is_same_v<ViewClass, JSUint8Array>) {
-        if (Options::useUint8ArrayBase64Methods()) {
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromBase64"_s, uint8ArrayPrototypeSetFromBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromHex"_s, uint8ArrayPrototypeSetFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toBase64"_s, uint8ArrayPrototypeToBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-            JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toHex"_s, uint8ArrayPrototypeToHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
-        }
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromBase64"_s, uint8ArrayPrototypeSetFromBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("setFromHex"_s, uint8ArrayPrototypeSetFromHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toBase64"_s, uint8ArrayPrototypeToBase64, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("toHex"_s, uint8ArrayPrototypeToHex, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     }
 
     globalObject->installTypedArrayIteratorProtocolWatchpoint(this, ViewClass::TypedArrayStorageType);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1435,9 +1435,6 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     IntlObject* intl = IntlObject::create(vm, this, IntlObject::createStructure(vm, this, m_objectPrototype.get()));
     putDirectWithoutTransition(vm, vm.propertyNames->Intl, intl, static_cast<unsigned>(PropertyAttribute::DontEnum));
 
-    if (Options::useFloat16Array())
-        putDirectWithoutTransition(vm, Identifier::fromString(vm, "Float16Array"_s), JSGlobalObject::m_typedArrayFloat16.constructor(this), static_cast<unsigned>(PropertyAttribute::DontEnum));
-
     if (Options::useTemporal()) {
         m_calendarStructure.initLater(
             [] (const Initializer<Structure>& init) {

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -86,8 +86,7 @@ void JSPromiseConstructor::finishCreation(VM& vm, JSPromisePrototype* promisePro
     GetterSetter* speciesGetterSetter = GetterSetter::create(vm, globalObject, JSFunction::create(vm, globalObject, 0, "get [Symbol.species]"_s, globalFuncSpeciesGetter, ImplementationVisibility::Public, SpeciesGetterIntrinsic), nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, speciesGetterSetter, PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().withResolversPublicName(), promiseConstructorWithResolversCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    if (Options::usePromiseTryMethod())
-        JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->tryKeyword, promiseConstructorTryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->tryKeyword, promiseConstructorTryCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 void JSPromiseConstructor::addOwnInternalSlots(VM& vm, JSGlobalObject* globalObject)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -606,9 +606,6 @@ bool hasCapacityToUseLargeGigacage();
     \
     /* Feature Flags */\
     \
-    v(Bool, useAtomicsPause, true, Normal, "Expose Atomics.pause."_s) \
-    v(Bool, useErrorIsError, true, Normal, "Expose Error.isError feature."_s) \
-    v(Bool, useFloat16Array, true, Normal, "Expose Float16Array."_s) \
     v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorHelpers, true, Normal, "Expose the Iterator Helpers."_s) \
@@ -617,13 +614,10 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useMapGetOrInsert, false, Normal, "Expose the Map.prototype.getOrInsert family of methods."_s) \
     v(Bool, useMathSumPreciseMethod, false, Normal, "Expose the Math.sumPrecise() method."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \
-    v(Bool, usePromiseTryMethod, true, Normal, "Expose the Promise.try() method."_s) \
-    v(Bool, useRegExpEscape, true, Normal, "Expose RegExp.escape feature."_s) \
     v(Bool, useSharedArrayBuffer, false, Normal, nullptr) \
     v(Bool, useShadowRealm, false, Normal, "Expose the ShadowRealm object."_s) \
     v(Bool, useTemporal, false, Normal, "Expose the Temporal object."_s) \
     v(Bool, useTrustedTypes, false, Normal, "Enable trusted types eval protection feature."_s) \
-    v(Bool, useUint8ArrayBase64Methods, true, Normal, "Expose methods for converting Uint8Array to/from base64 and hex."_s) \
     v(Bool, useWasmSIMD, true, Normal, "Allow the new simd instructions and types from the wasm simd spec."_s) \
     v(Bool, useWasmRelaxedSIMD, false, Normal, "Allow the relaxed simd instructions and types from the wasm relaxed simd spec."_s) \
     v(Bool, useWasmTailCalls, true, Normal, "Allow the new instructions from the wasm tail calls spec."_s) \

--- a/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpConstructor.cpp
@@ -95,8 +95,7 @@ void RegExpConstructor::finishCreation(VM& vm, RegExpPrototype* regExpPrototype)
 
     JSGlobalObject* globalObject = regExpPrototype->globalObject();
 
-    if (Options::useRegExpEscape())
-        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("escape"_s, regExpConstructorEscape, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("escape"_s, regExpConstructorEscape, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
 
     GetterSetter* speciesGetterSetter = GetterSetter::create(vm, globalObject, JSFunction::create(vm, globalObject, 0, "get [Symbol.species]"_s, globalFuncSpeciesGetter, ImplementationVisibility::Public, SpeciesGetterIntrinsic), nullptr);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, speciesGetterSetter, PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);


### PR DESCRIPTION
#### a5d9483b566d31b579e7db915d5c630e4e303909
<pre>
[JSC] Remove already enabled &amp; shipped feature flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=288184">https://bugs.webkit.org/show_bug.cgi?id=288184</a>
<a href="https://rdar.apple.com/145274033">rdar://145274033</a>

Reviewed by Yijia Huang.

Remove already enabled &amp; shipped JS feature flags to clean up the code.

* JSTests/microbenchmarks/from-hex.js:
* JSTests/microbenchmarks/to-base64.js:
* JSTests/microbenchmarks/to-hex.js:
* JSTests/stress/error-isError.js:
* JSTests/stress/promise-try.js:
* JSTests/stress/regexp-escape.js:
* JSTests/stress/uint8array-fromBase64.js:
* JSTests/stress/uint8array-fromHex.js:
* JSTests/stress/uint8array-setFromBase64-write-up-to-error.js:
* JSTests/stress/uint8array-setFromBase64.js:
* JSTests/stress/uint8array-setFromHex.js:
* JSTests/stress/uint8array-toBase64.js:
* JSTests/stress/uint8array-toHex.js:
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
(JSC::AtomicsObject::finishCreation):
* Source/JavaScriptCore/runtime/ErrorConstructor.cpp:
(JSC::ErrorConstructor::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::JSGenericTypedArrayViewConstructor&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h:
(JSC::JSGenericTypedArrayViewPrototype&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSPromiseConstructor::finishCreation):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/runtime/RegExpConstructor.cpp:
(JSC::RegExpConstructor::finishCreation):

Canonical link: <a href="https://commits.webkit.org/290777@main">https://commits.webkit.org/290777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8590680145a36f441577d1f16abf682710a2400

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91099 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96105 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41866 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18960 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94100 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/114 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/40996 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83919 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98086 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89868 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18303 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78222 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22727 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/85 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14374 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18304 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112437 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18030 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32652 "Found 7 new JSC stress test failures: wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->