### PR TITLE
[Unified PDF] Zoom not working in WKWebView

### DIFF
--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -68,7 +68,6 @@ struct ViewportArguments {
         // These are ordered in increasing importance.
         Implicit,
 #if PLATFORM(IOS_FAMILY)
-        PluginDocument,
         ImageDocument,
 #endif
         ViewportMeta,

--- a/Source/WebCore/html/PluginDocument.cpp
+++ b/Source/WebCore/html/PluginDocument.cpp
@@ -107,11 +107,6 @@ void PluginDocumentParser::createDocumentStructure()
     if (document.frame())
         document.frame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 
-#if PLATFORM(IOS_FAMILY)
-    // Should not be able to zoom into standalone plug-in documents.
-    document.processViewport("user-scalable=no"_s, ViewportArguments::Type::PluginDocument);
-#endif
-
     auto body = HTMLBodyElement::create(document);
     rootElement->appendChild(body);
         

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -425,23 +425,6 @@ ViewportConfiguration::Parameters ViewportConfiguration::nativeWebpageParameters
     return parameters;
 }
 
-#if ENABLE(PDF_PLUGIN)
-ViewportConfiguration::Parameters ViewportConfiguration::pluginDocumentParameters()
-{
-    Parameters parameters;
-    parameters.width = ViewportArguments::ValueDeviceWidth;
-    parameters.widthIsSet = true;
-    parameters.allowsShrinkToFit = false;
-    parameters.minimumScale = 1;
-    parameters.maximumScale = 1;
-    parameters.initialScale = 1;
-    parameters.initialScaleIgnoringLayoutScaleFactor = 1;
-    parameters.initialScaleIsSet = true;
-    parameters.shouldHonorMinimumEffectiveDeviceWidthFromClient = false;
-    return parameters;
-}
-#endif
-
 ViewportConfiguration::Parameters ViewportConfiguration::webpageParameters()
 {
     Parameters parameters;

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -182,13 +182,13 @@ private:
     constexpr double forceAlwaysUserScalableMaximumScale() const
     {
         const double forceAlwaysUserScalableMaximumScaleIgnoringLayoutScaleFactor = 5;
-        return forceAlwaysUserScalableMaximumScaleIgnoringLayoutScaleFactor * effectiveLayoutSizeScaleFactor();
+        return std::max(m_configuration.maximumScale, forceAlwaysUserScalableMaximumScaleIgnoringLayoutScaleFactor) * effectiveLayoutSizeScaleFactor();
     }
 
     constexpr double forceAlwaysUserScalableMinimumScale() const
     {
         const double forceAlwaysUserScalableMinimumScaleIgnoringLayoutScaleFactor = 1;
-        return forceAlwaysUserScalableMinimumScaleIgnoringLayoutScaleFactor * effectiveLayoutSizeScaleFactor();
+        return std::min(m_configuration.minimumScale, forceAlwaysUserScalableMinimumScaleIgnoringLayoutScaleFactor) * effectiveLayoutSizeScaleFactor();
     }
 
     constexpr double effectiveLayoutSizeScaleFactor() const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2016,7 +2016,6 @@ header: <WebCore/RectEdges.h>
 [Nested] enum class WebCore::ViewportArguments::Type : uint8_t {
     Implicit,
 #if PLATFORM(IOS_FAMILY)
-    PluginDocument,
     ImageDocument,
 #endif
     ViewportMeta

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -36,6 +36,7 @@
 #include <WebCore/GraphicsLayerClient.h>
 #include <WebCore/Page.h>
 #include <WebCore/Timer.h>
+#include <WebCore/ViewportConfiguration.h>
 #include <wtf/OptionSet.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -216,6 +217,8 @@ public:
     double maxScaleFactor() const final;
 
     bool shouldSizeToFitContent() const final;
+
+    static WebCore::ViewportConfiguration::Parameters viewportParameters();
 
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
@@ -681,7 +684,11 @@ private:
 
     // FIXME: We should rationalize these with the values in ViewGestureController.
     // For now, we'll leave them differing as they do in PDFPlugin.
+#if PLATFORM(IOS_FAMILY)
+    static constexpr double minimumZoomScale = 1;
+#else
     static constexpr double minimumZoomScale = 0.2;
+#endif
     static constexpr double maximumZoomScale = 6.0;
 };
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4489,6 +4489,22 @@ bool UnifiedPDFPlugin::layerNeedsPlatformContext(const GraphicsLayer* layer) con
     return !shouldUseInProcessBackingStore() && (layer == layerForHorizontalScrollbar() || layer == layerForVerticalScrollbar() || layer == layerForScrollCorner());
 }
 
+ViewportConfiguration::Parameters UnifiedPDFPlugin::viewportParameters()
+{
+    ViewportConfiguration::Parameters parameters;
+    parameters.width = ViewportArguments::ValueDeviceWidth;
+    parameters.widthIsSet = true;
+    parameters.allowsUserScaling = true;
+    parameters.allowsShrinkToFit = false;
+    parameters.minimumScale = minimumZoomScale;
+    parameters.maximumScale = maximumZoomScale;
+    parameters.initialScale = 1;
+    parameters.initialScaleIgnoringLayoutScaleFactor = 1;
+    parameters.initialScaleIsSet = true;
+    parameters.shouldHonorMinimumEffectiveDeviceWidthFromClient = false;
+    return parameters;
+}
+
 TextStream& operator<<(TextStream& ts, RepaintRequirement requirement)
 {
     switch (requirement) {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -49,6 +49,7 @@
 #import "TapHandlingResult.h"
 #import "TextCheckingControllerProxy.h"
 #import "UIKitSPI.h"
+#import "UnifiedPDFPlugin.h"
 #import "UserData.h"
 #import "ViewGestureGeometryCollector.h"
 #import "VisibleContentRectUpdateInfo.h"
@@ -4560,7 +4561,7 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
             m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::textDocumentParameters());
 #if ENABLE(PDF_PLUGIN)
         else if (m_page->settings().unifiedPDFEnabled() && document->isPluginDocument())
-            m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::pluginDocumentParameters());
+            m_viewportConfiguration.setDefaultConfiguration(UnifiedPDFPlugin::viewportParameters());
 #endif
         else
             configureWithParametersForStandardFrame = true;


### PR DESCRIPTION
#### a30c570b4fcbafa412fed2b96ec5fe45f46fb52f
<pre>
[Unified PDF] Zoom not working in WKWebView
<a href="https://bugs.webkit.org/show_bug.cgi?id=288186">https://bugs.webkit.org/show_bug.cgi?id=288186</a>
<a href="https://rdar.apple.com/145047812">rdar://145047812</a>

Reviewed by Abrar Rahman Protyasha.

By default, WebKit respects &quot;user-scalable=no&quot;. Safari overrides this to force
pages to always be scalable. For multiple different reasons, all fixed in this patch,
the default viewport configuration for main frame UnifiedPDFPlugin had &quot;user-scalable=no&quot; set.

* Source/WebCore/html/PluginDocument.cpp:
Don&apos;t explicitly set user-scalable=no...

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::pluginDocumentParameters): Deleted.
Remove this PDFPlugin-specific code from WebCore.

* Source/WebCore/page/ViewportConfiguration.h:
(WebCore::ViewportConfiguration::forceAlwaysUserScalableMaximumScale const):
(WebCore::ViewportConfiguration::forceAlwaysUserScalableMinimumScale const):
Don&apos;t let &quot;force always user-scalable&quot; to ever *reduce* the available scale range, only increase it.
This prevents it from reducing our PDF maximum scale from 6x to 5x.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::viewportParameters):
Move the UnifiedPDFPlugin default viewport parameters computation to a static method on UnifiedPDFPlugin.
Critically, change the maximum scale to match UnifiedPDFPlugin&apos;s normal maximum scale,
and set `allowsUserScaling` to true (e.g. &quot;user-scalable=yes&quot;). The combination
of these two things make scaling work when in the default &quot;do not force always user-scalable&quot; state.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::resetViewportDefaultConfiguration):
Ask UnifiedPDFPlugin for its viewport configuration instead of WebCore.

Canonical link: <a href="https://commits.webkit.org/290779@main">https://commits.webkit.org/290779@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccf33cb27265a3a98680c9549a3528c21e9cb427

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/150 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18974 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94114 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/126 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41008 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98098 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18315 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78385 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78232 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19331 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22739 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/94 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18318 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19819 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->