### PR TITLE
Use smart pointers in GraphicsContextGLCVCocoa

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -133,7 +133,6 @@ platform/graphics/angle/GraphicsContextGLANGLE.cpp
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/PlatformCALayer.h
 platform/graphics/ca/TileController.cpp
-platform/graphics/cv/GraphicsContextGLCVCocoa.h
 platform/graphics/mac/LegacyDisplayRefreshMonitorMac.h
 platform/mediarecorder/MediaRecorderPrivateEncoder.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -67,7 +67,6 @@ platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
 platform/graphics/ca/TileController.h
 platform/graphics/controls/PlatformControl.h
 platform/graphics/coretext/DrawGlyphsRecorder.h
-platform/graphics/cv/GraphicsContextGLCVCocoa.h
 platform/mediarecorder/MediaRecorderPrivate.h
 platform/mediastream/AudioMediaStreamTrackRenderer.h
 platform/mediastream/mac/CoreAudioCaptureSource.h

--- a/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -151,7 +151,6 @@ platform/graphics/coretext/FontCascadeCoreText.cpp
 platform/graphics/coretext/FontCoreText.cpp
 platform/graphics/coretext/FontPlatformDataCoreText.cpp
 platform/graphics/cv/CVUtilities.mm
-platform/graphics/cv/GraphicsContextGLCVCocoa.mm
 platform/graphics/cv/ImageRotationSessionVT.mm
 platform/graphics/cv/ImageTransferSessionVT.mm
 platform/graphics/cv/VideoFrameCV.mm

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h
@@ -54,7 +54,7 @@ private:
 
     RetainPtr<CVPixelBufferRef> convertPixelBuffer(CVPixelBufferRef);
 
-    GraphicsContextGLCocoa& m_owner;
+    Ref<GraphicsContextGLCocoa> m_owner;
     GCGLDisplay m_display { nullptr };
     GCGLContext m_context { nullptr };
     GCGLConfig m_config { nullptr };

--- a/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
+++ b/Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm
@@ -495,7 +495,7 @@ GraphicsContextGLCVCocoa::GraphicsContextGLCVCocoa(GraphicsContextGLCocoa& owner
         EGL_DestroyContext(display, context);
     });
 
-    const bool useTexture2D = m_owner.drawingBufferTextureTarget() == GL_TEXTURE_2D;
+    const bool useTexture2D = owner.drawingBufferTextureTarget() == GL_TEXTURE_2D;
 
 #if PLATFORM(MAC)
     if (!useTexture2D) {
@@ -582,9 +582,9 @@ GraphicsContextGLCVCocoa::GraphicsContextGLCVCocoa(GraphicsContextGLCocoa& owner
 bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& videoFrame, PlatformGLObject outputTexture, GLint level, GLenum internalFormat, GLenum format, GLenum type, FlipY unpackFlipY)
 {
     RetainPtr<CVPixelBufferRef> convertedImage;
-    auto image = videoFrame.pixelBuffer();
+    RetainPtr<CVPixelBufferRef> image = videoFrame.pixelBuffer();
     // FIXME: This currently only supports '420v' and '420f' pixel formats. Investigate supporting more pixel formats.
-    OSType pixelFormat = CVPixelBufferGetPixelFormatType(image);
+    OSType pixelFormat = CVPixelBufferGetPixelFormatType(image.get());
     if (pixelFormat != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange // NOLINT
         && pixelFormat != kCVPixelFormatType_420YpCbCr8BiPlanarFullRange
 #if HAVE(COREVIDEO_COMPRESSED_PIXEL_FORMAT_TYPES)
@@ -592,21 +592,21 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
         && pixelFormat != kCVPixelFormatType_AGX_420YpCbCr8BiPlanarFullRange
 #endif
         ) {
-        convertedImage = convertPixelBuffer(image);
+        convertedImage = convertPixelBuffer(image.get());
         if (!convertedImage) {
             LOG(WebGL, "GraphicsContextGLCVCocoa(%p) - failed converting an image with pixel format ('%s').", this, FourCC(pixelFormat).string().data());
             return false;
         }
         image = convertedImage.get();
-        pixelFormat = CVPixelBufferGetPixelFormatType(image);
+        pixelFormat = CVPixelBufferGetPixelFormatType(image.get());
         ASSERT(pixelFormat == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange);
     }
-    IOSurfaceRef surface = CVPixelBufferGetIOSurface(image);
+    RetainPtr<IOSurfaceRef> surface = CVPixelBufferGetIOSurface(image.get());
     if (!surface)
         return false;
 
     auto orientation = videoFrame.orientation();
-    TextureContent content { reinterpret_cast<intptr_t>(surface), IOSurfaceGetID(surface), IOSurfaceGetSeed(surface), level, internalFormat, format, type, unpackFlipY, orientation };
+    TextureContent content { reinterpret_cast<intptr_t>(surface.get()), IOSurfaceGetID(surface.get()), IOSurfaceGetSeed(surface.get()), level, internalFormat, format, type, unpackFlipY, orientation };
     auto it = m_knownContent.find(outputTexture);
     if (it != m_knownContent.end() && it->value == content) {
         // If the texture hasn't been modified since the last time we copied to it, and the
@@ -664,8 +664,8 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     if (unpackFlipY == FlipY::Yes)
         flipY = !flipY;
 
-    size_t sourceWidth = CVPixelBufferGetWidth(image);
-    size_t sourceHeight = CVPixelBufferGetHeight(image);
+    size_t sourceWidth = CVPixelBufferGetWidth(image.get());
+    size_t sourceHeight = CVPixelBufferGetHeight(image.get());
 
     size_t width = swapXY ? sourceHeight : sourceWidth;
     size_t height = swapXY ? sourceWidth : sourceHeight;
@@ -692,12 +692,12 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     GL_BindTexture(GL_TEXTURE_2D, 0);
 
     // Bind and set up the textures for the video source.
-    auto yPlaneWidth = IOSurfaceGetWidthOfPlane(surface, 0);
-    auto yPlaneHeight = IOSurfaceGetHeightOfPlane(surface, 0);
-    auto uvPlaneWidth = IOSurfaceGetWidthOfPlane(surface, 1);
-    auto uvPlaneHeight = IOSurfaceGetHeightOfPlane(surface, 1);
+    auto yPlaneWidth = IOSurfaceGetWidthOfPlane(surface.get(), 0);
+    auto yPlaneHeight = IOSurfaceGetHeightOfPlane(surface.get(), 0);
+    auto uvPlaneWidth = IOSurfaceGetWidthOfPlane(surface.get(), 1);
+    auto uvPlaneHeight = IOSurfaceGetHeightOfPlane(surface.get(), 1);
 
-    GLenum videoTextureTarget = m_owner.drawingBufferTextureTarget();
+    GLenum videoTextureTarget = m_owner->drawingBufferTextureTarget();
 
     GLuint uvTexture = 0;
     GL_GenTextures(1, &uvTexture);
@@ -710,7 +710,7 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     GL_TexParameteri(videoTextureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    auto uvHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, videoTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RG, uvPlaneWidth, uvPlaneHeight, GL_UNSIGNED_BYTE, surface, 1);
+    auto uvHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, videoTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RG, uvPlaneWidth, uvPlaneHeight, GL_UNSIGNED_BYTE, surface.get(), 1);
     if (!uvHandle)
         return false;
     auto uvHandleCleanup = makeScopeExit([display = m_display, uvHandle] {
@@ -728,7 +728,7 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     GL_TexParameteri(videoTextureTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     GL_TexParameteri(videoTextureTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    auto yHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, videoTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RED, yPlaneWidth, yPlaneHeight, GL_UNSIGNED_BYTE, surface, 0);
+    auto yHandle = WebCore::createPbufferAndAttachIOSurface(m_display, m_config, videoTextureTarget, EGL_IOSURFACE_READ_HINT_ANGLE, GL_RED, yPlaneWidth, yPlaneHeight, GL_UNSIGNED_BYTE, surface.get(), 0);
     if (!yHandle)
         return false;
     auto yHandleCleanup = makeScopeExit([display = m_display, yHandle] {
@@ -745,7 +745,7 @@ bool GraphicsContextGLCVCocoa::copyVideoSampleToTexture(const VideoFrameCV& vide
     GL_Uniform2f(m_uvTextureSizeUniformLocation, uvPlaneWidth, uvPlaneHeight);
 
     auto range = pixelRangeFromPixelFormat(pixelFormat);
-    auto transferFunction = transferFunctionFromString(dynamic_cf_cast<CFStringRef>(CVBufferGetAttachment(image, kCVImageBufferYCbCrMatrixKey, nil)));
+    auto transferFunction = transferFunctionFromString(dynamic_cf_cast<CFStringRef>(CVBufferGetAttachment(image.get(), kCVImageBufferYCbCrMatrixKey, nil)));
     auto colorMatrix = YCbCrToRGBMatrixForRangeAndTransferFunction(range, transferFunction);
     GL_UniformMatrix4fv(m_colorMatrixUniformLocation, 1, GL_FALSE, colorMatrix);
 


### PR DESCRIPTION
#### e114331fe957f4e80e9e3bd18f772a320b0c3f16
<pre>
Use smart pointers in GraphicsContextGLCVCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=288192">https://bugs.webkit.org/show_bug.cgi?id=288192</a>

Reviewed by NOBODY (OOPS!).

Use smart pointers in GraphicsContextGLCVCocoa.

* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.h:
* Source/WebCore/platform/graphics/cv/GraphicsContextGLCVCocoa.mm:
(WebCore::GraphicsContextGLCVCocoa::GraphicsContextGLCVCocoa):
(WebCore::GraphicsContextGLCVCocoa::copyVideoSampleToTexture):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e114331fe957f4e80e9e3bd18f772a320b0c3f16

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/18301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103792 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/49256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/75121 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32268 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/14116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/89107 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55477 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13898 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/7072 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/7150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/106164 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25758 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18777 "Found 1 new test failure: webgl/pending/conformance2/misc/webgl2-after-webgl1-bug.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/84091 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/26135 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83576 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/28218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19469 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25716 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30898 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28854 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/27109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->