### PR TITLE
[scroll-animations] WPT test scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt
@@ -22,7 +22,7 @@ PASS Current times and effect phase at timeline boundary when delay = 250 and en
 PASS Current times and effect phase at timeline start when delay = -125 and endDelay = -125 |
 PASS Current times and effect phase in active range when delay = -125 and endDelay = -125 |
 PASS Current times and effect phase at timeline end when delay = -125 and endDelay = -125 |
-FAIL Playback rate affects whether active phase boundary is inclusive. assert_not_equals: Animation effect is in active phase when current time is 100%. got disallowed value null
+PASS Playback rate affects whether active phase boundary is inclusive.
 PASS Verify that (play -> pause -> play) doesn't change phase/progress.
 PASS Pause in before phase, scroll timeline into active phase, animation should remain in the before phase
 PASS Pause in before phase, set animation current time to be in active range, animation should become active. Scrolling should have no effect.

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/testcommon.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/testcommon.js
@@ -297,11 +297,20 @@ function assert_phase(animation, phase) {
 
   if (phase === 'active') {
     // If the fill mode is 'none', then progress will only be non-null if we
-    // are in the active phase.
+    // are in the active phase, except for progress-based timelines where
+    // currentTime = 100% is still 'active'.
     animation.effect.updateTiming({ fill: 'none' });
-    assert_not_equals(animation.effect.getComputedTiming().progress, null,
-                      'Animation effect is in active phase when current time ' +
-                      `is ${currentTime}.`);
+    if ('ScrollTimeline' in window && animation.timeline instanceof ScrollTimeline) {
+        const isActive = animation.currentTime?.toString() == "100%" ||
+                         animation.effect.getComputedTiming().progress != null;
+        assert_true(isActive,
+                    'Animation effect is in active phase when current time ' +
+                    `is ${currentTime}.`);
+    } else {
+      assert_not_equals(animation.effect.getComputedTiming().progress, null,
+                        'Animation effect is in active phase when current time ' +
+                        `is ${currentTime}.`);
+    }
   } else {
     // The easiest way to distinguish between the 'before' phase and the 'after'
     // phase is to toggle the fill mode. For example, if the progress is null

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -338,8 +338,15 @@ void WebAnimation::setTimeline(RefPtr<AnimationTimeline>&& timeline)
     }
 
     // 10. If the start time of animation is resolved, make animation’s hold time unresolved.
-    if (m_startTime)
+    if (m_startTime) {
+        // FIXME: we may now be in a state where the hold time and start times have
+        // incompatible time units per https://github.com/w3c/csswg-drafts/issues/11761.
+        // Until the spec knows how to handle this case, we ensure the start time matches
+        // the value type of the currently resolved hold time before we make it unresolved.
+        if (m_holdTime && m_holdTime->time().has_value() != m_startTime->time().has_value())
+            m_startTime = m_holdTime;
         m_holdTime = std::nullopt;
+    }
 
     // 11. Run the procedure to update an animation's finished state for animation with the did seek flag set to false,
     // and the synchronously notify flag set to false.


### PR DESCRIPTION
#### 03eccf44ee0d716d68e16dcdf4c0fa6a7b683c09
<pre>
[scroll-animations] WPT test scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=284545">https://bugs.webkit.org/show_bug.cgi?id=284545</a>
<a href="https://rdar.apple.com/problem/141356963">rdar://problem/141356963</a>

Reviewed by Anne van Kesteren.

The technique used by this test to determine the phase [0] in which an animation
is, which is not explicitly exposed via the Web Animations API, was not up-to-date
with the fact that progress-based animations remain active at the 100% boundary.

So we update the supporting `assert_phase()` function to deal with such animations
and pass the previously failing assertion.

But going further into this test, we would hit a debug assertion when trying to compute
the unconstrained current time as we get to the end of the procedure to set the timeline
as we move from the scroll timeline to the document timeline.

I filed a spec issue [1] to deal with this and came up with a temporary fix to restore
the timing incompatibility and pass this test.

[0] <a href="https://drafts.csswg.org/web-animations-1/#animation-effect-phases-and-states">https://drafts.csswg.org/web-animations-1/#animation-effect-phases-and-states</a>
[1] <a href="https://github.com/w3c/csswg-drafts/issues/11761">https://github.com/w3c/csswg-drafts/issues/11761</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/scroll-animation-effect-phases.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/testcommon.js:
(assert_phase):
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::setTimeline):

Canonical link: <a href="https://commits.webkit.org/290787@main">https://commits.webkit.org/290787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cda00ebbed1284e9b98c5357e5cbc4c79e07f948

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96133 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41891 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18992 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70032 "Failure limit exceed. At least found 1 new test failure: http/tests/dom/noreferrer-window-not-targetable.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27555 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94132 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8443 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82568 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50358 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/141 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41026 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78534 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/158 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98116 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18333 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79042 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78245 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22752 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14378 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18336 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18060 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21521 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19837 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->