### PR TITLE
Align document.importNode() with the latest proposal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id="host">

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <some-host id="host">
@@ -23,11 +23,11 @@
 <script>
 
 customElements.define('some-host', class SomeHost extends HTMLElement {
-    internals;
+    elementInternals;
 
     constructor() {
         super();
-        this.internals = this.attachInternals();
+        this.elementInternals = this.attachInternals();
     }
 });
 customElements.define('a-b', class GlobalABElement extends HTMLElement { });
@@ -43,28 +43,28 @@ test(() => {
     registry.define('a-b', class ABElement extends HTMLElement { });
 
     const clone = host.cloneNode(true);
-    registry.upgrade(clone.internals.shadowRoot);
-    assert_equals(clone.internals.shadowRoot.querySelector('a-b').__proto__.constructor.name, 'HTMLElement');
+    registry.upgrade(clone.elementInternals.shadowRoot);
+    assert_equals(clone.elementInternals.shadowRoot.querySelector('a-b').__proto__.constructor.name, 'HTMLElement');
 }, 'upgrade is a no-op when called on a shadow root with no association');
 
 test(() => {
     const registry = new CustomElementRegistry;
     registry.define('a-b', class ABElement extends HTMLElement {
-        internals;
+        elementInternals;
 
         constructor() {
             super();
-            this.internals = this.attachInternals();
+            this.elementInternals = this.attachInternals();
         }
     });
 
     const clone = host.cloneNode(true);
-    registry.initialize(clone.internals.shadowRoot);
-    registry.upgrade(clone.internals.shadowRoot);
-    const abElement = clone.internals.shadowRoot.querySelector('a-b');
+    registry.initialize(clone.elementInternals.shadowRoot);
+    registry.upgrade(clone.elementInternals.shadowRoot);
+    const abElement = clone.elementInternals.shadowRoot.querySelector('a-b');
     assert_equals(abElement.__proto__.constructor.name, 'ABElement');
-    assert_equals(abElement.internals.shadowRoot.customElements, null);
-    const cdElement = abElement.internals.shadowRoot.querySelector('c-d');
+    assert_equals(abElement.elementInternals.shadowRoot.customElements, null);
+    const cdElement = abElement.elementInternals.shadowRoot.querySelector('c-d');
     assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
     assert_equals(cdElement.customElements, null);
 }, 'upgrade should upgrade a candidate element when called on a shadow root with an association');
@@ -72,39 +72,39 @@ test(() => {
 test(() => {
     const registry = new CustomElementRegistry;
     registry.define('a-b', class ScopedABElement extends HTMLElement {
-        internals;
+        elementInternals;
 
         constructor() {
             super();
-            this.internals = this.attachInternals();
+            this.elementInternals = this.attachInternals();
         }
     });
 
     const clone = host.cloneNode(true);
-    registry.initialize(clone.internals.shadowRoot);
-    registry.upgrade(clone.internals.shadowRoot);
-    const abElement = clone.internals.shadowRoot.querySelector('a-b');
+    registry.initialize(clone.elementInternals.shadowRoot);
+    registry.upgrade(clone.elementInternals.shadowRoot);
+    const abElement = clone.elementInternals.shadowRoot.querySelector('a-b');
     assert_equals(abElement.__proto__.constructor.name, 'ScopedABElement');
-    registry.initialize(abElement.internals.shadowRoot);
-    assert_equals(abElement.internals.shadowRoot.customElements, registry);
-    const cdElement = abElement.internals.shadowRoot.querySelector('c-d');
+    registry.initialize(abElement.elementInternals.shadowRoot);
+    assert_equals(abElement.elementInternals.shadowRoot.customElements, registry);
+    const cdElement = abElement.elementInternals.shadowRoot.querySelector('c-d');
     assert_equals(cdElement.customElements, registry);
 
     registry.define('c-d', class ScopedCDElement extends HTMLElement {
-        internals;
+        elementInternals;
 
         constructor() {
             super();
-            this.internals = this.attachInternals();
+            this.elementInternals = this.attachInternals();
         }
     });
     assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
-    registry.upgrade(abElement.internals.shadowRoot);
+    registry.upgrade(abElement.elementInternals.shadowRoot);
     assert_equals(cdElement.__proto__.constructor.name, 'ScopedCDElement');
     assert_equals(cdElement.customElements, registry);
 
-    assert_equals(cdElement.internals.shadowRoot.customElements, window.customElements);
-    const innerAB = cdElement.internals.shadowRoot.querySelector('a-b');
+    assert_equals(cdElement.elementInternals.shadowRoot.customElements, window.customElements);
+    const innerAB = cdElement.elementInternals.shadowRoot.querySelector('a-b');
     assert_equals(innerAB.customElements, window.customElements);
     assert_equals(innerAB.__proto__.constructor.name, 'HTMLElement');
 }, 'upgrade should not upgrade a candidate element not associated with the registry');

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative-expected.txt
@@ -8,4 +8,13 @@ PASS importNode should clone an element originating from a scoped registry using
 PASS importNode should clone a template content using the global registry by default
 PASS importNode should clone a template content using a specified scoped registry
 PASS importNode should clone a template content with a nested template element using a scoped registry
+PASS importNode: don't pass options argument
+PASS importNode: pass options argument with value false
+PASS importNode: pass options argument with value true
+PASS importNode: pass options argument with value undefined
+PASS importNode: pass options argument with value { }
+PASS importNode: pass options argument with value { selfOnly: false }
+PASS importNode: pass options argument with value { selfOnly: true }
+PASS importNode: pass options argument with value { customElements: scopedRegistry }
+PASS importNode: pass options argument with value { customElements: null }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id="host">
@@ -25,18 +25,21 @@
         </template>
     </some-element>
 </template>
+<div id="root">
+    <span></span>
+</div>
 <script>
 
 const scopedRegistry = new CustomElementRegistry();
 const emptyRegistry = new CustomElementRegistry();
 class GlobalSomeElement extends HTMLElement {
-    internals;
+    elementInternals;
 
     constructor() {
         super();
-        this.internals = this.attachInternals();
-        if (this.internals.shadowRoot)
-            scopedRegistry.initialize(this.internals.shadowRoot);
+        this.elementInternals = this.attachInternals();
+        if (this.elementInternals.shadowRoot)
+            scopedRegistry.initialize(this.elementInternals.shadowRoot);
     }
 };
 class GlobalOtherElement extends HTMLElement {};
@@ -54,7 +57,7 @@ test(() => {
 }, 'importNode should clone using the specified scoped regsitry');
 
 test(() => {
-    const clone = document.importNode(host, {deep: true, customElements: scopedRegistry});
+    const clone = document.importNode(host, {selfOnly: false, customElements: scopedRegistry});
     assert_equals(clone.shadowRoot.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
     assert_false(clone.shadowRoot.querySelector('some-element') instanceof GlobalSomeElement);
     assert_false(clone.shadowRoot.querySelector('some-element') instanceof ScopedSomeElement);
@@ -63,14 +66,14 @@ test(() => {
 }, 'importNode should preserve null-ness of custom element registry');
 
 test(() => {
-    const clone = document.importNode(host.shadowRoot.querySelector('div'), {deep: true});
+    const clone = document.importNode(host.shadowRoot.querySelector('div'), {selfOnly: false});
     assert_equals(clone.customElements, window.customElements);
     assert_true(clone.querySelector('some-element') instanceof GlobalSomeElement);
     assert_true(clone.querySelector('other-element') instanceof GlobalOtherElement);
 }, 'importNode should clone a shadow host with a declarative shadow DOM using the global registry by default');
 
 test(() => {
-    const clone = document.importNode(host.shadowRoot.querySelector('div'), {deep: true, customElements: scopedRegistry});
+    const clone = document.importNode(host.shadowRoot.querySelector('div'), {selfOnly: false, customElements: scopedRegistry});
     assert_equals(clone.customElements, scopedRegistry);
     assert_true(clone.querySelector('some-element') instanceof ScopedSomeElement);
     assert_false(clone.querySelector('other-element') instanceof GlobalOtherElement);
@@ -79,7 +82,7 @@ test(() => {
 test(() => {
     const element = document.createElement('div', {customElements: emptyRegistry});
     element.innerHTML = '<some-element></some-element><other-element></other-element>';
-    const clone = document.importNode(element, {deep: true, customElements: scopedRegistry});
+    const clone = document.importNode(element, {selfOnly: false, customElements: scopedRegistry});
     assert_equals(clone.customElements, scopedRegistry);
     assert_true(clone.querySelector('some-element') instanceof ScopedSomeElement);
     assert_false(clone.querySelector('other-element') instanceof GlobalOtherElement);
@@ -90,7 +93,7 @@ test(() => {
     template.innerHTML = '<div><some-element>hello</some-element><other-element>world</other-element></div>';
     assert_equals(template.content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
     assert_equals(template.content.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
-    const clone = document.importNode(template.content, {deep: true});
+    const clone = document.importNode(template.content, {selfOnly: false});
     assert_equals(clone.querySelector('some-element').customElements, window.customElements);
     assert_equals(clone.querySelector('some-element').__proto__.constructor.name, 'GlobalSomeElement');
     assert_equals(clone.querySelector('other-element').__proto__.constructor.name, 'GlobalOtherElement');
@@ -101,7 +104,7 @@ test(() => {
     template.innerHTML = '<div><some-element>hello</some-element><other-element>world</other-element></div>';
     assert_equals(template.content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
     assert_equals(template.content.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
-    const clone = document.importNode(template.content, {deep: true, customElements: scopedRegistry});
+    const clone = document.importNode(template.content, {selfOnly: false, customElements: scopedRegistry});
     assert_equals(clone.querySelector('some-element').customElements, scopedRegistry);
     assert_equals(clone.querySelector('some-element').__proto__.constructor.name, 'ScopedSomeElement');
     assert_equals(clone.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
@@ -124,13 +127,57 @@ test(() => {
 </div>`;
     assert_equals(template.content.querySelector('some-element').__proto__.constructor.name, 'HTMLElement');
     assert_equals(template.content.querySelector('other-element').__proto__.constructor.name, 'HTMLElement');
-    const clone = document.importNode(template.content, {deep: true});
+    const clone = document.importNode(template.content, {selfOnly: false});
     assert_equals(clone.querySelector('some-element').customElements, window.customElements);
     assert_equals(clone.querySelector('some-element').__proto__.constructor.name, 'GlobalSomeElement');
     const otherElementInTemplate = clone.querySelector('template').content.querySelector('other-element');
     assert_equals(otherElementInTemplate.__proto__.constructor.name, 'HTMLElement');
     assert_equals(clone.querySelector('other-element').__proto__.constructor.name, 'GlobalOtherElement');
 }, 'importNode should clone a template content with a nested template element using a scoped registry');
+
+test(() => {
+    const clone = document.importNode(root);
+    assert_false(clone.hasChildNodes());
+}, "importNode: don't pass options argument");
+
+test(() => {
+    const clone = document.importNode(root, false);
+    assert_false(clone.hasChildNodes());
+}, "importNode: pass options argument with value false");
+
+test(() => {
+    const clone = document.importNode(root, true);
+    assert_true(clone.hasChildNodes());
+}, "importNode: pass options argument with value true");
+
+test(() => {
+    const clone = document.importNode(root, undefined);
+    assert_false(clone.hasChildNodes());
+}, "importNode: pass options argument with value undefined");
+
+test(() => {
+    const clone = document.importNode(root, { });
+    assert_true(clone.hasChildNodes());
+}, "importNode: pass options argument with value { }");
+
+test(() => {
+    const clone = document.importNode(root, { selfOnly: false });
+    assert_true(clone.hasChildNodes());
+}, "importNode: pass options argument with value { selfOnly: false }");
+
+test(() => {
+    const clone = document.importNode(root, { selfOnly: true });
+    assert_false(clone.hasChildNodes());
+}, "importNode: pass options argument with value { selfOnly: true }");
+
+test(() => {
+    const clone = document.importNode(root, { customElements: scopedRegistry });
+    assert_true(clone.hasChildNodes());
+}, "importNode: pass options argument with value { customElements: scopedRegistry }");
+
+test(() => {
+    assert_throws_js(TypeError, () => document.importNode(root, { customElements: null }));
+}, "importNode: pass options argument with value { customElements: null }");
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id="host-window"><template shadowrootmode="open"><a-b></a-b></template></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <div id="host-window"><template shadowrootmode="open" shadowrootclonable="true"><a-b></a-b></template></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html
@@ -3,8 +3,8 @@
 <head>
 <meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
-<script src="../../resources/testharness.js"></script>
-<script src="../../resources/testharnessreport.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log
@@ -1,0 +1,27 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -514,7 +514,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<ProcessingInstruction>> createProcessingInstruction(String&& target, String&& data);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttribute(const AtomString& name);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
-    WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, std::optional<std::variant<bool, ImportNodeOptions>>&&);
+    WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, std::variant<bool, ImportNodeOptions>&&);
     WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
 
     WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser, CustomElementRegistry* = nullptr);

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -68,7 +68,7 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     [NewObject] Comment createComment(DOMString data);
     [NewObject] ProcessingInstruction createProcessingInstruction(DOMString target, DOMString data);
 
-    [CEReactions=Needed, NewObject] Node importNode(Node node, optional (boolean or ImportNodeOptions) options);
+    [CEReactions=Needed, NewObject] Node importNode(Node node, optional (boolean or ImportNodeOptions) options = false);
     [CEReactions=Needed] Node adoptNode(Node node);
 
     [NewObject] Attr createAttribute([AtomString] DOMString localName);

--- a/Source/WebCore/dom/ImportNodeOptions.h
+++ b/Source/WebCore/dom/ImportNodeOptions.h
@@ -32,7 +32,7 @@ namespace WebCore {
 class CustomElementRegistry;
 
 struct ImportNodeOptions {
-    bool deep { false };
+    bool selfOnly { false };
     RefPtr<CustomElementRegistry> customElements;
 };
 

--- a/Source/WebCore/dom/ImportNodeOptions.idl
+++ b/Source/WebCore/dom/ImportNodeOptions.idl
@@ -24,6 +24,6 @@
  */
 
 dictionary ImportNodeOptions {
-    boolean deep = false;
-    CustomElementRegistry customElements = null;
+    boolean selfOnly = false;
+    CustomElementRegistry customElements;
 };


### PR DESCRIPTION
#### 7721708e4c99720795d94212a93e7ae46c19f427
<pre>
Align document.importNode() with the latest proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=288193">https://bugs.webkit.org/show_bug.cgi?id=288193</a>
<a href="https://rdar.apple.com/145287338">rdar://145287338</a>

Reviewed by Ryosuke Niwa.

When importNode() is used in the &quot;modern&quot; fashion we want it to clone
the children by default. Therefore we rename the options member from
deep to selfOnly.

New tests are proposed upstream here:
<a href="https://github.com/web-platform-tests/wpt/pull/50860">https://github.com/web-platform-tests/wpt/pull/50860</a>

Variable rename from &quot;internals&quot; to &quot;elementInternals&quot; in existing
tests was a change made upstream to account for linting rules.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Construct.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-define.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::importNode):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:
* Source/WebCore/dom/ImportNodeOptions.h:
* Source/WebCore/dom/ImportNodeOptions.idl:

Canonical link: <a href="https://commits.webkit.org/290864@main">https://commits.webkit.org/290864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eda605119a025a9a2bd45285fd8e0a13cbcc537

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96136 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41893 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/18995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27561 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50362 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/146 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41030 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98119 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18336 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13448 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79046 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78249 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22757 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11535 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14443 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23661 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19839 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->