### PR TITLE
Address safer C++ warnings in RenderLayerCompositor

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -75,7 +75,6 @@ rendering/RenderElement.cpp
 rendering/RenderEmbeddedObject.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
-rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp
 rendering/RenderMenuList.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -62,7 +62,6 @@ rendering/RenderBox.cpp
 rendering/RenderBoxModelObject.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
-rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp
 rendering/RenderMarquee.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1185,7 +1185,6 @@ rendering/RenderImageResourceStyleImage.cpp
 rendering/RenderImageResourceStyleImage.h
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
-rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -650,7 +650,6 @@ rendering/RenderImage.cpp
 rendering/RenderImageResource.cpp
 rendering/RenderLayer.cpp
 rendering/RenderLayerBacking.cpp
-rendering/RenderLayerCompositor.cpp
 rendering/RenderLayerFilters.cpp
 rendering/RenderLayerModelObject.cpp
 rendering/RenderListBox.cpp

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -519,7 +519,8 @@ private:
     FloatRect visibleRectForLayerFlushing() const;
     
     Page& page() const;
-    
+    Ref<Page> protectedPage() const;
+
     GraphicsLayerFactory* graphicsLayerFactory() const;
     ScrollingCoordinator* scrollingCoordinator() const;
 

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -69,6 +69,7 @@ public:
     virtual ~RenderWidget();
 
     HTMLFrameOwnerElement& frameOwnerElement() const { return downcast<HTMLFrameOwnerElement>(nodeForNonAnonymous()); }
+    Ref<HTMLFrameOwnerElement> protectedFrameOwnerElement() const { return frameOwnerElement(); }
 
     Widget* widget() const { return m_widget.get(); }
     RefPtr<Widget> protectedWidget() const { return m_widget; }


### PR DESCRIPTION
#### a4248b6482a3d37d21fe8e3883d2cc6ca9b1a493
<pre>
Address safer C++ warnings in RenderLayerCompositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=288198">https://bugs.webkit.org/show_bug.cgi?id=288198</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidateForLayer):
(WebCore::RenderLayerCompositor::cacheAcceleratedCompositingFlags):
(WebCore::RenderLayerCompositor::customPositionForVisibleRectComputation const):
(WebCore::RenderLayerCompositor::scheduleRenderingUpdate):
(WebCore::RenderLayerCompositor::visibleRectForLayerFlushing const):
(WebCore::RenderLayerCompositor::flushPendingLayerChanges):
(WebCore::RenderLayerCompositor::didPaintBacking):
(WebCore::RenderLayerCompositor::didChangeVisibleRect):
(WebCore::frameHostingNodeForFrame):
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::allowBackingStoreDetachingForFixedPosition):
(WebCore::RenderLayerCompositor::collectViewTransitionNewContentLayers):
(WebCore::RenderLayerCompositor::updateBackingAndHierarchy):
(WebCore::RenderLayerCompositor::adjustOverflowScrollbarContainerLayers):
(WebCore::RenderLayerCompositor::layerBecameNonComposited):
(WebCore::RenderLayerCompositor::updateRootContentLayerClipping):
(WebCore::RenderLayerCompositor::updateBacking):
(WebCore::RenderLayerCompositor::repaintOnCompositingChange):
(WebCore::RenderLayerCompositor::repaintInCompositedAncestor):
(WebCore::RenderLayerCompositor::computeExtent const):
(WebCore::RenderLayerCompositor::hasCoordinatedScrolling const):
(WebCore::RenderLayerCompositor::updateScrollLayerPosition):
(WebCore::RenderLayerCompositor::updateScrollLayerClipping):
(WebCore::RenderLayerCompositor::positionForClipLayer const):
(WebCore::RenderLayerCompositor::updateCompositingForLayerTreeAsTextDump):
(WebCore::RenderLayerCompositor::layerTreeAsText):
(WebCore::frameContentsRenderView):
(WebCore::RenderLayerCompositor::attachWidgetContentLayersIfNecessary):
(WebCore::RenderLayerCompositor::setIsInWindow):
(WebCore::RenderLayerCompositor::invalidateEventRegionForAllFrames):
(WebCore::RenderLayerCompositor::updateRootLayerPosition):
(WebCore::isDescendantOfFullScreenLayer):
(WebCore::RenderLayerCompositor::requiresCompositingForTransform const):
(WebCore::RenderLayerCompositor::requiresCompositingForCanvas const):
(WebCore::RenderLayerCompositor::requiresCompositingForScrollableFrame const):
(WebCore::RenderLayerCompositor::fixedLayerIntersectsViewport const):
(WebCore::RenderLayerCompositor::computeCoordinatedPositioningForLayer const):
(WebCore::RenderLayerCompositor::isLayerForIFrameWithScrollCoordinatedContents const):
(WebCore::RenderLayerCompositor::requiresScrollLayer const):
(WebCore::RenderLayerCompositor::paintContents):
(WebCore::RenderLayerCompositor::resetTrackedRepaintRects):
(WebCore::RenderLayerCompositor::isRootFrameCompositor const):
(WebCore::RenderLayerCompositor::isMainFrameCompositor const):
(WebCore::RenderLayerCompositor::shouldCompositeOverflowControls const):
(WebCore::RenderLayerCompositor::requiresScrollCornerLayer const):
(WebCore::RenderLayerCompositor::requiresOverhangAreasLayer const):
(WebCore::RenderLayerCompositor::updateLayerForTopOverhangArea):
(WebCore::RenderLayerCompositor::updateLayerForBottomOverhangArea):
(WebCore::RenderLayerCompositor::updateLayerForHeader):
(WebCore::RenderLayerCompositor::updateLayerForFooter):
(WebCore::RenderLayerCompositor::updateLayerForOverhangAreasBackgroundColor):
(WebCore::RenderLayerCompositor::viewHasTransparentBackground const):
(WebCore::RenderLayerCompositor::updateRootContentsLayerBackgroundColor):
(WebCore::RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer):
(WebCore::RenderLayerCompositor::updateOverflowControlsLayers):
(WebCore::RenderLayerCompositor::ensureRootLayer):
(WebCore::RenderLayerCompositor::destroyRootLayer):
(WebCore::RenderLayerCompositor::attachRootLayer):
(WebCore::RenderLayerCompositor::detachRootLayer):
(WebCore::RenderLayerCompositor::rootLayerAttachmentChanged):
(WebCore::RenderLayerCompositor::notifyIFramesOfCompositingChange):
(WebCore::RenderLayerCompositor::deviceOrPageScaleFactorChanged):
(WebCore::RenderLayerCompositor::computeFixedViewportConstraints const):
(WebCore::RenderLayerCompositor::computeStickyViewportConstraints const):
(WebCore::RenderLayerCompositor::attachScrollingNode):
(WebCore::RenderLayerCompositor::registerScrollingNodeID):
(WebCore::RenderLayerCompositor::detachScrollCoordinatedLayer):
(WebCore::RenderLayerCompositor::parentRelativeScrollableRect const):
(WebCore::RenderLayerCompositor::updateScrollingNodeLayers):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingRole):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole):
(WebCore::RenderLayerCompositor::updateScrollingNodeForPositioningRole):
(WebCore::RenderLayerCompositor::resolveScrollingTreeRelationships):
(WebCore::RenderLayerCompositor::updateSynchronousScrollingNodes):
(WebCore::RenderLayerCompositor::scrollableAreaForScrollingNodeID const):
(WebCore::RenderLayerCompositor::scrollingCoordinator const):
(WebCore::RenderLayerCompositor::protectedPage const):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderWidget.h:
(WebCore::RenderWidget::protectedFrameOwnerElement const):

Canonical link: <a href="https://commits.webkit.org/290869@main">https://commits.webkit.org/290869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9df63c0a87b1f19c554c5318fb7d1b2ff27bfa1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70097 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27610 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94226 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82645 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50423 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8277 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/328 "Found 3 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html imported/w3c/web-platform-tests/cookies/schemeful-same-site/schemeful-websockets.sub.tentative.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41105 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98208 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18416 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13496 "Found 1 new test failure: fast/mediastream/getDisplayMedia-max-constraints5.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79102 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18672 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78305 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19379 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22814 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18416 "Built successfully") | [💥 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23720 "An unexpected error occured. Recent messages:OS: Sequoia (15.3.1), Xcode: 16.2; Checked out pull request; Found 42407 issues") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18137 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21597 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->