### PR TITLE
Plumb BorderShape through BorderPainter

### DIFF
--- a/LayoutTests/fast/borders/hidpi-outline-hairline-painting-expected.html
+++ b/LayoutTests/fast/borders/hidpi-outline-hairline-painting-expected.html
@@ -14,22 +14,22 @@
 <body>
 <div style="border-style: solid; top: 9.5px; left: 9.5px;"></div>
 <div style="border-style: solid; top: 9.5px; left: 24.5px;"></div>
-<div style="border-style: solid; top: 9.5px; left: 39.5px;"></div>
-<div style="border-style: solid; top: 9.5px; left: 54.5px;"></div>
+<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 39px;"></div>
+<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 54px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 69px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 84px;"></div>
 <div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 99px;"></div>
-<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 114px;"></div>
-<div style="border-style: solid; width: 6px; height: 6px; top: 9px; left: 129px;"></div>
+<div style="border-style: solid; width: 7px; height: 7px; top: 8.5px; left: 113.5px;"></div>
+<div style="border-style: solid; width: 7px; height: 7px; top: 8.5px; left: 128.5px;"></div>
 <div style="border-style: solid; border-width: 1px; width: 7px; height: 7px; top: 8px; left: 143px;"></div>
 <div style="border-style: solid; border-width: 1px; width: 7px; height: 7px; top: 8px; left: 158px;"></div>
 
-<div style="border-style: double; top: 24px; left: 9px; width: 6px; height: 6px;"></div>
-<div style="border-style: double; top: 24px; left: 24px; width: 6px; height: 6px;"></div>
+<div style="border-style: double; top: 23.5px; left: 8.5px; width: 7px; height: 7px;"></div>
+<div style="border-style: double; top: 23.5px; left: 23.5px; width: 7px; height: 7px;"></div>
 <div style="border-style: double; border-width: 1px; top: 23px; left: 38px; width: 7px; height: 7px;"></div>
 <div style="border-style: double; border-width: 1px; top: 23px; left: 53px; width: 7px; height: 7px;"></div>
 <div style="border-style: double; border-width: 1px; top: 23px; left: 68px; width: 7px; height: 7px;"></div>
-<div style="border-style: double; border-width: 1px; top: 23px; left: 83px; width: 7px; height: 7px;"></div>
-<div style="border-style: double; border-width: 1px; top: 23px; left: 98px; width: 7px; height: 7px;"></div>
+<div style="border-style: double; border-width: 1px; top: 22.5px; left: 82.5px; width: 8px; height: 8px;"></div>
+<div style="border-style: double; border-width: 1px; top: 22.5px; left: 97.5px; width: 8px; height: 8px;"></div>
 </body>
 </html>

--- a/Source/WebCore/platform/graphics/Path.cpp
+++ b/Source/WebCore/platform/graphics/Path.cpp
@@ -333,6 +333,7 @@ void Path::addPath(const Path& path, const AffineTransform& transform)
     if (path.isEmpty() || !transform.isInvertible())
         return;
 
+    // FIXME: This should inspect the incoming path and add just the segments if possible.
     ensurePlatformPathImpl().addPath(const_cast<Path&>(path).ensurePlatformPathImpl(), transform);
 }
 

--- a/Source/WebCore/rendering/BorderEdge.cpp
+++ b/Source/WebCore/rendering/BorderEdge.cpp
@@ -46,18 +46,19 @@ BorderEdge::BorderEdge(float edgeWidth, Color edgeColor, BorderStyle edgeStyle, 
     m_flooredToDevicePixelWidth = floorf(edgeWidth * devicePixelRatio) / devicePixelRatio;
 }
 
-BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectEdges<bool> closedEdges, bool setColorsToBlack)
+BorderEdges borderEdges(const RenderStyle& style, float deviceScaleFactor, RectEdges<bool> closedEdges, LayoutSize inflation, bool setColorsToBlack)
 {
-    auto constructBorderEdge = [&](float width, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
+    auto constructBorderEdge = [&](float width, float inflation, CSSPropertyID borderColorProperty, BorderStyle borderStyle, bool isTransparent, bool isPresent) {
         auto color = setColorsToBlack ? Color::black : style.visitedDependentColorWithColorFilter(borderColorProperty);
-        return BorderEdge(width, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
+        auto inflatedWidth = width ? width + inflation : width;
+        return BorderEdge(inflatedWidth, color, borderStyle, !setColorsToBlack && isTransparent, isPresent, deviceScaleFactor);
     };
 
     return {
-        constructBorderEdge(style.borderTopWidth(), CSSPropertyBorderTopColor, style.borderTopStyle(), style.borderTopIsTransparent(), closedEdges.top()),
-        constructBorderEdge(style.borderRightWidth(), CSSPropertyBorderRightColor, style.borderRightStyle(), style.borderRightIsTransparent(), closedEdges.right()),
-        constructBorderEdge(style.borderBottomWidth(), CSSPropertyBorderBottomColor, style.borderBottomStyle(), style.borderBottomIsTransparent(), closedEdges.bottom()),
-        constructBorderEdge(style.borderLeftWidth(), CSSPropertyBorderLeftColor, style.borderLeftStyle(), style.borderLeftIsTransparent(), closedEdges.left())
+        constructBorderEdge(style.borderTopWidth(), inflation.height().toFloat(), CSSPropertyBorderTopColor, style.borderTopStyle(), style.borderTopIsTransparent(), closedEdges.top()),
+        constructBorderEdge(style.borderRightWidth(), inflation.width().toFloat(), CSSPropertyBorderRightColor, style.borderRightStyle(), style.borderRightIsTransparent(), closedEdges.right()),
+        constructBorderEdge(style.borderBottomWidth(), inflation.height().toFloat(), CSSPropertyBorderBottomColor, style.borderBottomStyle(), style.borderBottomIsTransparent(), closedEdges.bottom()),
+        constructBorderEdge(style.borderLeftWidth(), inflation.width().toFloat(), CSSPropertyBorderLeftColor, style.borderLeftStyle(), style.borderLeftIsTransparent(), closedEdges.left())
     };
 }
 

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -42,6 +42,7 @@ public:
     BorderEdge(float edgeWidth, Color edgeColor, BorderStyle edgeStyle, bool edgeIsTransparent, bool edgeIsPresent, float devicePixelRatio);
 
     BorderStyle style() const { return m_style; }
+    LayoutUnit width() const { return m_width; }
     const Color& color() const { return m_color; }
     bool isTransparent() const { return m_isTransparent; }
     bool isPresent() const { return m_isPresent; }
@@ -49,7 +50,7 @@ public:
     inline bool hasVisibleColorAndStyle() const { return m_style > BorderStyle::Hidden && !m_isTransparent; }
     inline bool shouldRender() const { return m_isPresent && widthForPainting() && hasVisibleColorAndStyle(); }
     inline bool presentButInvisible() const { return widthForPainting() && !hasVisibleColorAndStyle(); }
-    inline float widthForPainting() const { return m_isPresent ?  m_flooredToDevicePixelWidth : 0; }
+    inline float widthForPainting() const { return m_isPresent ? m_flooredToDevicePixelWidth : 0; }
     void getDoubleBorderStripeWidths(LayoutUnit& outerWidth, LayoutUnit& innerWidth) const;
     bool obscuresBackgroundEdge(float scale) const;
     bool obscuresBackground() const;
@@ -67,7 +68,8 @@ private:
 };
 
 using BorderEdges = RectEdges<BorderEdge>;
-BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true }, bool setColorsToBlack = false);
+// inflation is only added to edges with non-zero widths.
+BorderEdges borderEdges(const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true }, LayoutSize inflation = { }, bool setColorsToBlack = false);
 BorderEdges borderEdgesForOutline(const RenderStyle&, float deviceScaleFactor);
 
 inline bool edgesShareColor(const BorderEdge& firstEdge, const BorderEdge& secondEdge) { return firstEdge.color() == secondEdge.color(); }

--- a/Source/WebCore/rendering/BorderPainter.h
+++ b/Source/WebCore/rendering/BorderPainter.h
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+class BorderShape;
+
 class BorderPainter {
 public:
     BorderPainter(const RenderElement&, const PaintInfo&);
@@ -41,20 +43,19 @@ public:
 
     static std::optional<Path> pathForBorderArea(const LayoutRect&, const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true });
 
-    static bool allCornersClippedOut(const RoundedRect&, const LayoutRect&);
     static bool shouldAntialiasLines(GraphicsContext&);
 
 private:
     struct Sides;
-    void paintSides(const Sides&) const;
+    void paintSides(const BorderShape&, const Sides&) const;
 
-    void paintTranslucentBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder, const IntPoint& innerBorderAdjustment,
-        const BorderEdges&, BoxSideSet edgesToDraw, std::optional<BorderDataRadii>, BleedAvoidance, RectEdges<bool> closedEdges, bool antialias) const;
-    void paintBorderSides(const RoundedRect& outerBorder, const RoundedRect& innerBorder, const IntPoint& innerBorderAdjustment, const BorderEdges&, BoxSideSet edgeSet, std::optional<BorderDataRadii>, BleedAvoidance, RectEdges<bool> closedEdges, bool antialias, const Color* overrideColor = nullptr) const;
-    void paintOneBorderSide(const RoundedRect& outerBorder, const RoundedRect& innerBorder,
-        const LayoutRect& sideRect, BoxSide, BoxSide adjacentSide1, BoxSide adjacentSide2, const BorderEdges&, std::optional<BorderDataRadii>, const Path*, BleedAvoidance, RectEdges<bool> closedEdges, bool antialias, const Color* overrideColor) const;
+    void paintTranslucentBorderSides(const BorderShape&, const Sides&, BoxSideSet edgesToDraw, bool antialias) const;
+    void paintBorderSides(const BorderShape&, const Sides&, BoxSideSet edgesToDraw, bool antialias, const Color* overrideColor = nullptr) const;
+
+    void paintOneBorderSide(const BorderShape&, const Sides&, const LayoutRect& sideRect, BoxSide, BoxSide adjacentSide1, BoxSide adjacentSide2, const Path*, bool antialias, const Color* overrideColor) const;
+
     void drawBoxSideFromPath(const LayoutRect& borderRect, const Path& borderPath, const BorderEdges&, std::optional<BorderDataRadii>, float thickness, float drawThickness, BoxSide, Color, BorderStyle, BleedAvoidance, RectEdges<bool> closedEdges) const;
-    void clipBorderSidePolygon(const RoundedRect& outerBorder, const RoundedRect& innerBorder, BoxSide, bool firstEdgeMatches, bool secondEdgeMatches) const;
+    void clipBorderSidePolygon(const BorderShape&, BoxSide, bool firstEdgeMatches, bool secondEdgeMatches) const;
 
     LayoutRect borderRectAdjustedForBleedAvoidance(const LayoutRect&, BleedAvoidance) const;
 

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -51,16 +51,17 @@ public:
     // overrideBorderWidths describe custom insets from the border box, used instead of the border widths from the style.
     static BorderShape shapeForBorderRect(const RenderStyle&, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges = { true });
 
+    // Create a BorderShape suitable for rendering an outline. borderRect is provided to allow for scaling the corner radii.
+    static BorderShape shapeForOutlineRect(const RenderStyle&, const LayoutRect& borderRect, const LayoutRect& outlineBoxRect, const RectEdges<LayoutUnit>& outlineWidths, RectEdges<bool> closedEdges = { true });
+
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const RoundedRectRadii&);
 
-    BorderShape(const BorderShape& other)
-        : m_borderRect(other.m_borderRect)
-        , m_borderWidths(other.m_borderWidths)
-    {
-    }
+    BorderShape(const BorderShape&) = default;
 
     LayoutRect borderRect() const { return m_borderRect.rect(); }
+    // Takes `closedEdges` into account.
+    const RectEdges<LayoutUnit>& borderWidths() const { return m_borderWidths; }
 
     RoundedRect deprecatedRoundedRect() const;
     RoundedRect deprecatedInnerRoundedRect() const;
@@ -78,6 +79,10 @@ public:
     FloatRect snappedInnerRect(float deviceScaleFactor) const;
 
     bool isRounded() const { return m_borderRect.isRounded(); }
+
+    bool outerShapeIsRectangular() const;
+    bool innerShapeIsRectangular() const;
+
     bool isEmpty() const { return m_borderRect.rect().isEmpty(); }
 
     void move(LayoutSize);
@@ -88,22 +93,26 @@ public:
     Path pathForOuterShape(float deviceScaleFactor) const;
     Path pathForInnerShape(float deviceScaleFactor) const;
 
+    void addOuterShapeToPath(Path&, float deviceScaleFactor) const;
+    void addInnerShapeToPath(Path&, float deviceScaleFactor) const;
+
     Path pathForBorderArea(float deviceScaleFactor) const;
 
-    void clipToOuterShape(GraphicsContext&, float deviceScaleFactor);
-    void clipToInnerShape(GraphicsContext&, float deviceScaleFactor);
+    void clipToOuterShape(GraphicsContext&, float deviceScaleFactor) const;
+    void clipToInnerShape(GraphicsContext&, float deviceScaleFactor) const;
 
-    void clipOutOuterShape(GraphicsContext&, float deviceScaleFactor);
-    void clipOutInnerShape(GraphicsContext&, float deviceScaleFactor);
+    void clipOutOuterShape(GraphicsContext&, float deviceScaleFactor) const;
+    void clipOutInnerShape(GraphicsContext&, float deviceScaleFactor) const;
 
-    void fillOuterShape(GraphicsContext&, const Color&, float deviceScaleFactor);
-    void fillInnerShape(GraphicsContext&, const Color&, float deviceScaleFactor);
+    void fillOuterShape(GraphicsContext&, const Color&, float deviceScaleFactor) const;
+    void fillInnerShape(GraphicsContext&, const Color&, float deviceScaleFactor) const;
 
 private:
-    RoundedRect innerEdgeRoundedRect() const;
     LayoutRect innerEdgeRect() const;
+    static RoundedRect computeInnerEdgeRoundedRect(const RoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths);
 
     RoundedRect m_borderRect;
+    RoundedRect m_innerEdgeRect;
     RectEdges<LayoutUnit> m_borderWidths;
 };
 


### PR DESCRIPTION
#### fb08c78d67df648e6aef52eb2f8065c2495e1137
<pre>
Plumb BorderShape through BorderPainter
<a href="https://bugs.webkit.org/show_bug.cgi?id=288200">https://bugs.webkit.org/show_bug.cgi?id=288200</a>
<a href="https://rdar.apple.com/145296466">rdar://145296466</a>

Reviewed by Antti Koivisto.

In preparation for supporting `corner-shape` which introduces non-rounded
corners, we need to reduce the amount of code in `BorderPainter` that assumes
that the border is a rect or rounded rect.

Do this by plumbing BorderShape in deeper; it can replace much of the data
that&apos;s currently stored in `BorderPainter::Sides`. Code is also simplified because
BorderShape internally does much of the rect vs. rounded-rect handling.

There&apos;s some complexity with `BleedAvoidance::BackgroundOverBorder` where we
shrink the inner border edge by a device pixel; previously this was accounted
for by `innerBorderAdjustment` when painting individual edges, but we can instead
just retrieve the original border widths from the BorderShape.

* LayoutTests/fast/borders/hidpi-outline-hairline-painting-expected.html:
* Source/WebCore/platform/graphics/Path.cpp:
(WebCore::Path::addPath):
* Source/WebCore/rendering/BorderEdge.cpp:
(WebCore::borderEdges):
* Source/WebCore/rendering/BorderEdge.h:
(WebCore::BorderEdge::width const):
(WebCore::BorderEdge::widthForPainting const):
(WebCore::borderEdges):
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::BorderPainter):
(WebCore::calculateSideRect):
(WebCore::sizeForDevicePixel):
(WebCore::shrinkRectByOneDevicePixel):
(WebCore::BorderPainter::paintBorder const):
(WebCore::BorderPainter::paintOutline const):
(WebCore::BorderPainter::paintSides const):
(WebCore::BorderPainter::paintTranslucentBorderSides const):
(WebCore::BorderPainter::paintBorderSides const):
(WebCore::BorderPainter::paintOneBorderSide const):
(WebCore::BorderPainter::clipBorderSidePolygon const):
(WebCore::BorderPainter::allCornersClippedOut): Deleted.
* Source/WebCore/rendering/BorderPainter.h:
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::shapeForOutlineRect):
(WebCore::BorderShape::BorderShape): Precompute the inner rounded rect since it&apos;s used more.
(WebCore::BorderShape::deprecatedInnerRoundedRect const):
(WebCore::BorderShape::deprecatedPixelSnappedInnerRoundedRect const):
(WebCore::BorderShape::innerShapeContains const):
(WebCore::BorderShape::outerShapeIsRectangular const):
(WebCore::BorderShape::innerShapeIsRectangular const):
(WebCore::BorderShape::pathForInnerShape const):
(WebCore::BorderShape::addOuterShapeToPath const):
(WebCore::BorderShape::addInnerShapeToPath const):
(WebCore::BorderShape::pathForBorderArea const):
(WebCore::BorderShape::clipToOuterShape const):
(WebCore::BorderShape::clipToInnerShape const):
(WebCore::BorderShape::clipOutOuterShape const):
(WebCore::BorderShape::clipOutInnerShape const):
(WebCore::BorderShape::fillOuterShape const):
(WebCore::BorderShape::fillInnerShape const):
(WebCore::BorderShape::computeInnerEdgeRoundedRect):
(WebCore::BorderShape::innerEdgeRect const):
(WebCore::BorderShape::clipToOuterShape): Deleted.
(WebCore::BorderShape::clipToInnerShape): Deleted.
(WebCore::BorderShape::clipOutOuterShape): Deleted.
(WebCore::BorderShape::clipOutInnerShape): Deleted.
(WebCore::BorderShape::fillOuterShape): Deleted.
(WebCore::BorderShape::fillInnerShape): Deleted.
(WebCore::BorderShape::innerEdgeRoundedRect const): Deleted.
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::shapeForOutlineRect):
(WebCore::BorderShape::borderWidths const):
(WebCore::BorderShape::BorderShape): Deleted.

Canonical link: <a href="https://commits.webkit.org/290951@main">https://commits.webkit.org/290951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43ba4bc5fb8d724e2752ca90fb9e107de4c9ec7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/557 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96467 "Hash 43ba4bc5 for PR 41064 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42186 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19428 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96467 "Hash 43ba4bc5 for PR 41064 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27779 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94499 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8704 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82894 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96467 "Hash 43ba4bc5 for PR 41064 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8468 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/481 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41356 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78788 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98470 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18660 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13729 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79283 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18915 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78487 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19423 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23009 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/369 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11788 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23934 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18368 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21828 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->