### PR TITLE
[iOS] Unable to focus phone number field in Takeout/Ele.me (饿了么) Alipay mini program when adding a new delivery address

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -131,6 +131,7 @@ enum class SDKAlignedBehavior {
     BlobFileAccessEnforcement,
     DevolvableWidgets,
     SetSelectionRangeCachesSelectionIfNotFocusedOrSelected,
+    DispatchFocusEventBeforeNotifyingClient,
 
     NumberOfBehaviors
 };


### PR DESCRIPTION
#### 7eae9413cc52a9fee6d2a50316c753e86aa4d5a5
<pre>
[iOS] Unable to focus phone number field in Takeout/Ele.me (饿了么) Alipay mini program when adding a new delivery address
<a href="https://bugs.webkit.org/show_bug.cgi?id=288201">https://bugs.webkit.org/show_bug.cgi?id=288201</a>
<a href="https://rdar.apple.com/145026254">rdar://145026254</a>

Reviewed by Aditya Keerthi.

Add a new linked-on-or-after check to restore the order in which we dispatch the `focus` event and
notify the embedding client about the newly focused element, for apps linked on or before iOS 18.3.
In this particular case, this new ordering causes a certain telephone number field in the Ele.me
mini-program (in Alipay) to fail to show the keyboard when tapped. This phone number text field is
special because it&apos;s tagged with a `data-keyboard=number` DOM attribute, which the embedding context
(Alipay) handles in the following way:

1.  When the `focus` DOM event is dispatched for this text field, the page immediately calls `blur`
    on the text field, and posts a custom message to message handler in the app, which tells it to
    show a custom input view: `updateNativeKeyBoardInput`.

2.  In response to receiving this message, a `H5KeyboardField` (`UITextField` subclass) is unhidden,
    made first responder, and then positioned over the input field in the DOM, such that the text in
    this native field appears as if it were part of the web content. The input view used for this
    `H5KeyboardField` is custom — in this particular case, their own version of a numeric (0-9)
    keyplane.

    Crucially, however, this step appears to only happen if `-reloadInputViews` has been called on
    the content view *right before* receiving this message — on shipping versions of iOS, this
    happens as a result of handling the `WebPageProxy_ElementDidFocus` IPC message.

3.  As the user types, the value of the phone number field in the DOM is updated to reflect the text
    in the native `H5KeyboardField`.

Since the order in which this IPC is dispatched and when the `focus` DOM event is dispatched was
inverted in <a href="https://commits.webkit.org/287924@main">https://commits.webkit.org/287924@main</a>, step (2) no longer works properly, because the
UI process never receives the focused element information for an element that is immediately blurred
upon being focused. This new behavior is generally correct, so we can avoid this binary
incompatibility by deploying a linked-on-or-after check guarding this new behavior.

Note that Alipay has several ways to fix this issue with the new ordering, including:

- Using `inputmode=none` on the input field instead of blurring it.
- Override `-[WKWebView inputView]` to show their own custom view instead of blurring the field.
- Calling `blur()` on a zero-delay timer.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchFocusEvent):

Add the new linked-on-or-after check here, cached behind a global static variable.

Canonical link: <a href="https://commits.webkit.org/290818@main">https://commits.webkit.org/290818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/585e2d9b26fa9c6d45911683617decc2b82fcac5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/204 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70056 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27579 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8474 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82598 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50382 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8245 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41059 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/83987 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98150 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/89934 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18367 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78270 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19355 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22781 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18368 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112501 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18091 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32662 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21552 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->