### PR TITLE
Web Automation: modernize callback thunks for async protocol commands

### DIFF
--- a/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
+++ b/Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h
@@ -40,6 +40,18 @@ class BackendDispatcher;
 
 typedef String ErrorString;
 
+template<typename T>
+using CommandResult = Inspector::Protocol::ErrorStringOr<T>;
+
+template <typename T>
+using CommandCallback = Function<void(CommandResult<T>)>;
+
+template <typename... ArgTypes>
+using CommandResultOf = Inspector::Protocol::ErrorStringOr<std::tuple<ArgTypes...>>;
+
+template <typename... ArgTypes>
+using CommandCallbackOf = Function<void(CommandResultOf<ArgTypes...>)>;
+
 class SupplementalBackendDispatcher : public RefCounted<SupplementalBackendDispatcher> {
 public:
     JS_EXPORT_PRIVATE SupplementalBackendDispatcher(BackendDispatcher&);

--- a/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py
@@ -110,13 +110,15 @@ private:
     Alternate${domainName}BackendDispatcher* m_alternateDispatcher { nullptr };
 #endif // ENABLE(INSPECTOR_ALTERNATE_DISPATCHERS)""")
 
-    BackendDispatcherHeaderAsyncCommandDeclaration = (
+    BackendDispatcherHeaderAsyncCommandReplyThunkDeclaration = (
     """    ${classAndExportMacro} ${callbackName} : public BackendDispatcher::CallbackBase {
     public:
         ${callbackName}(Ref<BackendDispatcher>&&, int id);
         void sendSuccess(${returns});
-    };
-    virtual void ${commandName}(${parameters}) = 0;""")
+    };""")
+
+    BackendDispatcherHeaderAsyncCommandDeclaration = (
+        """    virtual void ${commandName}(${parameters}) = 0;""")
 
     BackendDispatcherImplementationSmallSwitch = (
     """void ${domainName}BackendDispatcher::dispatch(long protocol_requestId, const String& protocol_method, Ref<JSON::Object>&& protocol_message)
@@ -173,7 +175,7 @@ ${domainName}BackendDispatcher::${domainName}BackendDispatcher(BackendDispatcher
     }
 """)
 
-    BackendDispatcherImplementationAsyncCommand = (
+    BackendDispatcherImplementationAsyncCommandReplyThunk = (
 """${domainName}BackendDispatcherHandler::${callbackName}::${callbackName}(Ref<BackendDispatcher>&& backendDispatcher, int id) : BackendDispatcher::CallbackBase(WTFMove(backendDispatcher), id) { }
 
 void ${domainName}BackendDispatcherHandler::${callbackName}::sendSuccess(${callbackParameters})

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
@@ -108,9 +108,11 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
         else:
             implementations.append(self._generate_large_dispatcher_switch_implementation_for_domain(domain))
 
+        use_legacy_async_callbacks = self.model().framework.setting('legacy_async_callbacks', False)
         for command in commands:
-            if command.is_async:
-                implementations.append(self._generate_async_dispatcher_class_for_domain(command, domain))
+            if command.is_async and use_legacy_async_callbacks:
+                implementations.append(self._generate_legacy_async_command_response_thunk_class_for_domain(command, domain))
+
             implementations.append(self._generate_dispatcher_implementation_for_command(command, domain))
 
         return self.wrap_with_guard_for_condition(domain.condition, '\n\n'.join(implementations))
@@ -162,7 +164,7 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
 
         return Template(CppTemplates.BackendDispatcherImplementationLargeSwitch).substitute(None, **switch_args)
 
-    def _generate_async_dispatcher_class_for_domain(self, command, domain):
+    def _generate_legacy_async_command_response_thunk_class_for_domain(self, command, domain):
         return_assignments = []
         callback_parameters = []
 
@@ -211,7 +213,7 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
             'callbackParameters': ", ".join(callback_parameters),
             'returnAssignments': "\n".join(return_assignments)
         }
-        return self.wrap_with_guard_for_condition(command.condition, Template(CppTemplates.BackendDispatcherImplementationAsyncCommand).substitute(None, **async_args))
+        return self.wrap_with_guard_for_condition(command.condition, Template(CppTemplates.BackendDispatcherImplementationAsyncCommandReplyThunk).substitute(None, **async_args))
 
     def _generate_dispatcher_implementation_for_command(self, command, domain):
         parameter_declarations = []
@@ -219,6 +221,7 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
         alternate_dispatcher_method_parameters = ['protocol_requestId']
         method_parameters = []
 
+        # Step 1: build up arguments for the call.
         for parameter in command.call_parameters:
             parameter_name = parameter.parameter_name
             if parameter.is_optional:
@@ -277,8 +280,87 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
             }
             parameter_declarations.append('    auto %(parameterName)s = m_backendDispatcher->%(keyedGetMethod)s(protocol_parameters.get(), "%(parameterKey)s"_s, %(required)s);' % param_args)
 
+        result_destructured_names = []
+        result_conversion_lines = []
+
+        # Step 2: build up return value expressions if needed.
+        for parameter in command.return_parameters:
+            parameter_name = parameter.parameter_name
+            if parameter.is_optional:
+                parameter_name = 'opt_' + parameter_name
+            parameter_name = 'out_' + parameter_name
+
+            result_destructured_names.append(parameter_name)
+
+            parameter_value = parameter_name
+
+            _type = parameter.type
+            if isinstance(_type, AliasedType):
+                _type = _type.aliased_type
+            if isinstance(_type, EnumType) and _type.is_anonymous:
+                _type = _type.primitive_type
+
+            if _type.is_enum():
+                if parameter.is_optional:
+                    parameter_value = '*' + parameter_value
+                parameter_value = 'Protocol::%s::getEnumConstantValue(%s)' % (self.helpers_namespace(), parameter_value)
+            elif CppGenerator.should_release_argument(_type, parameter.is_optional):
+                parameter_value = parameter_value + '.releaseNonNull()'
+            elif CppGenerator.should_dereference_argument(_type, parameter.is_optional):
+                parameter_value = '*' + parameter_value
+            elif CppGenerator.should_move_argument(_type, parameter.is_optional):
+                parameter_value = 'WTFMove(%s)' % parameter_value
+
+            param_args = {
+                'keyedSetMethod': CppGenerator.cpp_setter_method_for_type(_type),
+                'parameterKey': parameter.parameter_name,
+                'parameterName': parameter_name,
+                'parameterValue': parameter_value,
+            }
+
+            if parameter.is_optional:
+                result_conversion_lines.append('    if (!!%(parameterName)s)' % param_args)
+                result_conversion_lines.append('        protocol_jsonMessage->%(keyedSetMethod)s("%(parameterKey)s"_s, %(parameterValue)s);' % param_args)
+            else:
+                result_conversion_lines.append('    protocol_jsonMessage->%(keyedSetMethod)s("%(parameterKey)s"_s, %(parameterValue)s);' % param_args)
+
         if command.is_async:
-            method_parameters.append('adoptRef(*new %sBackendDispatcherHandler::%s(m_backendDispatcher.copyRef(), protocol_requestId))' % (domain.domain_name, '%sCallback' % ucfirst(command.command_name)))
+            # FIXME: Remove legacy_async_callbacks when IndexedDBAgent moves off of it. <https://bugs.webkit.org/show_bug.cgi?id=288203>
+            use_legacy_async_callbacks = self.model().framework.setting('legacy_async_callbacks', False)
+            if use_legacy_async_callbacks:
+                callback_name = '%sBackendDispatcherHandler::%sCallback' % (domain.domain_name, ucfirst(command.command_name))
+                method_parameters.append('adoptRef(*new %s(m_backendDispatcher.copyRef(), protocol_requestId))' % callback_name)
+            else:
+                if len(command.return_parameters) > 1:
+                    result_type_alias = 'CommandResultOf'
+                    type_arguments = [CppGenerator.cpp_type_for_command_return_declaration(parameter.type, parameter.is_optional) for parameter in command.return_parameters]
+                elif len(command.return_parameters):
+                    result_type_alias = 'CommandResult'
+                    type_arguments = [CppGenerator.cpp_type_for_command_return_declaration(parameter.type, parameter.is_optional) for parameter in command.return_parameters]
+                else:
+                    result_type_alias = 'CommandResult'
+                    type_arguments = ['void']
+
+                thunkLines = [
+                    '[backendDispatcher = m_backendDispatcher.copyRef(), protocol_requestId](%s<%s> result) {' % (result_type_alias, ", ".join(type_arguments)),
+                    '        if (!result) {',
+                    '           ASSERT(!result.error().isEmpty());',
+                    '           backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, result.error());',
+                    '           return;',
+                    '        }',
+                ]
+
+                if len(result_destructured_names) > 1:
+                    thunkLines.append('        auto [%s] = WTFMove(result.value());' % ", ".join(result_destructured_names))
+                elif len(result_destructured_names):
+                    thunkLines.append('        auto %s = WTFMove(result.value());' % ", ".join(result_destructured_names))
+
+                thunkLines.append('')
+                thunkLines.append('        auto protocol_jsonMessage = JSON::Object::create();')
+                thunkLines.extend(['    ' + line for line in result_conversion_lines])
+                thunkLines.append('        backendDispatcher->sendResponse(protocol_requestId, WTFMove(protocol_jsonMessage), false);')
+                thunkLines.append('    }')
+                method_parameters.append("\n".join(thunkLines))
 
         command_args = {
             'domainName': domain.domain_name,
@@ -288,6 +370,7 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
             'alternateInvocationParameters': ', '.join(alternate_dispatcher_method_parameters),
         }
 
+        # Step 3: spit out the generated code one line at a time.
         lines = []
         if len(command.call_parameters) == 0:
             lines.append('void %(domainName)sBackendDispatcher::%(commandName)s(long protocol_requestId, RefPtr<JSON::Object>&&)' % command_args)
@@ -314,48 +397,6 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
         if command.is_async:
             lines.append('    m_agent->%(commandName)s(%(invocationParameters)s);' % command_args)
         else:
-            result_destructured_names = []
-            result_conversion_lines = []
-            for parameter in command.return_parameters:
-                parameter_name = parameter.parameter_name
-                if parameter.is_optional:
-                    parameter_name = 'opt_' + parameter_name
-                parameter_name = 'out_' + parameter_name
-
-                result_destructured_names.append(parameter_name)
-
-                parameter_value = parameter_name
-
-                _type = parameter.type
-                if isinstance(_type, AliasedType):
-                    _type = _type.aliased_type
-                if isinstance(_type, EnumType) and _type.is_anonymous:
-                    _type = _type.primitive_type
-
-                if _type.is_enum():
-                    if parameter.is_optional:
-                        parameter_value = '*' + parameter_value
-                    parameter_value = 'Protocol::%s::getEnumConstantValue(%s)' % (self.helpers_namespace(), parameter_value)
-                elif CppGenerator.should_release_argument(_type, parameter.is_optional):
-                    parameter_value = parameter_value + '.releaseNonNull()'
-                elif CppGenerator.should_dereference_argument(_type, parameter.is_optional):
-                    parameter_value = '*' + parameter_value
-                elif CppGenerator.should_move_argument(_type, parameter.is_optional):
-                    parameter_value = 'WTFMove(%s)' % parameter_value
-
-                param_args = {
-                    'keyedSetMethod': CppGenerator.cpp_setter_method_for_type(_type),
-                    'parameterKey': parameter.parameter_name,
-                    'parameterName': parameter_name,
-                    'parameterValue': parameter_value,
-                }
-
-                if parameter.is_optional:
-                    result_conversion_lines.append('    if (!!%(parameterName)s)' % param_args)
-                    result_conversion_lines.append('        protocol_jsonMessage->%(keyedSetMethod)s("%(parameterKey)s"_s, %(parameterValue)s);' % param_args)
-                else:
-                    result_conversion_lines.append('    protocol_jsonMessage->%(keyedSetMethod)s("%(parameterKey)s"_s, %(parameterValue)s);' % param_args)
-
             lines.append('    auto result = m_agent->%(commandName)s(%(invocationParameters)s);' % command_args)
             lines.append('    if (!result) {')
             lines.append('        ASSERT(!result.error().isEmpty());')

--- a/Source/JavaScriptCore/inspector/scripts/codegen/models.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/models.py
@@ -66,6 +66,8 @@ _FRAMEWORK_CONFIG_MAP = {
         "cpp_protocol_group": "Inspector",
         "export_macro": "JS_EXPORT_PRIVATE",
         "alternate_dispatchers": True,
+        # FIXME: Remove legacy_async_callbacks when IndexedDBAgent moves off of it. <rdar://143782962>
+        "legacy_async_callbacks": True,
     },
     "WebKit": {
         "cpp_protocol_group": "Automation",

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -238,21 +238,21 @@ void WebAutomationSession::terminate()
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
     for (auto& identifier : copyToVector(m_pendingKeyboardEventsFlushedCallbacksPerPage.keys())) {
         auto callback = m_pendingKeyboardEventsFlushedCallbacksPerPage.take(identifier);
-        callback(AUTOMATION_COMMAND_ERROR_WITH_NAME(InternalError));
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(InternalError)));
     }
 #endif // ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     for (auto& identifier : copyToVector(m_pendingMouseEventsFlushedCallbacksPerPage.keys())) {
         auto callback = m_pendingMouseEventsFlushedCallbacksPerPage.take(identifier);
-        callback(AUTOMATION_COMMAND_ERROR_WITH_NAME(InternalError));
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(InternalError)));
     }
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
     for (auto& identifier : copyToVector(m_pendingWheelEventsFlushedCallbacksPerPage.keys())) {
         auto callback = m_pendingWheelEventsFlushedCallbacksPerPage.take(identifier);
-        callback(AUTOMATION_COMMAND_ERROR_WITH_NAME(InternalError));
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(InternalError)));
     }
 #endif // ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
 
@@ -369,10 +369,10 @@ Ref<Inspector::Protocol::Automation::BrowsingContext> WebAutomationSession::buil
 
 // Platform-independent Commands.
 
-void WebAutomationSession::getNextContext(Ref<WebAutomationSession>&& protectedThis, Vector<Ref<WebPageProxy>>&& pages, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>> contexts, Ref<WebAutomationSession::GetBrowsingContextsCallback>&& callback)
+void WebAutomationSession::getNextContext(Ref<WebAutomationSession>&& protectedThis, Vector<Ref<WebPageProxy>>&& pages, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>> contexts, CommandCallback<Ref<JSON::ArrayOf<Protocol::Automation::BrowsingContext>>>&& callback)
 {
     if (pages.isEmpty()) {
-        callback->sendSuccess(WTFMove(contexts));
+        callback(WTFMove(contexts));
         return;
     }
     auto page = pages.takeLast();
@@ -383,7 +383,7 @@ void WebAutomationSession::getNextContext(Ref<WebAutomationSession>&& protectedT
     });
 }
 
-void WebAutomationSession::getBrowsingContexts(Ref<GetBrowsingContextsCallback>&& callback)
+void WebAutomationSession::getBrowsingContexts(CommandCallback<Ref<JSON::ArrayOf<Protocol::Automation::BrowsingContext>>>&& callback)
 {
     Vector<Ref<WebPageProxy>> pages;
     for (Ref process : protectedProcessPool()->processes()) {
@@ -397,14 +397,14 @@ void WebAutomationSession::getBrowsingContexts(Ref<GetBrowsingContextsCallback>&
     getNextContext(Ref { *this }, WTFMove(pages), JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>::create(), WTFMove(callback));
 }
 
-void WebAutomationSession::getBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, Ref<GetBrowsingContextCallback>&& callback)
+void WebAutomationSession::getBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, CommandCallback<Ref<Protocol::Automation::BrowsingContext>>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
 
     page->getWindowFrameWithCallback([protectedThis = Ref { *this }, page = Ref { *page }, callback = WTFMove(callback)](WebCore::FloatRect windowFrame) mutable {
-        callback->sendSuccess(protectedThis->buildBrowsingContextForPage(page.get(), windowFrame));
+        callback(protectedThis->buildBrowsingContextForPage(page.get(), windowFrame));
     });
 }
 
@@ -420,7 +420,7 @@ static Inspector::Protocol::Automation::BrowsingContextPresentation toProtocol(A
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void WebAutomationSession::createBrowsingContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&& presentationHint, Ref<CreateBrowsingContextCallback>&& callback)
+void WebAutomationSession::createBrowsingContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&& presentationHint, CommandCallbackOf<String, Protocol::Automation::BrowsingContextPresentation>&& callback)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -437,11 +437,11 @@ void WebAutomationSession::createBrowsingContext(std::optional<Inspector::Protoc
 
         // WebDriver allows running commands in a browsing context which has not done any loads yet. Force WebProcess to be created so it can receive messages.
         page->launchInitialProcessIfNecessary();
-        callback->sendSuccess(protectedThis->handleForWebPageProxy(*page), toProtocol(protectedThis->m_client->currentPresentationOfPage(protectedThis.get(), *page)));
+        callback({ { protectedThis->handleForWebPageProxy(*page), toProtocol(protectedThis->m_client->currentPresentationOfPage(protectedThis.get(), *page)) } });
     });
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::closeBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle)
+CommandResult<void> WebAutomationSession::closeBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
@@ -451,7 +451,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::closeBrowsingCont
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::deleteSession()
+CommandResult<void> WebAutomationSession::deleteSession()
 {
 #if ENABLE(REMOTE_INSPECTOR)
     if (!isPaired())
@@ -462,7 +462,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::deleteSession()
     return { };
 }
 
-void WebAutomationSession::switchToBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<SwitchToBrowsingContextCallback>&& callback)
+void WebAutomationSession::switchToBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -477,11 +477,11 @@ void WebAutomationSession::switchToBrowsingContext(const Inspector::Protocol::Au
     m_client->requestSwitchToPage(*this, *page, [page = Ref { *page }, callback = WTFMove(callback)]() {
         page->setFocus(true);
 
-        callback->sendSuccess();
+        callback({ });
     });
 }
 
-void WebAutomationSession::setWindowFrameOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, RefPtr<JSON::Object>&& origin, RefPtr<JSON::Object>&& size, Ref<SetWindowFrameOfBrowsingContextCallback>&& callback)
+void WebAutomationSession::setWindowFrameOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, RefPtr<JSON::Object>&& origin, RefPtr<JSON::Object>&& size, CommandCallback<void>&& callback)
 {
     std::optional<double> x;
     std::optional<double> y;
@@ -526,13 +526,13 @@ void WebAutomationSession::setWindowFrameOfBrowsingContext(const Inspector::Prot
                 if (newFrame != originalFrame)
                     page->setWindowFrame(newFrame);
                 
-                callback->sendSuccess();
+                callback({ });
             });
         });
     });
 }
 
-void WebAutomationSession::waitForNavigationToComplete(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& optionalFrameHandle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, Ref<WaitForNavigationToCompleteCallback>&& callback)
+void WebAutomationSession::waitForNavigationToComplete(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& optionalFrameHandle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -557,30 +557,32 @@ void WebAutomationSession::waitForNavigationToComplete(const Inspector::Protocol
         RefPtr frame = WebFrameProxy::webFrame(frameID.value());
         if (!frame)
             ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
-        if (!shouldTimeoutDueToUnexpectedAlert)
+        if (!shouldTimeoutDueToUnexpectedAlert) {
             waitForNavigationToCompleteOnFrame(*frame, pageLoadStrategy, pageLoadTimeout, WTFMove(callback));
+            return;
+        }
     } else {
-        if (!shouldTimeoutDueToUnexpectedAlert)
+        if (!shouldTimeoutDueToUnexpectedAlert) {
             waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTFMove(callback));
+            return;
+        }
     }
 
-    if (shouldTimeoutDueToUnexpectedAlert) {
-        // §9 Navigation.
-        // 7. If the previous step completed by the session page load timeout being reached and the browser does not
-        // have an active user prompt, return error with error code timeout.
-        // 8. Return success with data null.
-        // https://w3c.github.io/webdriver/webdriver-spec.html#dfn-wait-for-navigation-to-complete
-        callback->sendSuccess();
-    }
+    // §9 Navigation.
+    // 7. If the previous step completed by the session page load timeout being reached and the browser does not
+    // have an active user prompt, return error with error code timeout.
+    // 8. Return success with data null.
+    // https://w3c.github.io/webdriver/webdriver-spec.html#dfn-wait-for-navigation-to-complete
+    callback({ });
 }
 
-void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Ref<Inspector::BackendDispatcher::CallbackBase>&& callback)
+void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Inspector::CommandCallback<void>&& callback)
 {
     ASSERT(!m_loadTimer.isActive());
     Ref pageLoadState = page.pageLoadState();
 
     if (loadStrategy == Inspector::Protocol::Automation::PageLoadStrategy::None || (!pageLoadState->isLoading() && !pageLoadState->hasUncommittedLoad())) {
-        callback->sendSuccess(JSON::Object::create());
+        callback({ });
         return;
     }
 
@@ -597,11 +599,11 @@ void WebAutomationSession::waitForNavigationToCompleteOnPage(WebPageProxy& page,
     }
 }
 
-void WebAutomationSession::waitForNavigationToCompleteOnFrame(WebFrameProxy& frame, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Ref<Inspector::BackendDispatcher::CallbackBase>&& callback)
+void WebAutomationSession::waitForNavigationToCompleteOnFrame(WebFrameProxy& frame, Inspector::Protocol::Automation::PageLoadStrategy loadStrategy, Seconds timeout, Inspector::CommandCallback<void>&& callback)
 {
     ASSERT(!m_loadTimer.isActive());
     if (loadStrategy == Inspector::Protocol::Automation::PageLoadStrategy::None || frame.frameLoadState().state() == FrameLoadState::State::Finished) {
-        callback->sendSuccess(JSON::Object::create());
+        callback({ });
         return;
     }
 
@@ -618,16 +620,15 @@ void WebAutomationSession::waitForNavigationToCompleteOnFrame(WebFrameProxy& fra
     }
 }
 
-void WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>>& map)
+void WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>>& map)
 {
-    auto timeoutError = STRING_FOR_PREDEFINED_ERROR_NAME(Timeout);
     for (auto id : copyToVector(map.keys())) {
         auto page = WebProcessProxy::webPage(id);
         auto callback = map.take(id);
         if (page && m_client->isShowingJavaScriptDialogOnPage(*this, *page))
-            callback->sendSuccess(JSON::Object::create());
+            callback({ });
         else
-            callback->sendFailure(timeoutError);
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
     }
 }
 
@@ -638,16 +639,15 @@ static WebPageProxy* findPageForFrameID(const WebProcessPool& processPool, Frame
     return nullptr;
 }
 
-void WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<FrameIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>>& map)
+void WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<FrameIdentifier, Inspector::CommandCallback<void>>& map)
 {
-    auto timeoutError = STRING_FOR_PREDEFINED_ERROR_NAME(Timeout);
     for (auto id : copyToVector(map.keys())) {
         RefPtr page = findPageForFrameID(*protectedProcessPool(), id);
         auto callback = map.take(id);
         if (page && m_client->isShowingJavaScriptDialogOnPage(*this, *page))
-            callback->sendSuccess(JSON::Object::create());
+            callback({ });
         else
-            callback->sendFailure(timeoutError);
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
     }
 }
 
@@ -659,7 +659,7 @@ void WebAutomationSession::loadTimerFired()
     respondToPendingPageNavigationCallbacksWithTimeout(m_pendingEagerNavigationInBrowsingContextCallbacksPerPage);
 }
 
-void WebAutomationSession::maximizeWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<MaximizeWindowOfBrowsingContextCallback>&& callback)
+void WebAutomationSession::maximizeWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -669,13 +669,13 @@ void WebAutomationSession::maximizeWindowOfBrowsingContext(const Inspector::Prot
         auto& webPage = *page;
         restoreWindowForPage(webPage, [this, protectedThis, callback = WTFMove(callback), page = RefPtr { page }]() mutable {
             maximizeWindowForPage(*page, [callback = WTFMove(callback)]() {
-                callback->sendSuccess();
+                callback({ });
             });
         });
     });
 }
 
-void WebAutomationSession::hideWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<HideWindowOfBrowsingContextCallback>&& callback)
+void WebAutomationSession::hideWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -683,7 +683,7 @@ void WebAutomationSession::hideWindowOfBrowsingContext(const Inspector::Protocol
     
     exitFullscreenWindowForPage(*page, [protectedThis = Ref { *this }, callback = WTFMove(callback), page = RefPtr { page }]() mutable {
         protectedThis->hideWindowForPage(*page, [callback = WTFMove(callback)]() mutable {
-            callback->sendSuccess();
+            callback({ });
         });
     });
 }
@@ -749,7 +749,7 @@ void WebAutomationSession::willShowJavaScriptDialog(WebPageProxy& page)
         if (!m_evaluateJavaScriptFunctionCallbacks.isEmpty()) {
             for (auto key : copyToVector(m_evaluateJavaScriptFunctionCallbacks.keys())) {
                 auto callback = m_evaluateJavaScriptFunctionCallbacks.take(key);
-                callback->sendSuccess("null"_s);
+                callback(String("null"_s));
             }
         }
 
@@ -757,7 +757,7 @@ void WebAutomationSession::willShowJavaScriptDialog(WebPageProxy& page)
         if (!m_pendingMouseEventsFlushedCallbacksPerPage.isEmpty()) {
             for (auto key : copyToVector(m_pendingMouseEventsFlushedCallbacksPerPage.keys())) {
                 auto callback = m_pendingMouseEventsFlushedCallbacksPerPage.take(key);
-                callback(std::nullopt);
+                callback({ });
             }
         }
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
@@ -766,7 +766,7 @@ void WebAutomationSession::willShowJavaScriptDialog(WebPageProxy& page)
         if (!m_pendingKeyboardEventsFlushedCallbacksPerPage.isEmpty()) {
             for (auto key : copyToVector(m_pendingKeyboardEventsFlushedCallbacksPerPage.keys())) {
                 auto callback = m_pendingKeyboardEventsFlushedCallbacksPerPage.take(key);
-                callback(std::nullopt);
+                callback({ });
             }
         }
 #endif // ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
@@ -776,7 +776,7 @@ void WebAutomationSession::willShowJavaScriptDialog(WebPageProxy& page)
         if (!m_pendingWheelEventsFlushedCallbacksPerPage.isEmpty()) {
             for (auto key : copyToVector(m_pendingWheelEventsFlushedCallbacksPerPage.keys())) {
                 auto callback = m_pendingWheelEventsFlushedCallbacksPerPage.take(key);
-                callback(std::nullopt);
+                callback({ });
             }
         }
 #endif // ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
@@ -794,7 +794,7 @@ void WebAutomationSession::didExitFullScreenForPage(const WebPageProxy&)
         m_windowStateTransitionCallback(WindowTransitionedToState::Unfullscreen);
 }
 
-void WebAutomationSession::navigateBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const String& url, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, Ref<NavigateBrowsingContextCallback>&& callback)
+void WebAutomationSession::navigateBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const String& url, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
@@ -807,7 +807,7 @@ void WebAutomationSession::navigateBrowsingContext(const Inspector::Protocol::Au
     waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTFMove(callback));
 }
 
-void WebAutomationSession::goBackInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, Ref<GoBackInBrowsingContextCallback>&& callback)
+void WebAutomationSession::goBackInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
@@ -820,7 +820,7 @@ void WebAutomationSession::goBackInBrowsingContext(const Inspector::Protocol::Au
     waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTFMove(callback));
 }
 
-void WebAutomationSession::goForwardInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, Ref<GoForwardInBrowsingContextCallback>&& callback)
+void WebAutomationSession::goForwardInBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
@@ -833,7 +833,7 @@ void WebAutomationSession::goForwardInBrowsingContext(const Inspector::Protocol:
     waitForNavigationToCompleteOnPage(*page, pageLoadStrategy, pageLoadTimeout, WTFMove(callback));
 }
 
-void WebAutomationSession::reloadBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, Ref<ReloadBrowsingContextCallback>&& callback)
+void WebAutomationSession::reloadBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&& optionalPageLoadStrategy, std::optional<double>&& optionalPageLoadTimeout, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
@@ -864,13 +864,13 @@ void WebAutomationSession::navigationOccurredForFrame(const WebFrameProxy& frame
 
         if (auto callback = m_pendingNormalNavigationInBrowsingContextCallbacksPerPage.take(frame.page()->identifier())) {
             m_loadTimer.stop();
-            callback->sendSuccess(JSON::Object::create());
+            callback({ });
         }
         m_domainNotifier->browsingContextCleared(handleForWebPageProxy(*frame.protectedPage()));
     } else {
         if (auto callback = m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame.take(frame.frameID())) {
             m_loadTimer.stop();
-            callback->sendSuccess(JSON::Object::create());
+            callback({ });
         }
     }
 }
@@ -880,7 +880,7 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame)
     if (frame.isMainFrame()) {
         if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerPage.take(frame.page()->identifier())) {
             m_loadTimer.stop();
-            callback->sendSuccess(JSON::Object::create());
+            callback({ });
         }
 
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
@@ -889,7 +889,7 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame)
     } else {
         if (auto callback = m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame.take(frame.frameID())) {
             m_loadTimer.stop();
-            callback->sendSuccess(JSON::Object::create());
+            callback({ });
         }
     }
 }
@@ -897,14 +897,14 @@ void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame)
 void WebAutomationSession::inspectorFrontendLoaded(const WebPageProxy& page)
 {
     if (auto callback = m_pendingInspectorCallbacksPerPage.take(page.identifier()))
-        callback->sendSuccess(JSON::Object::create());
+        callback({ });
 }
 
 void WebAutomationSession::mouseEventsFlushedForPage(const WebPageProxy& page)
 {
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     if (auto callback = m_pendingMouseEventsFlushedCallbacksPerPage.take(page.identifier()))
-        callback(std::nullopt);
+        callback({ });
 #else
     UNUSED_PARAM(page);
 #endif
@@ -914,7 +914,7 @@ void WebAutomationSession::keyboardEventsFlushedForPage(const WebPageProxy& page
 {
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
     if (auto callback = m_pendingKeyboardEventsFlushedCallbacksPerPage.take(page.identifier()))
-        callback(std::nullopt);
+        callback({ });
 #else
     UNUSED_PARAM(page);
 #endif
@@ -924,7 +924,7 @@ void WebAutomationSession::wheelEventsFlushedForPage(const WebPageProxy& page)
 {
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
     if (auto callback = m_pendingWheelEventsFlushedCallbacksPerPage.take(page.identifier()))
-        callback(std::nullopt);
+        callback({ });
 #else
     UNUSED_PARAM(page);
 #endif
@@ -939,15 +939,15 @@ void WebAutomationSession::willClosePage(const WebPageProxy& page)
     // actions to be aborted and the SimulatedInputDispatcher::run() call will unwind and fail.
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     if (auto callback = m_pendingMouseEventsFlushedCallbacksPerPage.take(page.identifier()))
-        callback(AUTOMATION_COMMAND_ERROR_WITH_NAME(WindowNotFound));
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(WindowNotFound)));
 #endif
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
     if (auto callback = m_pendingKeyboardEventsFlushedCallbacksPerPage.take(page.identifier()))
-        callback(AUTOMATION_COMMAND_ERROR_WITH_NAME(WindowNotFound));
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(WindowNotFound)));
 #endif
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
     if (auto callback = m_pendingWheelEventsFlushedCallbacksPerPage.take(page.identifier()))
-        callback(AUTOMATION_COMMAND_ERROR_WITH_NAME(WindowNotFound));
+        callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(WindowNotFound)));
 #endif
 
 #if ENABLE(WEBDRIVER_ACTIONS_API)
@@ -1044,7 +1044,7 @@ void WebAutomationSession::handleRunOpenPanel(const WebPageProxy& page, const We
     m_domainNotifier->fileChooserDismissed(browsingContextHandle, false, WTFMove(selectedFiles));
 }
 
-void WebAutomationSession::evaluateJavaScriptFunction(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const String& function, Ref<JSON::Array>&& arguments, std::optional<bool>&& expectsImplicitCallbackArgument, std::optional<bool>&& forceUserGesture, std::optional<double>&& callbackTimeout, Ref<EvaluateJavaScriptFunctionCallback>&& callback)
+void WebAutomationSession::evaluateJavaScriptFunction(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const String& function, Ref<JSON::Array>&& arguments, std::optional<bool>&& expectsImplicitCallbackArgument, std::optional<bool>&& forceUserGesture, std::optional<double>&& callbackTimeout, Inspector::CommandCallback<String>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1068,13 +1068,13 @@ void WebAutomationSession::evaluateJavaScriptFunction(const Inspector::Protocol:
             return;
 
         if (!errorType.isEmpty())
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE_AND_DETAILS(errorType, result));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE_AND_DETAILS(errorType, result)));
         else
-            callback->sendSuccess(result);
+            callback(result);
     } });
 }
 
-void WebAutomationSession::resolveChildFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, std::optional<int>&& optionalOrdinal, const String& optionalName, const Inspector::Protocol::Automation::NodeHandle& optionalNodeHandle, Ref<ResolveChildFrameHandleCallback>&& callback)
+void WebAutomationSession::resolveChildFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, std::optional<int>&& optionalOrdinal, const String& optionalName, const Inspector::Protocol::Automation::NodeHandle& optionalNodeHandle, CommandCallback<String>&& callback)
 {
     if (!optionalOrdinal && !optionalName && !optionalNodeHandle)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(MissingParameter, "Command must specify a child frame by ordinal, name, or element handle."_s);
@@ -1088,13 +1088,13 @@ void WebAutomationSession::resolveChildFrameHandle(const Inspector::Protocol::Au
     if (frameNotFound)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<FrameIdentifier>&&)> completionHandler = [this, protectedThis = Ref { *this }, callback](std::optional<String>&& errorType, std::optional<FrameIdentifier>&& frameID) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<FrameIdentifier>&&)> completionHandler = [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String>&& errorType, std::optional<FrameIdentifier>&& frameID) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess(handleForWebFrameID(frameID));
+        callback(handleForWebFrameID(frameID));
     };
 
     if (!!optionalNodeHandle) {
@@ -1115,7 +1115,7 @@ void WebAutomationSession::resolveChildFrameHandle(const Inspector::Protocol::Au
     ASSERT_NOT_REACHED();
 }
 
-void WebAutomationSession::resolveParentFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<ResolveParentFrameHandleCallback>&& callback)
+void WebAutomationSession::resolveParentFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, CommandCallback<String>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1126,13 +1126,13 @@ void WebAutomationSession::resolveParentFrameHandle(const Inspector::Protocol::A
     if (frameNotFound)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<FrameIdentifier>&&)> completionHandler = [this, protectedThis = Ref { *this }, callback](std::optional<String>&& errorType, std::optional<FrameIdentifier>&& frameID) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<FrameIdentifier>&&)> completionHandler = [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<String>&& errorType, std::optional<FrameIdentifier>&& frameID) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess(handleForWebFrameID(frameID));
+        callback(handleForWebFrameID(frameID));
     };
 
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::ResolveParentFrame(page->webPageIDInMainFrameProcess(), frameID), WTFMove(completionHandler));
@@ -1153,7 +1153,7 @@ static std::optional<CoordinateSystem> protocolStringToCoordinateSystem(Inspecto
     return std::nullopt;
 }
 
-void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, std::optional<bool>&& optionalScrollIntoViewIfNeeded, Inspector::Protocol::Automation::CoordinateSystem coordinateSystemValue, Ref<ComputeElementLayoutCallback>&& callback)
+void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, std::optional<bool>&& optionalScrollIntoViewIfNeeded, Inspector::Protocol::Automation::CoordinateSystem coordinateSystemValue, CommandCallbackOf<Ref<Protocol::Automation::Rect>, RefPtr<Protocol::Automation::Point>, bool>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1168,9 +1168,9 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
     if (!coordinateSystem)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InvalidParameter, "The parameter 'coordinateSystem' is invalid."_s);
 
-    WTF::CompletionHandler<void(std::optional<String>&&, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&&, bool)> completionHandler = [callback](std::optional<String> errorType, WebCore::FloatRect rect, std::optional<WebCore::IntPoint> inViewCenterPoint, bool isObscured) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, WebCore::FloatRect&&, std::optional<WebCore::IntPoint>&&, bool)> completionHandler = [callback = WTFMove(callback)](std::optional<String> errorType, WebCore::FloatRect rect, std::optional<WebCore::IntPoint> inViewCenterPoint, bool isObscured) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
@@ -1190,7 +1190,7 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
             .release();
 
         if (!inViewCenterPoint) {
-            callback->sendSuccess(WTFMove(rectObject), nullptr, isObscured);
+            callback({ { WTFMove(rectObject), nullptr, isObscured } });
             return;
         }
 
@@ -1199,14 +1199,14 @@ void WebAutomationSession::computeElementLayout(const Inspector::Protocol::Autom
             .setY(inViewCenterPoint.value().y())
             .release();
 
-        callback->sendSuccess(WTFMove(rectObject), WTFMove(inViewCenterPointObject), isObscured);
+        callback({ { WTFMove(rectObject), WTFMove(inViewCenterPointObject), isObscured } });
     };
 
     bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::ComputeElementLayout(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, coordinateSystem.value()), WTFMove(completionHandler));
 }
 
-void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<GetComputedRoleCallback>&& callback)
+void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, CommandCallback<String>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1217,19 +1217,19 @@ void WebAutomationSession::getComputedRole(const Inspector::Protocol::Automation
     if (frameNotFound)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<String>&&)> completionHandler = [callback](std::optional<String>&& errorType, std::optional<String>&& role) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<String>&&)> completionHandler = [callback = WTFMove(callback)](std::optional<String>&& errorType, std::optional<String>&& role) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess(*role);
+        callback(*role);
     };
 
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::GetComputedRole(page->webPageIDInMainFrameProcess(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
-void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<GetComputedLabelCallback>&& callback)
+void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, CommandCallback<String>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1240,19 +1240,19 @@ void WebAutomationSession::getComputedLabel(const Inspector::Protocol::Automatio
     if (frameNotFound)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<String>&&)> completionHandler = [callback](std::optional<String>&& errorType, std::optional<String>&& label) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&, std::optional<String>&&)> completionHandler = [callback = WTFMove(callback)](std::optional<String>&& errorType, std::optional<String>&& label) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess(*label);
+        callback(*label);
     };
 
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::GetComputedLabel(page->webPageIDInMainFrameProcess(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
-void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<SelectOptionElementCallback>&& callback)
+void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1263,19 +1263,19 @@ void WebAutomationSession::selectOptionElement(const Inspector::Protocol::Automa
     if (frameNotFound)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(FrameNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>&&)> completionHandler = [callback](std::optional<String>&& errorType) mutable {
+    WTF::CompletionHandler<void(std::optional<String>&&)> completionHandler = [callback = WTFMove(callback)](std::optional<String>&& errorType) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
-        
-        callback->sendSuccess();
+
+        callback({ });
     };
 
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::SelectOptionElement(page->webPageIDInMainFrameProcess(), frameID, nodeHandle), WTFMove(completionHandler));
 }
 
-Inspector::Protocol::ErrorStringOr<bool> WebAutomationSession::isShowingJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
+CommandResult<bool> WebAutomationSession::isShowingJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1288,7 +1288,7 @@ Inspector::Protocol::ErrorStringOr<bool> WebAutomationSession::isShowingJavaScri
     return m_client->isShowingJavaScriptDialogOnPage(*this, *page);
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::dismissCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
+CommandResult<void> WebAutomationSession::dismissCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1306,7 +1306,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::dismissCurrentJav
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::acceptCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
+CommandResult<void> WebAutomationSession::acceptCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1324,7 +1324,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::acceptCurrentJava
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<String> WebAutomationSession::messageOfCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
+CommandResult<String> WebAutomationSession::messageOfCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1340,7 +1340,7 @@ Inspector::Protocol::ErrorStringOr<String> WebAutomationSession::messageOfCurren
     return m_client->messageOfCurrentJavaScriptDialogOnPage(*this, *page);
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setUserInputForCurrentJavaScriptPrompt(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& promptValue)
+CommandResult<void> WebAutomationSession::setUserInputForCurrentJavaScriptPrompt(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& promptValue)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1376,7 +1376,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setUserInputForCu
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setFilesToSelectForFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<JSON::Array>&& filenames, RefPtr<JSON::Array>&& fileContents)
+CommandResult<void> WebAutomationSession::setFilesToSelectForFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<JSON::Array>&& filenames, RefPtr<JSON::Array>&& fileContents)
 {
     Vector<String> newFileList;
     newFileList.reserveInitialCapacity(filenames->length());
@@ -1410,7 +1410,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setFilesToSelectF
     return { };
 }
 
-void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<JSON::Array>&& filenames, Ref<SetFilesForInputFileUploadCallback>&& callback)
+void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, Ref<JSON::Array>&& filenames, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1431,13 +1431,13 @@ void WebAutomationSession::setFilesForInputFileUpload(const Inspector::Protocol:
         newFileList.append(filename);
     }
 
-    CompletionHandler<void(std::optional<String>&&)> completionHandler = [callback](std::optional<String>&& errorType) mutable {
+    CompletionHandler<void(std::optional<String>&&)> completionHandler = [callback = WTFMove(callback)](std::optional<String>&& errorType) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess();
+        callback({ });
     };
 
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::SetFilesForInputFileUpload(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, WTFMove(newFileList)), WTFMove(completionHandler));
@@ -1495,37 +1495,37 @@ static Ref<JSON::ArrayOf<Inspector::Protocol::Automation::Cookie>> buildArrayFor
     return cookies;
 }
 
-void WebAutomationSession::getAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<GetAllCookiesCallback>&& callback)
+void WebAutomationSession::getAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, CommandCallback<Ref<JSON::ArrayOf<Protocol::Automation::Cookie>>>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>, Vector<WebCore::Cookie>)> completionHandler = [callback](std::optional<String> errorType, Vector<WebCore::Cookie> cookies) mutable {
+    WTF::CompletionHandler<void(std::optional<String>, Vector<WebCore::Cookie>)> completionHandler = [callback = WTFMove(callback)](std::optional<String> errorType, Vector<WebCore::Cookie> cookies) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess(buildArrayForCookies(cookies));
+        callback(buildArrayForCookies(cookies));
     };
 
     page->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebAutomationSessionProxy::GetCookiesForFrame(page->webPageIDInMainFrameProcess(), std::nullopt), WTFMove(completionHandler));
 }
 
-void WebAutomationSession::deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& cookieName, Ref<DeleteSingleCookieCallback>&& callback)
+void WebAutomationSession::deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, const String& cookieName, CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
 
-    WTF::CompletionHandler<void(std::optional<String>)> completionHandler = [callback](std::optional<String> errorType) mutable {
+    WTF::CompletionHandler<void(std::optional<String>)> completionHandler = [callback = WTFMove(callback)](std::optional<String> errorType) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        callback->sendSuccess();
+        callback({ });
     };
 
     page->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebAutomationSessionProxy::DeleteCookie(page->webPageIDInMainFrameProcess(), std::nullopt, cookieName), WTFMove(completionHandler));
@@ -1543,7 +1543,7 @@ static String domainByAddingDotPrefixIfNeeded(String domain)
     return domain;
 }
     
-void WebAutomationSession::addSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<JSON::Object>&& cookieObject, Ref<AddSingleCookieCallback>&& callback)
+void WebAutomationSession::addSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle, Ref<JSON::Object>&& cookieObject, CommandCallback<void>&& callback)
 {
     RefPtr page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1611,12 +1611,12 @@ void WebAutomationSession::addSingleCookie(const Inspector::Protocol::Automation
     cookie.sameSite = toWebCoreSameSitePolicy(*parsedSameSite);
 
     Ref cookieStore = page->protectedWebsiteDataStore()->cookieStore();
-    cookieStore->setCookies({ cookie }, [callback]() {
-        callback->sendSuccess();
+    cookieStore->setCookies({ cookie }, [callback = WTFMove(callback)]() {
+        callback({ });
     });
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
+CommandResult<void> WebAutomationSession::deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle& browsingContextHandle)
 {
     RefPtr page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1633,7 +1633,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::deleteAllCookies(
     return { };
 }
 
-Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>>> WebAutomationSession::getSessionPermissions()
+CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>>> WebAutomationSession::getSessionPermissions()
 {
     auto permissionsObjectArray = JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>::create();
     auto getUserMediaPermissionObject = Inspector::Protocol::Automation::SessionPermissionData::create()
@@ -1645,7 +1645,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Automa
     return permissionsObjectArray;
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setSessionPermissions(Ref<JSON::Array>&& permissions)
+CommandResult<void> WebAutomationSession::setSessionPermissions(Ref<JSON::Array>&& permissions)
 {
     for (auto& value : permissions.get()) {
         auto permission = value->asObject();
@@ -1693,7 +1693,7 @@ static WebCore::AuthenticatorTransport toAuthenticatorTransport(Inspector::Proto
 }
 #endif // ENABLE(WEB_AUTHN)
 
-Inspector::Protocol::ErrorStringOr<String /* authenticatorId */> WebAutomationSession::addVirtualAuthenticator(const String& browsingContextHandle, Ref<JSON::Object>&& authenticator)
+CommandResult<String /* authenticatorId */> WebAutomationSession::addVirtualAuthenticator(const String& browsingContextHandle, Ref<JSON::Object>&& authenticator)
 {
 #if ENABLE(WEB_AUTHN)
     auto protocol = authenticator->getString("protocol"_s);
@@ -1734,7 +1734,7 @@ Inspector::Protocol::ErrorStringOr<String /* authenticatorId */> WebAutomationSe
 #endif // ENABLE(WEB_AUTHN)
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::removeVirtualAuthenticator(const String& browsingContextHandle, const String& authenticatorId)
+CommandResult<void> WebAutomationSession::removeVirtualAuthenticator(const String& browsingContextHandle, const String& authenticatorId)
 {
 #if ENABLE(WEB_AUTHN)
     auto page = webPageProxyForHandle(browsingContextHandle);
@@ -1748,33 +1748,33 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::removeVirtualAuth
 #endif // ENABLE(WEB_AUTHN)
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::addVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, Ref<JSON::Object>&& credential)
+CommandResult<void> WebAutomationSession::addVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, Ref<JSON::Object>&& credential)
 {
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, "This method is not yet implemented."_s);
 }
 
-Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::VirtualAuthenticatorCredential>> /* credentials */> WebAutomationSession::getVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId)
+CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::VirtualAuthenticatorCredential>> /* credentials */> WebAutomationSession::getVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId)
 {
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, "This method is not yet implemented."_s);
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::removeVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, const String& credentialId)
+CommandResult<void> WebAutomationSession::removeVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, const String& credentialId)
 {
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, "This method is not yet implemented."_s);
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::removeAllVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId)
+CommandResult<void> WebAutomationSession::removeAllVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId)
 {
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, "This method is not yet implemented."_s);
 }
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::setVirtualAuthenticatorUserVerified(const String& browsingContextHandle, const String& authenticatorId, bool isUserVerified)
+CommandResult<void> WebAutomationSession::setVirtualAuthenticatorUserVerified(const String& browsingContextHandle, const String& authenticatorId, bool isUserVerified)
 {
     SYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NotImplemented, "This method is not yet implemented."_s);
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS_IN_WEBDRIVER)
-void WebAutomationSession::loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions resourceHint, const String& resource, Ref<LoadWebExtensionCallback>&& callback)
+void WebAutomationSession::loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions resourceHint, const String& resource, CommandCallback<String>&& callback)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1792,11 +1792,11 @@ void WebAutomationSession::loadWebExtension(const Inspector::Protocol::Automatio
         if (!extensionId)
             ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(UnableToLoadExtension, "Failed to load web extension."_s);
         else
-            callback->sendSuccess(extensionId);
+            callback(extensionId);
     });
 }
 
-void WebAutomationSession::unloadWebExtension(const String& identifier, Ref<UnloadWebExtensionCallback>&& callback)
+void WebAutomationSession::unloadWebExtension(const String& identifier, CommandCallback<void>&& callback)
 {
     ASSERT(m_client);
     if (!m_client)
@@ -1804,14 +1804,14 @@ void WebAutomationSession::unloadWebExtension(const String& identifier, Ref<Unlo
 
     m_client->unloadWebExtension(*this, identifier, [protectedThis = Ref { *this }, callback = WTFMove(callback)](const bool success) {
         if (success)
-            callback->sendSuccess();
+            callback({ });
         else
             ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(NoSuchExtension, "Failed to unload web extension because it could not be found."_s);
     });
 }
 #endif
 
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::generateTestReport(const String& browsingContextHandle, const String& message, const String& group)
+CommandResult<void> WebAutomationSession::generateTestReport(const String& browsingContextHandle, const String& message, const String& group)
 {
     auto page = webPageProxyForHandle(browsingContextHandle);
     if (!page)
@@ -1823,7 +1823,7 @@ Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::generateTestRepor
 }
 
 #if ENABLE(WEBDRIVER_BIDI)
-Inspector::Protocol::ErrorStringOr<void> WebAutomationSession::processBidiMessage(const String& message)
+CommandResult<void> WebAutomationSession::processBidiMessage(const String& message)
 {
     m_bidiProcessor->processBidiMessage(message);
 
@@ -1924,13 +1924,18 @@ void WebAutomationSession::simulateMouseInteraction(WebPageProxy& page, MouseInt
         }
 
         // Bridge the flushed callback to our command's completion handler.
-        auto mouseEventsFlushedCallback = [completionHandler = WTFMove(completionHandler)](std::optional<AutomationCommandError> error) mutable {
-            completionHandler(error);
+        auto mouseEventsFlushedCallback = [completionHandler = WTFMove(completionHandler)](CommandResult<void> result) mutable {
+            if (result) {
+                completionHandler(std::nullopt);
+                return;
+            }
+
+            completionHandler(AutomationCommandError(VALIDATED_ERROR_MESSAGE(result.error())));
         };
 
         auto& callbackInMap = m_pendingMouseEventsFlushedCallbacksPerPage.add(page->identifier(), nullptr).iterator->value;
         if (callbackInMap)
-            callbackInMap(AUTOMATION_COMMAND_ERROR_WITH_NAME(Timeout));
+            callbackInMap(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
         callbackInMap = WTFMove(mouseEventsFlushedCallback);
 
         platformSimulateMouseInteraction(page, interaction, mouseButton, locationInViewport, platformWebModifiersFromRaw(page, m_currentModifiers), pointerType);
@@ -1938,7 +1943,7 @@ void WebAutomationSession::simulateMouseInteraction(WebPageProxy& page, MouseInt
         // If the event does not hit test anything in the window, then it may not have been delivered.
         if (callbackInMap && !page->isProcessingMouseEvents()) {
             auto callbackToCancel = m_pendingMouseEventsFlushedCallbacksPerPage.take(page->identifier());
-            callbackToCancel(std::nullopt);
+            callbackToCancel({ });
         }
 
         // Otherwise, wait for mouseEventsFlushedCallback to run when all events are handled.
@@ -1969,13 +1974,18 @@ void WebAutomationSession::simulateTouchInteraction(WebPageProxy& page, TouchInt
 void WebAutomationSession::simulateKeyboardInteraction(WebPageProxy& page, KeyboardInteraction interaction, std::variant<VirtualKey, CharKey>&& key, CompletionHandler<void(std::optional<AutomationCommandError>)>&& completionHandler)
 {
     // Bridge the flushed callback to our command's completion handler.
-    auto keyboardEventsFlushedCallback = [completionHandler = WTFMove(completionHandler)](std::optional<AutomationCommandError> error) mutable {
-        completionHandler(error);
+    auto keyboardEventsFlushedCallback = [completionHandler = WTFMove(completionHandler)](CommandResult<void>&& result) mutable {
+        if (result) {
+            completionHandler(std::nullopt);
+            return;
+        }
+
+        completionHandler(AutomationCommandError(VALIDATED_ERROR_MESSAGE(result.error())));
     };
 
     auto& callbackInMap = m_pendingKeyboardEventsFlushedCallbacksPerPage.add(page.identifier(), nullptr).iterator->value;
     if (callbackInMap)
-        callbackInMap(AUTOMATION_COMMAND_ERROR_WITH_NAME(Timeout));
+        callbackInMap(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
     callbackInMap = WTFMove(keyboardEventsFlushedCallback);
 
     platformSimulateKeyboardInteraction(page, interaction, WTFMove(key));
@@ -1984,7 +1994,7 @@ void WebAutomationSession::simulateKeyboardInteraction(WebPageProxy& page, Keybo
     // This happens in some corner cases on macOS, such as releasing a key while Command is pressed.
     if (callbackInMap && !page.isProcessingKeyboardEvents()) {
         auto callbackToCancel = m_pendingKeyboardEventsFlushedCallbacksPerPage.take(page.identifier());
-        callbackToCancel(std::nullopt);
+        callbackToCancel({ });
     }
 
     // Otherwise, wait for keyboardEventsFlushedCallback to run when all events are handled.
@@ -2003,13 +2013,18 @@ void WebAutomationSession::simulateWheelInteraction(WebPageProxy& page, const We
         }
 
         // Bridge the flushed callback to our command's completion handler.
-        auto wheelEventsFlushedCallback = [completionHandler = WTFMove(completionHandler)](std::optional<AutomationCommandError> error) mutable {
-            completionHandler(error);
+        auto wheelEventsFlushedCallback = [completionHandler = WTFMove(completionHandler)](CommandResult<void>&& result) mutable {
+            if (result) {
+                completionHandler(std::nullopt);
+                return;
+            }
+
+            completionHandler(AutomationCommandError(VALIDATED_ERROR_MESSAGE(result.error())));
         };
 
         auto& callbackInMap = m_pendingWheelEventsFlushedCallbacksPerPage.add(page->identifier(), nullptr).iterator->value;
         if (callbackInMap)
-            callbackInMap(AUTOMATION_COMMAND_ERROR_WITH_NAME(Timeout));
+            callbackInMap(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
         callbackInMap = WTFMove(wheelEventsFlushedCallback);
 
         platformSimulateWheelInteraction(page, locationInViewport, delta);
@@ -2017,7 +2032,7 @@ void WebAutomationSession::simulateWheelInteraction(WebPageProxy& page, const We
         // If the event does not hit test anything in the window, then it may not have been delivered.
         if (callbackInMap && !page->isProcessingWheelEvents()) {
             auto callbackToCancel = m_pendingWheelEventsFlushedCallbacksPerPage.take(page->identifier());
-            callbackToCancel(std::nullopt);
+            callbackToCancel({ });
         }
 
         // Otherwise, wait for wheelEventsFlushedCallback to run when all events are handled.
@@ -2046,7 +2061,7 @@ static WebEventModifier protocolModifierToWebEventModifier(Inspector::Protocol::
 }
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 
-void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, Ref<JSON::Object>&& requestedPosition, Inspector::Protocol::Automation::MouseButton mouseButton, Inspector::Protocol::Automation::MouseInteraction mouseInteraction, Ref<JSON::Array>&& keyModifierStrings, Ref<PerformMouseInteractionCallback>&& callback)
+void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, Ref<JSON::Object>&& requestedPosition, Inspector::Protocol::Automation::MouseButton mouseButton, Inspector::Protocol::Automation::MouseInteraction mouseInteraction, Ref<JSON::Array>&& keyModifierStrings, CommandCallback<Ref<Protocol::Automation::Point>>&& callback)
 {
 #if !ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
     ASYNC_FAIL_WITH_PREDEFINED_ERROR(NotImplemented);
@@ -2086,12 +2101,12 @@ void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Au
 
         WebCore::IntPoint locationInViewport = WebCore::IntPoint(static_cast<int>(floatX), static_cast<int>(floatY));
 
-        auto mouseEventsFlushedCallback = [protectedThis = WTFMove(protectedThis), callback = WTFMove(callback), page, floatX, floatY](std::optional<AutomationCommandError> error) {
-            if (error)
-                callback->sendFailure(error.value().toProtocolString());
+        auto mouseEventsFlushedCallback = [protectedThis = WTFMove(protectedThis), callback = WTFMove(callback), page, floatX, floatY](CommandResult<void> result) {
+            if (!result)
+                callback(makeUnexpected(result.error()));
             else {
                 auto obscuredContentInsets = page->obscuredContentInsets();
-                callback->sendSuccess(Inspector::Protocol::Automation::Point::create()
+                callback(Inspector::Protocol::Automation::Point::create()
                     .setX(floatX - obscuredContentInsets.left())
                     .setY(floatY - obscuredContentInsets.top())
                     .release());
@@ -2100,7 +2115,7 @@ void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Au
 
         auto& callbackInMap = m_pendingMouseEventsFlushedCallbacksPerPage.add(page->identifier(), nullptr).iterator->value;
         if (callbackInMap)
-            callbackInMap(AUTOMATION_COMMAND_ERROR_WITH_NAME(Timeout));
+            callbackInMap(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
         callbackInMap = WTFMove(mouseEventsFlushedCallback);
 
         platformSimulateMouseInteraction(page, mouseInteraction, mouseButton, locationInViewport, keyModifiers, WebCore::mousePointerEventType());
@@ -2110,13 +2125,13 @@ void WebAutomationSession::performMouseInteraction(const Inspector::Protocol::Au
         // In W3C-only code paths, we can reject any pointer actions whose coordinates are outside the viewport rect.
         if (callbackInMap && !page->isProcessingMouseEvents()) {
             auto callbackToCancel = m_pendingMouseEventsFlushedCallbacksPerPage.take(page->identifier());
-            callbackToCancel(std::nullopt);
+            callbackToCancel({ });
         }
     });
 #endif // ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
 }
 
-void WebAutomationSession::performKeyboardInteractions(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, Ref<JSON::Array>&& interactions, Ref<PerformKeyboardInteractionsCallback>&& callback)
+void WebAutomationSession::performKeyboardInteractions(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, Ref<JSON::Array>&& interactions, CommandCallback<void>&& callback)
 {
 #if !ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
     ASYNC_FAIL_WITH_PREDEFINED_ERROR(NotImplemented);
@@ -2179,16 +2194,16 @@ void WebAutomationSession::performKeyboardInteractions(const Inspector::Protocol
     if (!actionsToPerform.size())
         ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(InternalError, "No actions to perform."_s);
 
-    auto keyboardEventsFlushedCallback = [protectedThis = Ref { *this }, callback = WTFMove(callback), page = Ref { *page }](std::optional<AutomationCommandError> error) {
-        if (error)
-            callback->sendFailure(error.value().toProtocolString());
+    auto keyboardEventsFlushedCallback = [protectedThis = Ref { *this }, callback = WTFMove(callback), page = Ref { *page }](Inspector::CommandResult<void> result) {
+        if (!result)
+            callback(makeUnexpected(result.error()));
         else
-            callback->sendSuccess();
+            callback({ });
     };
 
     auto& callbackInMap = m_pendingKeyboardEventsFlushedCallbacksPerPage.add(page->identifier(), nullptr).iterator->value;
     if (callbackInMap)
-        callbackInMap(AUTOMATION_COMMAND_ERROR_WITH_NAME(Timeout));
+        callbackInMap(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
     callbackInMap = WTFMove(keyboardEventsFlushedCallback);
 
     for (auto& action : actionsToPerform)
@@ -2278,7 +2293,7 @@ static std::optional<char32_t> pressedCharKey(const String& pressedCharKeyString
 #endif // !ENABLE(WEBDRIVER_KEYBOARD_GRAPHEME_CLUSTERS)
 #endif // ENABLE(WEBDRIVER_ACTIONS_API)
 
-void WebAutomationSession::performInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<JSON::Array>&& inputSources, Ref<JSON::Array>&& steps, Ref<WebAutomationSession::PerformInteractionSequenceCallback>&& callback)
+void WebAutomationSession::performInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<JSON::Array>&& inputSources, Ref<JSON::Array>&& steps, CommandCallback<void>&& callback)
 {
     // This command implements WebKit support for §17.5 Perform Actions.
 
@@ -2473,14 +2488,14 @@ void WebAutomationSession::performInteractionSequence(const Inspector::Protocol:
     // Delegate the rest of §17.4 Dispatching Actions to the dispatcher.
     inputDispatcher->run(frameID, WTFMove(keyFrames), m_inputSources, [protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<AutomationCommandError> error) {
         if (error)
-            callback->sendFailure(error.value().toProtocolString());
+            callback(makeUnexpected(error.value().toProtocolString()));
         else
-            callback->sendSuccess();
+            callback({ });
     });
 #endif // ENABLE(WEBDRIVER_ACTIONS_API)
 }
 
-void WebAutomationSession::cancelInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, Ref<CancelInteractionSequenceCallback>&& callback)
+void WebAutomationSession::cancelInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, CommandCallback<void>&& callback)
 {
     // This command implements WebKit support for §17.6 Release Actions.
 
@@ -2502,15 +2517,15 @@ void WebAutomationSession::cancelInteractionSequence(const Inspector::Protocol::
     
     inputDispatcher->run(frameID, WTFMove(keyFrames), m_inputSources, [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](std::optional<AutomationCommandError> error) {
         if (error)
-            callback->sendFailure(error.value().toProtocolString());
+            callback(makeUnexpected(error.value().toProtocolString()));
         else
-            callback->sendSuccess();
+            callback({ });
         m_inputSources.clear();
     });
 #endif // ENABLE(WEBDRIVER_ACTIONS_API)
 }
 
-void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, std::optional<bool>&& optionalScrollIntoViewIfNeeded, std::optional<bool>&& optionalClipToViewport, Ref<TakeScreenshotCallback>&& callback)
+void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, const Inspector::Protocol::Automation::FrameHandle& frameHandle, const Inspector::Protocol::Automation::NodeHandle& nodeHandle, std::optional<bool>&& optionalScrollIntoViewIfNeeded, std::optional<bool>&& optionalClipToViewport, CommandCallback<String>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
@@ -2524,19 +2539,20 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
     bool scrollIntoViewIfNeeded = optionalScrollIntoViewIfNeeded ? *optionalScrollIntoViewIfNeeded : false;
     bool clipToViewport = optionalClipToViewport ? *optionalClipToViewport : false;
 
-    auto ipcCompletionHandler = [callback] {
-        return CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&, String&&)> { [callback] (std::optional<ShareableBitmap::Handle>&& imageDataHandle, String&& errorType) {
+#if PLATFORM(COCOA) || !PLATFORM(GTK)
+    auto ipcCompletionHandler = [] (CommandCallback<String>&& callback) mutable {
+        return CompletionHandler<void(std::optional<ShareableBitmap::Handle>&&, String&&)> { [callback = WTFMove(callback)] (std::optional<ShareableBitmap::Handle>&& imageDataHandle, String&& errorType) mutable {
             if (!errorType.isEmpty())
-                return callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(errorType));
+                return callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(errorType)));
             if (!imageDataHandle)
                 ASYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
             std::optional<String> base64EncodedData = platformGetBase64EncodedPNGData(WTFMove(*imageDataHandle));
             if (!base64EncodedData)
                 ASYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
-            callback->sendSuccess(base64EncodedData.value());
+            callback(base64EncodedData.value());
         } };
     };
-
+#endif
 #if PLATFORM(COCOA)
     // FIXME: <webkit.org/b/242215> We can currently only get viewport snapshots from the UIProcess, so fall back to
     // taking a snapshot in the WebProcess if we need to snapshot a specific element. This has the side effect of not
@@ -2547,10 +2563,10 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
     // pixels for accurate pixels in the rest of the viewport which help us verify features like CSS transforms are
     // actually behaving correctly.
     if (!nodeHandle.isEmpty())
-        return page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), ipcCompletionHandler());
+        return page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), ipcCompletionHandler(WTFMove(callback)));
 #endif
 #if PLATFORM(GTK) || PLATFORM(COCOA)
-    Function<void(WebPageProxy&, std::optional<WebCore::IntRect>&&, Ref<TakeScreenshotCallback>&&)> takeViewSnapsot = [](WebPageProxy& page, std::optional<WebCore::IntRect>&& rect, Ref<TakeScreenshotCallback>&& callback) {
+    Function<void(WebPageProxy&, std::optional<WebCore::IntRect>&&, CommandCallback<String>&&)> takeViewSnapshot = [](WebPageProxy& page, std::optional<WebCore::IntRect>&& rect, CommandCallback<String>&& callback) {
         page.callAfterNextPresentationUpdate([page = Ref { page }, rect = WTFMove(rect), callback = WTFMove(callback)] () mutable {
             RefPtr snapshot = page->takeViewSnapshot(WTFMove(rect), ForceSoftwareCapturingViewportSnapshot::Yes);
             if (!snapshot)
@@ -2560,27 +2576,27 @@ void WebAutomationSession::takeScreenshot(const Inspector::Protocol::Automation:
             if (!base64EncodedData)
                 ASYNC_FAIL_WITH_PREDEFINED_ERROR(InternalError);
 
-            callback->sendSuccess(base64EncodedData.value());
+            callback(base64EncodedData.value());
         });
     };
 
     if (nodeHandle.isEmpty()) {
-        takeViewSnapsot(*page, std::nullopt, WTFMove(callback));
+        takeViewSnapshot(*page, std::nullopt, WTFMove(callback));
         return;
     }
 
-    CompletionHandler<void(std::optional<String>&&, WebCore::IntRect&&)> completionHandler = [page = Ref { *page }, callback, takeViewSnapsot = WTFMove(takeViewSnapsot)](std::optional<String>&& errorType, WebCore::IntRect&& rect) mutable {
+    CompletionHandler<void(std::optional<String>&&, WebCore::IntRect&&)> completionHandler = [page = Ref { *page }, callback = WTFMove(callback), takeViewSnapshot = WTFMove(takeViewSnapshot)](std::optional<String>&& errorType, WebCore::IntRect&& rect) mutable {
         if (errorType) {
-            callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType));
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_MESSAGE(*errorType)));
             return;
         }
 
-        takeViewSnapsot(page.get(), WTFMove(rect), WTFMove(callback));
+        takeViewSnapshot(page.get(), WTFMove(rect), WTFMove(callback));
     };
 
     page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::SnapshotRectForScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), WTFMove(completionHandler));
 #else
-    page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), ipcCompletionHandler());
+    page->sendWithAsyncReplyToProcessContainingFrameWithoutDestinationIdentifier(frameID, Messages::WebAutomationSessionProxy::TakeScreenshot(page->webPageIDInMainFrameProcess(), frameID, nodeHandle, scrollIntoViewIfNeeded, clipToViewport), ipcCompletionHandler(WTFMove(callback)));
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -203,67 +203,67 @@ public:
     // and the --platform argument passed to the protocol bindings generator.
 
     // Platform: Generic
-    void getBrowsingContexts(Ref<GetBrowsingContextsCallback>&&) override;
-    void getBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<GetBrowsingContextCallback>&&) override;
-    void createBrowsingContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&&, Ref<CreateBrowsingContextCallback>&&) override;
-    Inspector::Protocol::ErrorStringOr<void> closeBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
-    Inspector::Protocol::ErrorStringOr<void> deleteSession() override;
-    void switchToBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Ref<SwitchToBrowsingContextCallback>&&) override;
-    void setWindowFrameOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, RefPtr<JSON::Object>&& origin, RefPtr<JSON::Object>&& size, Ref<SetWindowFrameOfBrowsingContextCallback>&&) override;
-    void maximizeWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<MaximizeWindowOfBrowsingContextCallback>&&) override;
-    void hideWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<HideWindowOfBrowsingContextCallback>&&) override;
-    void navigateBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& url, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Ref<NavigateBrowsingContextCallback>&&) override;
-    void goBackInBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Ref<GoBackInBrowsingContextCallback>&&) override;
-    void goForwardInBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Ref<GoForwardInBrowsingContextCallback>&&) override;
-    void reloadBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Ref<ReloadBrowsingContextCallback>&&) override;
-    void waitForNavigationToComplete(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Ref<WaitForNavigationToCompleteCallback>&&) override;
-    void evaluateJavaScriptFunction(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const String& function, Ref<JSON::Array>&& arguments, std::optional<bool>&& expectsImplicitCallbackArgument, std::optional<bool>&& forceUserGesture, std::optional<double>&& callbackTimeout, Ref<EvaluateJavaScriptFunctionCallback>&&) override;
-    void performMouseInteraction(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Object>&& requestedPosition, Inspector::Protocol::Automation::MouseButton, Inspector::Protocol::Automation::MouseInteraction, Ref<JSON::Array>&& keyModifiers, Ref<PerformMouseInteractionCallback>&&) override;
-    void performKeyboardInteractions(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Array>&& interactions, Ref<PerformKeyboardInteractionsCallback>&&) override;
-    void performInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Ref<JSON::Array>&& sources, Ref<JSON::Array>&& steps, Ref<PerformInteractionSequenceCallback>&&) override;
-    void cancelInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Ref<CancelInteractionSequenceCallback>&&) override;
-    void takeScreenshot(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, std::optional<bool>&& scrollIntoViewIfNeeded, std::optional<bool>&& clipToViewport, Ref<TakeScreenshotCallback>&&) override;
-    void resolveChildFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, std::optional<int>&& ordinal, const String& name, const Inspector::Protocol::Automation::NodeHandle&, Ref<ResolveChildFrameHandleCallback>&&) override;
-    void resolveParentFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Ref<ResolveParentFrameHandleCallback>&&) override;
-    void computeElementLayout(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, std::optional<bool>&& scrollIntoViewIfNeeded, Inspector::Protocol::Automation::CoordinateSystem, Ref<ComputeElementLayoutCallback>&&) override;
-    void getComputedRole(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Ref<GetComputedRoleCallback>&&) override;
-    void getComputedLabel(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Ref<GetComputedLabelCallback>&&) override;
-    void selectOptionElement(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Ref<SelectOptionElementCallback>&&) override;
-    Inspector::Protocol::ErrorStringOr<bool> isShowingJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
-    Inspector::Protocol::ErrorStringOr<void> dismissCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
-    Inspector::Protocol::ErrorStringOr<void> acceptCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
-    Inspector::Protocol::ErrorStringOr<String> messageOfCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
-    Inspector::Protocol::ErrorStringOr<void> setUserInputForCurrentJavaScriptPrompt(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& text) override;
-    Inspector::Protocol::ErrorStringOr<void> setFilesToSelectForFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Array>&& filenames, RefPtr<JSON::Array>&& fileContents) override;
-    void setFilesForInputFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Ref<JSON::Array>&& filenames, Ref<SetFilesForInputFileUploadCallback>&&) override;
-    void getAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<GetAllCookiesCallback>&&) override;
-    void deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& cookieName, Ref<DeleteSingleCookieCallback>&&) override;
-    void addSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Object>&& cookie, Ref<AddSingleCookieCallback>&&) override;
-    Inspector::Protocol::ErrorStringOr<void> deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
-    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>>> getSessionPermissions() override;
-    Inspector::Protocol::ErrorStringOr<void> setSessionPermissions(Ref<JSON::Array>&&) override;
+    void getBrowsingContexts(Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&) override;
+    void getBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::CommandCallback<Ref<Inspector::Protocol::Automation::BrowsingContext>>&&) override;
+    void createBrowsingContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&&, Inspector::CommandCallbackOf<String, Inspector::Protocol::Automation::BrowsingContextPresentation>&&) override;
+    Inspector::CommandResult<void> closeBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    Inspector::CommandResult<void> deleteSession() override;
+    void switchToBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Inspector::CommandCallback<void>&&) override;
+    void setWindowFrameOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, RefPtr<JSON::Object>&& origin, RefPtr<JSON::Object>&& size, Inspector::CommandCallback<void>&&) override;
+    void maximizeWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::CommandCallback<void>&&) override;
+    void hideWindowOfBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::CommandCallback<void>&&) override;
+    void navigateBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& url, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
+    void goBackInBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
+    void goForwardInBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
+    void reloadBrowsingContext(const String&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
+    void waitForNavigationToComplete(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, std::optional<Inspector::Protocol::Automation::PageLoadStrategy>&&, std::optional<double>&& pageLoadTimeout, Inspector::CommandCallback<void>&&) override;
+    void evaluateJavaScriptFunction(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const String& function, Ref<JSON::Array>&& arguments, std::optional<bool>&& expectsImplicitCallbackArgument, std::optional<bool>&& forceUserGesture, std::optional<double>&& callbackTimeout, Inspector::CommandCallback<String>&&) override;
+    void performMouseInteraction(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Object>&& requestedPosition, Inspector::Protocol::Automation::MouseButton, Inspector::Protocol::Automation::MouseInteraction, Ref<JSON::Array>&& keyModifiers, Inspector::CommandCallback<Ref<Inspector::Protocol::Automation::Point>>&&) override;
+    void performKeyboardInteractions(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Array>&& interactions, Inspector::CommandCallback<void>&&) override;
+    void performInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Ref<JSON::Array>&& sources, Ref<JSON::Array>&& steps, Inspector::CommandCallback<void>&&) override;
+    void cancelInteractionSequence(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Inspector::CommandCallback<void>&&) override;
+    void takeScreenshot(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, std::optional<bool>&& scrollIntoViewIfNeeded, std::optional<bool>&& clipToViewport, Inspector::CommandCallback<String>&&) override;
+    void resolveChildFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, std::optional<int>&& ordinal, const String& name, const Inspector::Protocol::Automation::NodeHandle&, Inspector::CommandCallback<String>&&) override;
+    void resolveParentFrameHandle(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, Inspector::CommandCallback<String>&&) override;
+    void computeElementLayout(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, std::optional<bool>&& scrollIntoViewIfNeeded, Inspector::Protocol::Automation::CoordinateSystem, Inspector::CommandCallbackOf<Ref<Inspector::Protocol::Automation::Rect>, RefPtr<Inspector::Protocol::Automation::Point>, bool>&&) override;
+    void getComputedRole(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Inspector::CommandCallback<String>&&) override;
+    void getComputedLabel(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Inspector::CommandCallback<String>&&) override;
+    void selectOptionElement(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Inspector::CommandCallback<void>&&) override;
+    Inspector::CommandResult<bool> isShowingJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    Inspector::CommandResult<void> dismissCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    Inspector::CommandResult<void> acceptCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    Inspector::CommandResult<String> messageOfCurrentJavaScriptDialog(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    Inspector::CommandResult<void> setUserInputForCurrentJavaScriptPrompt(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& text) override;
+    Inspector::CommandResult<void> setFilesToSelectForFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Array>&& filenames, RefPtr<JSON::Array>&& fileContents) override;
+    void setFilesForInputFileUpload(const Inspector::Protocol::Automation::BrowsingContextHandle&, const Inspector::Protocol::Automation::FrameHandle&, const Inspector::Protocol::Automation::NodeHandle&, Ref<JSON::Array>&& filenames, Inspector::CommandCallback<void>&&) override;
+    void getAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::Cookie>>>&&) override;
+    void deleteSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle&, const String& cookieName, Inspector::CommandCallback<void>&&) override;
+    void addSingleCookie(const Inspector::Protocol::Automation::BrowsingContextHandle&, Ref<JSON::Object>&& cookie, Inspector::CommandCallback<void>&&) override;
+    Inspector::CommandResult<void> deleteAllCookies(const Inspector::Protocol::Automation::BrowsingContextHandle&) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::SessionPermissionData>>> getSessionPermissions() override;
+    Inspector::CommandResult<void> setSessionPermissions(Ref<JSON::Array>&&) override;
 
-    Inspector::Protocol::ErrorStringOr<String /* authenticatorId */> addVirtualAuthenticator(const String& browsingContextHandle, Ref<JSON::Object>&& authenticator) override;
-    Inspector::Protocol::ErrorStringOr<void> removeVirtualAuthenticator(const String& browsingContextHandle, const String& authenticatorId) override;
-    Inspector::Protocol::ErrorStringOr<void> addVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, Ref<JSON::Object>&& credential) override;
-    Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::VirtualAuthenticatorCredential>> /* credentials */> getVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId) override;
-    Inspector::Protocol::ErrorStringOr<void> removeVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, const String& credentialId) override;
-    Inspector::Protocol::ErrorStringOr<void> removeAllVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId) override;
-    Inspector::Protocol::ErrorStringOr<void> setVirtualAuthenticatorUserVerified(const String& browsingContextHandle, const String& authenticatorId, bool isUserVerified) override;
-    Inspector::Protocol::ErrorStringOr<void> generateTestReport(const String& browsingContextHandle, const String& message, const String& group) override;
+    Inspector::CommandResult<String /* authenticatorId */> addVirtualAuthenticator(const String& browsingContextHandle, Ref<JSON::Object>&& authenticator) override;
+    Inspector::CommandResult<void> removeVirtualAuthenticator(const String& browsingContextHandle, const String& authenticatorId) override;
+    Inspector::CommandResult<void> addVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, Ref<JSON::Object>&& credential) override;
+    Inspector::CommandResult<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::VirtualAuthenticatorCredential>> /* credentials */> getVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId) override;
+    Inspector::CommandResult<void> removeVirtualAuthenticatorCredential(const String& browsingContextHandle, const String& authenticatorId, const String& credentialId) override;
+    Inspector::CommandResult<void> removeAllVirtualAuthenticatorCredentials(const String& browsingContextHandle, const String& authenticatorId) override;
+    Inspector::CommandResult<void> setVirtualAuthenticatorUserVerified(const String& browsingContextHandle, const String& authenticatorId, bool isUserVerified) override;
+    Inspector::CommandResult<void> generateTestReport(const String& browsingContextHandle, const String& message, const String& group) override;
 
 #if ENABLE(WK_WEB_EXTENSIONS_IN_WEBDRIVER)
-    void loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions, const String& resource, Ref<LoadWebExtensionCallback>&&) override;
-    void unloadWebExtension(const String& identifier, Ref<UnloadWebExtensionCallback>&&) override;
+    void loadWebExtension(const Inspector::Protocol::Automation::WebExtensionResourceOptions, const String& resource, Inspector::CommandCallback<String>&&) override;
+    void unloadWebExtension(const String& identifier, Inspector::CommandCallback<void>&&) override;
 #endif
 
 #if ENABLE(WEBDRIVER_BIDI)
-    Inspector::Protocol::ErrorStringOr<void> processBidiMessage(const String&) override;
+    Inspector::CommandResult<void> processBidiMessage(const String&) override;
     void sendBidiMessage(const String&);
 #endif
 
 #if PLATFORM(MAC)
-    void inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, std::optional<bool>&& enableAutoCapturing, Ref<InspectBrowsingContextCallback>&&) override;
+    void inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle&, std::optional<bool>&& enableAutoCapturing, Inspector::CommandCallback<void>&&) override;
 #endif
 
     // Event Simulation Support.
@@ -283,16 +283,16 @@ private:
     RefPtr<WebPageProxy> webPageProxyForHandle(const String&);
     String handleForWebPageProxy(const WebPageProxy&);
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
-    void getNextContext(Ref<WebAutomationSession>&&, Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Ref<WebAutomationSession::GetBrowsingContextsCallback>&&);
+    void getNextContext(Ref<WebAutomationSession>&&, Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);
 
     std::optional<WebCore::FrameIdentifier> webFrameIDForHandle(const String&, bool& frameNotFound);
     String handleForWebFrameID(std::optional<WebCore::FrameIdentifier>);
     String handleForWebFrameProxy(const WebFrameProxy&);
 
-    void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Ref<Inspector::BackendDispatcher::CallbackBase>&&);
-    void waitForNavigationToCompleteOnFrame(WebFrameProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Ref<Inspector::BackendDispatcher::CallbackBase>&&);
-    void respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>>&);
-    void respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<WebCore::FrameIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>>&);
+    void waitForNavigationToCompleteOnPage(WebPageProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
+    void waitForNavigationToCompleteOnFrame(WebFrameProxy&, Inspector::Protocol::Automation::PageLoadStrategy, Seconds, Inspector::CommandCallback<void>&&);
+    void respondToPendingPageNavigationCallbacksWithTimeout(HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>>&);
+    void respondToPendingFrameNavigationCallbacksWithTimeout(HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>>&);
     void loadTimerFired();
 
     void exitFullscreenWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
@@ -368,23 +368,23 @@ private:
     HashMap<WebCore::FrameIdentifier, String> m_webFrameHandleMap;
     HashMap<String, WebCore::FrameIdentifier> m_handleWebFrameMap;
 
-    HashMap<WebPageProxyIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>> m_pendingNormalNavigationInBrowsingContextCallbacksPerPage;
-    HashMap<WebPageProxyIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>> m_pendingEagerNavigationInBrowsingContextCallbacksPerPage;
-    HashMap<WebCore::FrameIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>> m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame;
-    HashMap<WebCore::FrameIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>> m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame;
-    HashMap<WebPageProxyIdentifier, RefPtr<Inspector::BackendDispatcher::CallbackBase>> m_pendingInspectorCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingNormalNavigationInBrowsingContextCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingEagerNavigationInBrowsingContextCallbacksPerPage;
+    HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>> m_pendingNormalNavigationInBrowsingContextCallbacksPerFrame;
+    HashMap<WebCore::FrameIdentifier, Inspector::CommandCallback<void>> m_pendingEagerNavigationInBrowsingContextCallbacksPerFrame;
+    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingInspectorCallbacksPerPage;
 #if ENABLE(WEBDRIVER_KEYBOARD_INTERACTIONS)
-    HashMap<WebPageProxyIdentifier, Function<void(std::optional<AutomationCommandError>)>> m_pendingKeyboardEventsFlushedCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingKeyboardEventsFlushedCallbacksPerPage;
 #endif
 #if ENABLE(WEBDRIVER_MOUSE_INTERACTIONS)
-    HashMap<WebPageProxyIdentifier, Function<void(std::optional<AutomationCommandError>)>> m_pendingMouseEventsFlushedCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingMouseEventsFlushedCallbacksPerPage;
 #endif
 #if ENABLE(WEBDRIVER_WHEEL_INTERACTIONS)
-    HashMap<WebPageProxyIdentifier, Function<void(std::optional<AutomationCommandError>)>> m_pendingWheelEventsFlushedCallbacksPerPage;
+    HashMap<WebPageProxyIdentifier, Inspector::CommandCallback<void>> m_pendingWheelEventsFlushedCallbacksPerPage;
 #endif
 
     uint64_t m_nextEvaluateJavaScriptCallbackID { 1 };
-    HashMap<uint64_t, RefPtr<Inspector::AutomationBackendDispatcherHandler::EvaluateJavaScriptFunctionCallback>> m_evaluateJavaScriptFunctionCallbacks;
+    HashMap<uint64_t, Inspector::CommandCallback<String>> m_evaluateJavaScriptFunctionCallbacks;
 
     enum class WindowTransitionedToState {
         Fullscreen,

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h
@@ -54,12 +54,12 @@ do { \
 
 #define ASYNC_FAIL_WITH_PREDEFINED_ERROR(errorName) \
 do { \
-    callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_NAME(errorName)); \
+    callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(errorName))); \
     return; \
 } while (false)
 
 #define ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS(errorName, detailsString) \
 do { \
-    callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString)); \
+    callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(errorName, detailsString))); \
     return; \
 } while (false)

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -113,7 +113,7 @@ void WebDriverBidiProcessor::sendMessageToFrontend(const String& message)
 
 // MARK: Inspector::BrowsingContextDispatcherHandler methods.
 
-void WebDriverBidiProcessor::navigate(const BrowsingContext& browsingContext, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Ref<NavigateCallback>&& callback)
+void WebDriverBidiProcessor::navigate(const BrowsingContext& browsingContext, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, CommandCallbackOf<String, String>&& callback)
 {
     RefPtr session = m_session.get();
     if (!session)

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h
@@ -56,7 +56,7 @@ public:
     void sendMessageToFrontend(const String&) override;
 
     // Inspector::BidiBrowsingContextDispatcherHandler methods.
-    void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Ref<NavigateCallback>&&) override;
+    void navigate(const Inspector::Protocol::BidiBrowsingContext::BrowsingContext&, const String& url, std::optional<Inspector::Protocol::BidiBrowsingContext::ReadinessState>&&, Inspector::CommandCallbackOf<String, String>&&) override;
 
     // Inspector::BidiBrowserBackendDispatcherHandler methods.
     Inspector::Protocol::ErrorStringOr<void> close() override;

--- a/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
+++ b/Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm
@@ -49,14 +49,15 @@ using namespace WebCore;
 
 #pragma mark Commands for 'PLATFORM(MAC)'
 
-void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<bool>&& enableAutoCapturing, Ref<InspectBrowsingContextCallback>&& callback)
+void WebAutomationSession::inspectBrowsingContext(const Inspector::Protocol::Automation::BrowsingContextHandle& handle, std::optional<bool>&& enableAutoCapturing, Inspector::CommandCallback<void>&& callback)
 {
     auto page = webPageProxyForHandle(handle);
     if (!page)
         ASYNC_FAIL_WITH_PREDEFINED_ERROR(WindowNotFound);
 
-    if (auto callback = m_pendingInspectorCallbacksPerPage.take(page->identifier()))
-        callback->sendFailure(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout));
+    if (auto pendingCallback = m_pendingInspectorCallbacksPerPage.take(page->identifier()))
+        pendingCallback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME(Timeout)));
+
     m_pendingInspectorCallbacksPerPage.set(page->identifier(), WTFMove(callback));
 
     // Don't bring the inspector to front since this may be done automatically.


### PR DESCRIPTION
#### 9e1b4bc5f110647270eef4dfff5d7dc8e61337a2
<pre>
Web Automation: modernize callback thunks for async protocol commands
<a href="https://bugs.webkit.org/show_bug.cgi?id=284470">https://bugs.webkit.org/show_bug.cgi?id=284470</a>
&lt;<a href="https://rdar.apple.com/141291944">rdar://141291944</a>&gt;

Reviewed by Devin Rousso and Patrick Angle.

To avoid code duplication, we need to be able to connect async `WebAutomationSession` / `WebDriverBidiProcessor`
methods to each other. Right now these callbacks are all `BackendDispatcher::CallbackBase` subclasses,
which does not have a standalone constructor. So, we cannot easily pass a lambda that chains completion handlers.

In order to chain callbacks, switch from using `CallbackBase` subclasses to using `Function&lt;&gt;` with proper type parameters.
We can move away from CallbackBase by capturing any needed state in a closure and changing the type of callbacks to mention return types.
We deploy the new type aliases `CommandResponse&lt;T&gt;` and `CommandCallback&lt;T&gt;` to make code more readable, adding the &apos;Of&apos;
suffix for multiple arguments.

```
namespace Inspector {
    typedef String ErrorString;

    template &lt;typename T&gt;
    using ErrorStringOr = Expected&lt;T, ErrorString&gt;;

    template &lt;typename T&gt;
    using CommandResponse = Inspector::Protocol::ErrorStringOr&lt;T&gt;;

    template &lt;typename T&gt;
    using CommandResponseOf = Inspector::Protocol::ErrorStringOr&lt;std::tuple&lt;T&gt;&gt;;

    template &lt;typename T&gt;
    using CommandCallback = Function&lt;void(CommandResponse&lt;T&gt;)&gt;;

    template &lt;typename T&gt;
    using CommandCallbackOf = Function&lt;void(CommandResponseOf&lt;T&gt;)&gt;;
}
```

These changes are scoped to *not* affect existing Web Inspector protocol generated code. I&apos;d love to remove
uses of `CallbackBase` from the existing uses of &apos;async&apos; commands entirely. However, doing so is essentially the
same work as refactoring/modernizing IndexedDBAgent. We can do that at a time of our choosing. Fixing this is
tracked by &lt;<a href="https://webkit.org/b/288203">https://webkit.org/b/288203</a>&gt;.

The remainder of this commit is updating callsites in `WebAutomationSession` to reflect that calling `sendSuccess()` /
`sendFailure()` has been superceded by returning expected or unexpected values of `CommandResult&lt;T&gt;` (aka `ErrorStringOr&lt;T&gt;`).
Also, adapt code to use `CommandCallback&lt;T&gt;` for zero and single parameter async commands, and `CommandCallbackOf&lt;T&gt;` for
async commands with more than one return value.

* Source/JavaScriptCore/inspector/InspectorBackendDispatcher.h:
Introduce new type aliases which make it easier to express the type of an async callback in command implementations.

* Source/JavaScriptCore/inspector/scripts/codegen/cpp_generator_templates.py:
Split out the declaration of the reply thunk class from the command&apos;s method declaration.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_header.py:
(CppBackendDispatcherHeaderGenerator._generate_handler_declarations_for_domain):
(CppBackendDispatcherHeaderGenerator._generate_async_response_thunk_declaration_for_command): Added.
(CppBackendDispatcherHeaderGenerator):
(CppBackendDispatcherHeaderGenerator._generate_async_handler_declaration_for_command):
Now that the return types are part of the type signature, enhance `_generate_dispatcher_declaration_for_command`
to compute the type arguments for `Inspector::CommandCallbackOf&lt;T...&gt;`.
Add a new framework setting so that we can continue to generate existing async protocol code
for non-WebDriver domains.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py:
(CppBackendDispatcherImplementationGenerator._generate_dispatcher_implementations_for_domain):
(CppBackendDispatcherImplementationGenerator._generate_async_command_response_thunk_class_for_domain): Added.
(CppBackendDispatcherImplementationGenerator._generate_async_dispatcher_class_for_domain): Deleted.
(CppBackendDispatcherImplementationGenerator._generate_dispatcher_implementation_for_command):
Refactor `_generate_dispatcher_implementation_for_command` so that the code to convert return parameters
is shared between the sync and async command cases. Move the return parameter passing code from the thunk
class to the anonymous lambda function passed as the last argument. Inside the lambda, capture what would
have been stored in the thunk class&apos;s member variables so that we can associate the error with the
originating command request (`protocol_requestId`).

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::terminate):
(WebKit::WebAutomationSession::getBrowsingContext):
(WebKit::WebAutomationSession::createBrowsingContext):
(WebKit::WebAutomationSession::switchToBrowsingContext):
(WebKit::WebAutomationSession::setWindowFrameOfBrowsingContext):
(WebKit::WebAutomationSession::waitForNavigationToComplete):
Fix this function so that it explicitly returns after moving `callback` into
the queue of callbacks waiting for navigation. It&apos;s not safe to use it anyway,
so simplify the control flow to make it easier to read.

(WebKit::WebAutomationSession::waitForNavigationToCompleteOnPage):
(WebKit::WebAutomationSession::waitForNavigationToCompleteOnFrame):
(WebKit::WebAutomationSession::respondToPendingPageNavigationCallbacksWithTimeout):
(WebKit::WebAutomationSession::respondToPendingFrameNavigationCallbacksWithTimeout):
(WebKit::WebAutomationSession::maximizeWindowOfBrowsingContext):
(WebKit::WebAutomationSession::hideWindowOfBrowsingContext):
(WebKit::WebAutomationSession::willShowJavaScriptDialog):
(WebKit::WebAutomationSession::navigateBrowsingContext):
(WebKit::WebAutomationSession::goBackInBrowsingContext):
(WebKit::WebAutomationSession::goForwardInBrowsingContext):
(WebKit::WebAutomationSession::reloadBrowsingContext):
(WebKit::WebAutomationSession::navigationOccurredForFrame):
(WebKit::WebAutomationSession::documentLoadedForFrame):
(WebKit::WebAutomationSession::inspectorFrontendLoaded):
(WebKit::WebAutomationSession::mouseEventsFlushedForPage):
(WebKit::WebAutomationSession::keyboardEventsFlushedForPage):
(WebKit::WebAutomationSession::wheelEventsFlushedForPage):
(WebKit::WebAutomationSession::willClosePage):
(WebKit::WebAutomationSession::evaluateJavaScriptFunction):
(WebKit::WebAutomationSession::resolveChildFrameHandle):
(WebKit::WebAutomationSession::resolveParentFrameHandle):
(WebKit::WebAutomationSession::computeElementLayout):
(WebKit::WebAutomationSession::getComputedRole):
(WebKit::WebAutomationSession::getComputedLabel):
(WebKit::WebAutomationSession::selectOptionElement):
(WebKit::WebAutomationSession::setFilesForInputFileUpload):
(WebKit::WebAutomationSession::getAllCookies):
(WebKit::WebAutomationSession::deleteSingleCookie):
(WebKit::WebAutomationSession::addSingleCookie):
Add missing move for `callback` to be owned the completion handler.

(WebKit::WebAutomationSession::simulateMouseInteraction):
(WebKit::WebAutomationSession::simulateTouchInteraction):
(WebKit::WebAutomationSession::simulateKeyboardInteraction):
(WebKit::WebAutomationSession::simulateWheelInteraction):
These cases require a bit more care to bridge between `CommandResponse&lt;void&gt;`
and `AutomationCommandError`.

(WebKit::WebAutomationSession::performMouseInteraction):
(WebKit::WebAutomationSession::performKeyboardInteractions):
(WebKit::pressedCharKey):
(WebKit::WebAutomationSession::performInteractionSequence):
(WebKit::WebAutomationSession::cancelInteractionSequence):
(WebKit::WebAutomationSession::takeScreenshot):
Adapt to using `CommandCallback&lt;void&gt;` and `CommandCallback&lt;T&gt;`.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h:
* Source/WebKit/UIProcess/Automation/mac/WebAutomationSessionMac.mm:
(WebKit::WebAutomationSession::inspectBrowsingContext):
Adapt to using `CommandCallback&lt;void&gt;` and `CommandCallback&lt;T&gt;`.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/Automation/WebAutomationSessionMacros.h:
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.h:
* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::WebDriverBidiProcessor::navigate): Update signature.

Canonical link: <a href="https://commits.webkit.org/291284@main">https://commits.webkit.org/291284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e520bec7aa163cb7f5c381887a4894fc42103cea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92452 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97436 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42959 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70843 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28298 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1367 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42290 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85162 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79347 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99462 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91118 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19503 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79852 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79123 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23663 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24659 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113766 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19174 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32899 "Found 7 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->