### PR TITLE
Use more site-isolation friendly frame tree traversal in FullscreenManager

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -1,11 +1,17 @@
 supportsFullScreen() == true
 enterFullScreenForElement()
 beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {300, 150}
+exitFullScreenForElement()
+beganExitFullScreen() - initialRect.size: {300, 150}, finalRect.size: {300, 150}
 
 FIXME: Size after entering should be 600x800 like it is with site isolation off.
 The size currently comes from screenRectOfContents.
-Also, there should be exitFullScreenForElement and beganExitFullScreen callbacks like there are with site isolation off.
+Also, the iframe's border 'inset' style should be 'none' after entering fullscreen.
 
 Size after entering fullscreen: 150x300
+iframe border style after transition: 0px inset rgb(0, 0, 0)
+
 Size after exiting fullscreen: 150x300
+iframe border style after transition: 0px inset rgb(0, 0, 0)
+
 

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -7,12 +7,13 @@
     }
     addEventListener("message", (event) => {
         document.getElementById("mylog").innerHTML += event.data + "<br>";
+        document.getElementById("mylog").innerHTML += 'iframe border style after transition: ' + getComputedStyle(document.getElementById("frame")).getPropertyValue('border') + "<br><br>";
         if (event.data.startsWith('Size after exiting') && window.testRunner) { testRunner.notifyDone() }
     });
 </script>
-<iframe allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen.html" frameborder=0></iframe>
+<iframe id='frame' allowfullscreen src="http://localhost:8000/site-isolation/resources/fullscreen.html" frameborder=0></iframe>
 <div id=mylog>
 FIXME: Size after entering should be 600x800 like it is with site isolation off.<br>
 The size currently comes from screenRectOfContents.<br>
-Also, there should be exitFullScreenForElement and beganExitFullScreen callbacks like there are with site isolation off.<br><br>
+Also, the iframe's border 'inset' style should be 'none' after entering fullscreen.<br><br>
 </div>

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-in-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-in-iframe-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Exit fullscreen for nested fullscreen inside an iframe assert_equals: expected null but got Element node <iframe allowfullscreen="" srcdoc="<div id='outer'><div i...
+PASS Exit fullscreen for nested fullscreen inside an iframe
 

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -81,7 +81,7 @@ public:
     void dispatchPendingEvents();
 
     enum class ExitMode : bool { Resize, NoResize };
-    void finishExitFullscreen(Document&, ExitMode);
+    void finishExitFullscreen(Frame&, ExitMode);
 
     void exitRemovedFullscreenElement(Element&);
 


### PR DESCRIPTION
#### a17d0c381b91c4db749a290c344e5c8943fbc658
<pre>
Use more site-isolation friendly frame tree traversal in FullscreenManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=288213">https://bugs.webkit.org/show_bug.cgi?id=288213</a>
<a href="https://rdar.apple.com/145304768">rdar://145304768</a>

Reviewed by Ryosuke Niwa.

In a few places we were making assumptions like:

1. The main frame is in the same process as the current document
2. A document&apos;s owner element is in the same process as the document
3. When we are traversing, if we find a document without an owner element
in this process, we must be at the main frame.

All 3 assumptions are invalid when site isolation is on.  I&apos;ve replaced
the traversal with traversing the FrameTree including LocalFrames and
RemoteFrames and only visiting the LocalFrames.

Before this change, exiting a fullscreen third party iframe would not actually
exit, as seen by the lack of UI process exitFullScreenForElement and
beganExitFullScreen calls in the test output.  That is fixed with this change.
The style and size isn&apos;t yet correct, but those will be fixed in future PRs.

I also replaced a few Deques with Vector+makeReversedRange to accomplish
the same reverse iteration without the overhead of a Deque.

FullscreenManager::exitFullscreen had an assumption that the exit mode is
NoResize unless we know we are exiting fullscreen in the main frame.  In
order for exiting fullscreen to work in iframes with site isolation on,
I needed to make the assumption that if the main frame is in another process
we are exiting with ExitMode::Resize.  This only applies with site isolation
on.

* LayoutTests/http/tests/site-isolation/fullscreen-expected.txt:
* LayoutTests/http/tests/site-isolation/fullscreen.html:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::documentsToUnfullscreen):
(WebCore::FullscreenManager::exitFullscreen):
(WebCore::FullscreenManager::finishExitFullscreen):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::didExitFullscreen):
* Source/WebCore/dom/FullscreenManager.h:

Canonical link: <a href="https://commits.webkit.org/290822@main">https://commits.webkit.org/290822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/123fae350719fff5449f0038437116f70bbe585a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/244 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96206 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93257 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19064 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94208 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98190 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/18399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/78459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/78293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14403 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/18399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21580 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->