### PR TITLE
AX: After dynamic page changes, WebKit can report the wrong AXEmptyGroup subrole state to assistive technologies

### DIFF
--- a/LayoutTests/accessibility/mac/dynamic-empty-group-expected.txt
+++ b/LayoutTests/accessibility/mac/dynamic-empty-group-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we report or don't report the AXEmptyGroup subrole after dynamic page changes.
+
+PASS: accessibilityController.accessibleElementById('target').subrole === 'AXSubrole: AXEmptyGroup'
+PASS: accessibilityController.accessibleElementById('target').subrole === 'AXSubrole: AXApplicationGroup'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Press

--- a/LayoutTests/accessibility/mac/dynamic-empty-group.html
+++ b/LayoutTests/accessibility/mac/dynamic-empty-group.html
@@ -1,0 +1,34 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="target" role="group" aria-label="Group here!">
+    <div id="container">
+    </div>
+</div>
+
+<script>
+var output = "This test ensures we report or don't report the AXEmptyGroup subrole after dynamic page changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    output += expect("accessibilityController.accessibleElementById('target').subrole", "'AXSubrole: AXEmptyGroup'");
+    let button = document.createElement("button");
+    button.innerText = "Press";
+    document.getElementById("container").appendChild(button);
+    setTimeout(async function() {
+        output += await expectAsync("accessibilityController.accessibleElementById('target').subrole", "'AXSubrole: AXApplicationGroup'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -895,6 +895,9 @@ public:
 
     virtual bool isFieldset() const = 0;
     bool isGroup() const;
+#if PLATFORM(MAC)
+    bool isEmptyGroup();
+#endif
 
     // Native spin buttons.
     bool isSpinButton() const { return roleValue() == AccessibilityRole::SpinButton; }
@@ -1263,9 +1266,15 @@ public:
     };
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     bool onlyAddsUnignoredChildren() const { return isTableColumn() || roleValue() == AccessibilityRole::TableHeaderContainer; }
-    virtual AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
+    AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
+    AXCoreObject* firstUnignoredChild();
 #else
     const AccessibilityChildrenVector& unignoredChildren(bool updateChildrenIfNeeded = true) { return children(updateChildrenIfNeeded); }
+    AXCoreObject* firstUnignoredChild()
+    {
+        const auto& children = this->children();
+        return children.size() ? children[0].ptr() : nullptr;
+    }
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
 
     // When ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) is true, this returns IDs of ignored children.

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -205,43 +205,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return Accessibility::roleToPlatformString(role);
 }
 
-static bool isEmptyGroup(AccessibilityObject& object)
-{
-#if ENABLE(MODEL_ELEMENT)
-    if (object.isModel())
-        return false;
-#endif
-
-    if (object.isRemoteFrame())
-        return false;
-
-    return [object.rolePlatformString() isEqual:NSAccessibilityGroupRole]
-        && object.unignoredChildren().isEmpty()
-        && ![renderWidgetChildren(object) count];
-}
-
-NSArray *renderWidgetChildren(const AXCoreObject& object)
-{
-    if (!object.isWidget())
-        return nil;
-
-    id child = Accessibility::retrieveAutoreleasedValueFromMainThread<id>([object = Ref { object }] () -> RetainPtr<id> {
-        auto* widget = object->widget();
-        return widget ? widget->accessibilityObject() : nil;
-    });
-
-    if (child)
-        return @[child];
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-    return [object.platformWidget() accessibilityAttributeValue:NSAccessibilityChildrenAttribute];
-ALLOW_DEPRECATED_DECLARATIONS_END
-}
-
 String AccessibilityObject::subrolePlatformString() const
 {
-    if (isEmptyGroup(*const_cast<AccessibilityObject*>(this)))
-        return NSAccessibilityEmptyGroupSubrole;
-
     if (isSecureField())
         return NSAccessibilitySecureTextFieldSubrole;
     if (isSearchField())

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1106,6 +1106,9 @@ static NSString *roleString(AXCoreObject& backingObject)
 
 static NSString *subroleString(AXCoreObject& backingObject)
 {
+    if (backingObject.isEmptyGroup())
+        return NSAccessibilityEmptyGroupSubrole;
+
     String subrole = backingObject.subrolePlatformString();
     if (!subrole.isEmpty())
         return subrole;


### PR DESCRIPTION
#### 0aca7bdaf628ee0b9ddf5d444df66f14e3dbd515
<pre>
AX: After dynamic page changes, WebKit can report the wrong AXEmptyGroup subrole state to assistive technologies
<a href="https://bugs.webkit.org/show_bug.cgi?id=288215">https://bugs.webkit.org/show_bug.cgi?id=288215</a>
<a href="https://rdar.apple.com/145306055">rdar://145306055</a>

Reviewed by Chris Fleizach.

We cache AXProperty::SubrolePlatformString, but never update it after dynamic page changes, meaning we can return
a stale value when considering AXEmptyGroup, which is dependent on whether an object has unignored children.

This was never a problem prior to ENABLE(INCLUDE_IGNORED_IN_CORE_TREE), as anytime an object&apos;s unignored chlidren changed,
we created a whole new node change for it. But with this feature, we no longer do that, since each object&apos;s unignored
children is dependent on arbitrary layers of descendants underneath it.

Fix this by computing isEmptyGroup lazily off the main-thread, ensuring we never use stale information.

* LayoutTests/accessibility/mac/dynamic-empty-group-expected.txt: Added.
* LayoutTests/accessibility/mac/dynamic-empty-group.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::isValidChildForTable):
(WebCore::AXCoreObject::unignoredChildren):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::onlyAddsUnignoredChildren const):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendChildrenToArray):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::renderWidgetChildren):
(WebCore::AXCoreObject::isEmptyGroup):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::subrolePlatformString const):
(WebCore::isEmptyGroup): Deleted.
(WebCore::renderWidgetChildren): Deleted.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(subroleString):

Canonical link: <a href="https://commits.webkit.org/290893@main">https://commits.webkit.org/290893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be094564d1fec1d221a10e34e7658d5e20aef6ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42082 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70168 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27693 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94384 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8605 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50494 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/357 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41241 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78691 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18547 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79190 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18801 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78394 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19392 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11691 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23830 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21716 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->