### PR TITLE
AX: aria-activedescendant should be supported on text fields

### DIFF
--- a/LayoutTests/accessibility/textbox-active-element-expected.txt
+++ b/LayoutTests/accessibility/textbox-active-element-expected.txt
@@ -1,0 +1,11 @@
+Tests that aria-activedescendant is supported on a contenteditable textbox.
+
+PASS: axTextbox.activeElement.role === "AXRole: AXCell"
+PASS: axTextbox.activeElement.title === "AXTitle: Cell 1"
+PASS: axTextbox.activeElement.role === "AXRole: AXCell"
+PASS: axTextbox.activeElement.title === "AXTitle: Cell 2"
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/textbox-active-element.html
+++ b/LayoutTests/accessibility/textbox-active-element.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="textbox" role="textbox" tabindex="0" contenteditable="true" aria-activedescendant="cell1">
+
+  <table role="grid">
+    <tr>
+      <td role="gridcell" id="cell1" aria-label="Cell 1"></td>
+      <td role="gridcell" id="cell2" aria-label="Cell 2"></td>
+    </tr>
+  </table>
+
+</div>
+
+<script>
+let output = "Tests that aria-activedescendant is supported on a contenteditable textbox.\n\n";
+window.jsTestIsAsync = true;
+
+if (window.accessibilityController) {
+    var textbox = document.getElementById("textbox");
+    textbox.focus();
+    var axTextbox = accessibilityController.accessibleElementById("textbox");
+    output += expect("axTextbox.activeElement.role", '"AXRole: AXCell"');
+    output += expect("axTextbox.activeElement.title", '"AXTitle: Cell 1"');
+
+    accessibilityController.addNotificationListener((target, notification) => {
+        if (notification === "AXActiveElementChanged") {
+            output += expect("axTextbox.activeElement.role", '"AXRole: AXCell"');
+            output += expect("axTextbox.activeElement.title", '"AXTitle: Cell 2"');
+            textbox.hidden = true;
+            debug(output);
+            finishJSTest();
+        }
+    });
+
+    textbox.setAttribute('aria-activedescendant', 'cell2');
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2216,6 +2216,8 @@ accessibility/deep-tree.html [ Skip ]
 accessibility/mac/table-wrapped-by-role-grid.html [ Skip ]
 accessibility/aria-labeled-with-hidden-node.html [ Skip ]
 accessibility/text-alternative-calculation-from-unrendered-table.html [ Skip ]
+# Mac-WK1 does not support activeElement
+accessibility/textbox-active-element.html
 
 # <rdar://problem/61066929> [ Stress GC ] flaky JSC::ExceptionScope::assertNoException crash under WebCore::ReadableStreamDefaultController
 webkit.org/b/211923 imported/w3c/web-platform-tests/fetch/api/basic/stream-safe-creation.any.html [ Pass Crash ]

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -958,6 +958,8 @@ bool AXCoreObject::supportsActiveDescendant() const
     case AccessibilityRole::Grid:
     case AccessibilityRole::List:
     case AccessibilityRole::ListBox:
+    case AccessibilityRole::TextArea:
+    case AccessibilityRole::TextField:
     case AccessibilityRole::Tree:
     case AccessibilityRole::TreeGrid:
         return true;


### PR DESCRIPTION
#### 97fe594024a4b692c71e95c393ae9654f60770ad
<pre>
AX: aria-activedescendant should be supported on text fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=288216">https://bugs.webkit.org/show_bug.cgi?id=288216</a>
<a href="https://rdar.apple.com/145307212">rdar://145307212</a>

Reviewed by Tyler Wilcock.

According to the spec, aria-active descendant is supposed to be supported on role=textbox:

<a href="https://w3c.github.io/aria/#aria-activedescendant">https://w3c.github.io/aria/#aria-activedescendant</a>

Google Sheets uses that in order to have focus on an offscreen
contenteditable to capture input, while providing accessibility
notifications when the selected cell changes.

* LayoutTests/accessibility/textbox-active-element-expected.txt: Added.
* LayoutTests/accessibility/textbox-active-element.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::supportsActiveDescendant const):

Canonical link: <a href="https://commits.webkit.org/291049@main">https://commits.webkit.org/291049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/184ef8ebbaa0d8fe3c87ae99d2ade2a7fb92cc70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70366 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27880 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94646 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8818 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50692 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/656 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41495 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98618 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18795 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13856 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/cache-storage/serviceworker/cache-abort.https.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79402 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78613 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11903 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24055 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18497 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->