### PR TITLE
Move WebFullScreenManagerProxy::willEnterFullScreen to a lambda

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -1212,11 +1212,7 @@ void WKPageSetFullScreenClientForTesting(WKPageRef pageRef, const WKPageFullScre
         void closeFullScreenManager() override { }
         bool isFullScreen() override { return false; }
 
-        void enterFullScreen(
-#if PLATFORM(IOS_FAMILY)
-            WebCore::FloatSize,
-#endif
-            CompletionHandler<void(bool)>&& completionHandler) override
+        void enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&& completionHandler) override
         {
             if (!m_client.willEnterFullScreen)
                 return completionHandler(false);

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp
@@ -413,7 +413,7 @@ bool PageClientImpl::isFullScreen()
     return webkitWebViewBaseIsFullScreen(WEBKIT_WEB_VIEW_BASE(m_viewWidget));
 }
 
-void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_viewWidget)
         return completionHandler(false);

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -132,7 +132,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
+    void enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&&) override;
     void exitFullScreen(CompletionHandler<void()>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp
@@ -2624,10 +2624,7 @@ void webkitWebViewBaseWillEnterFullScreen(WebKitWebViewBase* webkitWebViewBase, 
 {
     WebKitWebViewBasePrivate* priv = webkitWebViewBase->priv;
     ASSERT(priv->fullScreenState == WebFullScreenManagerProxy::FullscreenState::NotInFullscreen);
-    if (auto* fullScreenManagerProxy = priv->pageProxy->fullScreenManager())
-        fullScreenManagerProxy->willEnterFullScreen(WTFMove(completionHandler));
-    else
-        completionHandler(false);
+    completionHandler(true);
     priv->fullScreenState = WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -434,7 +434,7 @@ bool PageClientImpl::isFullScreen()
     return m_view.isFullScreen();
 }
 
-void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (isFullScreen())
         return completionHandler(false);

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -167,7 +167,7 @@ private:
 
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
+    void enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&&) override;
     void exitFullScreen(CompletionHandler<void()>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -153,10 +153,7 @@ bool View::isFullScreen() const
 void View::willEnterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(m_fullscreenState == WebFullScreenManagerProxy::FullscreenState::NotInFullscreen);
-    if (auto* fullScreenManagerProxy = page().fullScreenManager())
-        fullScreenManagerProxy->willEnterFullScreen(WTFMove(completionHandler));
-    else
-        completionHandler(false);
+    completionHandler(true);
     m_fullscreenState = WebFullScreenManagerProxy::FullscreenState::EnteringFullscreen;
 }
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -64,11 +64,7 @@ public:
 
     virtual void closeFullScreenManager() = 0;
     virtual bool isFullScreen() = 0;
-#if PLATFORM(IOS_FAMILY)
     virtual void enterFullScreen(WebCore::FloatSize mediaDimensions, CompletionHandler<void(bool)>&&) = 0;
-#else
-    virtual void enterFullScreen(CompletionHandler<void(bool)>&&) = 0;
-#endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual void updateImageSource() = 0;
 #endif
@@ -112,7 +108,6 @@ public:
         ExitingFullscreen,
     };
     FullscreenState fullscreenState() const { return m_fullscreenState; }
-    void willEnterFullScreen(CompletionHandler<void(bool)>&&);
     void setAnimatingFullScreen(bool);
     void requestRestoreFullScreen(CompletionHandler<void(bool)>&&);
     void requestExitFullScreen();

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -222,7 +222,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
+    void enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&&) override;
     void exitFullScreen(CompletionHandler<void()>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -824,11 +824,11 @@ bool PageClientImpl::isFullScreen()
     return m_impl->fullScreenWindowController().isFullScreen;
 }
 
-void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::enterFullScreen(FloatSize, CompletionHandler<void(bool)>&& completionHandler)
 {
     if (!m_impl->fullScreenWindowController())
         return completionHandler(false);
-    [m_impl->fullScreenWindowController() enterFullScreen:nil completionHandler:WTFMove(completionHandler)];
+    [m_impl->fullScreenWindowController() enterFullScreen:WTFMove(completionHandler)];
 }
 
 void PageClientImpl::exitFullScreen(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h
@@ -77,7 +77,7 @@ typedef enum FullScreenState : NSInteger FullScreenState;
 
 - (BOOL)isFullScreen;
 
-- (void)enterFullScreen:(NSScreen *)screen completionHandler:(CompletionHandler<void(bool)>&&)completionHandler;
+- (void)enterFullScreen:(CompletionHandler<void(bool)>&&)completionHandler;
 - (void)exitFullScreen:(CompletionHandler<void()>&&)completionHandler;
 - (void)exitFullScreenImmediately;
 - (void)requestExitFullScreen;

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -227,14 +227,13 @@ static RetainPtr<CGImageRef> createImageWithCopiedData(CGImageRef sourceImage)
     return adoptCF(CGImageCreate(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, colorSpace, bitmapInfo, provider.get(), 0, shouldInterpolate, intent));
 }
 
-- (void)enterFullScreen:(NSScreen *)screen completionHandler:(CompletionHandler<void(bool)>&&)completionHandler
+- (void)enterFullScreen:(CompletionHandler<void(bool)>&&)completionHandler
 {
     if ([self isFullScreen])
         return completionHandler(false);
     _fullScreenState = WaitingToEnterFullScreen;
 
-    if (!screen)
-        screen = [NSScreen mainScreen];
+    NSScreen *screen = [NSScreen mainScreen];
 
     NSRect screenFrame = WebCore::safeScreenFrame(screen);
     NSRect webViewFrame = convertRectToScreen([_webView window], [_webView convertRect:[_webView frame] toView:nil]);
@@ -283,7 +282,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _savedScale = _page->pageScaleFactor();
     _page->scalePageRelativeToScrollPosition(1, { });
     [self _manager]->setAnimatingFullScreen(true);
-    [self _manager]->willEnterFullScreen(WTFMove(completionHandler));
+    completionHandler(true);
 }
 
 - (void)beganEnterFullScreenWithInitialFrame:(NSRect)initialFrame finalFrame:(NSRect)finalFrame completionHandler:(CompletionHandler<void(bool)>&&)completionHandler

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -261,7 +261,7 @@ bool PageClientImpl::isFullScreen()
     return m_view.isFullScreen();
 }
 
-void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&& completionHandler)
 {
     m_view.enterFullScreen(WTFMove(completionHandler));
 }

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.h
@@ -137,7 +137,7 @@ private:
 
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
+    void enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&&) override;
     void exitFullScreen(CompletionHandler<void()>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;

--- a/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
+++ b/Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp
@@ -118,7 +118,7 @@ void PlayStationWebView::setViewNeedsDisplay(const WebCore::Region& region)
 void PlayStationWebView::willEnterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
 {
     m_isFullScreen = true;
-    m_page->fullScreenManager()->willEnterFullScreen(WTFMove(completionHandler));
+    completionHandler(true);
 }
 
 void PlayStationWebView::requestExitFullScreen()

--- a/Source/WebKit/UIProcess/win/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.cpp
@@ -318,7 +318,7 @@ bool PageClientImpl::isFullScreen()
     return false;
 }
 
-void PageClientImpl::enterFullScreen(CompletionHandler<void(bool)>&& completionHandler)
+void PageClientImpl::enterFullScreen(FloatSize, CompletionHandler<void(bool)>&& completionHandler)
 {
     notImplemented();
     completionHandler(false);

--- a/Source/WebKit/UIProcess/win/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/win/PageClientImpl.h
@@ -127,7 +127,7 @@ private:
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;
     bool isFullScreen() override;
-    void enterFullScreen(CompletionHandler<void(bool)>&&) override;
+    void enterFullScreen(WebCore::FloatSize, CompletionHandler<void(bool)>&&) override;
     void exitFullScreen(CompletionHandler<void()>&&) override;
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&) override;
     void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&) override;


### PR DESCRIPTION
#### f5a697f57dea2175017d407e06f4c585e58aa237
<pre>
Move WebFullScreenManagerProxy::willEnterFullScreen to a lambda
<a href="https://bugs.webkit.org/show_bug.cgi?id=288220">https://bugs.webkit.org/show_bug.cgi?id=288220</a>
<a href="https://rdar.apple.com/145312937">rdar://145312937</a>

Reviewed by Charlie Wolfe.

There&apos;s no need to find the WebFullScreenManagerProxy to give it the CompletionHandler.
Just call the CompletionHandler, and it has the context needed to do what it needs to do.

Also, the NSScreen given to WKFullScreenWindowController was only nil, so remove that parameter.
And make the signature of enterFullScreen no longer platform-dependent.

No change in behavior, this just makes the code more sane.

* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageSetFullScreenClientForTesting):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.cpp:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/gtk/WebKitWebViewBase.cpp:
(webkitWebViewBaseWillEnterFullScreen):
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::willEnterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::willEnterFullScreen): Deleted.
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
(WebKit::WebFullScreenManagerProxy::fullscreenState const):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.h:
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController enterFullScreen:completionHandler:]): Deleted.
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/playstation/PageClientImpl.h:
* Source/WebKit/UIProcess/playstation/PlayStationWebView.cpp:
(WebKit::PlayStationWebView::willEnterFullScreen):
* Source/WebKit/UIProcess/win/PageClientImpl.cpp:
(WebKit::PageClientImpl::enterFullScreen):
* Source/WebKit/UIProcess/win/PageClientImpl.h:

Canonical link: <a href="https://commits.webkit.org/290838@main">https://commits.webkit.org/290838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/414259b7773108ba4fbce938e8735682322f2a66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96215 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50410 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8273 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41097 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98200 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18408 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79095 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78469 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78298 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22809 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14418 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18408 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18129 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->