### PR TITLE
Address Safer CPP failures in QueuedVideoOutput.mm

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -111,7 +111,6 @@ platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/graphics/GraphicsLayer.cpp
 platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
 platform/graphics/avfoundation/objc/CDMSessionMediaSourceAVFObjC.h
-platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
 platform/graphics/ca/GraphicsLayerCA.cpp
 platform/graphics/ca/cocoa/PlatformCAAnimationCocoa.mm
 platform/graphics/mac/controls/ControlFactoryMac.mm

--- a/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm
@@ -37,6 +37,10 @@
 
 #include <wtf/TZoneMallocInlines.h>
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(AVPlayerItemVideoOutput)
+static bool isType(const AVPlayerItemOutput& output) { return [&output isKindOfClass:PAL::getAVPlayerItemVideoOutputClass()]; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 @interface WebQueuedVideoOutputDelegate : NSObject<AVPlayerItemOutputPullDelegate> {
     WeakPtr<WebCore::QueuedVideoOutput> _parent;
 }
@@ -59,8 +63,7 @@
 
 - (void)outputMediaDataWillChange:(AVPlayerItemOutput *)output
 {
-    ASSERT([output isKindOfClass:PAL::getAVPlayerItemVideoOutputClass()]);
-    auto* videoOutput = (AVPlayerItemVideoOutput*)output;
+    auto* videoOutput = downcast<AVPlayerItemVideoOutput>(output);
 
     Vector<WebCore::QueuedVideoOutput::VideoFrameEntry> videoFrameEntries;
     do {
@@ -86,8 +89,7 @@
 
 - (void)outputSequenceWasFlushed:(AVPlayerItemOutput *)output
 {
-    ASSERT([output isKindOfClass:PAL::getAVPlayerItemVideoOutputClass()]);
-    auto* videoOutput = (AVPlayerItemVideoOutput*)output;
+    auto* videoOutput = downcast<AVPlayerItemVideoOutput>(output);
     [videoOutput requestNotificationOfMediaDataChangeAsSoonAsPossible];
 
     callOnMainRunLoop([parent = _parent] {


### PR DESCRIPTION
#### e31e39e35b2e3e92598bd6de2548d64d8bd3fa42
<pre>
Address Safer CPP failures in QueuedVideoOutput.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=288224">https://bugs.webkit.org/show_bug.cgi?id=288224</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/QueuedVideoOutput.mm:
(isType):
(SPECIALIZE_TYPE_TRAITS_END):
(-[WebQueuedVideoOutputDelegate outputMediaDataWillChange:]):
(-[WebQueuedVideoOutputDelegate outputSequenceWasFlushed:]):

Canonical link: <a href="https://commits.webkit.org/290847@main">https://commits.webkit.org/290847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/888495f0befd3495c502fca26f918373aa49c76a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96207 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19065 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70080 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27597 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82629 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8264 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/204 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41090 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98191 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18400 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79088 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18656 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78292 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22803 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/151 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14428 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21581 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->