### PR TITLE
[WebGPUSwift] fix crash in texture_zero.html

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -111,6 +111,7 @@ public:
     void setEncoderState(EncoderState state) { m_state = state; }
     EncoderState getEncoderState() { return m_state; }
     NSString * encoderStateNameWrapper() { return encoderStateName(); }
+    static id<MTLFunction> nopVertexFunction(id<MTLDevice>);
 #endif
 
     id<MTLBlitCommandEncoder> ensureBlitCommandEncoder();

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -353,7 +353,27 @@ bool Device::isStencilOnlyFormat(MTLPixelFormat format)
         return false;
     }
 }
-
+#if ENABLE(WEBGPU_SWIFT)
+id<MTLFunction> CommandEncoder::nopVertexFunction(id<MTLDevice> device)
+{
+    static id<MTLFunction> function = nil;
+    NSError *error = nil;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [&] {
+        MTLCompileOptions* options = [MTLCompileOptions new];
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        options.fastMathEnabled = YES;
+        ALLOW_DEPRECATED_DECLARATIONS_END
+        id<MTLLibrary> library = [device newLibraryWithSource:@"[[vertex]] float4 vsNop() { return (float4)0; }" options:options error:&error];
+        if (error)
+            WTFLogAlways("%@", error); // NOLINT
+        RELEASE_ASSERT(!error);
+        function = [library newFunctionWithName:@"vsNop"];
+    });
+    RELEASE_ASSERT(function);
+    return function;
+}
+#endif
 #if !ENABLE(WEBGPU_SWIFT)
 static std::pair<id<MTLRenderPipelineState>, id<MTLDepthStencilState>> createSimplePso(NSMutableDictionary<NSNumber*, TextureAndClearColor*> *attachmentsToClear, id<MTLTexture> depthStencilAttachmentToClear, bool depthAttachmentToClear, bool stencilAttachmentToClear, id<MTLDevice> device)
 {

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -165,10 +165,14 @@ extension WebGPU.CommandEncoder {
         return result
     }
     public func clearTextureIfNeeded(destination: WGPUImageCopyTexture, slice: UInt) {
-        return WebGPU.CommandEncoder.clearTextureIfNeeded(destination, slice, m_device.ptr(), m_blitCommandEncoder)
+        return clearTextureIfNeeded(destination: destination, slice: slice, device: m_device.ptr(), blitCommandEncoder: m_blitCommandEncoder)
     }
     private func clearTextureIfNeeded(destination: WGPUImageCopyTexture , slice: UInt, device: WebGPU.Device , blitCommandEncoder: MTLBlitCommandEncoder?)
     {
+        guard destination.texture != nil else {
+            WebGPU_Internal.logString("\(#function) called with nil texture")
+            return
+        }
         let texture = WebGPU.fromAPI(destination.texture)
         let mipLevel: UInt = UInt(destination.mipLevel)
         clearTextureIfNeeded(texture, mipLevel, slice, device, blitCommandEncoder)
@@ -203,15 +207,14 @@ extension WebGPU.CommandEncoder {
         }
         
         let physicalExtent = WebGPU.Texture.physicalTextureExtent(texture.dimension(), textureFormat, logicalExtent)
-        var sourceBytesPerRow: UInt = WebGPU.Texture.bytesPerRow(textureFormat, physicalExtent.width, texture.sampleCount())
+        let sourceBytesPerRow: UInt = WebGPU.Texture.bytesPerRow(textureFormat, physicalExtent.width, texture.sampleCount())
         let depth: UInt = UInt(texture.dimension() == WGPUTextureDimension_3D ? physicalExtent.depthOrArrayLayers : 1)
+        var bytesPerImage = sourceBytesPerRow
         var didOverflow: Bool = false
-        var checkedBytesPerImage: UInt = sourceBytesPerRow
-        (checkedBytesPerImage, didOverflow) = sourceBytesPerRow.multipliedReportingOverflow(by: UInt(physicalExtent.height))
+        (bytesPerImage, didOverflow) = bytesPerImage.multipliedReportingOverflow(by: UInt(physicalExtent.height))
         if didOverflow {
             return
         }
-        let bytesPerImage = checkedBytesPerImage
         var bufferLength = bytesPerImage
         (bufferLength, didOverflow) = bufferLength.multipliedReportingOverflow(by: depth)
         if didOverflow {
@@ -253,6 +256,9 @@ extension WebGPU.CommandEncoder {
         if mutableSlice >= mtlTexture!.arrayLength {
             return
         }
+        if blitCommandEncoder == nil {
+            WebGPU_Internal.logString("\(#function): blitCommandEncoder is nil. Should not be")
+        }
         blitCommandEncoder?.copy(
             from: temporaryBuffer!,
             sourceOffset: 0,
@@ -266,20 +272,18 @@ extension WebGPU.CommandEncoder {
             options: options)
 
         if options != MTLBlitOptionNone {
-            // FIXME:  maybe it needs to be another value that is not sizeof.
-            sourceBytesPerRow /= UInt(MemoryLayout<Float>.stride)
             sourceBytesPerImage /= UInt(MemoryLayout<Float>.stride)
             blitCommandEncoder?.copy(
                 from: temporaryBuffer!,
                 sourceOffset: 0,
-                sourceBytesPerRow: Int(sourceBytesPerRow),
+                sourceBytesPerRow: Int(sourceBytesPerRow / UInt(MemoryLayout<Float>.stride),
                 sourceBytesPerImage: Int(sourceBytesPerImage),
                 sourceSize: sourceSize!,
                 to: mtlTexture!,
                 destinationSlice: Int(mutableSlice),
                 destinationLevel: Int(mipLevel),
                 destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0),
-                options: options)
+                options: .stencilFromDepthStencil)
         }
     }
     public func runClearEncoder(attachmentsToClear: [NSNumber: TextureAndClearColor], depthStencilAttachmentToClear: inout MTLTexture?, depthAttachmentToClear: Bool, stencilAttachmentToClear: Bool, depthClearValue: Double, stencilClearValue: UInt32, existingEncoder: MTLRenderCommandEncoder?) {
@@ -309,7 +313,7 @@ extension WebGPU.CommandEncoder {
                 }
             }
 
-            mtlRenderPipelineDescriptor.vertexFunction = device.m_nopVertexFunction
+            mtlRenderPipelineDescriptor.vertexFunction = WebGPU.CommandEncoder.nopVertexFunction(device.device())
             mtlRenderPipelineDescriptor.fragmentFunction = nil
 
             precondition(sampleCount != 0, "sampleCount must be non-zero")
@@ -742,7 +746,9 @@ extension WebGPU.CommandEncoder {
             if (!self.protectedDevice().ptr().hasFeature(WGPUFeatureName_TimestampQuery)) {
                 return "device does not have timestamp query feature"
             }
-
+            if timestampWrites.querySet == nil {
+                return "query set is nil"
+            }
             let querySet = WebGPU.fromAPI(timestampWrites.querySet)
             if (querySet.type() != WGPUQueryType_Timestamp) {
                 return "query type is not timestamp but \(querySet.type())"
@@ -831,7 +837,9 @@ extension WebGPU.CommandEncoder {
         if let error = errorValidatingRenderPassDescriptor(descriptor: descriptor) {
             return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), error)
         }
-
+        if m_commandBuffer == nil {
+            WebGPU_Internal.logString("\(#function): m_commandBuffer is nil. Should not be.")
+        }
         guard m_commandBuffer.status.rawValue < MTLCommandBufferStatus.enqueued.rawValue else {
             return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "command buffer has already been committed")
         }
@@ -865,7 +873,7 @@ extension WebGPU.CommandEncoder {
 
         finalizeBlitCommandEncoder()
 
-        var attachmentsToClear: [NSNumber:TextureAndClearColor] = [:]
+        var attachmentsToClear: [NSNumber: TextureAndClearColor] = [:]
         var zeroColorTargets = true
         var bytesPerSample: UInt32 = 0
         let maxColorAttachmentBytesPerSample = m_device.ptr().limitsCopy().maxColorAttachmentBytesPerSample
@@ -875,7 +883,7 @@ extension WebGPU.CommandEncoder {
         for i in 0..<descriptor.colorAttachmentsSpan().count {
             let attachment = descriptor.colorAttachmentsSpan()[i]
 
-            if (attachment.view == nil) {
+            if attachment.view == nil {
                 continue
             }
 
@@ -1123,10 +1131,9 @@ extension WebGPU.CommandEncoder {
         }
 
         if (attachmentsToClear.count != 0 || depthStencilAttachmentToClear != nil) {
-            let attachment = descriptor.depthStencilAttachment
-            if attachment != nil && depthStencilAttachmentToClear != nil {
-                // FIXME: rdar://138042799 remove default argument.
-                WebGPU.fromAPI(attachment.pointee.view).setPreviouslyCleared(0, 0)
+            if descriptor.depthStencilAttachment != nil && depthStencilAttachmentToClear != nil {
+                    // FIXME: rdar://138042799 remove default argument.
+                    WebGPU.fromAPI(descriptor.depthStencilAttachment.pointee.view).setPreviouslyCleared(0, 0)
             }
             // FIXME: rdar://138042799 remove default argument.
             runClearEncoder(attachmentsToClear: attachmentsToClear, depthStencilAttachmentToClear: &depthStencilAttachmentToClear, depthAttachmentToClear: depthAttachmentToClear, stencilAttachmentToClear: stencilAttachmentToClear, depthClearValue: 0 ,stencilClearValue: 0 ,existingEncoder: nil)
@@ -1137,7 +1144,7 @@ extension WebGPU.CommandEncoder {
         }
 
         let mtlRenderCommandEncoder = m_commandBuffer.makeRenderCommandEncoder(descriptor: mtlDescriptor)
-        if (m_existingCommandEncoder != nil)  {
+        if m_existingCommandEncoder != nil  {
             assertionFailure("!m_existingCommandEncoder")
         }
         setExistingEncoder(mtlRenderCommandEncoder)

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -234,10 +234,6 @@ private:
         std::optional<Error> error;
         const WGPUErrorFilter filter;
     };
-#if ENABLE(WEBGPU_SWIFT)
-private PUBLIC_IN_WEBGPU_SWIFT:
-    id<MTLFunction> m_nopVertexFunction;
-#endif
 private:
     id<MTLDevice> m_device { nil };
     const Ref<Queue> m_defaultQueue;

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -281,22 +281,6 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     , m_instance(adapter.weakInstance())
     , m_maxVerticesPerDrawCall(computeMaxCountForDevice(device))
 {
-#if ENABLE(WEBGPU_SWIFT)
-    NSError *error = nil;
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [&] {
-        MTLCompileOptions* options = [MTLCompileOptions new];
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-        options.fastMathEnabled = YES;
-        ALLOW_DEPRECATED_DECLARATIONS_END
-        id<MTLLibrary> library = [device newLibraryWithSource:@"[[vertex]] float4 vsNop() { return (float4)0; }" options:options error:&error];
-        if (error)
-            WTFLogAlways("%@", error); // NOLINT
-        m_nopVertexFunction = [library newFunctionWithName:@"vsNop"];
-    });
-    RELEASE_ASSERT(m_nopVertexFunction);
-    RELEASE_ASSERT(!error);
-#endif
 
 #if PLATFORM(MAC)
     auto devices = MTLCopyAllDevicesWithObserver(&m_deviceObserver, [weakThis = ThreadSafeWeakPtr { *this }](id<MTLDevice> device, MTLDeviceNotificationName) {


### PR DESCRIPTION
#### 17240f7ea89d925bc767ec35cea4f190ddfe11a5
<pre>
[WebGPUSwift] fix crash in texture_zero.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=288239">https://bugs.webkit.org/show_bug.cgi?id=288239</a>
<a href="https://rdar.apple.com/145320646">rdar://145320646</a>

Reviewed by NOBODY (OOPS!).

This fixes a bug landed in 290231@main.
The swift implementation of CommandEncoder::clearTextureIsNeeded
had some problems:
- I had re-used a local variable holding the result of a checked multiplication
which was subsequently getting used at the interface for the Metal library.
That was causing a:
GPU Address Fault Error (0000000b:kIOGPUCommandBufferCallbackErrorPageFault)
- last argument to blitCommandEncoder.copy() was also wrong.
- Some null checks were missing.

Also, some cleanup for conditionals and other cosmetic things.

testing: Local at desk testing using:
http/tests/webgpu/webgpu/api/operation/resource_init/texture_zero.html

* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::mtlFunction):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.clearTextureIfNeeded(_:slice:)):
(WebGPU.runClearEncoder(_:depthStencilAttachmentToClear:depthAttachmentToClear:stencilAttachmentToClear:depthClearValue:stencilClearValue:existingEncoder:)):
(WebGPU.errorValidatingTimestampWrites(_:)):
(WebGPU.beginRenderPass(_:)):
(WebGPU.sourceBytesPerRow): Deleted.
(WebGPU.checkedBytesPerImage): Deleted.
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17240f7ea89d925bc767ec35cea4f190ddfe11a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/291 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96248 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41988 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70105 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27618 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50431 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8295 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41128 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78616 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98236 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18440 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13514 "Found 1 new test failure: imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-peerconnection.https.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79118 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78320 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11611 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23741 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21619 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19931 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->