### PR TITLE
Use the org.webkit prefix for TestWebKitAPI.app's bundle identifier

### DIFF
--- a/Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig
+++ b/Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig
@@ -24,7 +24,7 @@
 #include "TestWebKitAPIBase.xcconfig"
 
 PRODUCT_NAME = TestWebKitAPI;
-PRODUCT_BUNDLE_IDENTIFIER = com.apple.WebKit.TestWebKitAPIApp;
+PRODUCT_BUNDLE_IDENTIFIER = org.webkit.$(PRODUCT_NAME:rfc1034identifier);
 
 EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = ios/app/*;
 EXCLUDED_SOURCE_FILE_NAMES[sdk=embedded*] = mac/app/*;


### PR DESCRIPTION
#### 5b80752a5caab4a3ef2ff0af2d586768dc51f1a3
<pre>
Use the org.webkit prefix for TestWebKitAPI.app&apos;s bundle identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=288245">https://bugs.webkit.org/show_bug.cgi?id=288245</a>

Reviewed by Richard Robinson and Elliott Williams.

Using a bundle identifier prefix of com.apple. is incompatible with apps built against a Public
SDK. For consistency with WebKitTestRunner.app, MiniBrowser.app, etc., changed TestWebKitAPI.app&apos;s
bundle identifier to org.webkit.TestWebKitAPI.

* Tools/TestWebKitAPI/Configurations/TestWebKitAPIApp.xcconfig:

Canonical link: <a href="https://commits.webkit.org/290963@main">https://commits.webkit.org/290963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9dd07f2211f96f4236da9f1132d9f77652fc566

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/41979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27615 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94249 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8514 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98226 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18430 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13635 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79116 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18686 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78493 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19437 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22824 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18429 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18150 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->