### PR TITLE
Re-import dom/observable WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/idlharness.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/idlharness.html
@@ -1,7 +1,7 @@
 <!doctype html>
   <meta charset="utf-8" />
   <meta name="author" title="Keith Cirkel" href="mailto:keithamus@github.com" />
-  <link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+  <link rel="help" href="https://github.com/WICG/observable" />
   <script src="/resources/testharness.js"></script>
   <script src="/resources/testharnessreport.js"></script>
   <script src="/resources/WebIDLParser.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt
@@ -31,9 +31,9 @@ PASS Subscriber#signal is not the same AbortSignal as the one passed into `subsc
 PASS Subscription does not emit values after completion
 PASS Subscription does not emit values after error
 PASS Completing or nexting a subscriber after an error does nothing
-FAIL Errors pushed to the subscriber that are not handled by the subscription are reported to the global assert_equals: Error message matches expected "Uncaught Error: custom error" but got "Error: custom error"
-FAIL Errors thrown in the initializer that are not handled by the subscription are reported to the global assert_equals: Error message matches expected "Uncaught Error: custom error" but got "Error: custom error"
-FAIL Subscription reports errors that are pushed after subscriber is closed by completion assert_equals: Error message matches expected "Uncaught Error: custom error" but got "Error: custom error"
+PASS Errors pushed to the subscriber that are not handled by the subscription are reported to the global
+PASS Errors thrown in the initializer that are not handled by the subscription are reported to the global
+PASS Subscription reports errors that are pushed after subscriber is closed by completion
 PASS Errors thrown by initializer function after subscriber is closed by completion are reported
 PASS Errors thrown by initializer function after subscriber is closed by error are reported
 PASS Errors pushed by initializer function after subscriber is closed by error are reported
@@ -52,4 +52,7 @@ PASS Teardowns should be called when subscription is closed by completion
 PASS Teardowns should be called when subscription is closed by subscriber pushing an error
 PASS Teardowns should be called when subscription is closed by subscriber throwing error
 PASS Teardowns should be called synchronously during addTeardown() if the subscription is inactive
+FAIL Multiple subscriptions share the same producer and teardown runs only after last subscription abort assert_equals: Producer should not be invoked again for second subscription expected 1 but got 2
+FAIL New subscription after complete creates new producer assert_array_equals: lengths differ, expected array ["producer start", "teardown"] length 2, got ["producer start", "producer start", "teardown"] length 3
+FAIL Teardown runs after last unsubscribe regardless of unsubscription order assert_equals: Producer should be invoked once expected 1 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt
@@ -18,9 +18,9 @@ PASS Subscriber#signal is not the same AbortSignal as the one passed into `subsc
 PASS Subscription does not emit values after completion
 PASS Subscription does not emit values after error
 PASS Completing or nexting a subscriber after an error does nothing
-FAIL Errors pushed to the subscriber that are not handled by the subscription are reported to the global assert_equals: Error message matches expected "Uncaught Error: custom error" but got "Error: custom error"
-FAIL Errors thrown in the initializer that are not handled by the subscription are reported to the global assert_equals: Error message matches expected "Uncaught Error: custom error" but got "Error: custom error"
-FAIL Subscription reports errors that are pushed after subscriber is closed by completion assert_equals: Error message matches expected "Uncaught Error: custom error" but got "Error: custom error"
+PASS Errors pushed to the subscriber that are not handled by the subscription are reported to the global
+PASS Errors thrown in the initializer that are not handled by the subscription are reported to the global
+PASS Subscription reports errors that are pushed after subscriber is closed by completion
 PASS Errors thrown by initializer function after subscriber is closed by completion are reported
 PASS Errors thrown by initializer function after subscriber is closed by error are reported
 PASS Errors pushed by initializer function after subscriber is closed by error are reported
@@ -39,4 +39,7 @@ PASS Teardowns should be called when subscription is closed by completion
 PASS Teardowns should be called when subscription is closed by subscriber pushing an error
 PASS Teardowns should be called when subscription is closed by subscriber throwing error
 PASS Teardowns should be called synchronously during addTeardown() if the subscription is inactive
+FAIL Multiple subscriptions share the same producer and teardown runs only after last subscription abort assert_equals: Producer should not be invoked again for second subscription expected 1 but got 2
+FAIL New subscription after complete creates new producer assert_array_equals: lengths differ, expected array ["producer start", "teardown"] length 2, got ["producer start", "producer start", "teardown"] length 3
+FAIL Teardown runs after last unsubscribe regardless of unsubscription order assert_equals: Producer should be invoked once expected 1 but got 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any-expected.txt
@@ -1,0 +1,88 @@
+
+FAIL finally(): Mirrors all values and completions from source source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      results.push("finally called");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Mirrors all values and errors from the source source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      results.push("finally called");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Callback handler fires BEFORE the source observable completes source.finally is not a function. (In 'source.finally(() => {
+    results.push("finally handler");
+  })', 'source.finally' is undefined)
+FAIL finally(): Callback handler fires BEFORE the source observable errors source.finally is not a function. (In 'source.finally(() => {
+    results.push("finally handler");
+  })', 'source.finally' is undefined)
+FAIL finally(): Handlers run in composition order source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      results.push("finally handler 1");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Errors thrown in the finally handler (during Subscriber#error()) are reported to the global immediately source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      throw new Error("error from finally");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Errors thrown in the finally handler (during Subscriber#complete()) are reported to the global immediately source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      throw new Error("error from finally");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Callback is run if consumer aborts the subscription source
+    .finally is not a function. (In 'source
+    .finally(() => results.push("downstream finally handler"))', 'source
+    .finally' is undefined)
+FAIL finally(): Callback is run before next inner subscription in flatMap() new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap is not a function. (In 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap((value) => {
+    results.push(`flatMap ${value}`);
+    return new Observable((subscriber) => {
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.complete();
+    }).finally(() => {
+      results.push(`finally ${value}`);
+    });
+  })', 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap' is undefined)
+FAIL finally(): Callback is run before next inner subscription in switchMap() new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap is not a function. (In 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap((value) => {
+    results.push(`switchMap ${value}`);
+    return new Observable((subscriber) => {
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.complete();
+    }).finally(() => {
+      results.push(`finally ${value}`);
+    });
+  })', 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap' is undefined)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.js
@@ -1,0 +1,265 @@
+// Because we test that the global error handler is called at various times.
+setup({allow_uncaught_exception: true});
+
+test(() => {
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    subscriber.complete();
+  });
+
+  const results = [];
+
+  source
+    .finally(() => {
+      results.push("finally called");
+    })
+    .subscribe({
+      next: (value) => results.push(value),
+      error: (e) => results.push(e.message),
+      complete: () => results.push("complete"),
+    });
+
+  assert_array_equals(results, [1, 2, 3, "finally called", "complete"],
+      "finally is called with teardown timing, before complete() is forwarded");
+}, "finally(): Mirrors all values and completions from source");
+
+test(() => {
+  const source = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.next(3);
+    subscriber.error(new Error("error from source"));
+  });
+
+  const results = [];
+
+  source
+    .finally(() => {
+      results.push("finally called");
+    })
+    .subscribe({
+      next: (value) => results.push(value),
+      error: (e) => results.push(e.message),
+      complete: () => results.push("complete"),
+    });
+
+  assert_array_equals(results, [1, 2, 3, "finally called", "error from source"],
+      "finally is called with teardown timing, before complete() is forwarded");
+}, "finally(): Mirrors all values and errors from the source");
+
+test(() => {
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    results.push("source subscribe");
+    subscriber.addTeardown(() => results.push("source teardown"));
+    results.push("source send complete");
+    subscriber.complete();
+  });
+
+  const result = source.finally(() => {
+    results.push("finally handler");
+  });
+
+  result.subscribe({
+    complete: () => results.push("result complete"),
+  });
+
+  assert_array_equals(results, [
+    "source subscribe",
+    "source send complete",
+    "source teardown",
+    "finally handler",
+    "result complete",
+  ]);
+}, "finally(): Callback handler fires BEFORE the source observable completes");
+
+test(() => {
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    results.push("source subscribe");
+    subscriber.addTeardown(() => results.push("source teardown"));
+    results.push("source send error");
+    subscriber.error(new Error("error from source"));
+  });
+
+  const result = source.finally(() => {
+    results.push("finally handler");
+  });
+
+  result.subscribe({
+    error: (e) => results.push(e.message),
+  });
+
+  assert_array_equals(results, [
+    "source subscribe",
+    "source send error",
+    "source teardown",
+    "finally handler",
+    "error from source",
+  ]);
+}, "finally(): Callback handler fires BEFORE the source observable errors");
+
+test(() => {
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.complete();
+  });
+
+  const result = source
+    .finally(() => {
+      results.push("finally handler 1");
+    })
+    .finally(() => {
+      results.push("finally handler 2");
+    });
+
+  result.subscribe({ complete: () => results.push("result complete") });
+
+  assert_array_equals(results,
+    ["finally handler 1", "finally handler 2", "result complete"]);
+}, "finally(): Handlers run in composition order");
+
+test(() => {
+  const source = new Observable(subscriber => {
+    subscriber.error("producer error");
+  });
+
+  const results = [];
+
+  self.addEventListener('error', e => results.push(e.error.message), {once: true});
+
+  source
+    .finally(() => {
+      throw new Error("error from finally");
+    })
+    .subscribe({
+      next: () => results.push("next"),
+      error: (e) => results.push(e),
+      complete: () => results.push("complete"),
+    });
+
+  assert_array_equals(results, ["error from finally", "producer error"]);
+}, "finally(): Errors thrown in the finally handler " +
+   "(during Subscriber#error()) are reported to the global immediately");
+
+test(() => {
+  const source = new Observable((subscriber) => {
+    subscriber.complete();
+  });
+
+  const results = [];
+
+  self.addEventListener('error', e => results.push(e.error.message), {once: true});
+
+  source
+    .finally(() => {
+      throw new Error("error from finally");
+    })
+    .subscribe({
+      next: () => results.push("next"),
+      error: (e) => results.push("unreached"),
+      complete: () => results.push("complete"),
+    });
+
+  assert_array_equals(results, ["error from finally", "complete"]);
+}, "finally(): Errors thrown in the finally handler " +
+   "(during Subscriber#complete()) are reported to the global immediately");
+
+test(() => {
+  const results = [];
+
+  const source = new Observable((subscriber) => {
+    subscriber.addTeardown(() => results.push("source teardown"));
+  });
+
+  const controller = new AbortController();
+
+  source
+    .finally(() => results.push("downstream finally handler"))
+    .subscribe({}, { signal: controller.signal });
+
+  controller.abort();
+
+  assert_array_equals(results, ["source teardown", "downstream finally handler"]);
+}, "finally(): Callback is run if consumer aborts the subscription");
+
+test(() => {
+  const results = [];
+  const result = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap((value) => {
+    results.push(`flatMap ${value}`);
+    return new Observable((subscriber) => {
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.complete();
+    }).finally(() => {
+      results.push(`finally ${value}`);
+    });
+  });
+
+  result.subscribe({
+    next: (value) => results.push(`result ${value}`),
+    complete: () => results.push("result complete"),
+  });
+
+  assert_array_equals(results, [
+    "flatMap 1",
+    "result 1",
+    "result 1",
+    "result 1",
+    "finally 1",
+    "flatMap 2",
+    "result 2",
+    "result 2",
+    "result 2",
+    "finally 2",
+    "result complete",
+  ]);
+}, "finally(): Callback is run before next inner subscription in flatMap()");
+
+test(() => {
+  const results = [];
+  const result = new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap((value) => {
+    results.push(`switchMap ${value}`);
+    return new Observable((subscriber) => {
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.complete();
+    }).finally(() => {
+      results.push(`finally ${value}`);
+    });
+  });
+
+  result.subscribe({
+    next: (value) => results.push(`result ${value}`),
+    complete: () => results.push("result complete"),
+  });
+
+  assert_array_equals(results, [
+    "switchMap 1",
+    "result 1",
+    "result 1",
+    "result 1",
+    "finally 1",
+    "switchMap 2",
+    "result 2",
+    "result 2",
+    "result 2",
+    "finally 2",
+    "result complete",
+  ]);
+}, "finally(): Callback is run before next inner subscription in switchMap()");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.worker-expected.txt
@@ -1,0 +1,88 @@
+
+FAIL finally(): Mirrors all values and completions from source source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      results.push("finally called");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Mirrors all values and errors from the source source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      results.push("finally called");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Callback handler fires BEFORE the source observable completes source.finally is not a function. (In 'source.finally(() => {
+    results.push("finally handler");
+  })', 'source.finally' is undefined)
+FAIL finally(): Callback handler fires BEFORE the source observable errors source.finally is not a function. (In 'source.finally(() => {
+    results.push("finally handler");
+  })', 'source.finally' is undefined)
+FAIL finally(): Handlers run in composition order source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      results.push("finally handler 1");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Errors thrown in the finally handler (during Subscriber#error()) are reported to the global immediately source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      throw new Error("error from finally");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Errors thrown in the finally handler (during Subscriber#complete()) are reported to the global immediately source
+    .finally is not a function. (In 'source
+    .finally(() => {
+      throw new Error("error from finally");
+    })', 'source
+    .finally' is undefined)
+FAIL finally(): Callback is run if consumer aborts the subscription source
+    .finally is not a function. (In 'source
+    .finally(() => results.push("downstream finally handler"))', 'source
+    .finally' is undefined)
+FAIL finally(): Callback is run before next inner subscription in flatMap() new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap is not a function. (In 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap((value) => {
+    results.push(`flatMap ${value}`);
+    return new Observable((subscriber) => {
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.complete();
+    }).finally(() => {
+      results.push(`finally ${value}`);
+    });
+  })', 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).flatMap' is undefined)
+FAIL finally(): Callback is run before next inner subscription in switchMap() new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap is not a function. (In 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap((value) => {
+    results.push(`switchMap ${value}`);
+    return new Observable((subscriber) => {
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.next(value);
+      subscriber.complete();
+    }).finally(() => {
+      results.push(`finally ${value}`);
+    });
+  })', 'new Observable((subscriber) => {
+    subscriber.next(1);
+    subscriber.next(2);
+    subscriber.complete();
+  }).switchMap' is undefined)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.worker-expected.txt
@@ -5,7 +5,9 @@ FAIL from(): Given an observable, it returns that exact observable target.when i
 FAIL from(): Given an array Observable.from is not a function. (In 'Observable.from(array)', 'Observable.from' is undefined)
 FAIL from(): Iterable converts to Observable Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): [Symbol.iterator] side-effects (one observable) Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
-FAIL from(): [Symbol.iterator] not callable assert_equals: expected "Failed to execute 'from' on 'Observable': @@iterator must be a callable." but got "Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)"
+PASS from(): [Symbol.iterator] not callable
+FAIL from(): [Symbol.iterator] not callable AFTER SUBSCRIBE throws Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
+FAIL from(): [Symbol.iterator] returns null AFTER SUBSCRIBE throws Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): [Symbol.iterator] is not cached Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): [Symbol.iterator] side-effects (many observables) Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): [Symbol.iterator] next() throws error Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
@@ -16,11 +18,10 @@ FAIL from(): Observable that implements @@iterator protocol gets converted as an
 FAIL from(): Promise that implements @@iterator protocol gets converted as an iterable, not Promise Observable.from is not a function. (In 'Observable.from(promise)', 'Observable.from' is undefined)
 FAIL from(): Promise whose [Symbol.iterator] returns null converts as Promise promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(promise)', 'Observable.from' is undefined)"
 FAIL from(): Rethrows the error when Converting an object whose @@iterator method *getter* throws an error assert_equals: expected object "Error: thrown from @@iterator getter" but got object "TypeError: Observable.from is not a function. (In 'Observable.from(obj)', 'Observable.from' is undefined)"
-FAIL from(): Throws 'callable' error when @@iterator property is a non-callable primitive assert_equals: expected "Failed to execute 'from' on 'Observable': @@iterator must be a callable." but got "Observable.from is not a function. (In 'Observable.from(obj)', 'Observable.from' is undefined)"
 FAIL from(): Async iterable protocol null, converts as iterator Observable.from is not a function. (In 'Observable.from(sync_iterable)', 'Observable.from' is undefined)
 FAIL from(): Asynchronous iterable conversion promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(async_iterable)', 'Observable.from' is undefined)"
-FAIL from(): Asynchronous iterable multiple in-flight subscriptions competing promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(async_iterable)', 'Observable.from' is undefined)"
-FAIL from(): Sync iterable multiple in-flight subscriptions competing Observable.from is not a function. (In 'Observable.from(array)', 'Observable.from' is undefined)
+FAIL from(): Asynchronous iterable multiple in-flight subscriptions promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(async_iterable)', 'Observable.from' is undefined)"
+FAIL from(): Sync iterable multiple in-flight subscriptions Observable.from is not a function. (In 'Observable.from(array)', 'Observable.from' is undefined)
 FAIL from(): Asynchronous generator conversion: can only be used once promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(async_generator())', 'Observable.from' is undefined)"
 FAIL from(): Promise-wrapping semantics of IteratorResult interface promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(async_iterable)', 'Observable.from' is undefined)"
 FAIL from(): Errors thrown in Symbol.asyncIterator() are propagated synchronously Observable.from is not a function. (In 'Observable.from(async_iterable)', 'Observable.from' is undefined)
@@ -41,7 +42,8 @@ FAIL from(): Sync iterable: error thrown from IteratorRecord#return() can be syn
 FAIL from(): Async iterable: error thrown from IteratorRecord#return() is wrapped in rejected Promise promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)"
 FAIL from(): Subscribing to an iterable Observable with an aborted signal does not call next() Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): When iterable conversion aborts the subscription, next() is never called Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
-FAIL from(): When async iterable conversion aborts the subscription, next() is never called Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 FAIL from(): Aborting an async iterable subscription stops subsequent next() calls, but old next() Promise reactions are web-observable promise_test: Unhandled rejection with value: object "TypeError: Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)"
 FAIL from(): Abort after complete does NOT call IteratorRecord#return() Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
+FAIL Invalid async iterator protocol error is surfaced before Subscriber#signal is consulted Observable.from is not a function. (In 'Observable.from(asyncIterable)', 'Observable.from' is undefined)
+FAIL Invalid iterator protocol error is surfaced before Subscriber#signal is consulted Observable.from is not a function. (In 'Observable.from(iterable)', 'Observable.from' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt
@@ -12,5 +12,5 @@ PASS inspect(): Throwing an error in the next handler function in do should be c
 PASS inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback
 PASS inspect(): Provides a way to tap into the moment a source observable is unsubscribed from
 PASS inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from
-FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when('error')', 'self.when' is undefined)
+FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when("error")', 'self.when' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt
@@ -11,5 +11,5 @@ PASS inspect(): Throwing an error in the next handler function in do should be c
 PASS inspect(): Errors thrown in subscribe() Inspector handler subscribe handler are caught and sent to error callback
 PASS inspect(): Provides a way to tap into the moment a source observable is unsubscribed from
 PASS inspect(): Inspector abort() handler is not called if the source completes before the result is unsubscribed from
-FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when('error')', 'self.when' is undefined)
+FAIL inspect(): Errors thrown from inspect()'s abort() handler are caught and reported to the global, because the subscription is already closed by the time the handler runs self.when is not a function. (In 'self.when("error")', 'self.when' is undefined)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-takeUntil.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-takeUntil.any.js
@@ -347,7 +347,7 @@ promise_test(async t => {
 
   assert_false(errorCallbackCalled);
   assert_true(errorReported !== null, "Exception was reported to global");
-  assert_equals(errorReported.message, "Uncaught error 2", "Error message matches");
+  assert_true(errorReported.message.includes("error 2"), "Error message matches");
   assert_greater_than(errorReported.lineno, 0, "Error lineno is greater than 0");
   assert_greater_than(errorReported.colno, 0, "Error lineno is greater than 0");
   assert_equals(errorReported.error, 'error 2', "Error object is equivalent (just a string)");

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/w3c-import.log
@@ -23,6 +23,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-event-target.window.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-every.any.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-filter.any.js
+/LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-find.any.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-first.any.js
 /LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-flatMap.any.js


### PR DESCRIPTION
#### 9c154b3a916e7871e594a05024615e1c907f4fb1
<pre>
Re-import dom/observable WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=288246">https://bugs.webkit.org/show_bug.cgi?id=288246</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/12acca9b67ce3bece2f1c19e1ea603d2d1d5a70d">https://github.com/web-platform-tests/wpt/commit/12acca9b67ce3bece2f1c19e1ea603d2d1d5a70d</a>

* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/idlharness.html:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-constructor.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-finally.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.js:
(test):
(test.const.iterable.get Symbol):
(promise_test.async t):
(test.get const):
(test.const.asyncIterable.get Symbol):
(promise_test.async t.const.subscribeFunction): Deleted.
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-from.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-inspect.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/observable-takeUntil.any.js:
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/dom/observable/tentative/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/290934@main">https://commits.webkit.org/290934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/196c38e97191687a5b0a87a7d48f877a6e1d4600

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91476 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/531 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42164 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70238 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27757 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8450 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/458 "Found 1 new test failure: fast/dom/view-transition-without-global-object.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41334 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78770 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98448 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13704 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79261 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78709 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78465 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/355 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11770 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14483 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18636 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->