### PR TITLE
Address safer CPP failures in DocumentLoader.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -881,7 +881,6 @@ loader/ApplicationManifestLoader.cpp
 loader/CrossOriginAccessControl.cpp
 loader/CrossOriginOpenerPolicy.cpp
 loader/CrossOriginPreflightChecker.cpp
-loader/DocumentLoader.cpp
 loader/DocumentThreadableLoader.cpp
 loader/DocumentWriter.cpp
 loader/FormSubmission.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -112,7 +112,6 @@ html/track/TrackListBase.cpp
 html/track/VTTCue.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
-loader/DocumentLoader.cpp
 loader/FrameLoader.cpp
 loader/NetscapePlugInStreamLoader.cpp
 loader/ResourceLoader.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -485,7 +485,6 @@ layout/formattingContexts/inline/InlineLineBoxBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
 layout/layouttree/LayoutTreeBuilder.cpp
 loader/ApplicationManifestLoader.cpp
-loader/DocumentLoader.cpp
 loader/FrameLoader.cpp
 loader/NavigationAction.cpp
 loader/NavigationScheduler.cpp

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -298,7 +298,7 @@ public:
     WEBCORE_EXPORT void frameDestroyed() final;
 
     // Return the ArchiveResource for the URL only when loading an Archive
-    WEBCORE_EXPORT ArchiveResource* archiveResourceForURL(const URL&) const;
+    WEBCORE_EXPORT RefPtr<ArchiveResource> archiveResourceForURL(const URL&) const;
 
     WEBCORE_EXPORT RefPtr<ArchiveResource> mainResource() const;
 
@@ -631,7 +631,7 @@ private:
     bool disallowWebArchive() const;
     bool disallowDataRequest() const;
 
-    Ref<CachedResourceLoader> m_cachedResourceLoader;
+    const Ref<CachedResourceLoader> m_cachedResourceLoader;
 
     CachedResourceHandle<CachedRawResource> m_mainResource;
     ResourceLoaderMap m_subresourceLoaders;

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "ImageLoader.h"
 
+#include "ArchiveResource.h"
 #include "BitmapImage.h"
 #include "CachedImage.h"
 #include "CachedResourceLoader.h"

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -74,11 +74,6 @@ public:
     void clearRequestCountTracker() { m_requestCountTracker = std::nullopt; }
     void resetRequestCountTracker(CachedResourceLoader& loader, const CachedResource& resource) { m_requestCountTracker = RequestCountTracker { loader, resource }; }
 
-private:
-    SubresourceLoader(LocalFrame&, CachedResource&, const ResourceLoaderOptions&);
-
-    void init(ResourceRequest&&, CompletionHandler<void(bool)>&&) final;
-
     void willSendRequestInternal(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&&) final;
     void didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent) final;
     void didReceiveResponse(const ResourceResponse&, CompletionHandler<void()>&& policyCompletionHandler) final;
@@ -87,6 +82,11 @@ private:
     void didFail(const ResourceError&) final;
     void willCancel(const ResourceError&) final;
     void didCancel(LoadWillContinueInAnotherProcess) final;
+
+private:
+    SubresourceLoader(LocalFrame&, CachedResource&, const ResourceLoaderOptions&);
+
+    void init(ResourceRequest&&, CompletionHandler<void(bool)>&&) final;
     
     void updateReferrerPolicy(const String&);
 

--- a/Source/WebCore/loader/SubstituteData.h
+++ b/Source/WebCore/loader/SubstituteData.h
@@ -50,7 +50,8 @@ public:
     bool isValid() const { return m_content != nullptr; }
     SessionHistoryVisibility shouldRevealToSessionHistory() const { return m_shouldRevealToSessionHistory; }
 
-    const RefPtr<FragmentedSharedBuffer>& content() const { return m_content; }
+    FragmentedSharedBuffer* content() const { return m_content.get(); }
+    RefPtr<FragmentedSharedBuffer> protectedContent() const { return m_content; }
     const String& mimeType() const { return m_response.mimeType(); }
     const String& textEncoding() const { return m_response.textEncodingName(); }
     const URL& failingURL() const { return m_failingURL; }

--- a/Source/WebCore/loader/SubstituteResource.h
+++ b/Source/WebCore/loader/SubstituteResource.h
@@ -38,6 +38,7 @@ public:
     const URL& url() const { return m_url; }
     const ResourceResponse& response() const { return m_response; }
     FragmentedSharedBuffer& data() const { return *m_data.get(); }
+    Ref<FragmentedSharedBuffer> protectedData() const { return data(); }
     void append(const SharedBuffer& buffer) { m_data.append(buffer); }
     void clear() { m_data.empty(); }
 

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -139,13 +139,6 @@ Frame::~Frame()
 #endif
 }
 
-std::optional<PageIdentifier> Frame::pageID() const
-{
-    if (auto* page = this->page())
-        return page->identifier();
-    return std::nullopt;
-}
-
 void Frame::resetWindowProxy()
 {
     m_windowProxy = WindowProxy::create(*this);

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -73,7 +73,7 @@ public:
     FrameIdentifier frameID() const { return m_frameID; }
     inline Page* page() const; // Defined in Page.h.
     inline RefPtr<Page> protectedPage() const; // Defined in Page.h.
-    WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
+    inline std::optional<PageIdentifier> pageID() const; // Defined in Page.h.
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() { return *m_mainFrame; }
     const Frame& mainFrame() const { return *m_mainFrame; }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1766,6 +1766,13 @@ inline Page* Frame::page() const
     return m_page.get();
 }
 
+inline std::optional<PageIdentifier> Frame::pageID() const
+{
+    if (auto* page = this->page())
+        return page->identifier();
+    return std::nullopt;
+}
+
 inline RefPtr<Page> Frame::protectedPage() const
 {
     return m_page.get();

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.cpp
@@ -54,4 +54,9 @@ void ServiceWorkerProvider::setSharedProvider(ServiceWorkerProvider& newProvider
     sharedProvider = &newProvider;
 }
 
+Ref<SWClientConnection> ServiceWorkerProvider::protectedServiceWorkerConnection()
+{
+    return serviceWorkerConnection();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/service/ServiceWorkerProvider.h
+++ b/Source/WebCore/workers/service/ServiceWorkerProvider.h
@@ -41,6 +41,7 @@ public:
     static void setSharedProvider(ServiceWorkerProvider&);
 
     virtual SWClientConnection& serviceWorkerConnection() = 0;
+    Ref<SWClientConnection> protectedServiceWorkerConnection();
     virtual SWClientConnection* existingServiceWorkerConnection() = 0;
     virtual void terminateWorkerForTesting(ServiceWorkerIdentifier, CompletionHandler<void()>&&) = 0;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5341,7 +5341,7 @@ struct WebCore::PolicyContainer {
 [Nested] enum class WebCore::SubstituteData::SessionHistoryVisibility : bool
 
 class WebCore::SubstituteData {
-    RefPtr<WebCore::FragmentedSharedBuffer> content();
+    RefPtr<WebCore::FragmentedSharedBuffer> protectedContent();
     URL failingURL();
     WebCore::ResourceResponse response();
     WebCore::SubstituteData::SessionHistoryVisibility shouldRevealToSessionHistory();

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -25,6 +25,7 @@
 #include "WebResourceLoadScheduler.h"
 
 #include "PingHandle.h"
+#include <WebCore/ArchiveResource.h>
 #include <WebCore/CachedResource.h>
 #include <WebCore/Document.h>
 #include <WebCore/DocumentLoader.h>


### PR DESCRIPTION
#### d67d36afa34ac87781e935cafd75a758aa2309b4
<pre>
Address safer CPP failures in DocumentLoader.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288244">https://bugs.webkit.org/show_bug.cgi?id=288244</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::mainResourceData const):
(WebCore::DocumentLoader::stopLoading):
(WebCore::DocumentLoader::notifyFinished):
(WebCore::DocumentLoader::finishedLoading):
(WebCore::DocumentLoader::handleSubstituteDataLoadNow):
(WebCore::DocumentLoader::matchRegistration):
(WebCore::DocumentLoader::redirectReceived):
(WebCore::DocumentLoader::willSendRequest):
(WebCore::DocumentLoader::doCrossOriginOpenerHandlingOfResponse):
(WebCore::DocumentLoader::tryLoadingSubstituteData):
(WebCore::DocumentLoader::tryLoadingRedirectRequestFromApplicationCache):
(WebCore::DocumentLoader::stopLoadingAfterXFrameOptionsOrContentSecurityPolicyDenied):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::continueAfterContentPolicy):
(WebCore::DocumentLoader::commitLoad):
(WebCore::DocumentLoader::commitData):
(WebCore::DocumentLoader::setupForReplace):
(WebCore::DocumentLoader::checkLoadComplete):
(WebCore::DocumentLoader::detachFromFrame):
(WebCore::DocumentLoader::loadApplicationManifest):
(WebCore::DocumentLoader::isLoadingInAPISense const):
(WebCore::DocumentLoader::maybeCreateArchive):
(WebCore::DocumentLoader::setArchive):
(WebCore::DocumentLoader::archiveResourceForURL const):
(WebCore::DocumentLoader::subresource const):
(WebCore::DocumentLoader::scheduleArchiveLoad):
(WebCore::DocumentLoader::documentURL const):
(WebCore::DocumentLoader::setDefersLoading):
(WebCore::DocumentLoader::isMultipartReplacingLoad const):
(WebCore::DocumentLoader::startLoadingMainResource):
(WebCore::DocumentLoader::unregisterReservedServiceWorkerClient):
(WebCore::DocumentLoader::loadMainResource):
(WebCore::DocumentLoader::cancelMainResourceLoad):
(WebCore::DocumentLoader::startIconLoading):
(WebCore::DocumentLoader::shouldOpenExternalURLsPolicyToPropagate const):
(WebCore::DocumentLoader::addConsoleMessage):
(WebCore::DocumentLoader::enqueueSecurityPolicyViolationEvent):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/SubresourceLoader.h:
* Source/WebCore/loader/SubstituteData.h:
(WebCore::SubstituteData::content const):
(WebCore::SubstituteData::protectedContent const):
* Source/WebCore/loader/SubstituteResource.h:
(WebCore::SubstituteResource::protectedData const):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::pageID const): Deleted.
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/Page.h:
(WebCore::Frame::pageID const):
* Source/WebCore/workers/service/ServiceWorkerProvider.cpp:
(WebCore::ServiceWorkerProvider::protectedServiceWorkerConnection):
* Source/WebCore/workers/service/ServiceWorkerProvider.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/290882@main">https://commits.webkit.org/290882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c72356cfa7e8e71ca96498e8bcff087a63ff73d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70142 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27670 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94352 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8578 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50469 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/321 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78668 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/328 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98322 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18516 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79164 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78369 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11673 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14454 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23803 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18229 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->