### PR TITLE
Fix and enable multiple web extension tests that now pass.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -586,8 +586,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, DynamicRules)
     Util::run(&receivedActionNotification);
 }
 
-// FIXME: rdar://116459903 (Web Process is crashing when using declarativeNetRequest to redirect a page)
-TEST(WKWebExtensionAPIDeclarativeNetRequest, DISABLED_RedirectRule)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm
@@ -85,7 +85,7 @@ TEST(WKWebExtensionAPIDevTools, Basics)
     [manager run];
 }
 
-// FIX-ME: rdar://137268889
+// FIXME: rdar://137268889 (4x TestWebKitAPI.WKWebExtensionAPIDevTools* (api-tests) are near constant timeouts)
 TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
 {
     TestWebKitAPI::HTTPServer server({
@@ -155,7 +155,7 @@ TEST(WKWebExtensionAPIDevTools, DISABLED_CreatePanel)
     [manager runUntilTestMessage:@"Panel Hidden"];
 }
 
-// FIX-ME: rdar://137268889
+// FIXME: rdar://137268889 (4x TestWebKitAPI.WKWebExtensionAPIDevTools* (api-tests) are near constant timeouts)
 TEST(WKWebExtensionAPIDevTools, DISABLED_InspectedWindowEval)
 {
     TestWebKitAPI::HTTPServer server({
@@ -238,7 +238,7 @@ TEST(WKWebExtensionAPIDevTools, InspectedWindowReload)
     EXPECT_TRUE(server.totalRequests() == 1lu || server.totalRequests() == 2lu);
 }
 
-// FIX-ME: rdar://137268889
+// FIXME: rdar://137268889 (4x TestWebKitAPI.WKWebExtensionAPIDevTools* (api-tests) are near constant timeouts)
 TEST(WKWebExtensionAPIDevTools, DISABLED_InspectedWindowReloadIgnoringCache)
 {
     TestWebKitAPI::HTTPServer server({
@@ -487,7 +487,8 @@ TEST(WKWebExtensionAPIDevTools, MessagePassingFromPanelToDevToolsBackground)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIDevTools, PortMessagePassingToBackground)
+// FIXME: rdar://137268889 (4x TestWebKitAPI.WKWebExtensionAPIDevTools* (api-tests) are near constant timeouts)
+TEST(WKWebExtensionAPIDevTools, DISABLED_PortMessagePassingToBackground)
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -1918,8 +1918,7 @@ TEST(WKWebExtensionAPIMenus, MacLinkContextMenuItems)
     [manager run];
 }
 
-// rdar://144626088 ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
-TEST(WKWebExtensionAPIMenus, DISABLED_MacImageContextMenuItems)
+TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
@@ -1935,7 +1934,7 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacImageContextMenuItems)
         @"  browser.test.assertEq(info.menuItemId, 'image-menu-item')",
         @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.mediaType, 'image')",
-        @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.png')",
+        @"  browser.test.assertTrue(info.srcUrl.endsWith('/test.png'))",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
         @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
         @"  browser.test.assertEq(info.frameId, 0)",
@@ -1976,7 +1975,8 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacImageContextMenuItems)
     [manager runUntilTestMessage:@"Menus Created"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<img src='http://example.com/example.png' style='width: 400px; height: 400px'>"_s } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<img src='test.png' style='width: 400px; height: 400px'>"_s } },
+        { "/test.png"_s, [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"400x400-green" withExtension:@"png"]] },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -2003,8 +2003,7 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacImageContextMenuItems)
     [manager run];
 }
 
-// rdar://144626088 ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
-TEST(WKWebExtensionAPIMenus, DISABLED_MacVideoContextMenuItems)
+TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
@@ -2020,7 +2019,7 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacVideoContextMenuItems)
         @"  browser.test.assertEq(info.menuItemId, 'video-menu-item')",
         @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.mediaType, 'video')",
-        @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.mp4')",
+        @"  browser.test.assertTrue(info.srcUrl.endsWith('/test.mp4'))",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
         @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
         @"  browser.test.assertEq(info.frameId, 0)",
@@ -2061,7 +2060,8 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacVideoContextMenuItems)
     [manager runUntilTestMessage:@"Menus Created"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<video src='http://example.com/example.mp4' style='width: 400px; height: 400px' controls></video>"_s } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<video src='test.mp4' style='width: 400px; height: 400px' controls></video>"_s } },
+        { "/test.mp4"_s, [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"mp4"]] },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *urlRequest = server.requestWithLocalhost();
@@ -2088,8 +2088,7 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacVideoContextMenuItems)
     [manager run];
 }
 
-// rdar://144626088 ([ macOS ] 3x TestWebKitAPI.WKWebExtensionAPIMenus.* (api-tests) are flaky timeouts (287490))
-TEST(WKWebExtensionAPIMenus, DISABLED_MacAudioContextMenuItems)
+TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)
 {
     auto *backgroundScript = Util::constructScript(@[
         @"browser.menus.create({",
@@ -2105,7 +2104,7 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacAudioContextMenuItems)
         @"  browser.test.assertEq(info.menuItemId, 'audio-menu-item')",
         @"  browser.test.assertEq(info.parentMenuItemId, undefined)",
         @"  browser.test.assertEq(info.mediaType, 'audio')",
-        @"  browser.test.assertEq(info.srcUrl, 'http://example.com/example.mp3')",
+        @"  browser.test.assertTrue(info.srcUrl.endsWith('/test.m4a'))",
         @"  browser.test.assertEq(typeof info.pageUrl, 'string')",
         @"  browser.test.assertTrue(info.pageUrl.startsWith('http://localhost:'))",
         @"  browser.test.assertEq(info.frameId, 0)",
@@ -2146,7 +2145,8 @@ TEST(WKWebExtensionAPIMenus, DISABLED_MacAudioContextMenuItems)
     [manager runUntilTestMessage:@"Menus Created"];
 
     TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<audio src='http://example.com/example.mp3' style='width: 400px; height: 400px' controls></audio>"_s } },
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<audio src='test.m4a' style='width: 400px; height: 400px' controls></audio>"_s } },
+        { "/test.m4a"_s, [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"silence-long" withExtension:@"m4a"]] },
     }, TestWebKitAPI::HTTPServer::Protocol::Http);
 
     auto *urlRequest = server.requestWithLocalhost();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm
@@ -339,12 +339,7 @@ TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)
     TestWebKitAPI::Util::run(&requestComplete);
 }
 
-// rdar://142487203
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 140000
-TEST(WKWebExtensionAPIPermissions, DISABLED_GrantOnlySomePermissions)
-#else
 TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)
-#endif
 {
     auto *manifest = @{
         @"manifest_version": @3,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
@@ -167,6 +167,7 @@ TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)
     TestWebKitAPI::Util::run(&fetchComplete);
 }
 
+// FIXME: rdar://125926932 (Enable the WKWebExtensionDataRecord.RemoveDataRecords test (272236))
 TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
 {
     auto *backgroundScript = Util::constructScript(@[
@@ -211,6 +212,7 @@ TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecords)
     TestWebKitAPI::Util::run(&removalComplete);
 }
 
+// FIXME: rdar://125926932 (Enable the WKWebExtensionDataRecord.RemoveDataRecords test (272236))
 TEST(WKWebExtensionDataRecord, DISABLED_RemoveDataRecordsForMultipleContexts)
 {
     auto *backgroundScriptOne = Util::constructScript(@[


### PR DESCRIPTION
#### f85f48a446aaf33d07c1173e53b336d761b01785
<pre>
Fix and enable multiple web extension tests that now pass.
<a href="https://webkit.org/b/287490">https://webkit.org/b/287490</a>, <a href="https://webkit.org/b/279081">https://webkit.org/b/279081</a>, <a href="https://webkit.org/b/285543">https://webkit.org/b/285543</a>
<a href="https://rdar.apple.com/144626088">rdar://144626088</a>, <a href="https://rdar.apple.com/135213974">rdar://135213974</a>, <a href="https://rdar.apple.com/142487203">rdar://142487203</a>

Unreviewed test gardening.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)): Crash was fixed.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIDevTools.mm: Updated FIXME comments.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacImageContextMenuItems)): Use local resource.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacVideoContextMenuItems)): Ditto.
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, MacAudioContextMenuItems)): Ditto.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, GrantOnlySomePermissions)): No longer fails.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithImmediateMessage)):
Stop using setTimeout and use test.sendMessage to trigger the load.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm: Added FIXMEs.

Canonical link: <a href="https://commits.webkit.org/290888@main">https://commits.webkit.org/290888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af8283a37cdcec1c6a64b69b01725c1982cb07e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/439 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11312 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/19270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94404 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18565 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/19270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/98374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18820 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/78622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14457 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/18563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21734 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->