### PR TITLE
[JSC] DirectArguments::visitChildrenImpl calls JSObject::visitChildrenImpl twice

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1019,7 +1019,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/FunctionRareData.h
     runtime/FuzzerAgent.h
     runtime/Gate.h
-    runtime/GenericArguments.h
+    runtime/GenericArgumentsImpl.h
     runtime/GenericOffset.h
     runtime/GenericTypedArrayView.h
     runtime/GenericTypedArrayViewInlines.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -550,8 +550,8 @@
 		0FE050141AA9091100D33B33 /* ArgumentsMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0500C1AA9091100D33B33 /* ArgumentsMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FE050161AA9091100D33B33 /* DirectArgumentsOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0500E1AA9091100D33B33 /* DirectArgumentsOffset.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FE050181AA9091100D33B33 /* DirectArguments.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE050101AA9091100D33B33 /* DirectArguments.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0FE050191AA9091100D33B33 /* GenericArguments.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE050111AA9091100D33B33 /* GenericArguments.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		0FE0501A1AA9091100D33B33 /* GenericArgumentsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE050121AA9091100D33B33 /* GenericArgumentsInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0FE050191AA9091100D33B33 /* GenericArgumentsImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE050111AA9091100D33B33 /* GenericArgumentsImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		0FE0501A1AA9091100D33B33 /* GenericArgumentsImplInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE050121AA9091100D33B33 /* GenericArgumentsImplInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FE0501B1AA9091100D33B33 /* GenericOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE050131AA9091100D33B33 /* GenericOffset.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FE050261AA9095600D33B33 /* ClonedArguments.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0501D1AA9095600D33B33 /* ClonedArguments.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		0FE050281AA9095600D33B33 /* ScopedArguments.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE0501F1AA9095600D33B33 /* ScopedArguments.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -3387,8 +3387,8 @@
 		0FE0500E1AA9091100D33B33 /* DirectArgumentsOffset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectArgumentsOffset.h; sourceTree = "<group>"; };
 		0FE0500F1AA9091100D33B33 /* DirectArguments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DirectArguments.cpp; sourceTree = "<group>"; };
 		0FE050101AA9091100D33B33 /* DirectArguments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DirectArguments.h; sourceTree = "<group>"; };
-		0FE050111AA9091100D33B33 /* GenericArguments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenericArguments.h; sourceTree = "<group>"; };
-		0FE050121AA9091100D33B33 /* GenericArgumentsInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenericArgumentsInlines.h; sourceTree = "<group>"; };
+		0FE050111AA9091100D33B33 /* GenericArgumentsImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenericArgumentsImpl.h; sourceTree = "<group>"; };
+		0FE050121AA9091100D33B33 /* GenericArgumentsImplInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenericArgumentsImplInlines.h; sourceTree = "<group>"; };
 		0FE050131AA9091100D33B33 /* GenericOffset.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenericOffset.h; sourceTree = "<group>"; };
 		0FE0501C1AA9095600D33B33 /* ClonedArguments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClonedArguments.cpp; sourceTree = "<group>"; };
 		0FE0501D1AA9095600D33B33 /* ClonedArguments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ClonedArguments.h; sourceTree = "<group>"; };
@@ -8278,8 +8278,8 @@
 				70B791891C024432002481E2 /* GeneratorPrototype.cpp */,
 				70B7918A1C024432002481E2 /* GeneratorPrototype.h */,
 				276B385D2A71D0B600252F4E /* GeneratorPrototypeInlines.h */,
-				0FE050111AA9091100D33B33 /* GenericArguments.h */,
-				0FE050121AA9091100D33B33 /* GenericArgumentsInlines.h */,
+				0FE050111AA9091100D33B33 /* GenericArgumentsImpl.h */,
+				0FE050121AA9091100D33B33 /* GenericArgumentsImplInlines.h */,
 				0FE050131AA9091100D33B33 /* GenericOffset.h */,
 				0F2B66B217B6B5AB00A7AE3F /* GenericTypedArrayView.h */,
 				0F2B66B317B6B5AB00A7AE3F /* GenericTypedArrayViewInlines.h */,
@@ -11108,8 +11108,8 @@
 				276B386B2A71D0B600252F4E /* GeneratorFunctionPrototypeInlines.h in Headers */,
 				70B791991C024A29002481E2 /* GeneratorPrototype.h in Headers */,
 				276B386C2A71D0B600252F4E /* GeneratorPrototypeInlines.h in Headers */,
-				0FE050191AA9091100D33B33 /* GenericArguments.h in Headers */,
-				0FE0501A1AA9091100D33B33 /* GenericArgumentsInlines.h in Headers */,
+				0FE050191AA9091100D33B33 /* GenericArgumentsImpl.h in Headers */,
+				0FE0501A1AA9091100D33B33 /* GenericArgumentsImplInlines.h in Headers */,
 				0FE0501B1AA9091100D33B33 /* GenericOffset.h in Headers */,
 				0F2B66E017B6B5AB00A7AE3F /* GenericTypedArrayView.h in Headers */,
 				0F2B66E117B6B5AB00A7AE3F /* GenericTypedArrayViewInlines.h in Headers */,

--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -69,7 +69,7 @@ runtime/Exception.cpp
 runtime/ExecutableBase.cpp
 runtime/FunctionExecutable.cpp
 runtime/FunctionRareData.cpp
-runtime/GenericArgumentsInlines.h
+runtime/GenericArgumentsImplInlines.h
 runtime/Identifier.cpp
 runtime/Identifier.h
 runtime/IdentifierInlines.h

--- a/Source/JavaScriptCore/runtime/DirectArguments.cpp
+++ b/Source/JavaScriptCore/runtime/DirectArguments.cpp
@@ -27,7 +27,7 @@
 #include "DirectArguments.h"
 
 #include "CodeBlock.h"
-#include "GenericArgumentsInlines.h"
+#include "GenericArgumentsImplInlines.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -38,7 +38,7 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(DirectArguments);
 const ClassInfo DirectArguments::s_info = { "Arguments"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(DirectArguments) };
 
 DirectArguments::DirectArguments(VM& vm, Structure* structure, unsigned length, unsigned capacity)
-    : GenericArguments(vm, structure)
+    : GenericArgumentsImpl(vm, structure)
     , m_length(length)
     , m_minCapacity(capacity)
 {
@@ -97,14 +97,13 @@ void DirectArguments::visitChildrenImpl(JSCell* thisCell, Visitor& visitor)
 {
     DirectArguments* thisObject = static_cast<DirectArguments*>(thisCell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    Base::visitChildren(thisObject, visitor);
+    GenericArgumentsImpl::visitChildren(thisCell, visitor); // Including Base::visitChildren.
 
     visitor.appendValues(thisObject->storage(), std::max(thisObject->m_length, thisObject->m_minCapacity));
     visitor.append(thisObject->m_callee);
 
     if (thisObject->m_mappedArguments)
         visitor.markAuxiliary(thisObject->m_mappedArguments.get());
-    GenericArguments<DirectArguments>::visitChildren(thisCell, visitor);
 }
 
 DEFINE_VISIT_CHILDREN(DirectArguments);
@@ -165,7 +164,7 @@ void DirectArguments::copyToArguments(JSGlobalObject* globalObject, JSValue* fir
         return;
     }
 
-    GenericArguments::copyToArguments(globalObject, firstElementDest, offset, length);
+    GenericArgumentsImpl::copyToArguments(globalObject, firstElementDest, offset, length);
 }
 
 unsigned DirectArguments::mappedArgumentsSize()

--- a/Source/JavaScriptCore/runtime/DirectArguments.h
+++ b/Source/JavaScriptCore/runtime/DirectArguments.h
@@ -27,7 +27,7 @@
 
 #include "CagedBarrierPtr.h"
 #include "DirectArgumentsOffset.h"
-#include "GenericArguments.h"
+#include "GenericArgumentsImpl.h"
 #include <wtf/CagedPtr.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -43,7 +43,7 @@ namespace JSC {
 //
 // To speed allocation, this object will hold all of the arguments in-place. The arguments as well
 // as a table of flags saying which arguments were overridden.
-class DirectArguments final : public GenericArguments<DirectArguments> {
+class DirectArguments final : public GenericArgumentsImpl<DirectArguments> {
 private:
     DirectArguments(VM&, Structure*, unsigned length, unsigned capacity);
     
@@ -125,7 +125,7 @@ public:
         return storage()[offset.offset()];
     }
     
-    // Methods intended for use by the GenericArguments mixin.
+    // Methods intended for use by the GenericArgumentsImpl mixin.
     bool overrodeThings() const { return !!m_mappedArguments; }
     void overrideThings(JSGlobalObject*);
     void overrideThingsIfNecessary(JSGlobalObject*);
@@ -133,17 +133,17 @@ public:
 
     void initModifiedArgumentsDescriptorIfNecessary(JSGlobalObject* globalObject)
     {
-        GenericArguments<DirectArguments>::initModifiedArgumentsDescriptorIfNecessary(globalObject, m_length);
+        GenericArgumentsImpl<DirectArguments>::initModifiedArgumentsDescriptorIfNecessary(globalObject, m_length);
     }
 
     void setModifiedArgumentDescriptor(JSGlobalObject* globalObject, unsigned index)
     {
-        GenericArguments<DirectArguments>::setModifiedArgumentDescriptor(globalObject, index, m_length);
+        GenericArgumentsImpl<DirectArguments>::setModifiedArgumentDescriptor(globalObject, index, m_length);
     }
 
     bool isModifiedArgumentDescriptor(unsigned index)
     {
-        return GenericArguments<DirectArguments>::isModifiedArgumentDescriptor(index, m_length);
+        return GenericArgumentsImpl<DirectArguments>::isModifiedArgumentDescriptor(index, m_length);
     }
 
     void copyToArguments(JSGlobalObject*, JSValue* firstElementDest, unsigned offset, unsigned length);

--- a/Source/JavaScriptCore/runtime/GenericArgumentsImpl.h
+++ b/Source/JavaScriptCore/runtime/GenericArgumentsImpl.h
@@ -33,13 +33,13 @@ namespace JSC {
 // This is a mixin for the two kinds of Arguments-class objects that arise when you say
 // "arguments" inside a function. This class doesn't show up in the JSCell inheritance hierarchy.
 template<typename Type>
-class GenericArguments : public JSNonFinalObject {
+class GenericArgumentsImpl : public JSNonFinalObject {
 public:
-    typedef JSNonFinalObject Base;
+    using Base = JSNonFinalObject;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | OverridesGetOwnPropertyNames | OverridesPut | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero;
 
 protected:
-    GenericArguments(VM& vm, Structure* structure)
+    GenericArgumentsImpl(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
     }
@@ -53,7 +53,7 @@ protected:
     static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
     static bool deletePropertyByIndex(JSCell*, JSGlobalObject*, unsigned propertyName);
     static bool defineOwnProperty(JSObject*, JSGlobalObject*, PropertyName, const PropertyDescriptor&, bool shouldThrow);
-    
+
     void initModifiedArgumentsDescriptor(JSGlobalObject*, unsigned length);
     void initModifiedArgumentsDescriptorIfNecessary(JSGlobalObject*, unsigned length);
     void setModifiedArgumentDescriptor(JSGlobalObject*, unsigned index, unsigned length);

--- a/Source/JavaScriptCore/runtime/ScopedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "ScopedArguments.h"
 
-#include "GenericArgumentsInlines.h"
+#include "GenericArgumentsImplInlines.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -37,7 +37,7 @@ STATIC_ASSERT_IS_TRIVIALLY_DESTRUCTIBLE(ScopedArguments);
 const ClassInfo ScopedArguments::s_info = { "Arguments"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(ScopedArguments) };
 
 ScopedArguments::ScopedArguments(VM& vm, Structure* structure, WriteBarrier<Unknown>* storage, unsigned totalLength, JSFunction* callee, ScopedArgumentsTable* table, JSLexicalEnvironment* scope)
-    : GenericArguments(vm, structure)
+    : GenericArgumentsImpl(vm, structure)
     , m_totalLength(totalLength)
     , m_callee(callee, WriteBarrierEarlyInit)
     , m_table(table, WriteBarrierEarlyInit)
@@ -99,7 +99,7 @@ void ScopedArguments::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     ScopedArguments* thisObject = static_cast<ScopedArguments*>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
-    Base::visitChildren(thisObject, visitor);
+    GenericArgumentsImpl::visitChildren(thisObject, visitor); // Including Base::visitChildren.
 
     visitor.append(thisObject->m_callee);
     visitor.append(thisObject->m_table);
@@ -159,7 +159,7 @@ void ScopedArguments::unmapArgument(JSGlobalObject* globalObject, uint32_t i)
 
 void ScopedArguments::copyToArguments(JSGlobalObject* globalObject, JSValue* firstElementDest, unsigned offset, unsigned length)
 {
-    GenericArguments::copyToArguments(globalObject, firstElementDest, offset, length);
+    GenericArgumentsImpl::copyToArguments(globalObject, firstElementDest, offset, length);
 }
 
 bool ScopedArguments::isIteratorProtocolFastAndNonObservable()

--- a/Source/JavaScriptCore/runtime/ScopedArguments.h
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "GenericArguments.h"
+#include "GenericArgumentsImpl.h"
 #include "JSLexicalEnvironment.h"
 #include "Watchpoint.h"
 
@@ -39,10 +39,10 @@ namespace JSC {
 // object will store the overflow arguments, if there are any. This object will use the symbol
 // table's ScopedArgumentsTable and the activation, or its overflow storage, to handle all indexed
 // lookups.
-class ScopedArguments final : public GenericArguments<ScopedArguments> {
+class ScopedArguments final : public GenericArgumentsImpl<ScopedArguments> {
 private:
     ScopedArguments(VM&, Structure*, WriteBarrier<Unknown>* storage, unsigned totalLength, JSFunction* callee, ScopedArgumentsTable*, JSLexicalEnvironment*);
-    using Base = GenericArguments<ScopedArguments>;
+    using Base = GenericArgumentsImpl<ScopedArguments>;
 
 public:
     template<typename CellType, SubspaceAccess>
@@ -139,17 +139,17 @@ public:
     
     void initModifiedArgumentsDescriptorIfNecessary(JSGlobalObject* globalObject)
     {
-        GenericArguments<ScopedArguments>::initModifiedArgumentsDescriptorIfNecessary(globalObject, m_table->length());
+        GenericArgumentsImpl<ScopedArguments>::initModifiedArgumentsDescriptorIfNecessary(globalObject, m_table->length());
     }
 
     void setModifiedArgumentDescriptor(JSGlobalObject* globalObject, unsigned index)
     {
-        GenericArguments<ScopedArguments>::setModifiedArgumentDescriptor(globalObject, index, m_table->length());
+        GenericArgumentsImpl<ScopedArguments>::setModifiedArgumentDescriptor(globalObject, index, m_table->length());
     }
 
     bool isModifiedArgumentDescriptor(unsigned index)
     {
-        return GenericArguments<ScopedArguments>::isModifiedArgumentDescriptor(index, m_table->length());
+        return GenericArgumentsImpl<ScopedArguments>::isModifiedArgumentDescriptor(index, m_table->length());
     }
 
     void copyToArguments(JSGlobalObject*, JSValue* firstElementDest, unsigned offset, unsigned length);


### PR DESCRIPTION
#### 9996e4031b794c1c166ff57020304d56e55291f7
<pre>
[JSC] DirectArguments::visitChildrenImpl calls JSObject::visitChildrenImpl twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=287502">https://bugs.webkit.org/show_bug.cgi?id=287502</a>
<a href="https://rdar.apple.com/145080419">rdar://145080419</a>

Reviewed by Yijia Huang.

Avoid calling Base::visitChildren twice. We also rename GenericArguments
to GenericArgumentsImpl to make it clear that this is Impl interface for
JSCells.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/JavaScriptCore/runtime/DirectArguments.cpp:
(JSC::DirectArguments::DirectArguments):
(JSC::DirectArguments::visitChildrenImpl):
(JSC::DirectArguments::copyToArguments):
* Source/JavaScriptCore/runtime/DirectArguments.h:
* Source/JavaScriptCore/runtime/GenericArgumentsImpl.h: Renamed from Source/JavaScriptCore/runtime/GenericArguments.h.
(JSC::GenericArgumentsImpl::GenericArgumentsImpl):
* Source/JavaScriptCore/runtime/GenericArgumentsImplInlines.h: Renamed from Source/JavaScriptCore/runtime/GenericArgumentsInlines.h.
(JSC::GenericArgumentsImpl&lt;Type&gt;::visitChildrenImpl):
(JSC::GenericArgumentsImpl&lt;Type&gt;::getOwnPropertySlot):
(JSC::GenericArgumentsImpl&lt;Type&gt;::getOwnPropertySlotByIndex):
(JSC::GenericArgumentsImpl&lt;Type&gt;::getOwnPropertyNames):
(JSC::GenericArgumentsImpl&lt;Type&gt;::put):
(JSC::GenericArgumentsImpl&lt;Type&gt;::putByIndex):
(JSC::GenericArgumentsImpl&lt;Type&gt;::deleteProperty):
(JSC::GenericArgumentsImpl&lt;Type&gt;::deletePropertyByIndex):
(JSC::GenericArgumentsImpl&lt;Type&gt;::defineOwnProperty):
(JSC::GenericArgumentsImpl&lt;Type&gt;::initModifiedArgumentsDescriptor):
(JSC::GenericArgumentsImpl&lt;Type&gt;::initModifiedArgumentsDescriptorIfNecessary):
(JSC::GenericArgumentsImpl&lt;Type&gt;::setModifiedArgumentDescriptor):
(JSC::GenericArgumentsImpl&lt;Type&gt;::isModifiedArgumentDescriptor):
(JSC::GenericArgumentsImpl&lt;Type&gt;::copyToArguments):
* Source/JavaScriptCore/runtime/ScopedArguments.cpp:
(JSC::ScopedArguments::ScopedArguments):
(JSC::ScopedArguments::visitChildrenImpl):
(JSC::ScopedArguments::copyToArguments):
* Source/JavaScriptCore/runtime/ScopedArguments.h:

Canonical link: <a href="https://commits.webkit.org/290839@main">https://commits.webkit.org/290839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/408af6ee2cab6e48c79b54012f228a785f86d90c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/293 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19114 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94264 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41130 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84073 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98238 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90019 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/18441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78500 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/78326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14419 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/18440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112597 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->