### PR TITLE
[Cocoa] Adopt CASpatialAudioExperience

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5930,6 +5930,22 @@ PreferSandboxedMediaParsing:
     WebKit:
       default: true
 
+PreferSpatialAudioExperience:
+  type: bool
+  status: internal
+  category: media
+  condition: HAVE(SPATIAL_AUDIO_EXPERIENCE)
+  humanReadableName: "Prefer Spatial Audio Experience over Spatial Tracking Labels"
+  humanReadableDescription: "Prefer Spatial Audio Experience over Spatial Tracking Labels"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  defaultsOverridable: true
+
 PrivateClickMeasurementDebugModeEnabled:
   type: bool
   status: developer

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -630,6 +630,21 @@ void AudioContext::pageMutedStateDidChange()
         destination().setMuted(document()->page()->isAudioMuted());
 }
 
+#if PLATFORM(IOS_FAMILY)
+void AudioContext::sceneIdentifierDidChange()
+{
+    if (document() && document()->page())
+        destination().setSceneIdentifier(document()->page()->sceneIdentifier());
+}
+
+const String& AudioContext::sceneIdentifier() const
+{
+    if (document() && document()->page())
+        return document()->page()->sceneIdentifier();
+    return nullString();
+}
+#endif
+
 void AudioContext::mediaCanStart(Document& document)
 {
     ASSERT_UNUSED(document, &document == this->document());

--- a/Source/WebCore/Modules/webaudio/AudioContext.h
+++ b/Source/WebCore/Modules/webaudio/AudioContext.h
@@ -101,6 +101,10 @@ public:
 
     void defaultDestinationWillBecomeConnected();
 
+#if PLATFORM(IOS_FAMILY)
+    const String& sceneIdentifier() const final;
+#endif
+
 private:
     AudioContext(Document&, const AudioContextOptions&);
 
@@ -124,6 +128,9 @@ private:
     // MediaProducer
     MediaProducerMediaStateFlags mediaState() const final;
     void pageMutedStateDidChange() final;
+#if PLATFORM(IOS_FAMILY)
+    void sceneIdentifierDidChange() final;
+#endif
 
     // PlatformMediaSessionClient
     PlatformMediaSession::MediaType mediaType() const final { return isSuspended() || isStopped() ? PlatformMediaSession::MediaType::None : PlatformMediaSession::MediaType::WebAudio; }

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.h
@@ -58,6 +58,10 @@ public:
     void ref() const final;
     void deref() const final;
 
+#if PLATFORM(IOS_FAMILY)
+    virtual void setSceneIdentifier(const String&) { }
+#endif
+
 protected:
     AudioDestinationNode(BaseAudioContext&, float sampleRate);
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -108,6 +108,9 @@ public:
     virtual bool isOfflineContext() const = 0;
     virtual AudioDestinationNode& destination() = 0;
     virtual const AudioDestinationNode& destination() const = 0;
+#if PLATFORM(IOS_FAMILY)
+    virtual const String& sceneIdentifier() const { return nullString(); }
+#endif
 
     size_t currentSampleFrame() const { return destination().currentSampleFrame(); }
     double currentTime() const { return destination().currentTime(); }

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -117,6 +117,11 @@ void DefaultAudioDestinationNode::createDestination()
     ALWAYS_LOG(LOGIDENTIFIER, "contextSampleRate = ", sampleRate(), ", hardwareSampleRate = ", AudioDestination::hardwareSampleRate());
     ASSERT(!m_destination);
     m_destination = platformStrategies()->mediaStrategy().createAudioDestination(*this, m_inputDeviceId, m_numberOfInputChannels, channelCount(), sampleRate());
+
+#if PLATFORM(IOS_FAMILY)
+    if (m_destination)
+        m_destination->setSceneIdentifier(String { context().sceneIdentifier() });
+#endif
 }
 
 void DefaultAudioDestinationNode::recreateDestination()
@@ -290,6 +295,15 @@ void DefaultAudioDestinationNode::updateIsEffectivelyPlayingAudio()
     m_isEffectivelyPlayingAudio = isEffectivelyPlayingAudio;
     context().isPlayingAudioDidChange();
 }
+
+#if PLATFORM(IOS_FAMILY)
+void DefaultAudioDestinationNode::setSceneIdentifier(const String& sceneIdentifier)
+{
+    if (m_destination)
+        m_destination->setSceneIdentifier(sceneIdentifier);
+}
+#endif
+
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h
@@ -58,6 +58,10 @@ public:
     bool isPlayingAudio() const { return m_isEffectivelyPlayingAudio; }
     bool isConnected() const;
 
+#if PLATFORM(IOS_FAMILY)
+    void setSceneIdentifier(const String&) final;
+#endif
+
 private:
     void createDestination();
     void clearDestination();

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		A3C66CDC1F462D6A009E6EE9 /* SessionID.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3C66CDA1F462D6A009E6EE9 /* SessionID.cpp */; };
 		CD6122CD2559B6AC00FC657A /* OutputContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD6122CB2559B6AC00FC657A /* OutputContext.mm */; };
 		CD6122D12559B8F200FC657A /* OutputDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD6122CF2559B8F200FC657A /* OutputDevice.mm */; };
+		CD722A092D6914BB00F2E1E7 /* AudioToolboxCoreSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = CD722A082D6914BB00F2E1E7 /* AudioToolboxCoreSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CDACB3602387425B0018D7CE /* MediaToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CDACB35E23873E480018D7CE /* MediaToolboxSoftLink.cpp */; };
 		D065131629B69F11008C65C4 /* QuartzCoreSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = D065131429B69F11008C65C4 /* QuartzCoreSoftLink.mm */; };
 		D065131729B69F12008C65C4 /* QuartzCoreSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = D065131529B69F11008C65C4 /* QuartzCoreSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -724,6 +725,7 @@
 		CD6122CB2559B6AC00FC657A /* OutputContext.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OutputContext.mm; sourceTree = "<group>"; };
 		CD6122CE2559B8F200FC657A /* OutputDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OutputDevice.h; sourceTree = "<group>"; };
 		CD6122CF2559B8F200FC657A /* OutputDevice.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OutputDevice.mm; sourceTree = "<group>"; };
+		CD722A082D6914BB00F2E1E7 /* AudioToolboxCoreSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AudioToolboxCoreSPI.h; sourceTree = "<group>"; };
 		CDACB35E23873E480018D7CE /* MediaToolboxSoftLink.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MediaToolboxSoftLink.cpp; sourceTree = "<group>"; };
 		CDACB35F23873E480018D7CE /* MediaToolboxSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaToolboxSoftLink.h; sourceTree = "<group>"; };
 		CDF91112220E4EEC001EA39E /* CelestialSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CelestialSPI.h; sourceTree = "<group>"; };
@@ -856,6 +858,7 @@
 				C037494124127CCB00D9A36E /* AccessibilitySupportSPI.h */,
 				576CA9D522B854AB0030143C /* AppSSOSPI.h */,
 				3A02FE2A2B214A38001724B1 /* ARKitSPI.h */,
+				CD722A082D6914BB00F2E1E7 /* AudioToolboxCoreSPI.h */,
 				2D02E93B2056FAA700A13797 /* AudioToolboxSPI.h */,
 				572A107722B456F500F410C8 /* AuthKitSPI.h */,
 				411A9AC02525D4CA00807D7E /* AVAssetWriterSPI.h */,
@@ -1397,6 +1400,7 @@
 				DD20DD1A27BC90D60093D175 /* AppSSOSoftLink.h in Headers */,
 				DD20DDD727BC90D70093D175 /* AppSSOSPI.h in Headers */,
 				3A02FE2B2B214A38001724B1 /* ARKitSPI.h in Headers */,
+				CD722A092D6914BB00F2E1E7 /* AudioToolboxCoreSPI.h in Headers */,
 				DD20DD1527BC90D60093D175 /* AudioToolboxSoftLink.h in Headers */,
 				DD20DDD827BC90D70093D175 /* AudioToolboxSPI.h in Headers */,
 				DD20DDD927BC90D70093D175 /* AuthKitSPI.h in Headers */,

--- a/Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxCoreSPI.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(APPLE_INTERNAL_SDK)
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+#import <AudioToolboxCore/CASpatialAudioExperience_Private.h>
+#endif
+
+#else
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+#import <AudioToolboxCore/CASpatialAudioExperience.h>
+
+@class NSUUID;
+
+typedef NS_ENUM(NSInteger, CAAudioTetherType) {
+    CAAudioTetherTypeUnknown,
+    CAAudioTetherTypeLayer,
+    CAAudioTetherTypeEntity,
+};
+
+@interface CAAudioTether : NSObject
+- (instancetype)initWithType:(CAAudioTetherType)type identifier:(NSUUID*)identifier pid:(pid_t)pid;
+@end
+
+@interface CAAudioTetherAnchoringStrategy : CAAnchoringStrategy
+- (instancetype)initWithAudioTether:(CAAudioTether*)audioTether;
+@end
+#endif
+
+#endif

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -278,6 +278,7 @@ platform/audio/cocoa/CAAudioStreamDescription.cpp
 platform/audio/cocoa/CARingBuffer.cpp
 platform/audio/cocoa/MediaSessionManagerCocoa.mm
 platform/audio/cocoa/PlatformRawAudioDataCocoa.cpp
+platform/audio/cocoa/SpatialAudioExperienceHelper.mm
 platform/audio/cocoa/WebAudioBufferList.cpp
 platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp @no-unify
 platform/audio/ios/AudioSessionIOS.mm @no-unify

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5600,6 +5600,14 @@ void Document::visibilityAdjustmentStateDidChange()
         audioProducer.visibilityAdjustmentStateDidChange();
 }
 
+#if PLATFORM(IOS_FAMILY)
+void Document::sceneIdentifierDidChange()
+{
+    for (auto& audioProducer : m_audioProducers)
+        audioProducer.sceneIdentifierDidChange();
+}
+#endif
+
 #if ENABLE(MEDIA_STREAM) && ENABLE(MEDIA_SESSION)
 static bool hasRealtimeMediaSource(const UncheckedKeyHashSet<Ref<RealtimeMediaSource>>& sources, NOESCAPE const Function<bool(const RealtimeMediaSource&)>& filterSource)
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1653,6 +1653,9 @@ public:
 #endif
     void pageMutedStateDidChange();
     void visibilityAdjustmentStateDidChange();
+#if PLATFORM(IOS_FAMILY)
+    void sceneIdentifierDidChange();
+#endif
 
     bool hasEverHadSelectionInsideTextFormControl() const { return m_hasEverHadSelectionInsideTextFormControl; }
     void setHasEverHadSelectionInsideTextFormControl() { m_hasEverHadSelectionInsideTextFormControl = true; }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9282,6 +9282,16 @@ void HTMLMediaElement::visibilityAdjustmentStateDidChange()
     player->setMuted(muted);
 }
 
+#if PLATFORM(IOS_FAMILY)
+void HTMLMediaElement::sceneIdentifierDidChange()
+{
+    if (RefPtr page = document().page()) {
+        if (RefPtr player = m_player)
+            player->setSceneIdentifier(page->sceneIdentifier());
+    }
+}
+#endif
+
 void HTMLMediaElement::pageMutedStateDidChange()
 {
     if (RefPtr page = document().page()) {

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1031,6 +1031,9 @@ private:
 
     void visibilityAdjustmentStateDidChange() final;
     void pageMutedStateDidChange() override;
+#if PLATFORM(IOS_FAMILY)
+    void sceneIdentifierDidChange() final;
+#endif
 
 #if USE(AUDIO_SESSION) && PLATFORM(MAC)
     void hardwareMutedStateDidChange(const AudioSession&) final;

--- a/Source/WebCore/page/MediaProducer.h
+++ b/Source/WebCore/page/MediaProducer.h
@@ -141,6 +141,10 @@ public:
     virtual void visibilityAdjustmentStateDidChange() { }
     virtual void pageMutedStateDidChange() = 0;
 
+#if PLATFORM(IOS_FAMILY)
+    virtual void sceneIdentifierDidChange() { }
+#endif
+
 protected:
     virtual ~MediaProducer() = default;
 };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5184,7 +5184,7 @@ CheckedRef<ElementTargetingController> Page::checkedElementTargetingController()
     return m_elementTargetingController.get();
 }
 
-String Page::sceneIdentifier() const
+const String& Page::sceneIdentifier() const
 {
 #if PLATFORM(IOS_FAMILY)
     return m_sceneIdentifier;
@@ -5196,7 +5196,13 @@ String Page::sceneIdentifier() const
 #if PLATFORM(IOS_FAMILY)
 void Page::setSceneIdentifier(String&& sceneIdentifier)
 {
+    if (m_sceneIdentifier == sceneIdentifier)
+        return;
     m_sceneIdentifier = WTFMove(sceneIdentifier);
+
+    forEachDocument([&] (Document& document) {
+        document.sceneIdentifierDidChange();
+    });
 }
 #endif
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1212,7 +1212,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT void setSceneIdentifier(String&&);
 #endif
-    WEBCORE_EXPORT String sceneIdentifier() const;
+    WEBCORE_EXPORT const String& sceneIdentifier() const;
 
     std::optional<std::pair<uint16_t, uint16_t>> portsForUpgradingInsecureSchemeForTesting() const;
     WEBCORE_EXPORT void setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort);

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -76,6 +76,10 @@ public:
 
     void callRenderCallback(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition);
 
+#if PLATFORM(IOS_FAMILY)
+    void setSceneIdentifier(const String&) { }
+#endif
+
 protected:
     explicit AudioDestination(AudioIOCallback&, float sampleRate);
 

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+OBJC_CLASS CASpatialAudioExperience;
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+namespace WebCore {
+
+struct SpatialAudioExperienceOptions {
+    bool hasLayer { false };
+    bool hasTarget { false };
+    bool isVisible { false };
+    String sceneIdentifier;
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    String spatialTrackingLabel;
+#endif
+};
+
+RetainPtr<CASpatialAudioExperience> createExperienceWithOptions(const SpatialAudioExperienceOptions&);
+
+}
+#endif

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SpatialAudioExperienceHelper.h"
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+
+#import <pal/spi/cocoa/AudioToolboxCoreSPI.h>
+
+namespace WebCore {
+
+RetainPtr<CASpatialAudioExperience> createExperienceWithOptions(const SpatialAudioExperienceOptions& options)
+{
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    if (options.isVisible && options.hasTarget) {
+        // Automatic anchoring does not yet work with remote video targets, so rely on
+        // the spatial tracking label, and use that label to create a CAAudioTether. This
+        // tether informs the audio rendering subsystem about the connection between the
+        // visual layer and the audio being generated.
+        RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:options.spatialTrackingLabel]);
+        RetainPtr tether = adoptNS([[CAAudioTether alloc] initWithType:CAAudioTetherTypeLayer identifier:uuid.get() pid:0]);
+        RetainPtr anchoringStrategy = adoptNS([[CAAudioTetherAnchoringStrategy alloc] initWithAudioTether:tether.get()]);
+        return adoptNS([[CAHeadTrackedSpatialAudio alloc] initWithSoundStageSize:CASoundStageSizeAutomatic anchoringStrategy:anchoringStrategy.get()]);
+    }
+#endif
+
+    if (options.isVisible && options.hasLayer)
+        return adoptNS([[CAAutomaticSpatialAudio alloc] init]);
+
+    // Either not visible, or with no layer or target:
+    RetainPtr anchoring = adoptNS([[CASceneAnchoringStrategy alloc] initWithSceneIdentifier:options.sceneIdentifier]);
+    return adoptNS([[CAHeadTrackedSpatialAudio alloc] initWithSoundStageSize:CASoundStageSizeAutomatic anchoringStrategy:anchoring.get()]);
+}
+
+}
+
+#endif

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -975,6 +975,14 @@ bool MediaPlayer::canShowWhileLocked() const
 {
     return client().canShowWhileLocked();
 }
+
+void MediaPlayer::setSceneIdentifier(const String& identifier)
+{
+    if (m_sceneIdentifier == identifier)
+        return;
+    m_sceneIdentifier = identifier;
+    m_private->sceneIdentifierDidChange();
+}
 #endif
 
 void MediaPlayer::videoLayerSizeDidChange(const FloatSize& size)
@@ -2007,6 +2015,16 @@ void MediaPlayer::setSpatialTrackingLabel(const String& spatialTrackingLabel)
         return;
     m_spatialTrackingLabel = spatialTrackingLabel;
     m_private->setSpatialTrackingLabel(spatialTrackingLabel);
+}
+#endif
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+void MediaPlayer::setPrefersSpatialAudioExperience(bool value)
+{
+    if (m_prefersSpatialAudioExperience == value)
+        return;
+    m_prefersSpatialAudioExperience = value;
+    m_private->prefersSpatialAudioExperienceChanged();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -781,6 +781,11 @@ public:
     void setSpatialTrackingLabel(const String&);
 #endif
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    void setPrefersSpatialAudioExperience(bool);
+    bool prefersSpatialAudioExperience() const { return m_prefersSpatialAudioExperience; }
+#endif
+
     void setInFullscreenOrPictureInPicture(bool);
     bool isInFullscreenOrPictureInPicture() const;
 
@@ -793,6 +798,8 @@ public:
 
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const;
+    void setSceneIdentifier(const String&);
+    const String& sceneIdentifier() const { return m_sceneIdentifier; }
 #endif
 
 private:
@@ -849,6 +856,10 @@ private:
     String m_spatialTrackingLabel;
 #endif
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    bool m_prefersSpatialAudioExperience { false };
+#endif
+
     bool m_isInFullscreenOrPictureInPicture { false };
 
     String m_lastErrorMessage;
@@ -856,6 +867,10 @@ private:
 #if USE(AVFOUNDATION)
     bool m_preferDecompressionSession { false };
     bool m_canFallbackToDecompressionSession { false };
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    String m_sceneIdentifier;
 #endif
 };
 

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -361,10 +361,18 @@ public:
     virtual void setSpatialTrackingLabel(const String&) { }
 #endif
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    virtual void prefersSpatialAudioExperienceChanged() { }
+#endif
+
     virtual void isInFullscreenOrPictureInPictureChanged(bool) { }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     virtual bool supportsLinearMediaPlayer() const { return false; }
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+    virtual void sceneIdentifierDidChange() { }
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -191,6 +191,7 @@ private:
     NSArray *timedMetadata() const final;
     String accessLog() const final;
     String errorLog() const final;
+    void sceneIdentifierDidChange() final;
 #endif
 
     bool supportsAcceleratedRendering() const final { return true; }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -165,6 +165,10 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void setVideoTarget(const PlatformVideoTarget&) final;
 #endif
 
+#if PLATFORM(IOS_FAMILY)
+    void sceneIdentifierDidChange() final;
+#endif
+
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
     ASCIILiteral logClassName() const override { return "MediaPlayerPrivateMediaSourceAVFObjC"_s; }

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -286,6 +286,11 @@ private:
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void setVideoTarget(const PlatformVideoTarget&) final;
 #endif
+
+#if PLATFORM(IOS_FAMILY)
+    void sceneIdentifierDidChange() final;
+#endif
+
     void isInFullscreenOrPictureInPictureChanged(bool) final;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -47,6 +47,7 @@
 #import "ResourceResponse.h"
 #import "SampleMap.h"
 #import "SecurityOrigin.h"
+#import "SpatialAudioExperienceHelper.h"
 #import "TextTrackRepresentation.h"
 #import "TrackBuffer.h"
 #import "VideoFrameCV.h"
@@ -1801,6 +1802,23 @@ void MediaPlayerPrivateWebM::setSpatialTrackingLabel(const String& spatialTracki
 void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
 {
     auto *renderer = m_sampleBufferVideoRenderer ? m_sampleBufferVideoRenderer.get() : [m_sampleBufferDisplayLayer sampleBufferRenderer];
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    if (RefPtr player = m_player.get(); player && player->prefersSpatialAudioExperience()) {
+        RetainPtr experience = createExperienceWithOptions({
+            .hasLayer = !!renderer,
+            .hasTarget = !!m_videoTarget,
+            .isVisible = m_visible,
+            .sceneIdentifier = player->sceneIdentifier(),
+#if HAVE(SPATIAL_TRACKING_LABEL)
+            .spatialTrackingLabel = m_spatialTrackingLabel,
+#endif
+        });
+        [m_synchronizer setIntendedSpatialAudioExperience:experience.get()];
+        return;
+    }
+#endif
+
     if (!m_spatialTrackingLabel.isNull()) {
         INFO_LOG(LOGIDENTIFIER, "Explicitly set STSLabel: ", m_spatialTrackingLabel);
         renderer.STSLabel = m_spatialTrackingLabel;
@@ -1993,6 +2011,15 @@ void MediaPlayerPrivateWebM::setVideoTarget(const PlatformVideoTarget& videoTarg
     m_usingLinearMediaPlayer = !!videoTarget;
     m_videoTarget = videoTarget;
     updateDisplayLayer();
+}
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+void MediaPlayerPrivateWebM::sceneIdentifierDidChange()
+{
+#if HAVE(SPATIAL_TRACKING_LABEL)
+    updateSpatialTrackingLabel();
+#endif
 }
 #endif
 

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -175,6 +175,11 @@ public:
 
     virtual void swapFullscreenModesWith(VideoPresentationInterfaceIOS&) { }
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    void setPrefersSpatialAudioExperience(bool value) { m_prefersSpatialAudioExperience = value; }
+    bool prefersSpatialAudioExperience() const { return m_prefersSpatialAudioExperience; }
+#endif
+
 #if !RELEASE_LOG_DISABLED
     WEBCORE_EXPORT uint64_t logIdentifier() const;
     WEBCORE_EXPORT const Logger* loggerPtr() const;
@@ -260,6 +265,10 @@ private:
     bool m_finalizeSetupNeedsReturnVideoContentLayer { false };
     Ref<PlaybackSessionInterfaceIOS> m_playbackSessionInterface;
     RetainPtr<UIView> m_pipPlacard;
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    bool m_prefersSpatialAudioExperience { false };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
+++ b/Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm
@@ -31,6 +31,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "FrameLoaderTypes.h"
 #import "QuickLook.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -416,6 +416,11 @@ void RemoteMediaPlayerProxy::errorLog(CompletionHandler<void(String)>&& completi
 {
     completionHandler(protectedPlayer()->errorLog());
 }
+
+void RemoteMediaPlayerProxy::setSceneIdentifier(String&& identifier)
+{
+    protectedPlayer()->setSceneIdentifier(identifier);
+}
 #endif
 
 void RemoteMediaPlayerProxy::mediaPlayerNetworkStateChanged()
@@ -1292,6 +1297,14 @@ void RemoteMediaPlayerProxy::setDefaultSpatialTrackingLabel(const String& defaul
 void RemoteMediaPlayerProxy::setSpatialTrackingLabel(const String& spatialTrackingLabel)
 {
     protectedPlayer()->setSpatialTrackingLabel(spatialTrackingLabel);
+}
+
+#endif
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+void RemoteMediaPlayerProxy::setPrefersSpatialAudioExperience(bool value)
+{
+    protectedPlayer()->setPrefersSpatialAudioExperience(value);
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -138,6 +138,7 @@ public:
 #if PLATFORM(IOS_FAMILY)
     void accessLog(CompletionHandler<void(String)>&&);
     void errorLog(CompletionHandler<void(String)>&&);
+    void setSceneIdentifier(String&&);
 #endif
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -381,6 +382,9 @@ private:
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setDefaultSpatialTrackingLabel(const String&);
     void setSpatialTrackingLabel(const String&);
+#endif
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    void setPrefersSpatialAudioExperience(bool);
 #endif
 
     void isInFullscreenOrPictureInPictureChanged(bool);

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -121,6 +121,7 @@ messages -> RemoteMediaPlayerProxy {
 #if PLATFORM(IOS_FAMILY)
     ErrorLog() -> (String errorLog) Synchronous
     AccessLog() -> (String accessLog) Synchronous
+    SetSceneIdentifier(String sceneIdentifier)
 #endif
 
 #if ENABLE(WEB_AUDIO)
@@ -151,6 +152,10 @@ messages -> RemoteMediaPlayerProxy {
 #if HAVE(SPATIAL_TRACKING_LABEL)
     SetDefaultSpatialTrackingLabel(String defaultSpatialTrackingLabel);
     SetSpatialTrackingLabel(String spatialTrackingLabel);
+#endif
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    SetPrefersSpatialAudioExperience(bool value)
 #endif
 
     AudioOutputDeviceChanged(String deviceId)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm
@@ -230,13 +230,16 @@ CALayer *VideoPresentationInterfaceLMK::captionsLayer()
     m_captionsLayer = adoptNS([[WKLinearMediaKitCaptionsLayer alloc] initWithParent:*this]);
     [m_captionsLayer setName:@"Captions Layer"];
 
-#if HAVE(SPATIAL_TRACKING_LABEL)
     m_spatialTrackingLayer = adoptNS([[CALayer alloc] init]);
     [m_spatialTrackingLayer setSeparatedState:kCALayerSeparatedStateTracked];
-    m_spatialTrackingLabel = makeString("VideoPresentationInterfaceLMK Label: "_s, createVersion4UUIDString());
-    [m_spatialTrackingLayer setValue:(NSString *)m_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
-    [m_captionsLayer addSublayer:m_spatialTrackingLayer.get()];
+    m_spatialTrackingLabel = makeString(createVersion4UUIDString());
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    if (prefersSpatialAudioExperience())
+        [m_spatialTrackingLayer setValue:(NSString *)m_spatialTrackingLabel forKeyPath:@"separatedOptions.AudioTether"];
+    else
 #endif
+        [m_spatialTrackingLayer setValue:(NSString *)m_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
+    [m_captionsLayer addSublayer:m_spatialTrackingLayer.get()];
 
     return m_captionsLayer.get();
 }

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -652,6 +652,10 @@ VideoPresentationManagerProxy::ModelInterfaceTuple VideoPresentationManagerProxy
     Ref playbackSessionInterface = playbackSessionManagerProxy->ensureInterface(contextId);
     Ref interface = videoPresentationInterface(page.get(), playbackSessionInterface.get());
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    interface->setPrefersSpatialAudioExperience(page->preferences().preferSpatialAudioExperience());
+#endif
+
     playbackSessionManagerProxy->addClientForContext(contextId);
 
     interface->setVideoPresentationModel(model.ptr());

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -314,15 +314,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _installVisibilityPropagationViews];
 #endif
 
-#if HAVE(SPATIAL_TRACKING_LABEL)
-    _spatialTrackingView = adoptNS([[UIView alloc] init]);
-    [_spatialTrackingView layer].separatedState = kCALayerSeparatedStateTracked;
-    _spatialTrackingLabel = makeString("WKContentView Label: "_s, createVersion4UUIDString());
-    [[_spatialTrackingView layer] setValue:(NSString *)_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
-    [_spatialTrackingView setAutoresizingMask:UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
-    [_spatialTrackingView setFrame:CGRectMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds), 0, 0)];
-    [_spatialTrackingView setUserInteractionEnabled:NO];
-    [self addSubview:_spatialTrackingView.get()];
+#if HAVE(SPATIAL_TRACKING_LABEL) && HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    if (!_page->preferences().preferSpatialAudioExperience()) {
+        _spatialTrackingView = adoptNS([[UIView alloc] init]);
+        [_spatialTrackingView layer].separatedState = kCALayerSeparatedStateTracked;
+        _spatialTrackingLabel = makeString("WKContentView Label: "_s, createVersion4UUIDString());
+        [[_spatialTrackingView layer] setValue:(NSString *)_spatialTrackingLabel forKeyPath:@"separatedOptions.STSLabel"];
+        [_spatialTrackingView setAutoresizingMask:UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin];
+        [_spatialTrackingView setFrame:CGRectMake(CGRectGetMidX(self.bounds), CGRectGetMidY(self.bounds), 0, 0)];
+        [_spatialTrackingView setUserInteractionEnabled:NO];
+        [self addSubview:_spatialTrackingView.get()];
+    }
 #endif
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_applicationWillResignActive:) name:UIApplicationWillResignActiveNotification object:[UIApplication sharedApplication]];

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1809,6 +1809,15 @@ void MediaPlayerPrivateRemote::setSpatialTrackingLabel(const String& spatialTrac
 }
 #endif
 
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+void MediaPlayerPrivateRemote::prefersSpatialAudioExperienceChanged()
+{
+    if (RefPtr player = m_player.get())
+        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetPrefersSpatialAudioExperience(player->prefersSpatialAudioExperience()), m_id);
+}
+#endif
+
 void MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
     protectedConnection()->send(Messages::RemoteMediaPlayerProxy::IsInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture), m_id);
@@ -1856,6 +1865,14 @@ Ref<RemoteMediaPlayerManager> MediaPlayerPrivateRemote::protectedManager() const
 {
     return m_manager.get().releaseNonNull();
 }
+
+#if PLATFORM(IOS_FAMILY)
+void MediaPlayerPrivateRemote::sceneIdentifierDidChange()
+{
+    if (RefPtr player = m_player.get())
+        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSceneIdentifier(player->sceneIdentifier()), m_id);
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -471,6 +471,10 @@ private:
     void setSpatialTrackingLabel(const String&) final;
 #endif
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    void prefersSpatialAudioExperienceChanged() final;
+#endif
+
     void isInFullscreenOrPictureInPictureChanged(bool) final;
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -486,6 +490,10 @@ private:
     Ref<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const { return videoFrameObjectHeapProxy(); }
 
     Ref<RemoteMediaPlayerManager> protectedManager() const;
+
+#if PLATFORM(IOS_FAMILY)
+    void sceneIdentifierDidChange() final;
+#endif
 
     ThreadSafeWeakPtr<WebCore::MediaPlayer> m_player;
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### 2f5b4a7bc46ee9003355321d82e59eb11fc68a80
<pre>
[Cocoa] Adopt CASpatialAudioExperience
<a href="https://rdar.apple.com/145320517">rdar://145320517</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288240">https://bugs.webkit.org/show_bug.cgi?id=288240</a>

Reviewed by Andy Estes.

Add support for CASpatialAudioExperience as a replacement for spatial tracking labels.

CASpatialAudioExperiences require a few pieces of information: whether the view is
currently visible (i.e., the web view isn&apos;t currently in a background tab that&apos;s not
rooted in the view heirarchy), whether the audio is automatically associated with
a visible layer (as is the case with AVPlayerLayer and AVSampleBufferRenderSynchronizer).
Currently the behavior is re-implemented across multiple different MediaPlayer subtypes,
so provide a helper function for creating these experience objects that can be
re-used.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::sceneIdentifierDidChange):
(WebCore::AudioContext::sceneIdentifier const):
* Source/WebCore/Modules/webaudio/AudioContext.h:
* Source/WebCore/Modules/webaudio/AudioDestinationNode.h:
(WebCore::AudioDestinationNode::setSceneIdentifier):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
(WebCore::BaseAudioContext::sceneIdentifier const):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::createDestination):
(WebCore::DefaultAudioDestinationNode::setSceneIdentifier):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.h:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxCoreSPI.h: Added.
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::sceneIdentifierDidChange):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::sceneIdentifierDidChange):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/page/MediaProducer.h:
(WebCore::MediaProducer::sceneIdentifierDidChange):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::sceneIdentifier const):
(WebCore::Page::setSceneIdentifier):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/audio/AudioDestination.h:
(WebCore::AudioDestination::setSceneIdentifier):
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h: Added.
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm: Added.
(WebCore::createExperienceWithOptions):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::setSceneIdentifier):
(WebCore::MediaPlayer::setPrefersSpatialAudioExperience):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::prefersSpatialAudioExperienceChanged):
(WebCore::MediaPlayerPrivateInterface::sceneIdentifierDidChange):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::sceneIdentifierDidChange):
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::sceneIdentifierDidChange):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::sceneIdentifierDidChange):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::setPrefersSpatialAudioExperience):
(WebCore::VideoPresentationInterfaceIOS::prefersSpatialAudioExperience const):
* Source/WebCore/platform/network/ios/WebCoreURLResponseIOS.mm:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::setSceneIdentifier):
(WebKit::RemoteMediaPlayerProxy::setPrefersSpatialAudioExperience):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.mm:
(WebKit::VideoPresentationInterfaceLMK::captionsLayer):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::prefersSpatialAudioExperienceChanged):
(WebKit::MediaPlayerPrivateRemote::sceneIdentifierDidChange):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/291033@main">https://commits.webkit.org/291033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7301cc238d3c7bdd9f92a19f2241db8900731b69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91284 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/314 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96267 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42006 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19136 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96267 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27632 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8540 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82681 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96267 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/262 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41149 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84094 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98258 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90040 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13527 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79131 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18715 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78333 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19476 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/23263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23758 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112618 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18177 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32678 "Found 10 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.default, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->