### PR TITLE
Unreviewed, reverting 290825@main (67d7e1c8fe78)

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.h
@@ -82,7 +82,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion The app extension bundle must contain a `manifest.json` file in its resources directory. If the manifest is invalid or missing,
  or the bundle is otherwise improperly configured, an error will be returned.
  */
-+ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT;
++ (void)extensionWithAppExtensionBundle:(NSBundle *)appExtensionBundle completionHandler:(void (^)(WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL, which can point to either a directory or a ZIP archive.
@@ -91,7 +91,7 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA)) WK
  @discussion The URL must be a file URL that points to either a directory with a `manifest.json` file or a ZIP archive containing a `manifest.json` file.
  If the manifest is invalid or missing, or the URL points to an unsupported format or invalid archive, an error will be returned.
  */
-+ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(WKWebExtension * _Nullable extension, NSError * _Nullable error))completionHandler NS_REFINED_FOR_SWIFT;
++ (void)extensionWithResourceBaseURL:(NSURL *)resourceBaseURL completionHandler:(void (^)(WKWebExtension * WK_NULLABLE_RESULT extension, NSError * _Nullable error))completionHandler WK_SWIFT_ASYNC_THROWS_ON_FALSE(1);
 
 /*!
  @abstract An array of all errors that occurred during the processing of the extension.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtension.mm
@@ -86,47 +86,29 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     });
 }
 
+// FIXME: Remove after Safari has adopted new methods.
+- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
+{
+    return [self _initWithAppExtensionBundle:appExtensionBundle error:error];
+}
+
 - (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
 {
-    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
+    return [self _initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
+}
+
+// FIXME: Remove after Safari has adopted new methods.
+- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self _initWithResourceBaseURL:resourceBaseURL error:error];
 }
 
 - (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
-    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+    return [self _initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
 }
 
-- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle resourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
-{
-    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:resourceBaseURL error:error];
-}
-
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
-{
-    return [self initWithManifestDictionary:manifest resources:nil];
-}
-
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
-{
-    return [self initWithManifestDictionary:manifest resources:resources];
-}
-
-- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
-{
-    return [self initWithResources:resources];
-}
-
-- (instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
-{
-    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
-}
-
-- (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
-{
-    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
-}
-
-- (instancetype)initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
+- (instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
 {
     NSParameterAssert(appExtensionBundle || resourceBaseURL);
 
@@ -156,14 +138,14 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     return self;
 }
 
-- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
 {
     NSParameterAssert([manifest isKindOfClass:NSDictionary.class]);
 
-    return [self initWithManifestDictionary:manifest resources:nil];
+    return [self _initWithManifestDictionary:manifest resources:nil];
 }
 
-- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
 {
     NSParameterAssert([manifest isKindOfClass:NSDictionary.class]);
 
@@ -175,7 +157,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     return self;
 }
 
-- (instancetype)initWithResources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
 {
     NSParameterAssert([resources isKindOfClass:NSDictionary.class]);
 
@@ -367,64 +349,44 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtension, WebExtension, _webExtensio
     completionHandler(nil, [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil]);
 }
 
-- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error
-{
-    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:nil error:error];
-}
-
-- (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
-{
-    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
-}
-
-- (instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle resourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
-{
-    return [self initWithAppExtensionBundle:appExtensionBundle resourceBaseURL:resourceBaseURL error:error];
-}
-
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
-{
-    return [self initWithManifestDictionary:manifest resources:nil];
-}
-
-- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
-{
-    return [self initWithManifestDictionary:manifest resources:resources];
-}
-
-- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
-{
-    return [self initWithResources:resources];
-}
-
 - (instancetype)initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
 {
-    return [self initWithAppExtensionBundle:bundle resourceBaseURL:nil error:error];
+    return [self _initWithAppExtensionBundle:bundle error:error];
+}
+
+- (instancetype)_initWithAppExtensionBundle:(NSBundle *)bundle error:(NSError **)error
+{
+    return [self _initWithAppExtensionBundle:bundle resourceBaseURL:nil error:error];
 }
 
 - (instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
 {
-    return [self initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+    return [self _initWithResourceBaseURL:resourceBaseURL error:error];
 }
 
-- (instancetype)initWithAppExtensionBundle:(nullable NSBundle *)bundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
+- (instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error
+{
+    return [self _initWithAppExtensionBundle:nil resourceBaseURL:resourceBaseURL error:error];
+}
+
+- (instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)bundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error
 {
     if (error)
         *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFeatureUnsupportedError userInfo:nil];
     return nil;
 }
 
-- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest
 {
-    return [self initWithManifestDictionary:manifest resources:nil];
+    return [self _initWithManifestDictionary:manifest resources:nil];
 }
 
-- (instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(NSDictionary<NSString *, id> *)resources
 {
     return nil;
 }
 
-- (instancetype)initWithResources:(NSDictionary<NSString *, id> *)resources
+- (instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources
 {
     return nil;
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionPrivate.h
@@ -29,12 +29,9 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @interface WKWebExtension ()
 
-- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_SWIFT_UNAVAILABLE("Use init(appExtensionBundle:).");
-- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_SWIFT_UNAVAILABLE("Use init(resourceBaseURL:).");
-- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle resourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_SWIFT_UNAVAILABLE("Use init(appExtensionBundle:resourceBaseURL:).");
-- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest NS_SWIFT_UNAVAILABLE("Use init(manifestDictionary:).");
-- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_SWIFT_UNAVAILABLE("Use init(manifestDictionary:resources:).");
-- (nullable instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_SWIFT_UNAVAILABLE("Use init(resources:).");
+// FIXME: Remove after Safari has adopted new methods.
+- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error;
+- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error;
 
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle.
@@ -42,7 +39,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @param error Set to \c nil or an error instance if an error occurred.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  */
-- (nullable instancetype)initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error NS_REFINED_FOR_SWIFT;
+- (nullable instancetype)_initWithAppExtensionBundle:(NSBundle *)appExtensionBundle error:(NSError **)error;
 
 /*!
  @abstract Returns a web extension initialized with a specified resource base URL.
@@ -51,7 +48,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  @discussion The URL must be a file URL that points to either a directory containing a `manifest.json` file or a valid ZIP archive.
  */
-- (nullable instancetype)initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error NS_REFINED_FOR_SWIFT;
+- (nullable instancetype)_initWithResourceBaseURL:(NSURL *)resourceBaseURL error:(NSError **)error;
 
 /*!
  @abstract Returns a web extension initialized with a specified app extension bundle and resource base URL.
@@ -62,14 +59,14 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion Either the app extension bundle or the resource base URL (which can point to a directory or a valid ZIP archive) must be provided.
  This initializer is useful when the extension resources are in a different location from the app extension bundle used for native messaging.
  */
-- (nullable instancetype)initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)_initWithAppExtensionBundle:(nullable NSBundle *)appExtensionBundle resourceBaseURL:(nullable NSURL *)resourceBaseURL error:(NSError **)error NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Returns a web extension initialized with a specified manifest dictionary.
  @param manifest The dictionary containing the manifest data for the web extension.
  @result An initialized web extension, or `nil` if the object could not be initialized due to an error.
  */
-- (nullable instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest;
+- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest;
 
 /*!
  @abstract Returns a web extension initialized with a specified manifest dictionary and resources.
@@ -79,7 +76,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion The resources dictionary provides additional data required for the web extension. Paths in resources can
  have subdirectories, such as `_locales/en/messages.json`.
  */
-- (nullable instancetype)initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)_initWithManifestDictionary:(NSDictionary<NSString *, id> *)manifest resources:(nullable NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
 /*!
  @abstract Returns a web extension initialized with specified resources.
@@ -88,7 +85,7 @@ WK_HEADER_AUDIT_BEGIN(nullability, sendability)
  @discussion The resources dictionary must provide at least the `manifest.json` resource.  Paths in resources can
  have subdirectories, such as `_locales/en/messages.json`.
  */
-- (nullable instancetype)initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)_initWithResources:(NSDictionary<NSString *, id> *)resources NS_DESIGNATED_INITIALIZER;
 
 /*! @abstract A Boolean value indicating whether the extension background content is a service worker. */
 @property (readonly, nonatomic) BOOL _hasServiceWorkerBackgroundContent;

--- a/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/WebKitSwiftOverlay.swift
@@ -25,10 +25,6 @@
 
 #if !os(tvOS) && !os(watchOS)
 
-#if compiler(>=6.0)
-internal import WebKit_Private
-#endif
-
 #if USE_APPLE_INTERNAL_SDK
 @_spi(CTypeConversion) import Network
 #endif
@@ -89,25 +85,7 @@ extension WKWebView {
 }
 #endif
 
-#if compiler(>=6.0)
 @available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
-@available(watchOS, unavailable)
-@available(tvOS, unavailable)
-extension WKWebExtension {
-    public convenience init(appExtensionBundle: Bundle) async throws {
-        // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
-        try self.init(appExtensionBundle: appExtensionBundle, resourceBaseURL: nil)
-    }
-
-    public convenience init(resourceBaseURL: URL) async throws {
-        // FIXME: <https://webkit.org/b/276194> Make the WebExtension class load data on a background thread.
-        try self.init(appExtensionBundle: nil, resourceBaseURL: resourceBaseURL)
-    }
-}
-
-@available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
-@available(watchOS, unavailable)
-@available(tvOS, unavailable)
 extension WKWebExtensionController {
     public func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
         __didClose(closedTab, windowIsClosing: windowIsClosing)
@@ -123,8 +101,6 @@ extension WKWebExtensionController {
 }
 
 @available(iOS 18.4, macOS 15.4, visionOS 2.4, *)
-@available(watchOS, unavailable)
-@available(tvOS, unavailable)
 extension WKWebExtensionContext {
     public func didCloseTab(_ closedTab: WKWebExtensionTab, windowIsClosing: Bool = false) {
         __didClose(closedTab, windowIsClosing: windowIsClosing)
@@ -138,7 +114,6 @@ extension WKWebExtensionContext {
         __didMove(movedTab, from: index, in: oldWindow)
     }
 }
-#endif
 
 // FIXME: Need to declare ProxyConfiguration SPI in order to build and test
 // this with public SDKs (https://bugs.webkit.org/show_bug.cgi?id=280911).


### PR DESCRIPTION
#### a1c69c005cb386bb3efbf695ae77b0556ce4b78e
<pre>
Unreviewed, reverting 290825@main (67d7e1c8fe78)
<a href="https://bugs.webkit.org/show_bug.cgi?id=288233">https://bugs.webkit.org/show_bug.cgi?id=288233</a>
<a href="https://rdar.apple.com/145324925">rdar://145324925</a>

Broke the build.

Reverted change:

    Refine the construction of WKWebExtension in Swift.
    <a href="https://bugs.webkit.org/show_bug.cgi?id=288129">https://bugs.webkit.org/show_bug.cgi?id=288129</a>
    <a href="https://rdar.apple.com/145235810">rdar://145235810</a>
    290825@main (67d7e1c8fe78)

Canonical link: <a href="https://commits.webkit.org/290833@main">https://commits.webkit.org/290833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d91e26c043a68f6bbaaba163768f6e74329dfd7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91266 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/10801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/41992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/19117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/41992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94267 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/18444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/19117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/98241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/18700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14414 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/18443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/21623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/19935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->