### PR TITLE
[MSE] WebKit may lose text samples after removal of video ranges

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -1010,6 +1010,7 @@ Ref<MediaPromise> SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegme
             // appropriate information from the initialization segment.
             auto newTextTrack = InbandTextTrack::create(*scriptExecutionContext(), textTrackPrivate);
             newTextTrack->addClient(*this);
+            newTextTrack->setShouldPurgeCuesFromUnbufferedRanges(false);
 
             // 5.4.2 If the mode property on new text track equals "showing" or "hidden", then set active
             // track flag to true.

--- a/Source/WebCore/html/track/InbandDataTextTrack.h
+++ b/Source/WebCore/html/track/InbandDataTextTrack.h
@@ -45,8 +45,6 @@ private:
 
     void addDataCue(const MediaTime& start, const MediaTime& end, std::span<const uint8_t>) final;
 
-    bool shouldPurgeCuesFromUnbufferedRanges() const final { return true; }
-
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final { return "DataCue"_s; }
 #endif

--- a/Source/WebCore/html/track/InbandGenericTextTrack.h
+++ b/Source/WebCore/html/track/InbandGenericTextTrack.h
@@ -77,8 +77,6 @@ private:
     void newStyleSheetsParsed() final;
     void fileFailedToParse() final;
 
-    bool shouldPurgeCuesFromUnbufferedRanges() const final { return true; }
-
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final { return "InbandGenericTextTrack"_s; }
 #endif

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -63,6 +63,7 @@ InbandTextTrack::InbandTextTrack(ScriptExecutionContext& context, InbandTextTrac
     : TextTrack(&context, emptyAtom(), trackPrivate.id(), trackPrivate.label(), trackPrivate.language(), InBand)
     , m_private(trackPrivate)
 {
+    setShouldPurgeCuesFromUnbufferedRanges(true);
     addClientToTrackPrivateBase(*this, trackPrivate);
     updateKindFromPrivate();
 }

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.h
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.h
@@ -52,8 +52,6 @@ private:
     void newStyleSheetsParsed() final;
     void fileFailedToParse() final;
 
-    bool shouldPurgeCuesFromUnbufferedRanges() const final { return true; }
-
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const final { return "InbandWebVTTTextTrack"_s; }
 #endif

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -137,7 +137,9 @@ public:
 
     const std::optional<Vector<String>>& styleSheets() const { return m_styleSheets; }
 
-    virtual bool shouldPurgeCuesFromUnbufferedRanges() const { return false; }
+    bool shouldPurgeCuesFromUnbufferedRanges() const { return m_shouldPurgeCuesFromUnbufferedRanges; }
+    void setShouldPurgeCuesFromUnbufferedRanges(bool shouldPurge) { m_shouldPurgeCuesFromUnbufferedRanges = shouldPurge; }
+
     virtual void removeCuesNotInTimeRanges(const PlatformTimeRanges&);
 
     ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
@@ -181,6 +183,7 @@ private:
     std::optional<int> m_trackIndex;
     std::optional<int> m_renderedTrackIndex;
     bool m_hasBeenConfigured { false };
+    bool m_shouldPurgeCuesFromUnbufferedRanges { false };
 };
 
 inline auto TextTrack::mode() const -> Mode


### PR DESCRIPTION
#### e053b2e792b64190025624a89bc8113ec7d4a9df
<pre>
[MSE] WebKit may lose text samples after removal of video ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=287709">https://bugs.webkit.org/show_bug.cgi?id=287709</a>
<a href="https://rdar.apple.com/145301735">rdar://145301735</a>

Reviewed by NOBODY (OOPS!).

Don&apos;t purge cues based on timeline buffered ranges for MSE tracks.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
* Source/WebCore/html/track/InbandDataTextTrack.h:
* Source/WebCore/html/track/InbandGenericTextTrack.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::InbandTextTrack::InbandTextTrack):
* Source/WebCore/html/track/InbandWebVTTTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
(WebCore::TextTrack::shouldPurgeCuesFromUnbufferedRanges const):
(WebCore::TextTrack::setShouldPurgeCuesFromUnbufferedRanges):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e053b2e792b64190025624a89bc8113ec7d4a9df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10825 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/320 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96269 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19318 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/96269 "") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27634 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94292 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8537 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82683 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/96269 "") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/264 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78628 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/274 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18461 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13642 "Found 1 new test failure: webrtc/vp8-then-h264-gpu-process-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79130 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78332 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/198 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11630 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23760 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18179 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->