### PR TITLE
[ResourceMonitor] Move network usage threshold from Checker to ResourceMonitor.

### DIFF
--- a/LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt
@@ -1,6 +1,6 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://127.0.0.1:8000/iframe-monitor/resources/--eligible--/iframe.html
 Test unloaded HTML supports dark mode correctly.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
 Test resource monitor.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
 Test iframe with huge resource usage is unloaded.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt
@@ -5,8 +5,8 @@ CONSOLE MESSAGE: Launched shared worker
 CONSOLE MESSAGE: iframe is ready
 CONSOLE MESSAGE: Get message from parent window
 CONSOLE MESSAGE: Send fetch request to worker
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/shared-worker.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/shared-worker.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/shared-worker.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/shared-worker.html
 Test iframes using same shared worker are unloaded.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/iframe-monitor/throttler-expected.txt
+++ b/LayoutTests/http/tests/iframe-monitor/throttler-expected.txt
@@ -1,8 +1,8 @@
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
-CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 4194304 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
+CONSOLE MESSAGE: Frame was unloaded because its network usage exceeded the limit: 10240 bytes, url=http://localhost:8080/iframe-monitor/resources/--eligible--/iframe.html
 CONSOLE MESSAGE: Frame's network usage exceeded the limit.
 Test throttler prevents unloaded.
 

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -40,6 +40,7 @@ public:
     using Eligibility = ResourceMonitorEligibility;
 
     static Ref<ResourceMonitor> create(LocalFrame&);
+    WEBCORE_EXPORT ~ResourceMonitor();
 
     Eligibility eligibility() const { return m_eligibility; }
     void setEligibility(Eligibility);
@@ -47,6 +48,8 @@ public:
 
     void setDocumentURL(URL&&);
     WEBCORE_EXPORT void addNetworkUsage(size_t);
+
+    void updateNetworkUsageThreshold(size_t);
 
 private:
     explicit ResourceMonitor(LocalFrame&);
@@ -58,9 +61,10 @@ private:
 
     WeakPtr<LocalFrame> m_frame;
     URL m_frameURL;
+    size_t m_networkUsageThreshold;
+    CheckedSize m_networkUsage;
     Eligibility m_eligibility { Eligibility::Unsure };
     bool m_networkUsageExceed { false };
-    CheckedSize m_networkUsage;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1465,7 +1465,7 @@ void LocalFrame::showResourceMonitoringError()
 
     FRAME_RELEASE_LOG(ResourceMonitoring, "Detected excessive network usage in frame at %" SENSITIVE_LOG_STRING " and main frame at %" SENSITIVE_LOG_STRING ": unloading", url.isValid() ? url.string().utf8().data() : "invalid", mainFrameURL.isValid() ? mainFrameURL.string().utf8().data() : "invalid");
 
-    document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Error, makeString("Frame was unloaded because its network usage exceeded the limit: "_s, ResourceMonitorChecker::networkUsageThreshold, " bytes, url="_s, url.string()));
+    document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Error, makeString("Frame was unloaded because its network usage exceeded the limit: "_s, ResourceMonitorChecker::singleton().networkUsageThreshold(), " bytes, url="_s, url.string()));
 
     for (RefPtr<Frame> frame = this; frame; frame = frame->tree().traverseNext()) {
         if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame)) {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1553,7 +1553,7 @@ public:
     void setResourceCachingDisabledByWebInspector(bool);
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    void setResourceMonitorNetworkUsageThreshold(size_t threshold, double randomness = ResourceMonitorChecker::networkUsageThresholdRandomness);
+    void setResourceMonitorNetworkUsageThreshold(size_t threshold, double randomness = ResourceMonitorChecker::defaultNetworkUsageThresholdRandomness);
     bool shouldSkipResourceMonitorThrottling() const;
     void setShouldSkipResourceMonitorThrottling(bool);
 #endif


### PR DESCRIPTION
#### 260e177ad19e8588d5f69c21f35d4b77b2ea743d
<pre>
[ResourceMonitor] Move network usage threshold from Checker to ResourceMonitor.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288256">https://bugs.webkit.org/show_bug.cgi?id=288256</a>
<a href="https://rdar.apple.com/145329002">rdar://145329002</a>

Reviewed by Chris Dumez.

It was moved to ResourceMonitorChecker to modify the value for testing purpose, but it ended up that
all ResourceMonitor uses same randomness. Move back to make the all monitors using different values.

* LayoutTests/http/tests/iframe-monitor/dark-mode-expected.txt:
* LayoutTests/http/tests/iframe-monitor/eligibility-expected.txt:
* LayoutTests/http/tests/iframe-monitor/iframe-unload-expected.txt:
* LayoutTests/http/tests/iframe-monitor/shared-worker-expected.txt:
* LayoutTests/http/tests/iframe-monitor/throttler-expected.txt:
* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::ResourceMonitor):
(WebCore::ResourceMonitor::~ResourceMonitor):
(WebCore::ResourceMonitor::addNetworkUsage):
(WebCore::ResourceMonitor::updateNetworkUsageThreshold):
(WebCore::ResourceMonitor::checkNetworkUsageExcessIfNecessary):
* Source/WebCore/loader/ResourceMonitor.h:
* Source/WebCore/loader/ResourceMonitorChecker.cpp:
(WebCore::ResourceMonitorChecker::ResourceMonitorChecker):
(WebCore::ResourceMonitorChecker::registerResourceMonitor):
(WebCore::ResourceMonitorChecker::unregisterResourceMonitor):
(WebCore::ResourceMonitorChecker::networkUsageThresholdWithNoise const):
(WebCore::ResourceMonitorChecker::setNetworkUsageThreshold):
(WebCore::networkUsageThresholdWithRandomNoise): Deleted.
(): Deleted.
* Source/WebCore/loader/ResourceMonitorChecker.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::showResourceMonitoringError):
* Source/WebCore/testing/Internals.h:

Canonical link: <a href="https://commits.webkit.org/290866@main">https://commits.webkit.org/290866@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e807ddb9d072816feea1cb48ce68882bb3e25ab1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10862 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96300 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70124 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27651 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50450 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/298 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41185 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98296 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18495 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79144 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78347 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22868 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18494 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18210 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21668 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->