### PR TITLE
Some RetainPtr cleanup

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -136,11 +136,6 @@ public:
 
     constexpr bool operator!() const { return !m_ptr; }
 
-    // This conversion operator allows implicit conversion to bool but not to other integer types.
-    // FIXME: Eventually we should remove this; it's an outdated technique and less needed since we have explicit operator bool.
-    typedef CFTypeRef RetainPtr::*UnspecifiedBoolType;
-    operator UnspecifiedBoolType() const { return m_ptr ? &RetainPtr::m_ptr : nullptr; }
-
     RetainPtr& operator=(const RetainPtr&);
     template<typename U> RetainPtr& operator=(const RetainPtr<U>&);
     RetainPtr& operator=(PtrType);

--- a/Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm
+++ b/Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm
@@ -50,7 +50,7 @@ CocoaImage *webCoreTextAttachmentMissingPlatformImage()
 #else
         RetainPtr image = [webCoreBundle imageForResource:@"missingImage"];
 #endif
-        ASSERT_WITH_MESSAGE(image != nil, "Unable to find missingImage.");
+        ASSERT_WITH_MESSAGE(!!image, "Unable to find missingImage.");
         webCoreTextAttachmentMissingPlatformImageIfExists() = WTFMove(image);
     });
 

--- a/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
+++ b/Source/WebCore/platform/cf/RunLoopObserverCF.cpp
@@ -99,7 +99,7 @@ void RunLoopObserver::invalidate()
 
 bool RunLoopObserver::isScheduled() const
 {
-    return m_runLoopObserver;
+    return !!m_runLoopObserver;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -116,7 +116,7 @@ void ContentFilterUnblockHandler::wrapWithDecisionHandler(const DecisionHandlerF
 bool ContentFilterUnblockHandler::needsUIProcess() const
 {
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
-    return m_webFilterEvaluator;
+    return !!m_webFilterEvaluator;
 #else
     return false;
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h
@@ -80,7 +80,7 @@ public:
 
     void didProvideContentKeyRequest(AVContentKeyRequest *);
 
-    bool hasContentKeySession() const { return m_contentKeySession; }
+    bool hasContentKeySession() const { return !!m_contentKeySession; }
     AVContentKeySession* contentKeySession();
 
     bool hasContentKeyRequest() const;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -323,7 +323,11 @@ bool CDMSessionAVContentKeySession::update(Uint8Array* key, RefPtr<Uint8Array>& 
 
         errorCode = MediaPlayer::NoError;
         systemCode = 0;
-        RetainPtr nsIdentifier = m_identifier ? RetainPtr<id>(toNSData(m_identifier->span())) : retainPtr(contentKeyRequest.get().identifier);
+        RetainPtr<id> nsIdentifier;
+        if (m_identifier)
+            nsIdentifier = toNSData(m_identifier->span());
+        else
+            nsIdentifier = contentKeyRequest.get().identifier;
 
         RetainPtr<NSError> error;
         RetainPtr<NSData> requestData;
@@ -438,7 +442,7 @@ RefPtr<Uint8Array> CDMSessionAVContentKeySession::generateKeyReleaseMessage(unsi
 bool CDMSessionAVContentKeySession::hasContentKeyRequest() const
 {
     Locker holder { m_keyRequestLock };
-    return m_keyRequest;
+    return !!m_keyRequest;
 }
 
 RetainPtr<AVContentKeyRequest> CDMSessionAVContentKeySession::contentKeyRequest() const

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -601,7 +601,7 @@ void GraphicsContextGLCocoa::bindExternalImage(GCGLenum target, GCGLExternalImag
 bool GraphicsContextGLCocoa::addFoveation(IntSize physicalSizeLeft, IntSize physicalSizeRight, IntSize screenSize, std::span<const GCGLfloat> horizontalSamplesLeft, std::span<const GCGLfloat> verticalSamplesLeft, std::span<const GCGLfloat> horizontalSamplesRight)
 {
     m_rasterizationRateMap[PlatformXR::Layout::Shared] = newRasterizationRateMap(m_displayObj, physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamplesLeft, horizontalSamplesRight);
-    return m_rasterizationRateMap[PlatformXR::Layout::Shared];
+    return !!m_rasterizationRateMap[PlatformXR::Layout::Shared];
 }
 
 void GraphicsContextGLCocoa::enableFoveation(PlatformGLObject rbo)

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp
@@ -71,9 +71,9 @@ CGFloat UnrealizedCoreTextFont::getSize() const
 UnrealizedCoreTextFont::operator bool() const
 {
     return WTF::switchOn(m_baseFont, [](const RetainPtr<CTFontRef>& font) -> bool {
-        return font;
+        return !!font;
     }, [](const RetainPtr<CTFontDescriptorRef>& fontDescriptor) -> bool {
-        return fontDescriptor;
+        return !!fontDescriptor;
     });
 }
 

--- a/Source/WebCore/platform/ios/wak/WebCoreThread.mm
+++ b/Source/WebCore/platform/ios/wak/WebCoreThread.mm
@@ -329,7 +329,7 @@ void WebThreadAdoptAndRelease(id obj)
 
     Locker locker { webThreadReleaseLock };
 
-    if (webThreadReleaseObjArray() == nil)
+    if (!webThreadReleaseObjArray())
         webThreadReleaseObjArray() = adoptCF(CFArrayCreateMutable(kCFAllocatorSystemDefault, 0, nullptr));
     CFArrayAppendValue(webThreadReleaseObjArray().get(), obj);
     CFRunLoopSourceSignal(webThreadReleaseSource().get());

--- a/Source/WebCore/platform/text/cf/HyphenationCF.cpp
+++ b/Source/WebCore/platform/text/cf/HyphenationCF.cpp
@@ -71,7 +71,7 @@ bool canHyphenate(const AtomString& localeIdentifier)
 {
     if (localeIdentifier.isNull())
         return false;
-    return TinyLRUCachePolicy<AtomString, RetainPtr<CFLocaleRef>>::cache().get(localeIdentifier);
+    return !!TinyLRUCachePolicy<AtomString, RetainPtr<CFLocaleRef>>::cache().get(localeIdentifier);
 }
 
 size_t lastHyphenLocation(StringView text, size_t beforeIndex, const AtomString& localeIdentifier)

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -428,7 +428,7 @@ NSType typeFromObject(id object)
 
 static inline bool isSerializableFont(CTFontRef font)
 {
-    return adoptCF(CTFontCopyAttribute(font, kCTFontURLAttribute));
+    return !!adoptCF(CTFontCopyAttribute(font, kCTFontURLAttribute));
 }
 
 bool isSerializableValue(id value)

--- a/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheetAssistant.mm
@@ -293,7 +293,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (BOOL)isShowingSheet
 {
-    return _interactionSheet != nil;
+    return !!_interactionSheet;
 }
 
 - (void)interactionDidStartWithPositionInformation:(const WebKit::InteractionInformationAtPosition&)information

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8950,7 +8950,7 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     if (_presentedQuickboardController)
         return YES;
 #endif // HAVE(QUICKBOARD_CONTROLLER)
-    return _presentedFullScreenInputViewController;
+    return !!_presentedFullScreenInputViewController;
 }
 
 - (void)dismissAllInputViewControllers:(BOOL)animated

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.h
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.h
@@ -47,7 +47,7 @@ public:
     static void recordAutocorrectionResponse(WebViewImpl&, NSInteger spellCheckerDocumentTag, NSCorrectionResponse, const String& replacedString, const String& replacementString);
 
 private:
-    bool isShowing() const { return m_view; }
+    bool isShowing() const { return !!m_view; }
     String dismissInternal(WebCore::ReasonForDismissingAlternativeText, bool dismissingExternally);
     void handleAcceptedReplacement(WebViewImpl&, NSString* acceptedReplacement, NSString* replaced, NSString* proposedReplacement, NSCorrectionIndicatorType);
 

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -503,8 +503,8 @@ static NSString *temporaryPDFDirectoryPath()
         auto temporaryDirectoryTemplate = [NSTemporaryDirectory() stringByAppendingPathComponent:@"WebKitPDFs-XXXXXX"];
         CString templateRepresentation = [temporaryDirectoryTemplate fileSystemRepresentation];
         if (mkdtemp(templateRepresentation.mutableSpanIncludingNullTerminator().data()))
-            return adoptNS([[[NSFileManager defaultManager] stringWithFileSystemRepresentation:templateRepresentation.data() length:templateRepresentation.length()] copy]);
-        return RetainPtr<id> { };
+            return adoptNS((NSString *)[[[NSFileManager defaultManager] stringWithFileSystemRepresentation:templateRepresentation.data() length:templateRepresentation.length()] copy]);
+        return RetainPtr<NSString> { };
     }();
     return path.get().get();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2724,7 +2724,7 @@ bool UnifiedPDFPlugin::isEditingCommandEnabled(const String& commandName)
         return true;
 
     if (equalLettersIgnoringASCIICase(commandName, "copy"_s) || equalLettersIgnoringASCIICase(commandName, "takefindstringfromselection"_s))
-        return m_currentSelection;
+        return !!m_currentSelection;
 
     return false;
 }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.h
@@ -44,7 +44,7 @@ public:
     static void recordAutocorrectionResponse(NSInteger spellCheckerDocumentTag, NSCorrectionResponse, const String& replacedString, const String& replacementString);
 
 private:
-    bool isShowing() const { return m_view; }
+    bool isShowing() const { return !!m_view; }
     String dismissInternal(WebCore::ReasonForDismissingAlternativeText, bool dismissingExternally);
     void handleAcceptedReplacement(NSString* acceptedReplacement, NSString* replaced, NSString* proposedReplacement, NSCorrectionIndicatorType);
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -1221,7 +1221,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<NSAttributedString> attributedString;
     if ([types containsObject:WebCore::legacyRTFDPasteboardType()])
         attributedString = adoptNS([[NSAttributedString alloc] initWithRTFD:[pasteboard dataForType:WebCore::legacyRTFDPasteboardType()] documentAttributes:NULL]);
-    if (attributedString == nil && [types containsObject:WebCore::legacyRTFPasteboardType()])
+    if (!attributedString && [types containsObject:WebCore::legacyRTFPasteboardType()])
         attributedString = adoptNS([[NSAttributedString alloc] initWithRTF:[pasteboard dataForType:WebCore::legacyRTFPasteboardType()] documentAttributes:NULL]);
     if (attributedString)
         return adoptNS([[attributedString string] copy]).autorelease();
@@ -4389,7 +4389,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         wrapper = [[self _dataSource] _fileWrapperForURL:draggingElementURL];
     }
     
-    if (wrapper == nil) {
+    if (!wrapper) {
         LOG_ERROR("Failed to create image file.");
         return nil;
     }
@@ -5092,7 +5092,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         return nil;
     // NSTextView does something more efficient by parsing the attributes only, but that's not available in API.
     auto string = adoptNS([[NSAttributedString alloc] initWithRTF:data documentAttributes:NULL]);
-    if (string == nil || [string length] == 0)
+    if (!string || [string length] == 0)
         return nil;
     return [string fontAttributesInRange:NSMakeRange(0, 1)];
 }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3537,7 +3537,7 @@ IGNORE_WARNINGS_END
 
 - (void)addCaretChangeListener:(id <WebCaretChangeListener>)listener
 {
-    if (_private->_caretChangeListeners == nil) {
+    if (!_private->_caretChangeListeners) {
         _private->_caretChangeListeners = adoptNS([[NSMutableSet alloc] init]);
     }
 
@@ -3591,7 +3591,7 @@ IGNORE_WARNINGS_END
     if (!dataSource)
         dataSource = [frame dataSource];
     auto unreachableURL = retainPtr([dataSource unreachableURL]);
-    auto url = unreachableURL != nil ? unreachableURL : retainPtr([[dataSource request] URL]);
+    auto url = !!unreachableURL ? unreachableURL : retainPtr([[dataSource request] URL]);
     return url.autorelease();
 }
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm
@@ -99,7 +99,7 @@ TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)
 {
     auto srgb = DestinationColorSpace::SRGB();
     auto cgContext = adoptCF(CGBitmapContextCreate(nullptr, 3, 3, 8, 4 * 3, srgb.platformColorSpace(), kCGImageAlphaPremultipliedLast));
-    ASSERT_NE(cgContext, nullptr);
+    ASSERT_NE(cgContext.get(), nullptr);
     GraphicsContextCG context(cgContext.get());
     EXPECT_EQ(context.renderingMode(), RenderingMode::Unaccelerated);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm
@@ -314,7 +314,7 @@ TEST(ResourceLoadDelegate, LoadInfo)
     EXPECT_WK_STREQ([otherParameters[0] URL].path, "/");
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[1] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[1] URL].path, "/");
-    EXPECT_EQ(otherParameters[2], nil);
+    EXPECT_EQ(otherParameters[2].get(), nil);
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[3] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[3] URL].path, "/");
 
@@ -322,7 +322,7 @@ TEST(ResourceLoadDelegate, LoadInfo)
     EXPECT_WK_STREQ([otherParameters[4] URL].path, "/iframeSrc");
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[5] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[5] URL].path, "/iframeSrc");
-    EXPECT_EQ(otherParameters[6], nil);
+    EXPECT_EQ(otherParameters[6].get(), nil);
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[7] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[7] URL].path, "/iframeSrc");
 
@@ -331,7 +331,7 @@ TEST(ResourceLoadDelegate, LoadInfo)
     EXPECT_WK_STREQ(adoptNS([[NSString alloc] initWithData:[otherParameters[8] HTTPBody] encoding:NSUTF8StringEncoding]).get(), "a=b&c=d");
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[9] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[9] URL].path, "/fetchTarget");
-    EXPECT_EQ(otherParameters[10], nil);
+    EXPECT_EQ(otherParameters[10].get(), nil);
     EXPECT_WK_STREQ(NSStringFromClass([otherParameters[11] class]), "NSHTTPURLResponse");
     EXPECT_WK_STREQ([otherParameters[11] URL].path, "/fetchTarget");
 


### PR DESCRIPTION
#### 94c637751ff29d9b2bb055edcde12ec71ea24f50
<pre>
Some RetainPtr cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=288269">https://bugs.webkit.org/show_bug.cgi?id=288269</a>
&lt;<a href="https://rdar.apple.com/problem/145371472">rdar://problem/145371472</a>&gt;

Reviewed by Ryosuke Niwa.

Removed implicit conversion to pointer, which was an old-school not 100%
type-safe way to do boolean tests.

Updated call sites to convert to boolean or load a pointer explicitly.

Added autorelease pools so that the OptionalRetainPtrNS API test passes in
debug builds with ARC, even though ARC autoreleases all intermediate pointers.

Added a test for leakRef() in ARC. This test currently fails (!!), so it&apos;s
disabled for now.

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::operator UnspecifiedBoolType const): Deleted.
* Source/WebCore/editing/cocoa/WebCoreTextAttachment.mm:
(WebCore::webCoreTextAttachmentMissingPlatformImage):
* Source/WebCore/platform/cf/RunLoopObserverCF.cpp:
(WebCore::RunLoopObserver::isScheduled const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.h:
(WebCore::CDMSessionAVContentKeySession::hasContentKeySession const):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::update):
(WebCore::CDMSessionAVContentKeySession::hasContentKeyRequest const):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.cpp:
(WebCore::UnrealizedCoreTextFont::operator bool const):
* Source/WebCore/platform/text/cf/HyphenationCF.cpp:
(WebCore::canHyphenate):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::isSerializableFont):
* Source/WebKit/UIProcess/mac/CorrectionPanel.h:
(WebKit::CorrectionPanel::isShowing const):
* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::temporaryPDFDirectoryPath):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::isEditingCommandEnabled):
* Source/WebKitLegacy/mac/WebCoreSupport/CorrectionPanel.h:
(CorrectionPanel::isShowing const):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _plainTextFromPasteboard:]):
(-[WebHTMLView namesOfPromisedFilesDroppedAtDestination:]):
(-[WebHTMLView _fontAttributesFromFontPasteboard]):
* Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm:
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, OptionalRetainPtrNS)):
* Tools/TestWebKitAPI/Tests/WebCore/cg/GraphicsContextCGTests.mm:
(TestWebKitAPI::TEST(GraphicsContextTests, CGBitmapRenderingModeIsUnaccelerated)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadDelegate.mm:
(LoadInfo)):

Canonical link: <a href="https://commits.webkit.org/290875@main">https://commits.webkit.org/290875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d46d6b2eb2d23fa2743d1153fc884135336ddb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91374 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96343 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93424 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19238 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94375 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41232 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84180 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90126 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18539 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/98345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18794 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/78598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/22905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14448 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18538 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/23823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112707 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18252 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21709 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20018 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->