### PR TITLE
Address safer cpp failures in WebsiteDataStore

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -212,10 +212,7 @@ UIProcess/WebPreferences.h
 UIProcess/WebProcessActivityState.cpp
 UIProcess/WebURLSchemeHandler.cpp
 UIProcess/WebURLSchemeTask.cpp
-UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
-UIProcess/WebsiteData/WebsiteDataStore.cpp
-UIProcess/WebsiteData/WebsiteDataStoreClient.h
 UIProcess/mac/CorrectionPanel.mm
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/UserMediaPermissionRequestProxyMac.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -38,8 +38,6 @@ UIProcess/WebAuthentication/AuthenticatorManager.cpp
 UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebPreferences.cpp
 UIProcess/WebProcessCache.cpp
-UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm
-UIProcess/WebsiteData/WebsiteDataStore.cpp
 UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebContextMenuProxyMac.mm

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -81,5 +81,5 @@ void WKNotificationManagerProviderDidRemoveNotificationPolicies(WKNotificationMa
 
 WKNotificationManagerRef WKNotificationManagerGetSharedServiceWorkerNotificationManager()
 {
-    return toAPI(&WebNotificationManagerProxy::sharedServiceWorkerManager());
+    return toAPI(&WebNotificationManagerProxy::serviceWorkerManagerSingleton());
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1058,7 +1058,7 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 + (WKNotificationManagerRef)_sharedServiceWorkerNotificationManager
 {
     LOG(Push, "Accessing _sharedServiceWorkerNotificationManager");
-    return WebKit::toAPI(&WebKit::WebNotificationManagerProxy::sharedServiceWorkerManager());
+    return WebKit::toAPI(&WebKit::WebNotificationManagerProxy::serviceWorkerManagerSingleton());
 }
 
 - (void)_allowTLSCertificateChain:(NSArray *)certificateChain forHost:(NSString *)host

--- a/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp
@@ -515,7 +515,7 @@ static void webkit_web_context_class_init(WebKitWebContextClass* webContextClass
     bindtextdomain(GETTEXT_PACKAGE, LOCALEDIR);
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
 
-    s_serviceWorkerNotificationProvider = makeUnique<WebKitNotificationProvider>(&WebNotificationManagerProxy::sharedServiceWorkerManager(), nullptr);
+    s_serviceWorkerNotificationProvider = makeUnique<WebKitNotificationProvider>(&WebNotificationManagerProxy::serviceWorkerManagerSingleton(), nullptr);
 
     gObjectClass->get_property = webkitWebContextGetProperty;
     gObjectClass->set_property = webkitWebContextSetProperty;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -1800,7 +1800,7 @@ void NetworkProcessProxy::processPushMessage(PAL::SessionID sessionID, const Web
         permission = PushPermissionState::Prompt;
         auto permissions = dataStore->client().notificationPermissions();
         if (permissions.isEmpty())
-            permissions = WebNotificationManagerProxy::protectedSharedServiceWorkerManager()->notificationPermissions();
+            permissions = WebNotificationManagerProxy::serviceWorkerManagerSingleton().notificationPermissions();
 
         auto origin = SecurityOriginData::fromURL(pushMessage.registrationURL).toString();
         if (auto it = permissions.find(origin); it != permissions.end())

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp
@@ -53,16 +53,11 @@ Ref<WebNotificationManagerProxy> WebNotificationManagerProxy::create(WebProcessP
     return adoptRef(*new WebNotificationManagerProxy(processPool));
 }
 
-WebNotificationManagerProxy& WebNotificationManagerProxy::sharedServiceWorkerManager()
+WebNotificationManagerProxy& WebNotificationManagerProxy::serviceWorkerManagerSingleton()
 {
     ASSERT(isMainRunLoop());
     static NeverDestroyed<Ref<WebNotificationManagerProxy>> sharedManager = adoptRef(*new WebNotificationManagerProxy(nullptr));
     return sharedManager->get();
-}
-
-Ref<WebNotificationManagerProxy> WebNotificationManagerProxy::protectedSharedServiceWorkerManager()
-{
-    return sharedServiceWorkerManager();
 }
 
 WebNotificationManagerProxy::WebNotificationManagerProxy(WebProcessPool* processPool)
@@ -340,7 +335,7 @@ void WebNotificationManagerProxy::providerDidUpdateNotificationPolicy(const API:
     if (originString.isEmpty())
         return;
 
-    if (this == &sharedServiceWorkerManager()) {
+    if (this == &serviceWorkerManagerSingleton()) {
         setPushesAndNotificationsEnabledForOrigin(origin->securityOrigin(), enabled);
         WebProcessPool::sendToAllRemoteWorkerProcesses(Messages::WebNotificationManager::DidUpdateNotificationDecision(originString, enabled));
         return;
@@ -356,7 +351,7 @@ void WebNotificationManagerProxy::providerDidRemoveNotificationPolicies(API::Arr
     if (!size)
         return;
 
-    if (this == &sharedServiceWorkerManager()) {
+    if (this == &serviceWorkerManagerSingleton()) {
         removePushSubscriptionsForOrigins(apiArrayToSecurityOrigins(origins));
         WebProcessPool::sendToAllRemoteWorkerProcesses(Messages::WebNotificationManager::DidRemoveNotificationDecisions(apiArrayToSecurityOriginStrings(origins)));
         return;

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h
@@ -62,8 +62,7 @@ public:
 
     static Ref<WebNotificationManagerProxy> create(WebProcessPool*);
 
-    static WebNotificationManagerProxy& sharedServiceWorkerManager();
-    static Ref<WebNotificationManagerProxy> protectedSharedServiceWorkerManager();
+    static WebNotificationManagerProxy& serviceWorkerManagerSingleton();
 
     virtual ~WebNotificationManagerProxy();
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2809,7 +2809,7 @@ void WebProcessProxy::getNotifications(const URL& registrationURL, const String&
         return;
     }
 
-    WebNotificationManagerProxy::protectedSharedServiceWorkerManager()->getNotifications(registrationURL, tag, sessionID(), WTFMove(callback));
+    WebNotificationManagerProxy::serviceWorkerManagerSingleton().getNotifications(registrationURL, tag, sessionID(), WTFMove(callback));
 }
 
 void WebProcessProxy::getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -532,7 +532,7 @@ private:
     void removeRecentSearches(WallTime, CompletionHandler<void()>&&);
 
     WebsiteDataStore();
-    static WorkQueue& websiteDataStoreIOQueue();
+    static WorkQueue& websiteDataStoreIOQueueSingleton();
 
     Ref<WorkQueue> protectedQueue() const;
 
@@ -586,7 +586,7 @@ private:
     bool m_hasDispatchedResolveDirectories { false };
     std::optional<WebsiteDataStoreConfiguration::Directories> m_resolvedDirectories WTF_GUARDED_BY_LOCK(m_resolveDirectoriesLock);
     FileSystem::Salt m_mediaKeysStorageSalt WTF_GUARDED_BY_LOCK(m_resolveDirectoriesLock);
-    Ref<const WebsiteDataStoreConfiguration> m_configuration;
+    const Ref<const WebsiteDataStoreConfiguration> m_configuration;
     bool m_hasResolvedDirectories { false };
     RefPtr<DeviceIdHashSaltStorage> m_deviceIdHashSaltStorage;
 #if ENABLE(ENCRYPTED_MEDIA)
@@ -604,7 +604,7 @@ private:
     TrackingPreventionEnabled m_trackingPreventionEnabled { TrackingPreventionEnabled::Default };
     Function<void(const String&)> m_statisticsTestingCallback;
 
-    Ref<WorkQueue> m_queue;
+    const Ref<WorkQueue> m_queue;
 
 #if PLATFORM(COCOA)
     Vector<uint8_t> m_uiProcessCookieStorageIdentifier;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h
@@ -64,7 +64,7 @@ public:
 
     virtual void didReceiveAuthenticationChallenge(Ref<AuthenticationChallengeProxy>&& challenge)
     {
-        challenge->listener().completeChallenge(AuthenticationChallengeDisposition::PerformDefaultHandling);
+        challenge->protectedListener()->completeChallenge(AuthenticationChallengeDisposition::PerformDefaultHandling);
     }
 
     virtual void openWindowFromServiceWorker(const String&, const WebCore::SecurityOriginData&, CompletionHandler<void(WebPageProxy*)>&& completionHandler)


### PR DESCRIPTION
#### cbd90d50a0ecf36a64c7ed9aed6cb8ad24f4c194
<pre>
Address safer cpp failures in WebsiteDataStore
<a href="https://bugs.webkit.org/show_bug.cgi?id=288272">https://bugs.webkit.org/show_bug.cgi?id=288272</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerGetSharedServiceWorkerNotificationManager):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(+[WKWebsiteDataStore _sharedServiceWorkerNotificationManager]):
* Source/WebKit/UIProcess/API/glib/WebKitWebContext.cpp:
(webkit_web_context_class_init):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::processPushMessage):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.cpp:
(WebKit::WebNotificationManagerProxy::serviceWorkerManagerSingleton):
(WebKit::WebNotificationManagerProxy::providerDidUpdateNotificationPolicy):
(WebKit::WebNotificationManagerProxy::providerDidRemoveNotificationPolicies):
(WebKit::WebNotificationManagerProxy::sharedServiceWorkerManager): Deleted.
(WebKit::WebNotificationManagerProxy::protectedSharedServiceWorkerManager): Deleted.
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::getNotifications):
* Source/WebKit/UIProcess/WebsiteData/Cocoa/WebsiteDataStoreCocoa.mm:
(WebKit::managedDomainQueueSingleton):
(WebKit::WebsiteDataStore::fetchAllDataStoreIdentifiers):
(WebKit::WebsiteDataStore::removeDataStoreWithIdentifier):
(WebKit::WebsiteDataStore::initializeManagedDomains):
(WebKit::WebsiteDataStore::ensureManagedDomains const):
(WebKit::managedDomainQueue): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::websiteDataStoreIOQueueSingleton):
(WebKit::WebsiteDataStore::soAuthorizationCoordinator):
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::showPersistentNotification):
(WebKit::WebsiteDataStore::cancelServiceWorkerNotification):
(WebKit::WebsiteDataStore::clearServiceWorkerNotification):
(WebKit::WebsiteDataStore::didDestroyServiceWorkerNotification):
(WebKit::WebsiteDataStore::openWindowFromServiceWorker):
(WebKit::WebsiteDataStore::updateServiceWorkerInspectability):
(WebKit::WebsiteDataStore::builtInNotificationsEnabled const):
(WebKit::WebsiteDataStore::websiteDataStoreIOQueue): Deleted.
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreClient.h:
(WebKit::WebsiteDataStoreClient::didReceiveAuthenticationChallenge):

Canonical link: <a href="https://commits.webkit.org/290895@main">https://commits.webkit.org/290895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55fb2c6e8d251b4f8e342b00140d50bbc0e5f9ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/401 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96293 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11230 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19273 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70118 "Failure limit exceed. At least found 1 new test failure: imported/w3c/web-platform-tests/css/css-transitions/pseudo-element-transform.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94319 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8553 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82755 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50444 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8322 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41175 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98313 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18485 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79155 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19393 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11649 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18484 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23779 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19971 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->