### PR TITLE
Address safer cpp failures in SerializedScriptValue.cpp

### DIFF
--- a/Source/WebCore/Modules/mediastream/RTCCertificate.h
+++ b/Source/WebCore/Modules/mediastream/RTCCertificate.h
@@ -47,6 +47,7 @@ public:
     const String& pemCertificate() const { return m_pemCertificate; }
     const String& pemPrivateKey() const { return m_pemPrivateKey; }
     const SecurityOrigin& origin() const { return m_origin.get(); }
+    Ref<SecurityOrigin> protectedOrigin() const { return m_origin; }
 
 private:
     RTCCertificate(Ref<SecurityOrigin>&&, double expires, Vector<DtlsFingerprint>&&, String&& pemCertificate, String&& pemPrivateKey);

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -332,7 +332,6 @@ bindings/js/JSDOMIterator.h
 bindings/js/JSDOMMapLike.h
 bindings/js/JSDOMPromiseDeferred.cpp
 bindings/js/JSDOMPromiseDeferred.h
-bindings/js/JSDOMQuadCustom.cpp
 bindings/js/JSDOMSetLike.h
 bindings/js/JSDOMWindowBase.cpp
 bindings/js/JSDOMWindowCustom.cpp
@@ -402,7 +401,6 @@ bindings/js/ScriptBufferSourceProvider.h
 bindings/js/ScriptCachedFrameData.cpp
 bindings/js/ScriptModuleLoader.cpp
 bindings/js/ScriptSourceCode.h
-bindings/js/SerializedScriptValue.cpp
 bindings/js/WebAssemblyScriptBufferSourceProvider.h
 bindings/js/WebCoreJSClientData.cpp
 bindings/js/WebCoreTypedArrayController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -69,7 +69,6 @@ accessibility/mac/WebAccessibilityObjectWrapperMac.mm
 animation/BlendingKeyframes.cpp
 animation/KeyframeEffect.cpp
 bindings/js/JSDOMPromiseDeferred.cpp
-bindings/js/SerializedScriptValue.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
 css/CSSFontFace.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -203,7 +203,6 @@ bindings/js/JSWorkerGlobalScopeCustom.cpp
 bindings/js/JSXMLHttpRequestCustom.cpp
 bindings/js/ScriptCachedFrameData.cpp
 bindings/js/ScriptModuleLoader.cpp
-bindings/js/SerializedScriptValue.cpp
 bindings/js/WebCoreJSClientData.cpp
 bindings/js/WindowProxy.cpp
 bridge/objc/WebScriptObject.mm

--- a/Source/WebCore/bindings/js/JSExecState.cpp
+++ b/Source/WebCore/bindings/js/JSExecState.cpp
@@ -58,4 +58,9 @@ ScriptExecutionContext* executionContext(JSC::JSGlobalObject* globalObject)
     return JSC::jsCast<JSDOMGlobalObject*>(globalObject)->scriptExecutionContext();
 }
 
+RefPtr<ScriptExecutionContext> protectedExecutionContext(JSC::JSGlobalObject* globalObject)
+{
+    return executionContext(globalObject);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSExecState.h
+++ b/Source/WebCore/bindings/js/JSExecState.h
@@ -219,5 +219,6 @@ JSC::JSValue functionCallHandlerFromAnyThread(JSC::JSGlobalObject*, JSC::JSValue
 JSC::JSValue evaluateHandlerFromAnyThread(JSC::JSGlobalObject*, const JSC::SourceCode&, JSC::JSValue thisValue, NakedPtr<JSC::Exception>& returnedException);
 
 ScriptExecutionContext* executionContext(JSC::JSGlobalObject*);
+RefPtr<ScriptExecutionContext> protectedExecutionContext(JSC::JSGlobalObject*);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DOMQuad.h
+++ b/Source/WebCore/dom/DOMQuad.h
@@ -55,10 +55,10 @@ private:
     DOMQuad(const DOMPointInit&, const DOMPointInit&, const DOMPointInit&, const DOMPointInit&);
     explicit DOMQuad(const DOMRectInit&);
     
-    Ref<DOMPoint> m_p1;
-    Ref<DOMPoint> m_p2;
-    Ref<DOMPoint> m_p3;
-    Ref<DOMPoint> m_p4;
+    const Ref<DOMPoint> m_p1;
+    const Ref<DOMPoint> m_p2;
+    const Ref<DOMPoint> m_p3;
+    const Ref<DOMPoint> m_p4;
 };
 
 }

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -39,6 +39,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ByteArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);
 
     JSC::Uint8ClampedArray& data() const { return m_data.get(); }
+    Ref<JSC::Uint8ClampedArray> protectedData() const { return m_data; }
     Ref<JSC::Uint8ClampedArray>&& takeData() { return WTFMove(m_data); }
     WEBCORE_EXPORT std::span<const uint8_t> span() const;
 


### PR DESCRIPTION
#### 7aff9134ae33408154331ba744d698c806e984af
<pre>
Address safer cpp failures in SerializedScriptValue.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288275">https://bugs.webkit.org/show_bug.cgi?id=288275</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/bindings/js/JSExecState.cpp:
(WebCore::protectedExecutionContext):
* Source/WebCore/bindings/js/JSExecState.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::serializeAndWrapCryptoKey):
(WebCore::unwrapCryptoKey):
(WebCore::CloneSerializer::dumpDOMPoint):
(WebCore::CloneSerializer::dumpDOMRect):
(WebCore::CloneSerializer::dumpDOMMatrix):
(WebCore::CloneSerializer::dumpDOMQuad):
(WebCore::CloneSerializer::dumpImageBitmap):
(WebCore::CloneSerializer::dumpWebCodecsEncodedVideoChunk):
(WebCore::CloneSerializer::dumpWebCodecsEncodedAudioChunk):
(WebCore::CloneSerializer::dumpDOMException):
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readFile):
(WebCore::CloneDeserializer::readTransferredImageBitmap):
(WebCore::CloneDeserializer::readOffscreenCanvas):
(WebCore::CloneDeserializer::readRTCDataChannel):
(WebCore::CloneDeserializer::readWebCodecsVideoFrame):
(WebCore::CloneDeserializer::readWebCodecsAudioData):
(WebCore::CloneDeserializer::readMediaStreamTrack):
(WebCore::CloneDeserializer::readImageBitmap):
(WebCore::CloneDeserializer::readTerminal):
(WebCore::SerializedScriptValue::create):
(WebCore::SerializedScriptValue::writeBlobsToDiskForIndexedDBSynchronously):
* Source/WebCore/dom/DOMQuad.h:

Canonical link: <a href="https://commits.webkit.org/290887@main">https://commits.webkit.org/290887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b536611b01bd030055d0051ae88e7b1318c4021

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96360 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42087 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19257 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94393 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82777 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50499 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/362 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78695 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/369 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98363 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18555 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79193 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18809 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19385 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22916 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18553 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23835 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18266 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21724 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20032 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->