### PR TITLE
Support writing-mode conversions for position-area

### DIFF
--- a/Source/WebCore/platform/BoxSides.h
+++ b/Source/WebCore/platform/BoxSides.h
@@ -121,6 +121,26 @@ constexpr LogicalBoxCorner mapCornerPhysicalToLogical(const WritingMode, const B
 
 /** Implementation Below **********************************************/
 
+constexpr BoxAxis WritingMode::inlineAxis() const
+{
+    return isHorizontal() ? BoxAxis::Horizontal : BoxAxis::Vertical;
+}
+
+constexpr BoxAxis WritingMode::blockAxis() const
+{
+    return isHorizontal() ? BoxAxis::Vertical : BoxAxis::Horizontal;
+}
+
+constexpr LogicalBoxAxis WritingMode::horizontalAxis() const
+{
+    return isHorizontal() ? LogicalBoxAxis::Inline : LogicalBoxAxis::Block;
+}
+
+constexpr LogicalBoxAxis WritingMode::verticalAxis() const
+{
+    return isHorizontal() ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
+}
+
 constexpr BoxAxis mapAxisLogicalToPhysical(const WritingMode writingMode, const LogicalBoxAxis logicalAxis)
 {
     bool isBlock = logicalAxis == LogicalBoxAxis::Block;

--- a/Source/WebCore/platform/text/WritingMode.h
+++ b/Source/WebCore/platform/text/WritingMode.h
@@ -56,6 +56,8 @@ enum class StyleWritingMode : uint8_t;
 enum class TextDirection : bool;
 enum class TextOrientation : uint8_t;
 enum class FlowDirection : uint8_t;
+enum class BoxAxis : uint8_t;
+enum class LogicalBoxAxis : uint8_t;
 
 class WritingMode final {
 public:
@@ -108,6 +110,12 @@ public:
     constexpr FlowDirection blockDirection() const;
     constexpr TextDirection bidiDirection() const;
     constexpr FlowDirection inlineDirection() const;
+
+    // Axes as enums. Prefer booleans if doing boolean checks.
+    constexpr BoxAxis blockAxis() const;
+    constexpr BoxAxis inlineAxis() const;
+    constexpr LogicalBoxAxis horizontalAxis() const;
+    constexpr LogicalBoxAxis verticalAxis() const;
 
     // Computed values. May differ from used values above.
     constexpr StyleWritingMode computedWritingMode() const;


### PR DESCRIPTION
#### 054862eb3b5d878ad8399239d949d60ff62cb5c9
<pre>
Support writing-mode conversions for position-area
<a href="https://bugs.webkit.org/show_bug.cgi?id=288261">https://bugs.webkit.org/show_bug.cgi?id=288261</a>
<a href="https://rdar.apple.com/145333147">rdar://145333147</a>

Reviewed by Alan Baradlay.

Adds helper methods for writing-mode conversions of position-area values.
The core mapping logic is in PositionArea::coordMatchedTrackForAxis().

We can consider adding PositionArea::flowMatchedTrackForAxis() if future
layout code needs it, but for now positioning is handled in RenderBox
coordinates, so that&apos;s all that&apos;s needed at the moment.

* Source/WebCore/platform/BoxSides.h:
(WebCore::WritingMode::blockAxis const): Implement method to return physical axis value.
(WebCore::WritingMode::inlineAxis const): Implement method to return physical axis value.
(WebCore::WritingMode::horizontalAxis const): Implement method to return logical axis value.
(WebCore::WritingMode::verticalAxis const): Implement method to return logical axis value.
* Source/WebCore/platform/text/WritingMode.h: Declare methods to return axis values.
* Source/WebCore/rendering/style/PositionArea.cpp:
(WebCore::PositionArea::coordMatchedTrackForAxis const): Implement writing-mode mapping for position-area values.
* Source/WebCore/rendering/style/PositionArea.h: Make enum values explicit, since we&apos;re encoding information into them.
(WebCore::isPositionAreaAxisLogical): Add helper method.
(WebCore::isPositionAreaDirectionLogical): Add helper method.
(WebCore::mapPositionAreaAxisToPhysicalAxis): Add helper method.
(WebCore::mapPositionAreaAxisToLogicalAxis): Add helper method.
(WebCore::flipPositionAreaTrack): Add helper method.

Canonical link: <a href="https://commits.webkit.org/291042@main">https://commits.webkit.org/291042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d191ca130c26381610264617e946805e86f27e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96681 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42374 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70483 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8891 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83099 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8636 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/691 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41567 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78951 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98695 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18870 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14019 "Build is in progress. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79445 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78666 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23185 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/529 "Found 1 new test failure: compositing/repaint/become-overlay-composited-layer.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11958 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14561 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24110 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18564 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->