### PR TITLE
REGRESSION(288357@main): Crash in `WebHistoryItemClient::historyItemChanged`

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp
@@ -52,14 +52,16 @@ void WebHistoryItemClient::historyItemChanged(const WebCore::HistoryItem& item)
 {
     if (m_shouldIgnoreChanges)
         return;
-    m_page->send(Messages::WebPageProxy::BackForwardUpdateItem(toFrameState(item)));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::BackForwardUpdateItem(toFrameState(item)));
 }
 
 void WebHistoryItemClient::clearChildren(const WebCore::HistoryItem& item) const
 {
     if (m_shouldIgnoreChanges)
         return;
-    m_page->send(Messages::WebPageProxy::BackForwardClearChildren(item.itemID(), item.frameItemID()));
+    if (RefPtr page = m_page.get())
+        page->send(Messages::WebPageProxy::BackForwardClearChildren(item.itemID(), item.frameItemID()));
 }
 
 }

--- a/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h
+++ b/Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h
@@ -43,7 +43,7 @@ private:
     void historyItemChanged(const WebCore::HistoryItem&) final;
     void clearChildren(const WebCore::HistoryItem&) const final;
 
-    const WeakRef<WebPage> m_page;
+    const WeakPtr<WebPage> m_page;
     bool m_shouldIgnoreChanges { false };
 };
 


### PR DESCRIPTION
#### 92ab86c96733339731d0c2abfeec831624851035
<pre>
REGRESSION(288357@main): Crash in `WebHistoryItemClient::historyItemChanged`
<a href="https://bugs.webkit.org/show_bug.cgi?id=288279">https://bugs.webkit.org/show_bug.cgi?id=288279</a>
<a href="https://rdar.apple.com/142947060">rdar://142947060</a>

Reviewed by Alex Christensen.

WebHistoryItemClient can outlive its WebPage, so it should hold a WeakPtr to WebPage instead of a
WeakRef.

* Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.cpp:
(WebKit::WebHistoryItemClient::historyItemChanged):
(WebKit::WebHistoryItemClient::clearChildren const):
* Source/WebKit/WebProcess/WebPage/WebHistoryItemClient.h:

Canonical link: <a href="https://commits.webkit.org/290892@main">https://commits.webkit.org/290892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14a5143336ff79e0c859aa464f6fc6747afb681c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91342 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42044 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70131 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27658 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8568 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50457 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8337 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41199 "Built successfully") | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78658 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18507 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13564 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79153 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18762 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/78632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78358 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22875 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11664 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14459 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18220 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21677 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/19986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->