### PR TITLE
Update fullscreen state in other processes when entering and exiting fullscreen with site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/fullscreen-expected.txt
@@ -2,14 +2,12 @@ supportsFullScreen() == true
 enterFullScreenForElement()
 beganEnterFullScreen() - initialRect.size: {300, 150}, finalRect.size: {300, 150}
 exitFullScreenForElement()
-beganExitFullScreen() - initialRect.size: {300, 150}, finalRect.size: {300, 150}
+beganExitFullScreen() - initialRect.size: {800, 600}, finalRect.size: {300, 150}
 
 FIXME: Size after entering should be 600x800 like it is with site isolation off.
 The size currently comes from screenRectOfContents.
-Also, the iframe's border 'inset' style should be 'none' after entering fullscreen.
-
-Size after entering fullscreen: 150x300
-iframe border style after transition: 0px inset rgb(0, 0, 0)
+Size after entering fullscreen: 600x800
+iframe border style after transition: 0px none rgb(0, 0, 0)
 
 Size after exiting fullscreen: 150x300
 iframe border style after transition: 0px inset rgb(0, 0, 0)

--- a/LayoutTests/http/tests/site-isolation/fullscreen.html
+++ b/LayoutTests/http/tests/site-isolation/fullscreen.html
@@ -15,5 +15,4 @@
 <div id=mylog>
 FIXME: Size after entering should be 600x800 like it is with site isolation off.<br>
 The size currently comes from screenRectOfContents.<br>
-Also, the iframe's border 'inset' style should be 'none' after entering fullscreen.<br><br>
 </div>

--- a/Source/WebCore/dom/FullscreenManager.h
+++ b/Source/WebCore/dom/FullscreenManager.h
@@ -78,10 +78,12 @@ public:
     WEBCORE_EXPORT bool willExitFullscreen();
     WEBCORE_EXPORT void didExitFullscreen(CompletionHandler<void(ExceptionOr<void>)>&&);
 
+    WEBCORE_EXPORT static void elementEnterFullscreen(Element&);
+
     void dispatchPendingEvents();
 
     enum class ExitMode : bool { Resize, NoResize };
-    void finishExitFullscreen(Frame&, ExitMode);
+    WEBCORE_EXPORT static void finishExitFullscreen(Frame&, ExitMode);
 
     void exitRemovedFullscreenElement(Element&);
 
@@ -96,7 +98,6 @@ protected:
     enum class EventType : bool { Change, Error };
     void dispatchFullscreenChangeOrErrorEvent(Deque<GCReachableRef<Node>>&, EventType, bool shouldNotifyMediaElement);
     void dispatchEventForNode(Node&, EventType);
-    void queueFullscreenChangeEventForDocument(Document&);
 
 private:
 #if !RELEASE_LOG_DISABLED
@@ -110,6 +111,7 @@ private:
     RefPtr<Document> protectedMainFrameDocument() { return mainFrameDocument(); }
 
     bool didEnterFullscreen();
+    static void queueFullscreenChangeEventForDocument(Document&);
     void addElementToChangeEventQueue(Node& target) { m_fullscreenChangeEventTargetQueue.append(GCReachableRef(target)); }
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -101,6 +101,9 @@ public:
     void detachFromClient();
     void attachToNewClient(WebFullScreenManagerProxyClient&);
 
+    void enterFullScreenForOwnerElementsInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
+    void exitFullScreenInOtherProcesses(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
+
     enum class FullscreenState : uint8_t {
         NotInFullscreen,
         EnteringFullscreen,
@@ -122,14 +125,14 @@ public:
 private:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
-    void enterFullScreen(IPC::Connection&, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&, CompletionHandler<void(bool)>&&);
+    void enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&, CompletionHandler<void(bool)>&&);
     void didEnterFullScreen(CompletionHandler<void(bool)>&&);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(FullScreenMediaDetails&&);
 #endif
     void exitFullScreen(CompletionHandler<void()>&&);
     void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&);
-    void beganExitFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&);
+    void beganExitFullScreen(WebCore::FrameIdentifier, const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&);
     void callCloseCompletionHandlers();
     template<typename M> void sendToWebProcess(M&&);
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in
@@ -28,13 +28,13 @@
     EnabledBy=FullScreenEnabled || VideoFullscreenRequiresElementFullscreen
 ]
 messages -> WebFullScreenManagerProxy {
-    EnterFullScreen(bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails) -> (bool success)
+    EnterFullScreen(WebCore::FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, struct WebKit::FullScreenMediaDetails mediaDetails) -> (bool success)
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     UpdateImageSource(struct WebKit::FullScreenMediaDetails mediaDetails)
 #endif
     ExitFullScreen() -> ()
     BeganEnterFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> (bool success)
-    BeganExitFullScreen(WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> ()
+    BeganExitFullScreen(WebCore::FrameIdentifier frameID, WebCore::IntRect initialRect, WebCore::IntRect finalRect) -> ()
     Close()
 }
 #endif

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h
@@ -76,6 +76,9 @@ public:
     void willExitFullScreen(CompletionHandler<void()>&&);
     void didExitFullScreen(CompletionHandler<void()>&&);
 
+    void enterFullScreenForOwnerElements(WebCore::FrameIdentifier, CompletionHandler<void()>&&);
+    void exitFullScreenInMainFrame(CompletionHandler<void()>&&);
+
     WebCore::Element* element();
 
     void videoControlsManagerDidChange();

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in
@@ -31,5 +31,7 @@ messages -> WebFullScreenManager {
     SetAnimatingFullScreen(bool animating)
     SetFullscreenInsets(WebCore::FloatBoxExtent insets)
     SetFullscreenAutoHideDuration(Seconds duration)
+    EnterFullScreenForOwnerElements(WebCore::FrameIdentifier frameID) -> ()
+    ExitFullScreenInMainFrame() -> ()
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1429,4 +1429,9 @@ String WebFrame::frameTextForTesting(bool includeSubframes)
     return builder.toString();
 }
 
+WebFrame* WebFrame::webFrame(std::optional<WebCore::FrameIdentifier> frameID)
+{
+    return WebProcess::singleton().webFrame(frameID);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -98,6 +98,7 @@ public:
     WebPage* page() const;
     RefPtr<WebPage> protectedPage() const;
 
+    static WebFrame* webFrame(std::optional<WebCore::FrameIdentifier>);
     static RefPtr<WebFrame> fromCoreFrame(const WebCore::Frame&);
     WebCore::LocalFrame* coreLocalFrame() const;
     RefPtr<WebCore::LocalFrame> protectedCoreLocalFrame() const;


### PR DESCRIPTION
#### bc4cb9e7454ee85a794a7fa32df1c88df850e711
<pre>
Update fullscreen state in other processes when entering and exiting fullscreen with site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=288280">https://bugs.webkit.org/show_bug.cgi?id=288280</a>

Reviewed by Tim Nguyen.

When entering fullscreen, we need to send IPC to other processes along the frame&apos;s ancestor chain
and tell them to enter fullscreen to make the HTMLFrameOwnerElement take the entirety of the screen.
Similarly when exiting fullscreen, we need to tell the processes to undo that state change.

* LayoutTests/http/tests/site-isolation/fullscreen-expected.txt:
* LayoutTests/http/tests/site-isolation/fullscreen.html:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::elementEnterFullscreen):
* Source/WebCore/dom/FullscreenManager.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
(WebKit::WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses):
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
(WebKit::WebFullScreenManagerProxy::exitFullScreenInOtherProcesses):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.messages.in:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::willExitFullScreen):
(WebKit::WebFullScreenManager::enterFullScreenForOwnerElements):
(WebKit::WebFullScreenManager::exitFullScreenInMainFrame):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.messages.in:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::webFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:

Canonical link: <a href="https://commits.webkit.org/290872@main">https://commits.webkit.org/290872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da9f432be0ed00fe7b680d81c9e84d93ac3334d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96337 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42070 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19231 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27681 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94369 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/82754 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50482 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8358 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41226 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98339 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18533 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78383 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22898 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14444 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18532 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23817 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21703 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->