### PR TITLE
[ResourceMonitor] Add more meaningful release log information part 2.

### DIFF
--- a/Source/WebCore/loader/ResourceMonitor.cpp
+++ b/Source/WebCore/loader/ResourceMonitor.cpp
@@ -154,6 +154,25 @@ void ResourceMonitor::addNetworkUsage(size_t bytes)
         checkNetworkUsageExcessIfNecessary();
 }
 
+ResourceMonitor::UsageLevel ResourceMonitor::networkUsageLevel() const
+{
+    if (m_networkUsage.hasOverflowed() || m_networkUsage > m_networkUsageThreshold)
+        return UsageLevel::Critical;
+
+    if (!m_networkUsage)
+        return UsageLevel::Empty;
+
+    auto percentage = static_cast<unsigned>(100.0 * m_networkUsage.value() / m_networkUsageThreshold);
+
+    if (percentage <= static_cast<unsigned>(UsageLevel::Low))
+        return UsageLevel::Low;
+    if (percentage <= static_cast<unsigned>(UsageLevel::Medium))
+        return UsageLevel::Medium;
+    if (percentage <= static_cast<unsigned>(UsageLevel::High))
+        return UsageLevel::High;
+    return UsageLevel::Critical;
+}
+
 void ResourceMonitor::updateNetworkUsageThreshold(size_t threshold)
 {
     if (m_networkUsageThreshold == threshold)

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -38,6 +38,13 @@ class LocalFrame;
 class ResourceMonitor final : public RefCountedAndCanMakeWeakPtr<ResourceMonitor> {
 public:
     using Eligibility = ResourceMonitorEligibility;
+    enum class UsageLevel : uint8_t {
+        Empty = 0,
+        Low = 20,
+        Medium = 60,
+        High = 80,
+        Critical = 100,
+    };
 
     static Ref<ResourceMonitor> create(LocalFrame&);
     WEBCORE_EXPORT ~ResourceMonitor();
@@ -48,6 +55,8 @@ public:
 
     void setDocumentURL(URL&&);
     WEBCORE_EXPORT void addNetworkUsage(size_t);
+    size_t networkUsageThreshold() const { return m_networkUsageThreshold; }
+    WEBCORE_EXPORT UsageLevel networkUsageLevel() const;
 
     void updateNetworkUsageThreshold(size_t);
 

--- a/Source/WebCore/loader/ResourceMonitorChecker.cpp
+++ b/Source/WebCore/loader/ResourceMonitorChecker.cpp
@@ -51,7 +51,7 @@ ResourceMonitorChecker::ResourceMonitorChecker()
         if (m_ruleList)
             return;
 
-        RESOURCEMONITOR_RELEASE_LOG("Did not receive rule list in time, using default eligibility");
+        RESOURCEMONITOR_RELEASE_LOG("ResourceMonitorChecker: Did not receive rule list in time, using default eligibility");
 
         m_ruleListIsPreparing = false;
         finishPendingQueries([](const auto&) {
@@ -90,7 +90,7 @@ ResourceMonitorChecker::Eligibility ResourceMonitorChecker::checkEligibility(con
     ASSERT(m_ruleList);
 
     auto matched = m_ruleList->processContentRuleListsForResourceMonitoring(info.resourceURL, info.mainDocumentURL, info.frameURL, info.type);
-    RESOURCEMONITOR_RELEASE_LOG("The url is %" PUBLIC_LOG_STRING ": %" SENSITIVE_LOG_STRING " (%" PUBLIC_LOG_STRING ")", (matched ? "eligible" : "not eligible"), info.resourceURL.string().utf8().data(), ContentExtensions::resourceTypeToString(info.type).characters());
+    RESOURCEMONITOR_RELEASE_LOG("checkEligibility: The url is %" PUBLIC_LOG_STRING ": %" SENSITIVE_LOG_STRING " (%" PUBLIC_LOG_STRING ")", (matched ? "eligible" : "not eligible"), info.resourceURL.string().utf8().data(), ContentExtensions::resourceTypeToString(info.type).characters());
 
     return matched ? Eligibility::Eligible : Eligibility::NotEligible;
 }
@@ -103,7 +103,7 @@ void ResourceMonitorChecker::setContentRuleList(ContentExtensions::ContentExtens
         m_ruleList = makeUnique<ContentExtensions::ContentExtensionsBackend>(WTFMove(backend));
         m_ruleListIsPreparing = false;
 
-        RESOURCEMONITOR_RELEASE_LOG("Content rule list is set");
+        RESOURCEMONITOR_RELEASE_LOG("ContentExtensionsBackend: Content rule list is set");
 
         if (!m_pendingQueries.isEmpty()) {
             finishPendingQueries([this](const auto& info) {
@@ -115,7 +115,7 @@ void ResourceMonitorChecker::setContentRuleList(ContentExtensions::ContentExtens
 
 void ResourceMonitorChecker::finishPendingQueries(Function<Eligibility(const ContentExtensions::ResourceLoadInfo&)> checker)
 {
-    RESOURCEMONITOR_RELEASE_LOG("Finish pending queries: count %lu", m_pendingQueries.size());
+    RESOURCEMONITOR_RELEASE_LOG("finishPendingQueries: Finish pending queries: count=%lu", m_pendingQueries.size());
 
     for (auto& pair : m_pendingQueries) {
         auto& [info, completionHandler] = pair;
@@ -154,7 +154,7 @@ void ResourceMonitorChecker::setNetworkUsageThreshold(size_t threshold, double r
     if (m_networkUsageThreshold == threshold && m_networkUsageThresholdRandomness == randomness)
         return;
 
-    RESOURCEMONITOR_RELEASE_LOG("Update network usage threshold: threshold=%zu, randomness=%.3f", threshold, randomness);
+    RESOURCEMONITOR_RELEASE_LOG("setNetworkUsageThreshold: Update network usage threshold: threshold=%zu, randomness=%.3f", threshold, randomness);
 
     m_networkUsageThreshold = threshold;
     m_networkUsageThresholdRandomness = randomness;

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1786,7 +1786,7 @@ void NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedP
 #if ENABLE(CONTENT_EXTENSIONS)
 void NetworkConnectionToWebProcess::shouldOffloadIFrameForHost(const String& host, CompletionHandler<void(bool)>&& completionHandler)
 {
-    CONNECTION_RELEASE_LOG(Loading, "shouldOffloadIFrameForHost: (host=%" SENSITIVE_LOG_STRING ")", host.utf8().data());
+    CONNECTION_RELEASE_LOG(ResourceMonitoring, "shouldOffloadIFrameForHost: (host=%" SENSITIVE_LOG_STRING ")", host.utf8().data());
     if (CheckedPtr session = networkSession())
         session->protectedResourceMonitorThrottler()->tryAccess(host, ContinuousApproximateTime::now(), WTFMove(completionHandler));
     else

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -940,8 +940,10 @@ Ref<NetworkBroadcastChannelRegistry> NetworkSession::protectedBroadcastChannelRe
 #if ENABLE(CONTENT_EXTENSIONS)
 WebCore::ResourceMonitorThrottlerHolder& NetworkSession::resourceMonitorThrottler()
 {
-    if (!m_resourceMonitorThrottler)
+    if (!m_resourceMonitorThrottler) {
+        RELEASE_LOG(ResourceMonitoring, "NetworkSession::resourceMonitorThrottler sessionID=%" PRIu64 ", ResourceMonitorThrottler is created.", m_sessionID.toUInt64());
         m_resourceMonitorThrottler = WebCore::ResourceMonitorThrottlerHolder::create(m_resourceMonitorThrottlerDirectory);
+    }
 
     return *m_resourceMonitorThrottler;
 }

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -149,6 +149,7 @@ extern "C" {
     M(RemoteLayerTree) \
     M(Resize) \
     M(ResourceLoadStatistics) \
+    M(ResourceMonitoring) \
     M(Sandbox) \
     M(ScreenTime) \
     M(ScrollAnimations) \

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -428,7 +428,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 
     [[PAL::getWPResourcesClass() sharedInstance] prepareResouceMonitorRulesForStore:store completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
         if (error)
-            RELEASE_LOG_ERROR(ResourceLoadStatistics, "Failed to request resource monitor urls from WebPrivacy");
+            RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls from WebPrivacy: %@", error);
 
         for (auto& completionHandler : std::exchange(lookupCompletionHandlers.get(), { }))
             completionHandler(list, updated);

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1409,12 +1409,17 @@ static RefPtr<WebCompiledContentRuleList> createCompiledContentRuleList(WKConten
 
 void WebProcessPool::platformLoadResourceMonitorRuleList(CompletionHandler<void(RefPtr<WebCompiledContentRuleList>)>&& completionHandler)
 {
+    RELEASE_LOG(ResourceMonitoring, "WebProcessPool::platformLoadResourceMonitorRuleList request to load rule list.");
+
     ResourceMonitorURLsController::singleton().prepare([weakThis = WeakPtr { *this }, completionHandler = WTFMove(completionHandler)](WKContentRuleList *list, bool updated) mutable {
         RefPtr<WebCompiledContentRuleList> ruleList;
 
         if (RefPtr protectedThis = weakThis.get()) {
-            if (list && (updated || !protectedThis->m_resourceMonitorRuleListCache))
+            if (list && (updated || !protectedThis->m_resourceMonitorRuleListCache)) {
+                RELEASE_LOG(ResourceMonitoring, "WebProcessPool::platformLoadResourceMonitorRuleList rule list is loaded.");
                 ruleList = createCompiledContentRuleList(list);
+            } else
+                RELEASE_LOG_ERROR(ResourceMonitoring, "WebProcessPool::platformLoadResourceMonitorRuleList failed to load rule list.");
         }
         completionHandler(WTFMove(ruleList));
     });

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -2721,7 +2721,7 @@ void WebProcessPool::loadOrUpdateResourceMonitorRuleList()
     if (m_resourceMonitorRuleListLoading || m_resourceMonitorRuleListFailed)
         return;
 
-    WEBPROCESSPOOL_RELEASE_LOG(Process, "loadOrUpdateResourceMonitorRuleList: rule list is requested");
+    WEBPROCESSPOOL_RELEASE_LOG(ResourceMonitoring, "loadOrUpdateResourceMonitorRuleList: rule list is requested");
 
     m_resourceMonitorRuleListLoading = true;
 

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -390,8 +390,13 @@ void WebResourceLoader::updateBytesTransferredOverNetwork(uint64_t bytesTransfer
 
     if (delta) {
         RefPtr coreLoader = m_coreLoader;
-        if (RefPtr resourceMonitor = coreLoader ? coreLoader->resourceMonitorIfExists() : nullptr)
+        if (RefPtr resourceMonitor = coreLoader ? coreLoader->resourceMonitorIfExists() : nullptr) {
+            auto oldLevel = resourceMonitor->networkUsageLevel();
             resourceMonitor->addNetworkUsage(delta);
+            auto newLevel = resourceMonitor->networkUsageLevel();
+            if (oldLevel != newLevel)
+                RELEASE_LOG(ResourceMonitoring, "(WebProcess) WebResourceLoader::updateBytesTransferredOverNetwork level=%d%% of %zu bytes", static_cast<int>(newLevel), resourceMonitor->networkUsageThreshold());
+        }
     }
 #endif
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -2040,6 +2040,8 @@ void WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold()
     if (url.isEmpty())
         return;
 
+    WebLocalFrameLoaderClient_RELEASE_LOG(ResourceMonitoring, "didExceedNetworkUsageThreshold host=%" SENSITIVE_LOG_STRING, url.host().utf8().data());
+
     auto action = [weakFrame = WeakPtr { m_frame->coreLocalFrame() }](bool wasGranted) {
         RefPtr frame = weakFrame.get();
         if (!frame)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -2573,9 +2573,11 @@ Ref<WebCookieJar> WebProcess::protectedCookieJar()
 #if ENABLE(CONTENT_EXTENSIONS)
 void WebProcess::setResourceMonitorContentRuleList(WebCompiledContentRuleListData&& ruleListData)
 {
+    WEBPROCESS_RELEASE_LOG(ResourceMonitoring, "setResourceMonitorContentRuleList");
+
     RefPtr compiledContentRuleList = WebCompiledContentRuleList::create(WTFMove(ruleListData));
     if (!compiledContentRuleList) {
-        WEBPROCESS_RELEASE_LOG_ERROR(ResourceLoadStatistics, "setResourceMonitorContentRuleList: Failed to create rule list");
+        WEBPROCESS_RELEASE_LOG_ERROR(ResourceMonitoring, "setResourceMonitorContentRuleList: Failed to create rule list");
         return;
     }
 
@@ -2588,6 +2590,7 @@ void WebProcess::setResourceMonitorContentRuleList(WebCompiledContentRuleListDat
 
 void WebProcess::setResourceMonitorContentRuleListAsync(WebCompiledContentRuleListData&& ruleListData, CompletionHandler<void()>&& completionHandler)
 {
+    WEBPROCESS_RELEASE_LOG(ResourceMonitoring, "setResourceMonitorContentRuleListAsync");
     setResourceMonitorContentRuleList(WTFMove(ruleListData));
     completionHandler();
 }


### PR DESCRIPTION
#### c7af5b9e0c4f785316499f4020ecd5dd8b4d4090
<pre>
[ResourceMonitor] Add more meaningful release log information part 2.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288174">https://bugs.webkit.org/show_bug.cgi?id=288174</a>
<a href="https://rdar.apple.com/145259890">rdar://145259890</a>

Reviewed by Chris Dumez.

Adding new log category and move current release logs to that category. And also add more meaningful information
for the record.

This is part 2, targeting WebKit.

* Source/WebCore/loader/ResourceMonitor.cpp:
(WebCore::ResourceMonitor::networkUsageLevel const):
* Source/WebCore/loader/ResourceMonitor.h:
* Source/WebCore/loader/ResourceMonitorChecker.cpp:
(WebCore::ResourceMonitorChecker::checkEligibility):
(WebCore::ResourceMonitorChecker::setContentRuleList):
(WebCore::ResourceMonitorChecker::finishPendingQueries):
(WebCore::ResourceMonitorChecker::setNetworkUsageThreshold):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::shouldOffloadIFrameForHost):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::resourceMonitorThrottler):
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::prepare):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformLoadResourceMonitorRuleList):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::loadOrUpdateResourceMonitorRuleList):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::updateBytesTransferredOverNetwork):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didExceedNetworkUsageThreshold):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::setResourceMonitorContentRuleList):
(WebKit::WebProcess::setResourceMonitorContentRuleListAsync):

Canonical link: <a href="https://commits.webkit.org/292052@main">https://commits.webkit.org/292052@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb014aaf66c06ec2f0020f6a7e37923a7af3b25c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45063 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29464 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52480 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3105 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44387 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101611 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21604 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15761 "Found 1 new test failure: html5lib/generated/run-entities01-data.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81151 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80525 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20160 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14823 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21581 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26711 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21260 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22998 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->