### PR TITLE
[css-anchor-position-1] Evaluate position-try-fallbacks with try-tactic

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-basic-anchor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-basic-anchor-expected.txt
@@ -1,0 +1,5 @@
+
+PASS Uses flip-block
+PASS Uses flip-inline
+PASS Uses flip-block flip-inline
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-basic-anchor.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-basic-anchor.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>CSS Anchor Positioning: simple try-tactic with anchor</title>
+<link rel="help" href="https://drafts.csswg.org/css-anchor-position-1/#typedef-position-try-fallbacks-try-tactic">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+  #cb {
+    position: absolute;
+    width: 200px;
+    height: 200px;
+    border: 1px solid black;
+  }
+  #anchor {
+    position: absolute;
+    left: 100px;
+    top: 100px;
+    width: 50px;
+    height: 50px;
+    background-color:red;
+    anchor-name: --anchor;
+  }
+  #target1 {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    /* Does not fit ... */
+    left: anchor(--anchor left);
+    top: anchor(--anchor bottom);
+    /* flip-block fits */
+    position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+    background-color: coral;
+  }
+  #target2 {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    /* Does not fit ... */
+    left: anchor(--anchor right);
+    top: anchor(--anchor top);
+    /* flip-inline fits */
+    position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+    background-color: blue;
+  }
+  #target3 {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    /* Does not fit ... */
+    left: anchor(--anchor right);
+    top: anchor(--anchor bottom);
+    /* flip-block flip-inline fits */
+    position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+    background-color: green;
+  }
+</style>
+<div id=cb>
+  <div id=anchor></div>
+  <div id=target1></div>
+  <div id=target2></div>
+  <div id=target3></div>
+</div>
+<script>
+  test(() => {
+    let cs = getComputedStyle(target1);
+    assert_equals(cs.left, '100px');
+    assert_equals(cs.top, '0px');
+  }, 'Uses flip-block');
+  test(() => {
+    let cs = getComputedStyle(target2);
+    assert_equals(cs.left, '0px');
+    assert_equals(cs.top, '100px');
+  }, 'Uses flip-inline');
+  test(() => {
+    let cs = getComputedStyle(target3);
+    assert_equals(cs.left, '0px');
+    assert_equals(cs.top, '0px');
+  }, 'Uses flip-block flip-inline');
+</script>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2756,7 +2756,7 @@ void Document::resolveStyle(ResolveStyleType type)
                 updateRenderTree(WTFMove(styleUpdate));
 
                 if (frameView->layoutContext().needsLayout())
-                    frameView->layoutContext().layout();
+                    frameView->layoutContext().interleavedLayout();
             }
 
             styleUpdate = resolver.resolve();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -172,6 +172,18 @@ void LocalFrameViewLayoutContext::layout(bool canDeferUpdateLayerPositions)
     }
 }
 
+void LocalFrameViewLayoutContext::interleavedLayout()
+{
+    LOG_WITH_STREAM(Layout, stream << "LocalFrameView " << &view() << " LocalFrameViewLayoutContext::interleavedLayout() with size " << view().layoutSize());
+
+    Ref protectedView(view());
+
+    performLayout(false);
+
+    Style::Scope::LayoutDependencyUpdateContext layoutDependencyUpdateContext;
+    document()->styleScope().invalidateForLayoutDependencies(layoutDependencyUpdateContext);
+}
+
 void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPositions)
 {
     Ref frame = this->frame();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -70,6 +70,8 @@ public:
     WEBCORE_EXPORT void layout(bool canDeferUpdateLayerPositions = false);
     bool needsLayout(OptionSet<LayoutOptions> layoutOptions = { }) const;
 
+    void interleavedLayout();
+
     // We rely on the side-effects of layout, like compositing updates, to update state in various subsystems
     // whose dependencies are poorly defined. This call triggers such updates.
     void setNeedsLayoutAfterViewConfigurationChange();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -166,6 +166,8 @@ void RenderBox::willBeDestroyed()
             view().unregisterContainerQueryBox(*this);
         if (!style().anchorNames().isEmpty())
             view().unregisterAnchor(*this);
+        if (!style().positionTryFallbacks().isEmpty())
+            view().unregisterPositionTryBox(*this);
     }
 
     RenderBoxModelObject::willBeDestroyed();
@@ -299,6 +301,11 @@ void RenderBox::styleWillChange(StyleDifference diff, const RenderStyle& newStyl
         view().registerAnchor(*this);
     else if (oldStyle && !oldStyle->anchorNames().isEmpty())
         view().unregisterAnchor(*this);
+
+    if (!style().positionTryFallbacks().isEmpty() && style().hasOutOfFlowPosition())
+        view().registerPositionTryBox(*this);
+    else if (oldStyle && !oldStyle->positionTryFallbacks().isEmpty() && oldStyle->hasOutOfFlowPosition())
+        view().unregisterPositionTryBox(*this);
 
     RenderBoxModelObject::styleWillChange(diff, newStyle);
 }

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -1100,6 +1100,16 @@ void RenderView::unregisterAnchor(const RenderBoxModelObject& renderer)
     m_anchors.remove(renderer);
 }
 
+void RenderView::registerPositionTryBox(const RenderBox& box)
+{
+    m_positionTryBoxes.add(box);
+}
+
+void RenderView::unregisterPositionTryBox(const RenderBox& box)
+{
+    m_positionTryBoxes.remove(box);
+}
+
 void RenderView::addCounterNeedingUpdate(RenderCounter& renderer)
 {
     m_countersNeedingUpdate.add(renderer);

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -212,6 +212,10 @@ public:
     void unregisterAnchor(const RenderBoxModelObject&);
     const SingleThreadWeakHashSet<const RenderBoxModelObject>& anchors() const { return m_anchors; }
 
+    void registerPositionTryBox(const RenderBox&);
+    void unregisterPositionTryBox(const RenderBox&);
+    const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes() const { return m_positionTryBoxes; }
+
     SingleThreadWeakPtr<RenderElement> viewTransitionRoot() const;
     void setViewTransitionRoot(RenderElement& renderer);
 
@@ -287,6 +291,7 @@ private:
     SingleThreadWeakHashSet<const RenderBox> m_boxesWithScrollSnapPositions;
     SingleThreadWeakHashSet<const RenderBox> m_containerQueryBoxes;
     SingleThreadWeakHashSet<const RenderBoxModelObject> m_anchors;
+    SingleThreadWeakHashSet<const RenderBox> m_positionTryBoxes;
 
     SingleThreadWeakPtr<RenderElement> m_viewTransitionRoot;
     HashMap<AtomString, SingleThreadWeakPtr<RenderElement>> m_viewTransitionGroups;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -28,6 +28,7 @@
 #include "EventTarget.h"
 #include "LayoutUnit.h"
 #include "ScopedName.h"
+#include "WritingMode.h"
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakHashMap.h>
@@ -40,8 +41,10 @@ class Document;
 class Element;
 class LayoutRect;
 class RenderBlock;
+class RenderBox;
 class RenderBoxModelObject;
 class RenderStyle;
+struct PositionTryFallback;
 
 enum CSSPropertyID : uint16_t;
 
@@ -116,6 +119,9 @@ public:
     static AnchorToAnchorPositionedMap makeAnchorPositionedForAnchorMap(Document&);
 
     static bool isLayoutTimeAnchorPositioned(const RenderStyle&);
+    static CSSPropertyID resolvePositionTryFallbackProperty(CSSPropertyID, WritingMode, const PositionTryFallback&);
+
+    static bool overflowsContainingBlock(const RenderBox& anchoredBox);
 
 private:
     static AnchorElements findAnchorsForAnchorPositionedElement(const Element&, const UncheckedKeyHashSet<AtomString>& anchorNames, const AnchorsForAnchorName&);

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -295,6 +295,9 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return applyProperty(newId, valueToApply.get(), linkMatchMask, cascadeLevel);
     }
 
+    if (m_state.positionTryFallback())
+        id = AnchorPositionEvaluator::resolvePositionTryFallbackProperty(id, style.writingMode(), *m_state.positionTryFallback());
+
     auto valueID = WebCore::valueID(valueToApply.get());
 
     const CSSCustomPropertyValue* customPropertyValue = nullptr;

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -28,6 +28,7 @@
 #include "CSSToLengthConversionData.h"
 #include "CSSToStyleMap.h"
 #include "CascadeLevel.h"
+#include "PositionTryFallback.h"
 #include "PropertyCascade.h"
 #include "RuleSet.h"
 #include "SelectorChecker.h"
@@ -66,6 +67,7 @@ struct BuilderContext {
     const RenderStyle& parentStyle;
     const RenderStyle* rootElementStyle = nullptr;
     RefPtr<const Element> element = nullptr;
+    std::optional<PositionTryFallback> positionTryFallback { };
 };
 
 class BuilderState {
@@ -129,6 +131,8 @@ public:
     void setCurrentPropertyInvalidAtComputedValueTime();
 
     Ref<Calculation::RandomKeyMap> randomKeyMap(bool perElement) const;
+
+    const std::optional<PositionTryFallback>& positionTryFallback() const { return m_context.positionTryFallback; }
 
 private:
     // See the comment in maybeUpdateFontForLetterSpacing() about why this needs to be a friend.

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -216,6 +216,7 @@ private:
 
     bool invalidateForContainerDependencies(LayoutDependencyUpdateContext&);
     bool invalidateForAnchorDependencies(LayoutDependencyUpdateContext&);
+    bool invalidateForPositionTryFallbacks(LayoutDependencyUpdateContext&);
 
     CheckedRef<Document> m_document;
     ShadowRoot* m_shadowRoot { nullptr };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -45,6 +45,7 @@
 #include "NodeRenderStyle.h"
 #include "Page.h"
 #include "PlatformStrategies.h"
+#include "PositionTryFallback.h"
 #include "Quirks.h"
 #include "RenderElement.h"
 #include "RenderStyleSetters.h"
@@ -149,6 +150,9 @@ ResolvedStyle TreeResolver::styleForStyleable(const Styleable& styleable, Resolu
         return { RenderStyle::clonePtr(*styleable.lastStyleChangeEventStyle()) };
 
     auto& element = styleable.element;
+
+    if (auto optionStyle = tryChoosePositionOption(styleable, existingStyle))
+        return WTFMove(*optionStyle);
 
     if (element.hasCustomStyleResolveCallbacks()) {
         RenderStyle* shadowHostStyle = scope().shadowRoot ? m_update->elementStyle(*scope().shadowRoot->host()) : nullptr;
@@ -279,6 +283,9 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
 
     Styleable styleable { element, { } };
     auto resolvedStyle = styleForStyleable(styleable, resolutionType, resolutionContext, existingStyle);
+
+    generatePositionOptionsIfNeeded(resolvedStyle, styleable, resolutionContext);
+
     auto update = createAnimatedElementUpdate(WTFMove(resolvedStyle), styleable, parent().change, resolutionContext, parent().isInDisplayNoneTree);
 
     if (!affectsRenderedSubtree(element, *update.style)) {
@@ -807,7 +814,7 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveStartingStyle(const ResolvedSt
     // We now resolve the starting style by applying all rules (including @starting-style ones) again.
     // We could compute it along with the primary style and include it in MatchedPropertiesCache but it is not
     // clear this would be benefitial as it is typically only used once.
-    return resolveAgainWithParentStyle(resolvedStyle, styleable, parentStyle, PropertyCascade::startingStyleProperties(), resolutionContext);
+    return resolveAgainInDifferentContext(resolvedStyle, styleable, parentStyle, PropertyCascade::startingStyleProperties(), { }, resolutionContext);
 }
 
 std::unique_ptr<RenderStyle> TreeResolver::resolveAfterChangeStyleForNonAnimated(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext) const
@@ -828,10 +835,10 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAfterChangeStyleForNonAnimated
 
     // "Likewise, define the after-change style as.. and inheriting from the after-change style of the parent."
     auto& parentStyle = parentAfterChangeStyle(styleable, resolutionContext);
-    return resolveAgainWithParentStyle(resolvedStyle, styleable, parentStyle, PropertyCascade::normalProperties(), resolutionContext);
+    return resolveAgainInDifferentContext(resolvedStyle, styleable, parentStyle, PropertyCascade::normalProperties(), { }, resolutionContext);
 }
 
-std::unique_ptr<RenderStyle> TreeResolver::resolveAgainWithParentStyle(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const RenderStyle& parentStyle, OptionSet<PropertyCascade::PropertyType> properties, const ResolutionContext& resolutionContext) const
+std::unique_ptr<RenderStyle> TreeResolver::resolveAgainInDifferentContext(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const RenderStyle& parentStyle, OptionSet<PropertyCascade::PropertyType> properties, const std::optional<PositionTryFallback>& positionTryFallback, const ResolutionContext& resolutionContext) const
 {
     ASSERT(resolvedStyle.matchResult);
 
@@ -845,7 +852,8 @@ std::unique_ptr<RenderStyle> TreeResolver::resolveAgainWithParentStyle(const Res
         m_document.get(),
         parentStyle,
         resolutionContext.documentElementStyle,
-        &styleable.element
+        &styleable.element,
+        positionTryFallback
     };
 
     auto styleBuilder = Builder {
@@ -1175,7 +1183,7 @@ void TreeResolver::resolveComposedTree()
             it.traverseNextSkippingChildren();
             continue;
         }
-        
+
         resetDescendantStyleRelations(element, descendantsToResolve);
 
         auto isInDisplayNoneTree = parent.isInDisplayNoneTree == IsInDisplayNoneTree::Yes || !style || style->display() == DisplayType::None;
@@ -1279,6 +1287,13 @@ std::unique_ptr<Update> TreeResolver::resolve()
         }
     }
 
+    for (auto& elementAndOptions : m_positionOptions) {
+        if (!elementAndOptions.value.chosen) {
+            elementAndOptions.key->invalidateForResumingAnchorPositionedElementResolution();
+            m_hasUnresolvedAnchorPositionedElements = true;
+        }
+    }
+
     if (m_update->roots().isEmpty())
         return { };
 
@@ -1304,6 +1319,85 @@ auto TreeResolver::updateAnchorPositioningState(Element& element, const RenderSt
 
     return AnchorPositionedElementAction::SkipDescendants;
 }
+
+void TreeResolver::generatePositionOptionsIfNeeded(const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)
+{
+    // https://drafts.csswg.org/css-anchor-position-1/#fallback-apply
+
+    if (!resolvedStyle.style || resolvedStyle.style->positionTryFallbacks().isEmpty())
+        return;
+
+    auto* anchorPositionedState = m_document->styleScope().anchorPositionedStates().get(styleable.element);
+    if (anchorPositionedState && anchorPositionedState->stage < AnchorPositionResolutionStage::Resolved)
+        return;
+
+    m_positionOptions.ensure(styleable.element, [&] {
+        auto options = PositionOptions { .originalStyle = RenderStyle::clonePtr(*resolvedStyle.style) };
+        options.optionStyles.reserveInitialCapacity(resolvedStyle.style->positionTryFallbacks().size());
+        for (auto& fallback : resolvedStyle.style->positionTryFallbacks()) {
+            auto optionStyle = generatePositionOption(fallback, resolvedStyle, styleable, resolutionContext);
+            if (!optionStyle)
+                continue;
+            options.optionStyles.append(WTFMove(optionStyle));
+        }
+        return options;
+    });
+}
+
+std::unique_ptr<RenderStyle> TreeResolver::generatePositionOption(const PositionTryFallback& fallback, const ResolvedStyle& resolvedStyle, const Styleable& styleable, const ResolutionContext& resolutionContext)
+{
+    // https://drafts.csswg.org/css-anchor-position-1/#fallback-apply
+
+    if (!resolvedStyle.matchResult)
+        return { };
+
+    return resolveAgainInDifferentContext(resolvedStyle, styleable, *resolutionContext.parentStyle, PropertyCascade::normalProperties(), fallback, resolutionContext);
+}
+
+std::optional<ResolvedStyle> TreeResolver::tryChoosePositionOption(const Styleable& styleable, const RenderStyle* existingStyle)
+{
+    // https://drafts.csswg.org/css-anchor-position-1/#fallback-apply
+
+    if (!existingStyle)
+        return { };
+
+    auto optionIt = m_positionOptions.find(styleable.element);
+    if (optionIt == m_positionOptions.end())
+        return { };
+
+    auto& options = optionIt->value;
+
+    auto renderer = dynamicDowncast<RenderBox>(styleable.element.renderer());
+    if (!renderer) {
+        options.chosen = true;
+        return ResolvedStyle { RenderStyle::clonePtr(*options.originalStyle) };
+    }
+
+    if (!AnchorPositionEvaluator::overflowsContainingBlock(*renderer)) {
+        // We don't overflow anymore so this is a good style.
+        options.chosen = true;
+        return ResolvedStyle { RenderStyle::clonePtr(*existingStyle) };
+    }
+
+    if (options.chosen) {
+        // We have already chosen.
+        return ResolvedStyle { RenderStyle::clonePtr(*existingStyle) };
+    }
+
+    if (options.index >= options.optionStyles.size()) {
+        // None of the options worked, return back to the original.
+        options.chosen = true;
+        return ResolvedStyle { RenderStyle::clonePtr(*options.originalStyle) };
+    }
+
+    auto& optionStyle = options.optionStyles[options.index];
+
+    // Next option to try if this doesn't work.
+    ++options.index;
+
+    return ResolvedStyle { RenderStyle::clonePtr(*optionStyle) };
+}
+
 
 static Vector<Function<void ()>>& postResolutionCallbackQueue()
 {


### PR DESCRIPTION
#### d86d00141e75e84612b84cd452cc15f54a7cecb2
<pre>
[css-anchor-position-1] Evaluate position-try-fallbacks with try-tactic
<a href="https://bugs.webkit.org/show_bug.cgi?id=288287">https://bugs.webkit.org/show_bug.cgi?id=288287</a>
<a href="https://rdar.apple.com/145359529">rdar://145359529</a>

Reviewed by Alan Baradlay.

Implement basic avaluation support for position-try-fallbacks property.
Only &lt;try-tactic&gt; values flip-inline and flip-block are supported by this patch.

<a href="https://drafts.csswg.org/css-anchor-position-1/#position-try-fallbacks">https://drafts.csswg.org/css-anchor-position-1/#position-try-fallbacks</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-basic-anchor-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-basic-anchor.html: Added.

Add a basic test. Almost all existing WPTs for &lt;try-tactic&gt; also use @position-try rules.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::interleavedLayout):

Add a simpified layout entry point for interleaving.

* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::willBeDestroyed):
(WebCore::RenderBox::styleWillChange):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::registerPositionTryBox):
(WebCore::RenderView::unregisterPositionTryBox):

Track boxes with position-try for invalidation.

* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::computeInsetValue):
(WebCore::Style::AnchorPositionEvaluator::evaluate):

Flip the sides used in anchor();

(WebCore::Style::flipHorizontal):
(WebCore::Style::flipVertical):
(WebCore::Style::AnchorPositionEvaluator::resolvePositionTryFallbackProperty):

Property flip helper.

(WebCore::Style::AnchorPositionEvaluator::overflowsContainingBlock):

Helper to test for overlow.

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::Builder):
(WebCore::Style::Builder::applyProperty):

Flip the property as needed when building position option styles.

* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::BuilderState):
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::positionTryFallback const):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForLayoutDependencies):
(WebCore::Style::Scope::invalidateForPositionTryFallbacks):

Invalidation support.

* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::styleForStyleable):

If we have position options return the next option instead of computing the style.

(WebCore::Style::TreeResolver::resolveElement):
(WebCore::Style::TreeResolver::resolveStartingStyle const):
(WebCore::Style::TreeResolver::resolveAfterChangeStyleForNonAnimated const):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext const):

Add argument and rename to use in fallback resolution.

(WebCore::Style::TreeResolver::resolveComposedTree):
(WebCore::Style::TreeResolver::resolve):

Invalidate for interleaving if we have positions options we haven&apos;t chosen yet.

(WebCore::Style::TreeResolver::resolveElement):

Generate position options from position-try-fallbacks after resolving the style.

(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):

Go through position-try-fallbacks and generate a position option for each as needed.

(WebCore::Style::TreeResolver::generatePositionOption):

Spin the style builder to generate a position option.

(WebCore::Style::TreeResolver::tryChoosePositionOption):

See if the current style overflows the containing block and try the next option if it does.

* Source/WebCore/style/StyleTreeResolver.h:

Canonical link: <a href="https://commits.webkit.org/290891@main">https://commits.webkit.org/290891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/793c9a5f8df595c24a4917d368221a4ef69d9f2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42095 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93455 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19272 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27701 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50505 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/373 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41263 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98376 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18567 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78406 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19390 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22928 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18565 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23843 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18277 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->