### PR TITLE
Some RetainPtr cleanup [v2]

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -45,8 +45,16 @@
 #define CF_RELEASES_ARGUMENT
 #endif
 
+#ifndef CF_RETURNS_RETAINED
+#define CF_RETURNS_RETAINED
+#endif
+
 #ifndef NS_RELEASES_ARGUMENT
 #define NS_RELEASES_ARGUMENT
+#endif
+
+#ifndef NS_RETURNS_RETAINED
+#define NS_RETURNS_RETAINED
 #endif
 
 #ifndef __OBJC__
@@ -62,27 +70,23 @@ typedef struct objc_object *id;
 
 namespace WTF {
 
-// Unlike most most of our smart pointers, RetainPtr can take either the pointer type or the pointed-to type,
-// so both RetainPtr<NSDictionary> and RetainPtr<CFDictionaryRef> will work.
+// RetainPtr can point to NS or CF objects, e.g. RetainPtr<NSDictionary> or RetainPtr<CFDictionaryRef>.
 
 template<typename T> class RetainPtr;
+
+template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
+template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T>, std::remove_pointer_t<T>, T>;
 
 template<typename T> constexpr RetainPtr<T> adoptCF(T CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
 #ifdef __OBJC__
-template<typename T> RetainPtr<typename RetainPtr<T>::HelperPtrType> adoptNS(T NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+template<typename T> RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 #endif
 
 template<typename T> class RetainPtr {
 public:
     using ValueType = std::remove_pointer_t<T>;
     using PtrType = ValueType*;
-
-#ifdef __OBJC__
-    using HelperPtrType = typename std::conditional_t<std::is_convertible_v<T, id> && !std::is_same_v<T, id>, std::remove_pointer_t<T>, T>;
-#else
-    using HelperPtrType = PtrType;
-#endif
 
     RetainPtr() = default;
     RetainPtr(PtrType);
@@ -101,23 +105,13 @@ public:
 
     void clear();
 
-#ifdef __OBJC__
-    template<typename U = T>
-    std::enable_if_t<std::is_convertible_v<U, id>, PtrType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        static_assert(std::is_same_v<T, U>, "explicit specialization not allowed");
+    template<typename U = PtrType>
+    std::enable_if_t<IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
         return fromStorageType(std::exchange(m_ptr, nullptr));
     }
-#else
-    template<typename U = T>
-    std::enable_if_t<std::is_same_v<U, id>, PtrType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        static_assert(std::is_same_v<T, U>, "explicit specialization not allowed");
-        return fromStorageType(std::exchange(m_ptr, nullptr));
-    }
-#endif
 
-    template<typename U = T>
-    std::enable_if_t<!std::is_convertible_v<U, id>, PtrType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        static_assert(std::is_same_v<T, U>, "explicit specialization not allowed");
+    template<typename U = PtrType>
+    std::enable_if_t<!IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
         return fromStorageType(std::exchange(m_ptr, nullptr));
     }
 
@@ -149,7 +143,7 @@ public:
     template<typename U> friend constexpr RetainPtr<U> adoptCF(U CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
 #ifdef __OBJC__
-    template<typename U> friend RetainPtr<typename RetainPtr<U>::HelperPtrType> adoptNS(U NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+    template<typename U> friend RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 #endif
 
 private:
@@ -158,14 +152,17 @@ private:
 
     static constexpr PtrType checkType(PtrType ptr) { return ptr; }
 
+    // ARC will try to retain/release this value, but it looks like a tagged immediate, so retain/release ends up being a no-op -- see _objc_registerTaggedPointerClass.
     static constexpr PtrType hashTableDeletedValue() { return fromStorageType(reinterpret_cast<CFTypeRef>(-1)); }
 
 #ifdef __OBJC__
-    template<typename U> static constexpr std::enable_if_t<std::is_convertible_v<U, id>, PtrType> fromStorageTypeHelper(CFTypeRef ptr)
+    template<typename U = PtrType>
+    static constexpr std::enable_if_t<IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> fromStorageTypeHelper(CFTypeRef ptr)
     {
         return (__bridge PtrType)const_cast<CF_BRIDGED_TYPE(id) void*>(ptr);
     }
-    template<typename U> static constexpr std::enable_if_t<!std::is_convertible_v<U, id>, PtrType> fromStorageTypeHelper(CFTypeRef ptr)
+    template<typename U = PtrType>
+    static constexpr std::enable_if_t<!IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> fromStorageTypeHelper(CFTypeRef ptr)
     {
         return (PtrType)const_cast<CF_BRIDGED_TYPE(id) void*>(ptr);
     }
@@ -183,10 +180,10 @@ private:
     CFTypeRef m_ptr { nullptr };
 };
 
-template<typename T> RetainPtr(T) -> RetainPtr<std::remove_pointer_t<T>>;
+template<typename T> RetainPtr(T) -> RetainPtr<RetainPtrType<T>>;
 
 // Helper function for creating a RetainPtr using template argument deduction.
-template<typename T> RetainPtr<typename RetainPtr<T>::HelperPtrType> retainPtr(T) WARN_UNUSED_RETURN;
+template<typename T> RetainPtr<RetainPtrType<T>> retainPtr(T) WARN_UNUSED_RETURN;
 
 template<typename T> inline RetainPtr<T>::~RetainPtr()
 {
@@ -221,7 +218,7 @@ template<typename T> inline void RetainPtr<T>::clear()
 template<typename T> inline auto RetainPtr<T>::autorelease() -> PtrType
 {
 #ifdef __OBJC__
-    if constexpr (std::is_convertible_v<PtrType, id>)
+    if constexpr (IsNSType<PtrType>)
         return CFBridgingRelease(std::exchange(m_ptr, nullptr));
 #endif
     if (m_ptr)
@@ -235,7 +232,7 @@ template<typename T> inline auto RetainPtr<T>::autorelease() -> PtrType
 // FIXME: It would be better if we could base the return type on the type that is toll-free bridged with T rather than using id.
 template<typename T> inline id RetainPtr<T>::bridgingAutorelease()
 {
-    static_assert(!std::is_convertible_v<PtrType, id>, "Don't use bridgingAutorelease for Objective-C pointer types.");
+    static_assert(!IsNSType<PtrType>, "Don't use bridgingAutorelease for Objective-C pointer types.");
     return CFBridgingRelease(leakRef());
 }
 
@@ -311,29 +308,24 @@ template<typename T, typename U> constexpr bool operator==(T* a, const RetainPtr
 template<typename T> constexpr RetainPtr<T> adoptCF(T CF_RELEASES_ARGUMENT ptr)
 {
 #ifdef __OBJC__
-    static_assert(!std::is_convertible_v<T, id>, "Don't use adoptCF with Objective-C pointer types, use adoptNS.");
+    static_assert(!IsNSType<T>, "Don't use adoptCF with Objective-C pointer types, use adoptNS.");
 #endif
     return RetainPtr<T>(ptr, RetainPtr<T>::Adopt);
 }
 
 #ifdef __OBJC__
-template<typename T> inline RetainPtr<typename RetainPtr<T>::HelperPtrType> adoptNS(T NS_RELEASES_ARGUMENT ptr)
+template<typename T> RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT ptr)
 {
-    static_assert(std::is_convertible_v<T, id>, "Don't use adoptNS with Core Foundation pointer types, use adoptCF.");
+    static_assert(IsNSType<T>, "Don't use adoptNS with Core Foundation pointer types, use adoptCF.");
 #if __has_feature(objc_arc)
     return ptr;
-#elif defined(OBJC_NO_GC)
-    using ReturnType = RetainPtr<typename RetainPtr<T>::HelperPtrType>;
-    return ReturnType { ptr, ReturnType::Adopt };
 #else
-    RetainPtr<typename RetainPtr<T>::HelperPtrType> result = ptr;
-    [ptr release];
-    return result;
+    return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
 #endif
 }
 #endif
 
-template<typename T> inline RetainPtr<typename RetainPtr<T>::HelperPtrType> retainPtr(T ptr)
+template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)
 {
     return ptr;
 }


### PR DESCRIPTION
#### 36514def01eb1550439a9edf6651654ca8967be6
<pre>
Some RetainPtr cleanup [v2]
<a href="https://bugs.webkit.org/show_bug.cgi?id=288291">https://bugs.webkit.org/show_bug.cgi?id=288291</a>
<a href="https://rdar.apple.com/145371975">rdar://145371975</a>

Reviewed by Timothy Hatcher.

Fixed a series of bugs where is_convertible_v tests attempting to distinguish id
from CFTypeRef were incorrect because they were testing e.g. NSString == id
instead of NSString* == id.

Added a helper for IsNSType, to simplify is_convertible_v tests.

Tightened type requirements so that e.g. RetainPtr&lt;NSString&gt; is supported but
RetainPtr&lt;NSString*&gt; is not.

Renamed HelperPtrType to RetainPtrType and pulled it outside the class for
clarity. The old model of RetainPtr&lt;NSString*&gt;::HelperPtrType == NSString was a
bit mind-bending because
    * RetainPtr&lt;NSString*&gt; is malformed
    * NSString is not a pointer type

Added #defines for CF_RETURNS_RETAINED and NS_RETURNS_RETAINED, to
reduce #ifdefs inside the class.

Removed support for ObjC GC because it&apos;s the year 2025 and the future is now.

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::fromStorageTypeHelper):
(WTF::RetainPtr&lt;T&gt;::autorelease):
(WTF::RetainPtr&lt;T&gt;::bridgingAutorelease):
(WTF::adoptCF):
(WTF::adoptNS):
(WTF::retainPtr):

Canonical link: <a href="https://commits.webkit.org/290899@main">https://commits.webkit.org/290899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f435ac48e6230d22b336fa4552cae1d1c1e98d2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91378 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96347 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42080 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70164 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27692 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50490 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/350 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41236 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84184 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98349 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90130 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79185 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78603 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78389 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/264 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11690 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18542 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23827 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112711 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18256 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32692 "Found 328 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21713 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->