### PR TITLE
Address safer C++ static analysis warnings in ElementAncestorIterator

### DIFF
--- a/Source/WebCore/dom/ElementAncestorIterator.h
+++ b/Source/WebCore/dom/ElementAncestorIterator.h
@@ -56,10 +56,10 @@ public:
     explicit ElementAncestorRange(ElementType* first);
     ElementAncestorIterator<ElementType> begin() const;
     static constexpr std::nullptr_t end() { return nullptr; }
-    ElementType* first() const { return m_first; }
+    ElementType* first() const { return m_first.get(); }
 
 private:
-    ElementType* const m_first;
+    RefPtr<ElementType> m_first;
 };
 
 // ElementAncestorIterator

--- a/Source/WebCore/dom/ElementAncestorIteratorInlines.h
+++ b/Source/WebCore/dom/ElementAncestorIteratorInlines.h
@@ -44,7 +44,7 @@ inline ElementAncestorIterator<ElementType>& ElementAncestorIterator<ElementType
 template <typename ElementType>
 inline ElementAncestorIterator<ElementType> ElementAncestorRange<ElementType>::begin() const
 {
-    return ElementAncestorIterator<ElementType>(m_first);
+    return ElementAncestorIterator<ElementType>(m_first.get());
 }
 
 // Standalone functions


### PR DESCRIPTION
#### a4a7342013a5e62e20e8e13a920cd36092409c58
<pre>
Address safer C++ static analysis warnings in ElementAncestorIterator
<a href="https://bugs.webkit.org/show_bug.cgi?id=288293">https://bugs.webkit.org/show_bug.cgi?id=288293</a>
<a href="https://rdar.apple.com/problem/145374613">rdar://problem/145374613</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning caused by using a raw reference to
store element in ElementAncestorIterator.

* Source/WebCore/dom/ElementAncestorIterator.h:
(WebCore::ElementAncestorRange::first const):
* Source/WebCore/dom/ElementAncestorIteratorInlines.h:
(WebCore::ElementAncestorRange&lt;ElementType&gt;::begin const):

Canonical link: <a href="https://commits.webkit.org/290970@main">https://commits.webkit.org/290970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4195f292c0229969958528eb46c8fbd72feeba4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91389 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42085 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19254 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70171 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27695 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50497 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8376 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/361 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78696 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/368 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98360 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79192 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18806 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78396 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19440 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22915 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/269 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11692 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18550 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23833 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21721 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->