### PR TITLE
Nullptr crash in WebCore::MathMLElement::isKeyboardFocusable

### DIFF
--- a/LayoutTests/mathml/mathml-invalid-frame-crash-expected.txt
+++ b/LayoutTests/mathml/mathml-invalid-frame-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/mathml/mathml-invalid-frame-crash.html
+++ b/LayoutTests/mathml/mathml-invalid-frame-crash.html
@@ -1,0 +1,23 @@
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function runTest() {
+  let dialogElement = document.getElementById("htmlvar00011");
+
+  let newDocument = window.document.implementation.createHTMLDocument();
+  newDocument.adoptNode(dialogElement);
+  dialogElement.show();
+  
+  window.testRunner?.notifyDone();
+}
+</script>
+
+<body onload="runTest()">
+  <p>This test passes if WebKit does not crash.</p>
+  <dialog id="htmlvar00011" ondragend="eventhandler5()">
+    <math href="x" dir="ltr"></math>
+  </dialog>
+</body>

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -268,8 +268,10 @@ bool MathMLElement::isKeyboardFocusable(KeyboardEvent* event) const
     if (isFocusable() && StyledElement::supportsFocus())
         return StyledElement::isKeyboardFocusable(event);
 
-    if (isLink())
-        return document().frame()->eventHandler().tabsToLinks(event);
+    if (isLink()) {
+        RefPtr frame = document().frame();
+        return frame && frame->eventHandler().tabsToLinks(event);
+    }
 
     return StyledElement::isKeyboardFocusable(event);
 }


### PR DESCRIPTION
#### 5a55a82ed2271d86c304a5c96fce208c3a072624
<pre>
Nullptr crash in WebCore::MathMLElement::isKeyboardFocusable
<a href="https://bugs.webkit.org/show_bug.cgi?id=288296">https://bugs.webkit.org/show_bug.cgi?id=288296</a>
<a href="https://rdar.apple.com/144405709">rdar://144405709</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

Added a nullptr check for the LocalFrame before focused keyboard events.

* LayoutTests/mathml/mathml-invalid-frame-crash-expected.txt: Added.
* LayoutTests/mathml/mathml-invalid-frame-crash.html: Added.
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::isKeyboardFocusable const):

Canonical link: <a href="https://commits.webkit.org/291060@main">https://commits.webkit.org/291060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9429c9a59720ea92544e180ea5b5ffaf2d64123e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91813 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11347 "Hash 9429c9a5 for PR 41150 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96768 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70481 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27976 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83186 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50809 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/778 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41655 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79014 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/779 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98785 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79507 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78730 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23261 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12016 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14577 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24165 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->