### PR TITLE
[fullscreen] Make fullscreen/api/element-request-fullscreen-same.html WPT pass

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6438,6 +6438,9 @@ imported/w3c/web-platform-tests/xhr/send-after-setting-document-domain.htm [ Ski
 imported/w3c/web-platform-tests/html/capability-delegation/delegate-fullscreen-request-subframe-same-origin.https.tentative.html [ Pass Failure ]
 imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-and-move-to-iframe.html [ Pass Failure ]
 
+# This test needs fixing (see https://github.com/web-platform-tests/wpt/pull/50895):
+imported/w3c/web-platform-tests/fullscreen/api/document-exit-fullscreen-nested-in-iframe.html [ Skip ]
+
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_annexb [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webcodecs/full-cycle-test.https.any.html?h264_avc [ DumpJSConsoleLogInStdErr ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.html [ DumpJSConsoleLogInStdErr ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Element#requestFullscreen() on the current fullscreen element assert_unreached: fullscreenchange event Reached unreachable code
+PASS Element#requestFullscreen() on the current fullscreen element
 

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -283,10 +283,11 @@ ExceptionOr<void> FullscreenManager::willEnterFullscreen(Element& element, HTMLM
             ancestors.append(ownerElement.releaseNonNull());
     }
 
+    bool elementWasFullscreen = &element == element.document().fullscreenManager().fullscreenElement();
     for (auto ancestor : makeReversedRange(ancestors))
         elementEnterFullscreen(ancestor);
 
-    if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element))
+    if (RefPtr iframe = dynamicDowncast<HTMLIFrameElement>(element); iframe && !elementWasFullscreen)
         iframe->setIFrameFullscreenFlag(true);
 
     return { };
@@ -294,6 +295,9 @@ ExceptionOr<void> FullscreenManager::willEnterFullscreen(Element& element, HTMLM
 
 void FullscreenManager::elementEnterFullscreen(Element& element)
 {
+    if (&element == element.document().fullscreenManager().fullscreenElement())
+        return;
+
     auto hideUntil = element.topmostPopoverAncestor(Element::TopLayerElementType::Other);
     element.document().hideAllPopoversUntil(hideUntil, FocusPreviousElement::No, FireEvents::No);
 


### PR DESCRIPTION
#### 5fd67dbdda1c02be97172789a85c585348157d23
<pre>
[fullscreen] Make fullscreen/api/element-request-fullscreen-same.html WPT pass
<a href="https://bugs.webkit.org/show_bug.cgi?id=288297">https://bugs.webkit.org/show_bug.cgi?id=288297</a>
<a href="https://rdar.apple.com/145382274">rdar://145382274</a>

Reviewed by Jer Noble.

Add step 13.2 in <a href="https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen">https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen</a>

&gt; If element is doc’s fullscreen element, continue.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/fullscreen/api/element-request-fullscreen-same-expected.txt:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::FullscreenManager::elementEnterFullscreen):

Canonical link: <a href="https://commits.webkit.org/291056@main">https://commits.webkit.org/291056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eadd6b9c9ad532598507f55e65f3c82f0cdb2dec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93465 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70195 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27708 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82815 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50521 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8397 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/401 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41273 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78717 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18577 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13663 "Found 1 new test failure: http/tests/iframe-monitor/blob-resource.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79211 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78415 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22937 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/303 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11709 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18575 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23851 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21745 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->