### PR TITLE
AX: With ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) we need to eagerly recompute is-ignored for descendants of aria-hidden elements

### DIFF
--- a/LayoutTests/accessibility/details-summary-content-hidden.html
+++ b/LayoutTests/accessibility/details-summary-content-hidden.html
@@ -33,7 +33,7 @@ if (window.accessibilityController) {
         document.getElementById("details").removeAttribute("open");
         output += await expectAsync("details.isExpanded", "false");
         output += await expectAsync("summary.isExpanded", "false");
-        output += expect("!accessibilityController.accessibleElementById('content')", "true");
+        output += await expectAsync("!accessibilityController.accessibleElementById('content')", "true");
 
         debug(output);
         finishJSTest();

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -362,6 +362,7 @@ public:
     void onPopoverToggle(const HTMLElement&);
     void onScrollbarFrameRectChange(const Scrollbar&);
     void onSelectedChanged(Element&);
+    void onSlottedContentChange(const HTMLSlotElement&);
     void onStyleChange(Element&, Style::Change, const RenderStyle* oldStyle, const RenderStyle* newStyle);
     void onStyleChange(RenderText&, StyleDifference, const RenderStyle* oldStyle, const RenderStyle& newStyle);
     void onTextSecurityChanged(HTMLInputElement&);

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2434,7 +2434,7 @@ void AccessibilityRenderObject::addNodeOnlyChildren()
     WeakPtr cache = axObjectCache();
     if (!cache)
         return;
-    // FIXME: This algorithm does not work correctly when ENABLE(INCLUDE_IGNORED_IN_CORE_TREE) due to use of m_children, as this algorithm is written assuming m_children only every contains unignored objects.
+    // FIXME: This algorithm does not work correctly when ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) due to use of m_children, as this algorithm is written assuming m_children only every contains unignored objects.
     // Iterate through all of the children, including those that may have already been added, and
     // try to insert the nodes in the correct place in the DOM order.
     unsigned insertionIndex = 0;

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -322,6 +322,8 @@ void NamedSlotAssignment::didChangeSlot(const AtomString& slotAttrValue, ShadowR
 
     if (slotElement->selfOrPrecedingNodesAffectDirAuto())
         slotElement->updateEffectiveTextDirection();
+
+    slotElement->updateAccessibilityOnSlotChange();
 }
 
 void NamedSlotAssignment::didRemoveAllChildrenOfShadowHost(ShadowRoot& shadowRoot)

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -232,4 +232,10 @@ void HTMLSlotElement::dispatchSlotChangeEvent()
     dispatchEvent(event);
 }
 
+void HTMLSlotElement::updateAccessibilityOnSlotChange() const
+{
+    if (CheckedPtr cache = protectedDocument()->existingAXObjectCache())
+        cache->onSlottedContentChange(*this);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -55,6 +55,7 @@ public:
 
     bool isInInsertedIntoAncestor() const { return m_isInInsertedIntoAncestor; }
 
+    void updateAccessibilityOnSlotChange() const;
 private:
     HTMLSlotElement(const QualifiedName&, Document&);
 


### PR DESCRIPTION
#### 1b9a2025ca119638448bfa4fc1e3b7875a1d4a81
<pre>
AX: With ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) we need to eagerly recompute is-ignored for descendants of aria-hidden elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=288299">https://bugs.webkit.org/show_bug.cgi?id=288299</a>
<a href="https://rdar.apple.com/145387158">rdar://145387158</a>

Reviewed by Chris Fleizach.

Prior to ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), we handled dynamic aria-hidden changes with AXObjectCache::childrenChanged.
However, with ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), there are no actual accessibility tree changes, just different
is-ignored values for the subtree. This fixes these two tests:

  - accessibility/aria-hidden-updates-alldescendants.html
  - accessibility/mac/iframe-aria-hidden.html

This commit also fixes an existing bug exposed by ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE) where we don&apos;t process
childrenChanged events when the elements filling a slot change, which impacts the accessibility tree. This fixes
accessibility/mac/invalid-summary-element.html.

Finally, we fix accessibility/details-summary-content-hidden.html by making the test more async.

* LayoutTests/accessibility/details-summary-content-hidden.html:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onSlottedContentChange):
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addNodeOnlyChildren):
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::NamedSlotAssignment::didChangeSlot):
* Source/WebCore/html/HTMLSlotElement.cpp:
(WebCore::HTMLSlotElement::updateAccessibilityOnSlotChange const):
* Source/WebCore/html/HTMLSlotElement.h:

Canonical link: <a href="https://commits.webkit.org/290908@main">https://commits.webkit.org/290908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25abe94a018040a9a3bc9f6e6b8c2d258c648f57

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96398 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70204 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27722 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50530 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/429 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98408 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13637 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79230 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78676 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78434 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/324 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11722 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18589 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23865 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21759 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20066 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->