### PR TITLE
[JSC] Add DFG node count inlining heuristics

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -3482,12 +3482,26 @@ CodePtr<JSEntryPtrTag> CodeBlock::addressForCallConcurrently(const ConcurrentJSL
 
 unsigned CodeBlock::bytecodeCost() const
 {
-#if ENABLE(FTL_JIT)
-    if (jitType() == JITType::FTLJIT) {
-        if (auto* jitCode = static_cast<FTL::JITCode*>(m_jitCode.get()))
-            return std::min(static_cast<unsigned>(jitCode->numberOfCompiledDFGNodes() * Options::ratioFTLNodesToBytecodeCost()), m_bytecodeCost);
+    switch (jitType()) {
+#if ENABLE(DFG_JIT)
+    case JITType::DFGJIT: {
+        if (auto* jitCode = static_cast<DFG::JITCode*>(m_jitCode.get()))
+            return std::min(static_cast<unsigned>(jitCode->numberOfCompiledDFGNodes() * Options::ratioDFGNodesToBytecodeCost()), m_bytecodeCost);
+        break;
     }
 #endif
+
+#if ENABLE(FTL_JIT)
+    case JITType::FTLJIT: {
+        if (auto* jitCode = static_cast<FTL::JITCode*>(m_jitCode.get()))
+            return std::min(static_cast<unsigned>(jitCode->numberOfCompiledDFGNodes() * Options::ratioFTLNodesToBytecodeCost()), m_bytecodeCost);
+        break;
+    }
+#endif
+
+    default:
+        break;
+    }
     return m_bytecodeCost;
 }
 

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -278,7 +278,13 @@ public:
     using DirectJITCode::initializeCodeRefForDFG;
 
     PCToCodeOriginMap* pcToCodeOriginMap() override { return common.m_pcToCodeOriginMap.get(); }
-    
+
+    unsigned numberOfCompiledDFGNodes() const { return m_numberOfCompiledDFGNodes; }
+    void setNumberOfCompiledDFGNodes(unsigned numberOfCompiledDFGNodes)
+    {
+        m_numberOfCompiledDFGNodes = numberOfCompiledDFGNodes;
+    }
+
 private:
     friend class JITCompiler; // Allow JITCompiler to call setCodeRef().
 
@@ -321,6 +327,7 @@ public:
     unsigned osrEntryRetry { 0 };
     bool abandonOSREntry { false };
 #endif // ENABLE(FTL_JIT)
+    unsigned m_numberOfCompiledDFGNodes { 0 };
 };
 
 inline std::unique_ptr<JITData> JITData::tryCreate(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode, ExitVector&& exits)

--- a/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp
@@ -63,6 +63,14 @@ bool JITFinalizer::finalize()
 
     CodeBlock* codeBlock = m_plan.codeBlock();
 
+    if (UNLIKELY(Options::dumpDFGCodeSize())) {
+        auto* baselineCodeBlock = codeBlock->baselineAlternative();
+        size_t baselineCodeSize = 0;
+        if (auto jitCode = baselineCodeBlock->jitCode())
+            baselineCodeSize = jitCode->size();
+        dataLogLn("DFG: codeSize:(", m_jitCode->size(), "),nodes:(", m_jitCode->numberOfCompiledDFGNodes(), "),baselineCodeSize:(", baselineCodeSize, "),bytecodeCost:(", baselineCodeBlock->bytecodeCost(), ")");
+    }
+
     codeBlock->setJITCode(m_jitCode.copyRef());
 
     auto data = m_plan.tryFinalizeJITData(m_jitCode.get());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2024,12 +2024,12 @@ void SpeculativeJIT::bail(AbortReason reason)
     clearGenerationInfo();
 }
 
-void SpeculativeJIT::compileCurrentBlock()
+unsigned SpeculativeJIT::compileCurrentBlock()
 {
     ASSERT(m_compileOkay);
     
     if (!m_block)
-        return;
+        return 0;
     
     ASSERT(m_block->isReachable);
     
@@ -2040,7 +2040,7 @@ void SpeculativeJIT::compileCurrentBlock()
         // But to be sure that nobody has generated a jump to this block, drop in a
         // breakpoint here.
         abortWithReason(DFGUnreachableBasicBlock);
-        return;
+        return 0;
     }
 
     if (m_block->isCatchEntrypoint) {
@@ -2096,6 +2096,7 @@ void SpeculativeJIT::compileCurrentBlock()
             store8(TrustedImm32(0), &vm().didEnterVM);
     }
 
+    unsigned codeGeneratedNodes = 0;
     for (m_indexInBlock = 0; m_indexInBlock < m_block->size(); ++m_indexInBlock) {
         m_currentNode = m_block->at(m_indexInBlock);
         
@@ -2103,7 +2104,7 @@ void SpeculativeJIT::compileCurrentBlock()
         // didn't cause directly.
         if (!m_state.isValid()) {
             bail(DFGBailedAtTopOfBlock);
-            return;
+            return codeGeneratedNodes;
         }
 
         m_interpreter.startExecuting();
@@ -2142,7 +2143,9 @@ void SpeculativeJIT::compileCurrentBlock()
             sizeMarker = vm().jitSizeStatistics->markStart(id, *this);
         }
 
-        compile(m_currentNode);
+        auto [notTerminated, result] = compileNode(m_currentNode);
+        if (result == CodeGenerationResult::Generated)
+            ++codeGeneratedNodes;
 
         if (UNLIKELY(sizeMarker))
             vm().jitSizeStatistics->markEnd(WTFMove(*sizeMarker), *this, m_graph.m_plan);
@@ -2154,9 +2157,9 @@ void SpeculativeJIT::compileCurrentBlock()
         clearRegisterAllocationOffsets();
 #endif
         
-        if (!m_compileOkay) {
+        if (!notTerminated) {
             bail(DFGBailedAtEndOfNode);
-            return;
+            return codeGeneratedNodes;
         }
         
         // Make sure that the abstract state is rematerialized for the next node.
@@ -2168,6 +2171,8 @@ void SpeculativeJIT::compileCurrentBlock()
         for (auto& info : m_generationInfo)
             RELEASE_ASSERT(!info.alive());
     }
+
+    return codeGeneratedNodes;
 }
 
 // If we are making type predictions about our arguments then
@@ -2249,11 +2254,13 @@ void SpeculativeJIT::compileBody()
     checkArgumentTypes();
     
     ASSERT(!m_currentNode);
+    unsigned numberOfCompiledDFGNodes = 0;
     for (BlockIndex blockIndex = 0; blockIndex < m_graph.numBlocks(); ++blockIndex) {
         setForBlockIndex(blockIndex);
         m_block = m_graph.block(blockIndex);
-        compileCurrentBlock();
+        numberOfCompiledDFGNodes += compileCurrentBlock();
     }
+    jitCode()->setNumberOfCompiledDFGNodes(numberOfCompiledDFGNodes);
     linkBranches();
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -350,10 +350,14 @@ public:
     void addSlowPathGeneratorLambda(Function<void()>&&);
     void runSlowPathGenerators(PCToCodeOriginMapBuilder&);
     
-    void compile(Node*);
+    enum class CodeGenerationResult : uint8_t {
+        NotGenerated,
+        Generated,
+    };
+    std::tuple<bool, CodeGenerationResult> compileNode(Node*);
     void noticeOSRBirth(Node*);
     void bail(AbortReason);
-    void compileCurrentBlock();
+    unsigned compileCurrentBlock();
 
     void exceptionCheck(GPRReg exceptionReg = InvalidGPRReg);
     CallSiteIndex recordCallSiteAndGenerateExceptionHandlingOSRExitIfNeeded(const CodeOrigin& callSiteCodeOrigin, unsigned eventStreamIndex);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2134,7 +2134,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
     } }
 }
 
-void SpeculativeJIT::compile(Node* node)
+auto SpeculativeJIT::compileNode(Node* node) -> std::tuple<bool, CodeGenerationResult>
 {
     NodeType op = node->op();
 
@@ -2152,6 +2152,7 @@ void SpeculativeJIT::compile(Node* node)
     clearRegisterAllocationOffsets();
 #endif
 
+    CodeGenerationResult codeGenerationResult = CodeGenerationResult::Generated;
     switch (op) {
     case JSConstant:
     case DoubleConstant:
@@ -2257,12 +2258,14 @@ void SpeculativeJIT::compile(Node* node)
 
     case MovHint:
     case ZombieHint: {
+        codeGenerationResult = CodeGenerationResult::NotGenerated;
         compileMovHint(m_currentNode);
         noResult(node);
         break;
     }
 
     case ExitOK: {
+        codeGenerationResult = CodeGenerationResult::NotGenerated;
         noResult(node);
         break;
     }
@@ -2523,22 +2526,22 @@ void SpeculativeJIT::compile(Node* node)
 
     case CompareLess:
         if (compare(node, LessThan, DoubleLessThanAndOrdered, operationCompareLess))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareLessEq:
         if (compare(node, LessThanOrEqual, DoubleLessThanOrEqualAndOrdered, operationCompareLessEq))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareGreater:
         if (compare(node, GreaterThan, DoubleGreaterThanAndOrdered, operationCompareGreater))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareGreaterEq:
         if (compare(node, GreaterThanOrEqual, DoubleGreaterThanOrEqualAndOrdered, operationCompareGreaterEq))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareBelow:
@@ -2551,12 +2554,12 @@ void SpeculativeJIT::compile(Node* node)
 
     case CompareEq:
         if (compare(node, Equal, DoubleEqualAndOrdered, operationCompareEq))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareStrictEq:
         if (compileStrictEq(node))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
         
     case CompareEqPtr:
@@ -4250,6 +4253,7 @@ void SpeculativeJIT::compile(Node* node)
 
     case PhantomLocal:
         // This is a no-op.
+        codeGenerationResult = CodeGenerationResult::NotGenerated;
         noResult(node);
         break;
     case LoopHint:
@@ -4414,10 +4418,12 @@ void SpeculativeJIT::compile(Node* node)
     }
 
     if (!m_compileOkay)
-        return;
+        return { false, codeGenerationResult };
     
     if (node->hasResult() && node->mustGenerate())
         use(node);
+
+    return { true, codeGenerationResult };
 }
 
 void SpeculativeJIT::moveTrueTo(GPRReg gpr)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3213,7 +3213,7 @@ void SpeculativeJIT::compileGetTypedArrayByteOffsetAsInt52(Node* node)
 }
 #endif // USE(LARGE_TYPED_ARRAYS)
 
-void SpeculativeJIT::compile(Node* node)
+auto SpeculativeJIT::compileNode(Node* node) -> std::tuple<bool, CodeGenerationResult>
 {
     NodeType op = node->op();
 
@@ -3228,6 +3228,7 @@ void SpeculativeJIT::compile(Node* node)
     clearRegisterAllocationOffsets();
 #endif
 
+    CodeGenerationResult codeGenerationResult = CodeGenerationResult::Generated;
     switch (op) {
     case JSConstant:
     case DoubleConstant:
@@ -3323,12 +3324,14 @@ void SpeculativeJIT::compile(Node* node)
 
     case MovHint:
     case ZombieHint: {
+        codeGenerationResult = CodeGenerationResult::NotGenerated;
         compileMovHint(m_currentNode);
         noResult(node);
         break;
     }
 
     case ExitOK: {
+        codeGenerationResult = CodeGenerationResult::NotGenerated;
         noResult(node);
         break;
     }
@@ -3643,22 +3646,22 @@ void SpeculativeJIT::compile(Node* node)
 
     case CompareLess:
         if (compare(node, LessThan, DoubleLessThanAndOrdered, operationCompareLess))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareLessEq:
         if (compare(node, LessThanOrEqual, DoubleLessThanOrEqualAndOrdered, operationCompareLessEq))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareGreater:
         if (compare(node, GreaterThan, DoubleGreaterThanAndOrdered, operationCompareGreater))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareGreaterEq:
         if (compare(node, GreaterThanOrEqual, DoubleGreaterThanOrEqualAndOrdered, operationCompareGreaterEq))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareBelow:
@@ -3671,12 +3674,12 @@ void SpeculativeJIT::compile(Node* node)
 
     case CompareEq:
         if (compare(node, Equal, DoubleEqualAndOrdered, operationCompareEq))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
 
     case CompareStrictEq:
         if (compileStrictEq(node))
-            return;
+            return { m_compileOkay, codeGenerationResult };
         break;
         
     case CompareEqPtr:
@@ -5737,6 +5740,7 @@ void SpeculativeJIT::compile(Node* node)
         
     case PhantomLocal:
         // This is a no-op.
+        codeGenerationResult = CodeGenerationResult::NotGenerated;
         noResult(node);
         break;
 
@@ -6506,10 +6510,12 @@ void SpeculativeJIT::compile(Node* node)
     }
 
     if (!m_compileOkay)
-        return;
+        return { false, codeGenerationResult };
     
     if (node->hasResult() && node->mustGenerate())
         use(node);
+
+    return { true, codeGenerationResult };
 }
 
 void SpeculativeJIT::moveTrueTo(GPRReg gpr)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -297,6 +297,7 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Unsigned, maximumFTLCandidateBytecodeCost, 20000, Normal, nullptr) \
     \
+    v(Double, ratioDFGNodesToBytecodeCost, 1.8, Normal, "Ratio converting DFG # of DFG nodes to approx bytecode cost") \
     v(Double, ratioFTLNodesToBytecodeCost, 1.8, Normal, "Ratio converting FTL # of DFG nodes to approx bytecode cost") \
     \
     /* Depth of inline stack, so 1 = no inlining, 2 = one level, etc. */ \
@@ -605,6 +606,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useOMGInlining, true, Normal, "Use OMG inlining"_s) \
     v(Bool, freeRetiredWasmCode, true, Normal, "free BBQ/OMG-OSR wasm code once it's no longer reachable."_s) \
     v(Bool, useArrayAllocationSinking, true, Normal, "free BBQ/OMG-OSR wasm code once it's no longer reachable."_s) \
+    v(Bool, dumpDFGCodeSize, false, Normal, nullptr) \
     v(Bool, dumpFTLCodeSize, false, Normal, nullptr) \
     \
     /* Feature Flags */\


### PR DESCRIPTION
#### b43988d2ef296fb1a031c1b34cf48d8ea88c67ee
<pre>
[JSC] Add DFG node count inlining heuristics
<a href="https://bugs.webkit.org/show_bug.cgi?id=288300">https://bugs.webkit.org/show_bug.cgi?id=288300</a>
<a href="https://rdar.apple.com/145389630">rdar://145389630</a>

Reviewed by NOBODY (OOPS!).

Doing similar thing to 290873@main. Compute more reliable bytecodeCost
approx number from compiled DFG code.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::bytecodeCost const):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGJITFinalizer.cpp:
(JSC::DFG::JITFinalizer::finalize):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileCurrentBlock):
(JSC::DFG::SpeculativeJIT::compileBody):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compileNode):
(JSC::DFG::SpeculativeJIT::compile): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileNode):
(JSC::DFG::SpeculativeJIT::compile): Deleted.
* Source/JavaScriptCore/runtime/OptionsList.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b43988d2ef296fb1a031c1b34cf48d8ea88c67ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91425 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19747 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70200 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27719 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94426 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8638 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/397 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41283 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84229 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98396 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90175 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79222 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18842 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78649 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78426 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22944 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11719 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18585 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23861 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112758 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18297 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32697 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-slow-memory ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21755 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->