### PR TITLE
Address safer cpp failures in MediaRecorderPrivateWriterWebM.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -120,7 +120,6 @@ platform/mac/ScrollbarThemeMac.mm
 platform/mac/ScrollbarsControllerMac.mm
 platform/mac/SerializedPlatformDataCueMac.mm
 platform/mac/WebCoreFullScreenWindow.mm
-platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
 platform/network/BlobResourceHandle.cpp
 rendering/BidiRun.cpp
 rendering/BidiRun.h

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp
@@ -40,6 +40,14 @@
 
 #import <pal/cf/CoreMediaSoftLink.h>
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(mkvmuxer::AudioTrack)
+    static bool isType(const mkvmuxer::Track& track) { return track.type() == mkvmuxer::Tracks::kAudio; }
+SPECIALIZE_TYPE_TRAITS_END()
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(mkvmuxer::VideoTrack)
+    static bool isType(const mkvmuxer::Track& track) { return track.type() == mkvmuxer::Tracks::kVideo; }
+SPECIALIZE_TYPE_TRAITS_END()
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaRecorderPrivateWriterWebM);
@@ -97,7 +105,7 @@ public:
         auto trackIndex = m_segment.AddAudioTrack(info.rate, info.channels, 0);
         if (!trackIndex)
             return { };
-        auto* audioTrack = reinterpret_cast<mkvmuxer::AudioTrack*>(m_segment.GetTrackByNumber(trackIndex));
+        auto* audioTrack = downcast<mkvmuxer::AudioTrack>(m_segment.GetTrackByNumber(trackIndex));
         ASSERT(audioTrack);
         audioTrack->set_bit_depth(32u);
         audioTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName));
@@ -115,7 +123,7 @@ public:
         auto trackIndex = m_segment.AddVideoTrack(info.size.width(), info.size.height(), 0);
         if (!trackIndex)
             return { };
-        auto* videoTrack = reinterpret_cast<mkvmuxer::VideoTrack*>(m_segment.GetTrackByNumber(trackIndex));
+        auto* videoTrack = downcast<mkvmuxer::VideoTrack>(m_segment.GetTrackByNumber(trackIndex));
         ASSERT(videoTrack);
         videoTrack->set_codec_id(mkvCodeIcForMediaVideoCodecId(info.codecName));
         if (RefPtr atomData = info.atomData; atomData && atomData->span().size())


### PR DESCRIPTION
#### 213a4d7e07fd0c8446d642220d920e387f735907
<pre>
Address safer cpp failures in MediaRecorderPrivateWriterWebM.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288307">https://bugs.webkit.org/show_bug.cgi?id=288307</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.cpp:
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addAudioTrack):
(WebCore::MediaRecorderPrivateWriterWebMDelegate::addVideoTrack):

Canonical link: <a href="https://commits.webkit.org/290920@main">https://commits.webkit.org/290920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcd79bcbadda60ece9a39d8b7d61d098738b9e83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11352 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19329 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70213 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27732 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50539 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41301 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78740 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98415 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18605 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13654 "Too many flaky failures: fast/dom/crash-with-bad-url.html, fast/mediastream/cloned-video-stream-aspect-ratio.html, fast/mediastream/getUserMedia-to-canvas-1.html, fast/mediastream/media-stream-page-muted.html, fast/mediastream/mediastreamtrack-video-clone.html, imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html, imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-invoke-pause-networkState.html, imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg, media/modern-media-controls/tracks-support/audio-multiple-tracks.html, pdf/annotations/radio-buttons-select-second.html, storage/indexeddb/open-cursor.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79235 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78439 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22958 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/318 "Found 1 new test failure: http/tests/iframe-monitor/blob-resource.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11733 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14473 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23879 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->