### PR TITLE
[ANGLE] Workaround ASan false-positive stack-use-after-scope in Xcode 16.3

### DIFF
--- a/Configurations/Sanitizers.xcconfig
+++ b/Configurations/Sanitizers.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Apple Inc. All rights reserved.
+// Copyright (C) 2023-2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,6 +25,8 @@
 // by setting ENABLE_*_SANITIZER Xcode variables to YES during a build.
 
 // Requires SDKVariant.xcconfig.
+
+#include "WebKitTargetConditionals.xcconfig"
 
 WK_SANITIZER_GCC_OPTIMIZATION_LEVEL = $(WK_SANITIZER_GCC_OPTIMIZATION_LEVEL_$(CONFIGURATION));
 WK_SANITIZER_GCC_OPTIMIZATION_LEVEL_Debug = 0;
@@ -64,10 +66,16 @@ WK_ANY_SANITIZER_LDFLAGS_YES = -Wl,-rpath,@executable_path/Frameworks;
 // Address Sanitizer
 
 // Add -fsanitize-address-use-after-return=never to disable ASan's "fake stack" to fix JSC garbage collection.
-WK_ADDRESS_SANITIZER_OTHER_CFLAGS_YES = -fsanitize-address-use-after-return=never;
+WK_ADDRESS_SANITIZER_OTHER_CFLAGS_YES = -fsanitize-address-use-after-return=never $(WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE);
 WK_ADDRESS_SANITIZER_OTHER_LDFLAGS_YES = -fsanitize-address-use-after-return=never;
 
 WK_ADDRESS_SANITIZER_OTHER_CPLUSPLUSFLAGS_YES = -U_LIBCPP_HAS_NO_ASAN;
+
+// Workaround ASan stack-use-after-scope false positive in Xcode 16.3: <https://bugs.webkit.org/show_bug.cgi?id=288308>.
+WK_NEEDS_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_WORKAROUND = $(WK_NOT_$(WK_XCODE_BEFORE_16_3));
+
+WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE = $(WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_$(WK_NEEDS_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_WORKAROUND);
+WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_YES = -DWK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE;
 
 // Undefined Behavior Sanitizer
 

--- a/Configurations/WebKitTargetConditionals.xcconfig
+++ b/Configurations/WebKitTargetConditionals.xcconfig
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+// Copyright (C) 2018-2025 Apple Inc. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -380,3 +380,14 @@ WK_XCODE_BEFORE_16_1500 = YES;
 WK_XCODE_16 = $(WK_XCODE_16_$(WK_XCODE_BEFORE_16));
 WK_XCODE_16_ = _XCODE_SINCE_16;
 WK_XCODE_16_YES = _XCODE_BEFORE_16;
+
+WK_XCODE_BEFORE_16_3 = $(WK_XCODE_BEFORE_16_3$(WK_XCODE_16));
+WK_XCODE_BEFORE_16_3_XCODE_BEFORE_16 = YES;
+WK_XCODE_BEFORE_16_3_XCODE_SINCE_16 = $(WK_XCODE_BEFORE_16_3_$(XCODE_VERSION_MINOR));
+WK_XCODE_BEFORE_16_3_1600 = YES;
+WK_XCODE_BEFORE_16_3_1610 = YES;
+WK_XCODE_BEFORE_16_3_1620 = YES;
+
+WK_XCODE_16_3 = $(WK_XCODE_16_3_$(WK_XCODE_BEFORE_16_3));
+WK_XCODE_16_3_ = _XCODE_SINCE_16_3;
+WK_XCODE_16_3_YES = _XCODE_BEFORE_16_3;

--- a/Source/ThirdParty/ANGLE/src/compiler/translator/InfoSink.h
+++ b/Source/ThirdParty/ANGLE/src/compiler/translator/InfoSink.h
@@ -21,6 +21,9 @@ class TSymbol;
 class TType;
 
 // Returns the fractional part of the given floating-point number.
+#ifdef WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE
+__attribute__((no_sanitize_address))
+#endif
 inline float fractionalPart(float f)
 {
     float intPart = 0.0f;


### PR DESCRIPTION
#### e40b0da91f79998db53271c8a9ad3740b9dfe23f
<pre>
[ANGLE] Workaround ASan false-positive stack-use-after-scope in Xcode 16.3
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=288308">https://bugs.webkit.org/show_bug.cgi?id=288308</a>&gt;
&lt;<a href="https://rdar.apple.com/144259986">rdar://144259986</a>&gt;

Reviewed by John Wilander and Kimmo Kinnunen.

* Configurations/Sanitizers.xcconfig:
(WK_ADDRESS_SANITIZER_OTHER_CFLAGS_YES):
(WK_NEEDS_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_WORKAROUND): Add.
(WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE): Add.
(WK_WORKAROUND_RDAR_145268301_ASAN_STACK_USE_AFTER_SCOPE_YES): Add.
- Include a command-line switch to define a macro if the workaround is
  needed.
* Configurations/WebKitTargetConditionals.xcconfig:
(WK_XCODE_BEFORE_16_3): Add.
(WK_XCODE_BEFORE_16_3_XCODE_BEFORE_16): Add.
(WK_XCODE_BEFORE_16_3_XCODE_SINCE_16): Add.
(WK_XCODE_BEFORE_16_3_1600): Add.
(WK_XCODE_BEFORE_16_3_1610): Add.
(WK_XCODE_BEFORE_16_3_1620): Add.
(WK_XCODE_16_3): Add.
(WK_XCODE_16_3_): Add.
(WK_XCODE_16_3_YES): Add.
- Add version checking variables for Xcode 16.3.
* Source/ThirdParty/ANGLE/src/compiler/translator/InfoSink.h:
(sh::fractionalPart):
- Disable ASan if the workaround is needed.

Canonical link: <a href="https://commits.webkit.org/290943@main">https://commits.webkit.org/290943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6659e17c70482324c58be148cf1142f6e137210

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42132 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70216 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27733 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82833 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50542 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8419 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/419 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98416 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18606 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79237 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18861 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11734 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14490 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18604 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20080 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->