### PR TITLE
[SwiftUI] Custom `NavigationDeciding` implementations have no effect

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift
@@ -42,7 +42,7 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
     weak var owner: WebPage? = nil
 
     private let downloadProgressContinuation: AsyncStream<WebPage.DownloadEvent>.Continuation
-    private let navigationDecider: any WebPage.NavigationDeciding
+    private var navigationDecider: any WebPage.NavigationDeciding
 
     // MARK: Navigation progress reporting
 


### PR DESCRIPTION
#### b00c01c1d451d2b7c71cab53d0c0d0220e10e857
<pre>
[SwiftUI] Custom `NavigationDeciding` implementations have no effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=288306">https://bugs.webkit.org/show_bug.cgi?id=288306</a>
<a href="https://rdar.apple.com/145390836">rdar://145390836</a>

Reviewed by Abrar Rahman Protyasha.

Consider the following simplified code:

```
protocol P {
    mutating func f() -&gt; Int
}

extension P {
    func f() -&gt; Int {
        1
    }
}

struct CustomP: P {
    func f() -&gt; Int {
        2
    }
}

class C {
    let p: any P

    init(_ p: any P) {
        self.p = p
    }

    func proxyF() -&gt; Int {
        p.f()
    }
}

let c = C(CustomP())
print(c.proxyF())
```

This results in `1` being printed, since the `CustomP` implementation of `f` isn&apos;t used because it implements the `f` requirement
of `P`, which is `mutating`, and therefore isn&apos;t allowed to be used with non-mutable value types. And so instead, the implementation
of `f` inside the `extension P` is used instead since that one is considered a separate function entirely, and therefore does not
implement the protocol requirement.

Because 290468@main changed the NavigationDeciding protocol functions to become `mutating`, and since `WKNavigationDelegateAdapter`
was using `let navigationDecider`, this subtle behavior difference was introduced, resulting in the default implementations always
being used.

Fix by using `var` instead of `let`, so that the mutating protocol requirement implementations in the custom deciders can actually be used.

* Source/WebKit/UIProcess/API/Swift/WKNavigationDelegateAdapter.swift:
(WKNavigationDelegateAdapter.navigationDecider):

Canonical link: <a href="https://commits.webkit.org/290916@main">https://commits.webkit.org/290916@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61dfa3eb2514f5e29b89b04181807915103d0391

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91445 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96414 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42133 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70217 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27735 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94446 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8652 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82835 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50543 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8418 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41303 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78738 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98417 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18607 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79239 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18862 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78443 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22960 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/321 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11735 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14469 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18605 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23881 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->