### PR TITLE
Fix warnings seen when running process-css-properties.py

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2224,6 +2224,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -4242,6 +4246,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -4351,6 +4359,10 @@
                 {
                     "value": "contain",
                     "status": "unimplemented"
+                },
+                {
+                    "value": "intrinsic",
+                    "status": "non-standard"
                 },
                 {
                     "value": "min-intrinsic",
@@ -5532,6 +5544,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -5585,6 +5601,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -5634,6 +5654,10 @@
                 {
                     "value": "contain",
                     "status": "unimplemented"
+                },
+                {
+                    "value": "intrinsic",
+                    "status": "non-standard"
                 },
                 {
                     "value": "min-intrinsic",
@@ -5707,6 +5731,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -5756,6 +5784,10 @@
                 {
                     "value": "contain",
                     "status": "unimplemented"
+                },
+                {
+                    "value": "intrinsic",
+                    "status": "non-standard"
                 },
                 {
                     "value": "min-intrinsic",
@@ -5811,6 +5843,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -5860,6 +5896,10 @@
                 {
                     "value": "contain",
                     "status": "unimplemented"
+                },
+                {
+                    "value": "intrinsic",
+                    "status": "non-standard"
                 },
                 {
                     "value": "min-intrinsic",
@@ -5913,6 +5953,10 @@
                 {
                     "value": "contain",
                     "status": "unimplemented"
+                },
+                {
+                    "value": "intrinsic",
+                    "status": "non-standard"
                 },
                 {
                     "value": "min-intrinsic",
@@ -7762,6 +7806,10 @@
                     "status": "unimplemented"
                 },
                 {
+                    "value": "intrinsic",
+                    "status": "non-standard"
+                },
+                {
                     "value": "min-intrinsic",
                     "status": "non-standard"
                 },
@@ -8945,6 +8993,10 @@
                 {
                     "value": "contain",
                     "status": "unimplemented"
+                },
+                {
+                    "value": "intrinsic",
+                    "status": "non-standard"
                 },
                 {
                     "value": "min-intrinsic",
@@ -11328,7 +11380,15 @@
             "animation-type": "discrete",
             "initial": "none",
             "values": [
-                "none"
+                "none",
+                {
+                    "value": "auto",
+                    "status": "non-standard"
+                },
+                {
+                    "value": "match-element",
+                    "status": "non-standard"
+                }
             ],
             "codegen-properties": {
                 "style-builder-converter": "ViewTransitionName",


### PR DESCRIPTION
#### 4d082633f9d78ef54c78b7d7d68b4574a51e6a64
<pre>
Fix warnings seen when running process-css-properties.py
<a href="https://bugs.webkit.org/show_bug.cgi?id=288310">https://bugs.webkit.org/show_bug.cgi?id=288310</a>

Reviewed by Darin Adler.

- Adds missing non-standard &quot;intrinsic&quot; value to the values
  array for sizing properties.
- Adds missing non-standard &quot;auto&quot; and &quot;match-element&quot; values
  to the values array for view-transition-name.
- Disable warnings for properties that use a non-builtin
  reference term in their grammar. These grammars are
  incomplete from the generators perspective, so they must
  be treated like any other custom parsing.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/290923@main">https://commits.webkit.org/290923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5060522593deab39d9eb0b55567b49444d0842f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91448 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/10980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70219 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27738 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94449 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8658 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50545 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/430 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78743 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98420 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18610 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79241 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78445 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19408 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/329 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11743 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23884 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18318 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->