### PR TITLE
[macOS] "Update AutoFill Information" prompt incorrectly shows up after performing AutoFill and then closing a tab

### DIFF
--- a/LayoutTests/fast/forms/textfield-lastchange-was-useredit-expected.txt
+++ b/LayoutTests/fast/forms/textfield-lastchange-was-useredit-expected.txt
@@ -9,6 +9,7 @@ PASS textField.value = "WebKit"; internals.wasLastChangeUserEdit(textField) is f
 PASS textField.style.display = null; internals.wasLastChangeUserEdit(textField) is false
 PASS document.execCommand("SelectAll", false, null); internals.wasLastChangeUserEdit(textField) is false
 PASS document.execCommand("Delete", false, null); internals.wasLastChangeUserEdit(textField) is true
+PASS dispatchTextEventsInTextField(textField, "foo"); internals.wasLastChangeUserEdit(textField) is false
 
 textarea
 PASS internals.wasLastChangeUserEdit(textField) is false
@@ -22,6 +23,7 @@ PASS document.execCommand("Delete", false, null); internals.wasLastChangeUserEdi
 PASS textField.textContent = "hello\nworld"; internals.wasLastChangeUserEdit(textField) is false
 PASS document.execCommand("InsertText", false, "\nWebKit rocks"); internals.wasLastChangeUserEdit(textField) is true
 PASS textField.innerText = " WebKit "; internals.wasLastChangeUserEdit(textField) is false
+PASS dispatchTextEventsInTextField(textField, "foo"); internals.wasLastChangeUserEdit(textField) is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/textfield-lastchange-was-useredit.html
+++ b/LayoutTests/fast/forms/textfield-lastchange-was-useredit.html
@@ -14,7 +14,16 @@ if (!window.testRunner || !window.internals)
     testFailed('This test requires access to window.internals');
 
 var textField;
-function runTest(element) {
+
+function dispatchTextEventsInTextField(targetElement, text) {
+    [...text].map(letter => {
+        const event = document.createEvent("TextEvent");
+        event.initTextEvent("textInput", true, true, null, letter);
+        targetElement.dispatchEvent(event);
+    });
+}
+
+[...document.querySelectorAll('input, textarea')].map(element => {
     debug((textField ? '\n' : '') + element.localName);
 
     textField = element;
@@ -46,11 +55,11 @@ function runTest(element) {
         shouldBeFalse('textField.innerText = " WebKit "; internals.wasLastChangeUserEdit(textField)');
     }
 
-    textField.parentNode.removeChild(textField);
-}
+    textField.focus();
+    shouldBeFalse('dispatchTextEventsInTextField(textField, "foo"); internals.wasLastChangeUserEdit(textField)');
 
-runTest(document.getElementsByTagName('input')[0]);
-runTest(document.getElementsByTagName('textarea')[0]);
+    textField.parentNode.removeChild(textField);
+});
 
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/dom/TextEvent.cpp
+++ b/Source/WebCore/dom/TextEvent.cpp
@@ -70,6 +70,7 @@ TextEvent::TextEvent()
     : UIEvent(EventInterfaceType::TextEvent)
     , m_shouldSmartReplace(false)
     , m_shouldMatchStyle(false)
+    , m_createdFromBindings(true)
     , m_mailBlockquoteHandling(MailBlockquoteHandling::RespectBlockquote)
 {
 }

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -64,6 +64,7 @@ namespace WebCore {
 
         bool shouldSmartReplace() const { return m_shouldSmartReplace; }
         bool shouldMatchStyle() const { return m_shouldMatchStyle; }
+        bool createdFromBindings() const { return m_createdFromBindings; }
         MailBlockquoteHandling mailBlockquoteHandling() const { return m_mailBlockquoteHandling; }
         DocumentFragment* pastingFragment() const { return m_pastingFragment.get(); }
         const Vector<DictationAlternative>& dictationAlternatives() const { return m_dictationAlternatives; }
@@ -83,6 +84,7 @@ namespace WebCore {
         RefPtr<DocumentFragment> m_pastingFragment;
         bool m_shouldSmartReplace;
         bool m_shouldMatchStyle;
+        bool m_createdFromBindings { false };
         MailBlockquoteHandling m_mailBlockquoteHandling;
         Vector<DictationAlternative> m_dictationAlternatives;
     };

--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -532,9 +532,9 @@ static bool executeInsertTab(LocalFrame& frame, Event* event, EditorCommandSourc
     return targetFrame(frame, event)->eventHandler().handleTextInputEvent("\t"_s, event);
 }
 
-static bool executeInsertText(LocalFrame& frame, Event*, EditorCommandSource, const String& value)
+static bool executeInsertText(LocalFrame& frame, Event* event, EditorCommandSource, const String& value)
 {
-    TypingCommand::insertText(*frame.document(), value, { });
+    TypingCommand::insertText(*frame.document(), value, event, { });
     return true;
 }
 

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -47,6 +47,7 @@
 #include "Range.h"
 #include "RenderElement.h"
 #include "StaticRange.h"
+#include "TextEvent.h"
 #include "TextIterator.h"
 #include "VisibleUnits.h"
 
@@ -222,23 +223,28 @@ void TypingCommand::updateSelectionIfDifferentFromCurrentSelection(TypingCommand
     typingCommand->setEndingSelection(currentSelection);
 }
 
-void TypingCommand::insertText(Ref<Document>&& document, const String& text, OptionSet<Option> options, TextCompositionType composition)
+void TypingCommand::insertText(Ref<Document>&& document, const String& text, Event* triggeringEvent, OptionSet<Option> options, TextCompositionType composition)
 {
     if (!text.isEmpty())
         document->editor().updateMarkersForWordsAffectedByEditing(deprecatedIsSpaceOrNewline(text[0]));
     
     auto& selection = document->selection().selection();
-    insertText(WTFMove(document), text, selection, options, composition);
+    insertText(WTFMove(document), text, triggeringEvent, selection, options, composition);
 }
 
 // FIXME: We shouldn't need to take selectionForInsertion. It should be identical to FrameSelection's current selection.
-void TypingCommand::insertText(Ref<Document>&& document, const String& text, const VisibleSelection& selectionForInsertion, OptionSet<Option> options, TextCompositionType compositionType)
+void TypingCommand::insertText(Ref<Document>&& document, const String& text, Event* triggeringEvent, const VisibleSelection& selectionForInsertion, OptionSet<Option> options, TextCompositionType compositionType)
 {
     LOG(Editing, "TypingCommand::insertText (text %s)", text.utf8().data());
 
     VisibleSelection currentSelection = document->selection().selection();
 
     String newText = dispatchBeforeTextInsertedEvent(text, selectionForInsertion, compositionType == TextCompositionType::Pending);
+
+    bool eventWasCreatedFromBindings = [&] {
+        RefPtr textEvent = dynamicDowncast<TextEvent>(triggeringEvent);
+        return textEvent && textEvent->createdFromBindings();
+    }();
 
     // Set the starting and ending selection appropriately if we are using a selection
     // that is different from the current selection.  In the future, we should change EditCommand
@@ -253,6 +259,7 @@ void TypingCommand::insertText(Ref<Document>&& document, const String& text, con
         lastTypingCommand->setCompositionType(compositionType);
         lastTypingCommand->setShouldRetainAutocorrectionIndicator(options.contains(Option::RetainAutocorrectionIndicator));
         lastTypingCommand->setShouldPreventSpellChecking(options.contains(Option::PreventSpellChecking));
+        lastTypingCommand->setTriggeringEventWasCreatedFromBindings(eventWasCreatedFromBindings);
 #if HAVE(INLINE_PREDICTIONS)
         if (compositionType != TextCompositionType::None)
             lastTypingCommand->insertText(newText, options.contains(Option::SelectInsertedText));
@@ -263,8 +270,9 @@ void TypingCommand::insertText(Ref<Document>&& document, const String& text, con
     }
 
     RefPtr frame = document->frame();
-    auto cmd = TypingCommand::create(WTFMove(document), Type::InsertText, newText, options, compositionType);
-    applyTextInsertionCommand(frame.get(), cmd.get(), selectionForInsertion, currentSelection);
+    auto command = TypingCommand::create(WTFMove(document), Type::InsertText, newText, options, compositionType);
+    command->setTriggeringEventWasCreatedFromBindings(eventWasCreatedFromBindings);
+    applyTextInsertionCommand(frame.get(), command.get(), selectionForInsertion, currentSelection);
 }
 
 void TypingCommand::insertLineBreak(Ref<Document>&& document, OptionSet<Option> options)
@@ -524,7 +532,7 @@ void TypingCommand::typingAddedToOpenCommand(Type commandTypeForAddedTyping)
 #endif
 }
 
-void TypingCommand::insertText(const String &text, bool selectInsertedText)
+void TypingCommand::insertText(const String& text, bool selectInsertedText)
 {
     // FIXME: Need to implement selectInsertedText for cases where more than one insert is involved.
     // This requires support from insertTextRunWithoutNewlines and insertParagraphSeparator for extending

--- a/Source/WebCore/editing/TypingCommand.h
+++ b/Source/WebCore/editing/TypingCommand.h
@@ -60,8 +60,8 @@ public:
     static void deleteSelection(Ref<Document>&&, OptionSet<Option> = { }, TextCompositionType = TextCompositionType::None);
     static void deleteKeyPressed(Ref<Document>&&, OptionSet<Option> = { }, TextGranularity = TextGranularity::CharacterGranularity);
     static void forwardDeleteKeyPressed(Ref<Document>&&, OptionSet<Option> = { }, TextGranularity = TextGranularity::CharacterGranularity);
-    static void insertText(Ref<Document>&&, const String&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
-    static void insertText(Ref<Document>&&, const String&, const VisibleSelection&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
+    static void insertText(Ref<Document>&&, const String&, Event* triggeringEvent, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
+    static void insertText(Ref<Document>&&, const String&, Event* triggeringEvent, const VisibleSelection&, OptionSet<Option>, TextCompositionType = TextCompositionType::None);
     static void insertLineBreak(Ref<Document>&&, OptionSet<Option>);
     static void insertParagraphSeparator(Ref<Document>&&, OptionSet<Option>);
     static void insertParagraphSeparatorInQuotedContent(Ref<Document>&&);
@@ -70,8 +70,8 @@ public:
     static void ensureLastEditCommandHasCurrentSelectionIfOpenForMoreTyping(Document&, const VisibleSelection&);
 #endif
 
-    void insertText(const String &text, bool selectInsertedText);
-    void insertTextRunWithoutNewlines(const String &text, bool selectInsertedText);
+    void insertText(const String&, bool selectInsertedText);
+    void insertTextRunWithoutNewlines(const String&, bool selectInsertedText);
     void insertLineBreak();
     void insertParagraphSeparatorInQuotedContent();
     void insertParagraphSeparator();
@@ -80,6 +80,8 @@ public:
     void deleteSelection(bool smartDelete);
     void setCompositionType(TextCompositionType type) { m_compositionType = type; }
     void setIsAutocompletion(bool isAutocompletion) { m_isAutocompletion = isAutocompletion; }
+    bool triggeringEventWasCreatedFromBindings() const { return m_triggeringEventWasCreatedFromBindings; }
+    void setTriggeringEventWasCreatedFromBindings(bool value) { m_triggeringEventWasCreatedFromBindings = value; }
 
 #if PLATFORM(IOS_FAMILY)
     void setEndingSelectionOnLastInsertCommand(const VisibleSelection& selection);
@@ -162,6 +164,11 @@ private:
 
     bool m_shouldRetainAutocorrectionIndicator;
     bool m_shouldPreventSpellChecking;
+    bool m_triggeringEventWasCreatedFromBindings { false };
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::TypingCommand)
+    static bool isType(const WebCore::CompositeEditCommand& command) { return command.isTypingCommand(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -145,14 +145,14 @@ void HTMLTextFormControlElement::dispatchBlurEvent(RefPtr<Element>&& newFocusedE
     HTMLFormControlElement::dispatchBlurEvent(WTFMove(newFocusedElement));
 }
 
-void HTMLTextFormControlElement::didEditInnerTextValue()
+void HTMLTextFormControlElement::didEditInnerTextValue(bool wasUserEdit)
 {
     if (!renderer() || !isTextField())
         return;
 
     LOG(Editing, "HTMLTextFormControlElement %p didEditInnerTextValue", this);
 
-    m_lastChangeWasUserEdit = true;
+    m_lastChangeWasUserEdit = wasUserEdit;
     subtreeHasChanged();
 }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -51,7 +51,7 @@ public:
 
     virtual ~HTMLTextFormControlElement();
 
-    void didEditInnerTextValue();
+    void didEditInnerTextValue(bool wasUserEdit);
     void forwardEvent(Event&);
 
     int maxLength() const { return m_maxLength; }

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -289,7 +289,7 @@ static void insertUnicodeCharacter(UChar character, LocalFrame& frame)
         return;
 
     ASSERT(frame.document());
-    TypingCommand::insertText(*frame.protectedDocument(), text, { }, TypingCommand::TextCompositionType::None);
+    TypingCommand::insertText(*frame.protectedDocument(), text, nullptr, { }, TypingCommand::TextCompositionType::None);
 }
 
 #endif


### PR DESCRIPTION
#### 97eba3acfe770439b967d2ce82b27c27d2c5fc2e
<pre>
[macOS] &quot;Update AutoFill Information&quot; prompt incorrectly shows up after performing AutoFill and then closing a tab
<a href="https://bugs.webkit.org/show_bug.cgi?id=288315">https://bugs.webkit.org/show_bug.cgi?id=288315</a>
<a href="https://rdar.apple.com/145085437">rdar://145085437</a>

Reviewed by Abrar Rahman Protyasha.

To improve web compatibility, Safari&apos;s AutoFill JavaScript creates and dispatches `TextEvent` on
text fields in order to simulate text insertion. This internally triggers typing commands, which
marks the text field as having been last modified via user edit. This, in turn, causes Safari to
(incorrectly) believe that the user had manually modified the AutoFilled text field after invoking
AutoFill, which then shows a prompt.

To fix this, we add some plumbing from `TextEvent` → `TypingCommand` → `Editor::appliedEditing` to
avoid marking the text field as having been modified through user editing, only in the case where
these text editing commands were triggered by a `TextEvent` that was created and initialized from
JS bindings.

* LayoutTests/fast/forms/textfield-lastchange-was-useredit-expected.txt:
* LayoutTests/fast/forms/textfield-lastchange-was-useredit.html:

Augment an existing layout test to cover this scenario.

* Source/WebCore/dom/TextEvent.cpp:
(WebCore::TextEvent::TextEvent):
* Source/WebCore/dom/TextEvent.h:

Add a flag to mark a `TextEvent`, as being created from JS bindings (as opposed to created from the
engine as a result of handling key events, etc.).

* Source/WebCore/editing/Editor.cpp:
(WebCore::notifyTextFromControls):
(WebCore::Editor::appliedEditing):

If the edit command is a typing command that was triggered by an event created from bindings, pass
`wasUserEdit := false`.

(WebCore::Editor::insertTextWithoutSendingTextEvent):
(WebCore::Editor::setComposition):
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeInsertText):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::insertText):

Add plumbing to send `TextEvent*` through `TypingCommand::insertText`, so that we can mark the
`TypingCommand` as being triggered by a text event that was created from bindings.

* Source/WebCore/editing/TypingCommand.h:

Add a flag to mark `TypingCommand` as being triggered by an event that was created from bindings.

(isType):

Make it possible to use `dynamicDowncast&lt;TypingCommand&gt;(…)` on an edit command.

* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::HTMLTextFormControlElement::didEditInnerTextValue):
* Source/WebCore/html/HTMLTextFormControlElement.h:

Plumb `wasUserEdit` down into the text form control, and set `m_lastChangeWasUserEdit`.

* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::insertUnicodeCharacter):

Canonical link: <a href="https://commits.webkit.org/290927@main">https://commits.webkit.org/290927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f3ef0c8705aed32de466d317d8b50e06e927099

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/535 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93530 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70244 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27763 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82869 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8449 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/456 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41338 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98452 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18642 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79265 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18897 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78469 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19411 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22991 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11772 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23916 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18350 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->