### PR TITLE
[JSC] Remove HandleExceptionWithCallFrameRollback thunk

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -372,11 +372,6 @@ void JITCompiler::disassemble(LinkBuffer& linkBuffer)
         m_disassembler->reportToProfiler(m_graph.m_plan.compilation(), linkBuffer);
 }
 
-void JITCompiler::exceptionJumpWithCallFrameRollback()
-{
-    jumpThunk(CodeLocationLabel(vm().getCTIStub(CommonJITThunkID::HandleExceptionWithCallFrameRollback).retaggedCode<NoPtrTag>()));
-}
-
 #if USE(JSVALUE32_64)
 void* JITCompiler::addressOfDoubleConstant(Node* node)
 {

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -167,8 +167,6 @@ public:
         call(address, OperationPtrTag);
     }
 
-    void exceptionJumpWithCallFrameRollback();
-
     OSRExitCompilationInfo& appendExitInfo(MacroAssembler::JumpList jumpsToFail = MacroAssembler::JumpList())
     {
         OSRExitCompilationInfo info;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1190,14 +1190,6 @@ public:
         return call;
     }
 
-    JITCompiler::Call callThrowOperationWithCallFrameRollback(V_JITOperation_Cb operation, GPRReg codeBlockGPR)
-    {
-        setupArguments<V_JITOperation_Cb>(codeBlockGPR);
-        JITCompiler::Call call = appendCall(operation);
-        exceptionJumpWithCallFrameRollback();
-        return call;
-    }
-
     void prepareForExternalCall()
     {
 #if !defined(NDEBUG) && !CPU(ARM_THUMB2)

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -1091,11 +1091,6 @@ void JIT::exceptionCheck()
     exceptionCheck(emitExceptionCheck(vm()));
 }
 
-void JIT::exceptionChecksWithCallFrameRollback(Jump jumpToHandler)
-{
-    jumpToHandler.linkThunk(CodeLocationLabel(vm().getCTIStub(CommonJITThunkID::HandleExceptionWithCallFrameRollback).retaggedCode<NoPtrTag>()), this);
-}
-
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -246,7 +246,6 @@ namespace JSC {
 
         void exceptionCheck(Jump jumpToHandler);
         void exceptionCheck();
-        void exceptionChecksWithCallFrameRollback(Jump jumpToHandler);
 
         void advanceToNextCheckpoint();
         void emitJumpSlowToHotForCheckpoint(Jump);
@@ -777,16 +776,6 @@ namespace JSC {
             setupArguments<OperationType>(args...);
             updateTopCallFrame();
             return appendCall(operation);
-        }
-
-        template<typename OperationType, typename... Args>
-        MacroAssembler::Call callThrowOperationWithCallFrameRollback(OperationType operation, Args... args)
-        {
-            setupArguments<OperationType>(args...);
-            updateTopCallFrame(); // The callee is responsible for setting topCallFrame to their caller
-            MacroAssembler::Call call = appendCall(operation);
-            exceptionChecksWithCallFrameRollback(jump());
-            return call;
         }
 
         enum class ProfilingPolicy {

--- a/Source/JavaScriptCore/jit/JITThunks.h
+++ b/Source/JavaScriptCore/jit/JITThunks.h
@@ -54,7 +54,6 @@ class NativeExecutable;
 // List up super common stubs so that we initialize them eagerly.
 #define JSC_FOR_EACH_COMMON_THUNK(macro) \
     macro(HandleException, handleExceptionGenerator) \
-    macro(HandleExceptionWithCallFrameRollback, handleExceptionWithCallFrameRollbackGenerator) \
     macro(CheckException, checkExceptionGenerator) \
     macro(NativeCall, nativeCallGenerator) \
     macro(NativeConstruct, nativeConstructGenerator) \

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -39,7 +39,6 @@ template<PtrTag> class MacroAssemblerCodeRef;
 class VM;
 
 MacroAssemblerCodeRef<JITThunkPtrTag> handleExceptionGenerator(VM&);
-MacroAssemblerCodeRef<JITThunkPtrTag> handleExceptionWithCallFrameRollbackGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> popThunkStackPreservesAndHandleExceptionGenerator(VM&);
 
 MacroAssemblerCodeRef<JITThunkPtrTag> throwExceptionFromCallGenerator(VM&);


### PR DESCRIPTION
#### a9baf3a34bde2fea859623aaae6f8893b03d5874
<pre>
[JSC] Remove HandleExceptionWithCallFrameRollback thunk
<a href="https://bugs.webkit.org/show_bug.cgi?id=288318">https://bugs.webkit.org/show_bug.cgi?id=288318</a>
<a href="https://rdar.apple.com/problem/145432961">rdar://problem/145432961</a>

Reviewed by Yijia Huang.

This patch removes HandleExceptionWithCallFrameRollback thunk
as it is only used by throwStackOverflow thunk. We just embed it into
throwStackOverflow thunk.

* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::exceptionJumpWithCallFrameRollback): Deleted.
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
(JSC::DFG::SpeculativeJIT::callThrowOperationWithCallFrameRollback): Deleted.
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::exceptionChecksWithCallFrameRollback): Deleted.
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITThunks.h:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::throwStackOverflowAtPrologueGenerator):
(JSC::handleExceptionWithCallFrameRollbackGenerator): Deleted.
* Source/JavaScriptCore/jit/ThunkGenerators.h:

Canonical link: <a href="https://commits.webkit.org/290924@main">https://commits.webkit.org/290924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91ad1db8c871940c417107bde55c1e751663837c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42166 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19399 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82875 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50566 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/462 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41336 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84282 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78768 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90227 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18640 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79262 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78713 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78466 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/22987 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11771 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14475 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18638 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23914 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112811 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18348 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32711 "Found 10 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-slow-memory, wasm.yaml/wasm/v8/multi-value.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21808 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->