### PR TITLE
[Site Isolation] Going back while creating remote iframes may create incorrect history state

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/add-iframes-and-go-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframes-and-go-back-expected.txt
@@ -1,0 +1,10 @@
+Verifies that using history.back() while recursively creating iframes does not increase history.length.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS history.length is 2
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/add-iframes-and-go-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/add-iframes-and-go-back.html
@@ -1,0 +1,18 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that using history.back() while recursively creating iframes does not increase history.length.");
+jsTestIsAsync = true;
+
+onload = async () => {
+    if (sessionStorage.didNavigate) {
+        delete sessionStorage.didNavigate;
+        shouldBe("history.length", "2");
+        finishJSTest();
+    } else {
+        await testRunner?.clearBackForwardList();
+        sessionStorage.didNavigate = true;
+        location.href = 'http://127.0.0.1:8000/site-isolation/history/resources/add-recursive-iframes-then-go-back.html';
+    }
+}
+</script>

--- a/LayoutTests/http/tests/site-isolation/history/resources/add-recursive-iframes-then-go-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/resources/add-recursive-iframes-then-go-back.html
@@ -1,0 +1,16 @@
+<script>
+onload = () => {
+    setInterval(() => {
+        const iframe = document.createElement('iframe');
+        iframe.src = 'http://localhost:8000/site-isolation/resources/recursive-create-remote-iframe.html#1';
+        document.body.appendChild(iframe);
+    }, 10);
+
+    onmessage = () => {
+        onmessage = null;
+        setTimeout(() => {
+            history.back();
+        }, 50);
+    }
+}
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/recursive-create-remote-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/recursive-create-remote-iframe.html
@@ -1,0 +1,12 @@
+<script>
+onload = () => {
+    const host = location.hash === '#1' ? 'localhost' : '127.0.0.1';
+    const nextHash = location.hash === '#1' ? '#2' : '#1';
+    setTimeout(() => {
+        const iframe = document.createElement('iframe');
+        iframe.src = `http://${host}:8000/site-isolation/resources/recursive-create-remote-iframe.html${nextHash}`;
+        document.body.appendChild(iframe);
+        window.top.postMessage("", '*');
+    }, 10);
+}
+</script>

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -190,6 +190,19 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
     page->didChangeBackForwardList(newItemPtr, WTFMove(removedItems));
 }
 
+void WebBackForwardList::addChildItem(FrameIdentifier parentFrameID, Ref<FrameState>&& frameState)
+{
+    RefPtr currentItem = this->currentItem();
+    if (!currentItem)
+        return;
+
+    RefPtr parentItem = currentItem->protectedMainFrameItem()->childItemForFrameID(parentFrameID);
+    if (!parentItem)
+        return;
+
+    parentItem->setChild(WTFMove(frameState));
+}
+
 void WebBackForwardList::goToItem(WebBackForwardListItem& item)
 {
     if (m_provisionalIndex)

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -56,6 +56,7 @@ public:
     WebBackForwardListItem* itemForID(WebCore::BackForwardItemIdentifier);
 
     void addItem(Ref<WebBackForwardListItem>&&);
+    void addChildItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
     void goToItem(WebBackForwardListItem&);
     void removeAllItems();
     void clear();

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -689,16 +689,6 @@ bool WebFrameProxy::isMainFrame() const
     return m_frameLoadState.isMainFrame() == IsMainFrame::Yes;
 }
 
-void WebFrameProxy::setPendingChildBackForwardItem(WebBackForwardListFrameItem* pendingChildBackForwardItem)
-{
-    m_pendingChildBackForwardItem = pendingChildBackForwardItem;
-}
-
-WebBackForwardListFrameItem* WebFrameProxy::takePendingChildBackForwardItem()
-{
-    return std::exchange(m_pendingChildBackForwardItem, nullptr).get();
-}
-
 void WebFrameProxy::updateScrollingMode(WebCore::ScrollbarMode scrollingMode)
 {
     m_scrollingMode = scrollingMode;

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -199,9 +199,8 @@ public:
     TraversalResult traverseNext(CanWrap) const;
     TraversalResult traversePrevious(CanWrap);
 
-    void setPendingChildBackForwardItem(WebBackForwardListFrameItem*);
-    bool hasPendingChildBackForwardItem() const { return !!m_pendingChildBackForwardItem; };
-    WebBackForwardListFrameItem* takePendingChildBackForwardItem();
+    void setIsPendingInitialHistoryItem(bool isPending) { m_isPendingInitialHistoryItem = isPending; }
+    bool isPendingInitialHistoryItem() const { return m_isPendingInitialHistoryItem; }
 
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
     void setRemoteFrameSize(WebCore::IntSize size) { m_remoteFrameSize = size; }
@@ -247,7 +246,7 @@ private:
 #endif
     CompletionHandler<void(std::optional<WebCore::PageIdentifier>, std::optional<WebCore::FrameIdentifier>)> m_navigateCallback;
     const WebCore::LayerHostingContextIdentifier m_layerHostingContextIdentifier;
-    WeakPtr<WebBackForwardListFrameItem> m_pendingChildBackForwardItem;
+    bool m_isPendingInitialHistoryItem { false };
     std::optional<WebCore::IntSize> m_remoteFrameSize;
     WebCore::SandboxFlags m_effectiveSandboxFlags;
     WebCore::ScrollbarMode m_scrollingMode;


### PR DESCRIPTION
#### 36fbb6b8eee7cb8caf806b06f6716913d4311b34
<pre>
[Site Isolation] Going back while creating remote iframes may create incorrect history state
<a href="https://bugs.webkit.org/show_bug.cgi?id=288319">https://bugs.webkit.org/show_bug.cgi?id=288319</a>
<a href="https://rdar.apple.com/142485711">rdar://142485711</a>

Reviewed by Alex Christensen.

When an iframe is embedded into a new process, we set state from the current back/forward item onto its
WebFrameProxy to indicate that we expect the iframe to soon load its initial history state. This approach
fails if, at the time of embedding, the current back/forward item has not yet been updated to reference
the page that is embedding the iframe. Instead, we should just set a bool on the WebFrameProxy to
indicate that its initial history state is not yet created, and then search and update the current
back/forward item to include the child frame&apos;s state when the history item is committed.

* LayoutTests/http/tests/site-isolation/history/add-iframes-and-go-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/add-iframes-and-go-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/resources/add-recursive-iframes-then-go-back.html: Added.
* LayoutTests/http/tests/site-isolation/resources/recursive-create-remote-iframe.html: Added.
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::addChildItem):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::setPendingChildBackForwardItem): Deleted.
(WebKit::WebFrameProxy::takePendingChildBackForwardItem): Deleted.
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::setIsPendingInitialHistoryItem):
(WebKit::WebFrameProxy::isPendingInitialHistoryItem const):
(WebKit::WebFrameProxy::hasPendingChildBackForwardItem const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::backForwardAddItemShared):

Canonical link: <a href="https://commits.webkit.org/290964@main">https://commits.webkit.org/290964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14309aef24634c1ee35cbad576261a2824c68f43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19415 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70261 "Failure limit exceed. At least found 4 new test failures: imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-015.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-016.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/auto-018.html imported/w3c/web-platform-tests/css/css-sizing/contain-intrinsic-size/contain-intrinsic-size-001.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27771 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50578 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8460 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41349 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78780 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98463 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18653 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13756 "Found 1 new test failure: webrtc/vp8-then-h264-gpu-process-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79274 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78478 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23002 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/361 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11782 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14506 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23927 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18361 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20127 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->