### PR TITLE
Adds WeakPtr<ModelPlayerProvider> to HTMLModelElement for deallocation purposes.

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -292,7 +292,10 @@ void HTMLModelElement::createModelPlayer()
     m_boundingBoxCenter = DOMPointReadOnly::create({ });
     m_boundingBoxExtents = DOMPointReadOnly::create({ });
 #endif
-    m_modelPlayer = document().page()->modelPlayerProvider().createModelPlayer(*this);
+    if (!m_modelPlayerProvider)
+        m_modelPlayerProvider = document().page()->modelPlayerProvider();
+    if (RefPtr protectedModelPlayerProvider = m_modelPlayerProvider.get())
+        m_modelPlayer = protectedModelPlayerProvider->createModelPlayer(*this);
     if (!m_modelPlayer) {
         if (!m_readyPromise->isFulfilled())
             m_readyPromise->reject(Exception { ExceptionCode::AbortError });
@@ -321,8 +324,10 @@ void HTMLModelElement::createModelPlayer()
 
 void HTMLModelElement::deleteModelPlayer()
 {
-    if (m_modelPlayer && document().page())
-        document().page()->modelPlayerProvider().deleteModelPlayer(*m_modelPlayer);
+    RefPtr protectedModelPlayerProvider = m_modelPlayerProvider.get();
+    if (protectedModelPlayerProvider && m_modelPlayer)
+        protectedModelPlayerProvider->deleteModelPlayer(*m_modelPlayer);
+
     m_modelPlayer = nullptr;
 }
 
@@ -368,8 +373,8 @@ void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
 
     if (CheckedPtr renderer = this->renderer())
         renderer->updateFromElement();
-
-    m_readyPromise->resolve(*this);
+    if (!m_readyPromise->isFulfilled())
+        m_readyPromise->resolve(*this);
 }
 
 void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, const ResourceError&)
@@ -1135,6 +1140,24 @@ bool HTMLModelElement::isURLAttribute(const Attribute& attribute) const
         || attribute.name() == environmentmapAttr
 #endif
         || HTMLElement::isURLAttribute(attribute);
+}
+
+Node::InsertedIntoAncestorResult HTMLModelElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
+{
+    auto insertResult = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+
+    if (insertionType.connectedToDocument)
+        m_modelPlayerProvider = document().page()->modelPlayerProvider();
+
+    return insertResult;
+}
+
+void HTMLModelElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+{
+    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+
+    if (removalType.disconnectedFromDocument)
+        deleteModelPlayer();
 }
 
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -55,6 +55,7 @@ class GraphicsLayer;
 class LayoutSize;
 class Model;
 class ModelPlayer;
+class ModelPlayerProvider;
 class MouseEvent;
 
 template<typename IDLType> class DOMPromiseDeferred;
@@ -214,6 +215,9 @@ private:
 #endif
     std::optional<PlatformLayerIdentifier> modelContentsLayerID() const final;
 
+    Node::InsertedIntoAncestorResult insertedIntoAncestor(InsertionType , ContainerNode& parentOfInsertedTree) override;
+    void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) override;
+
     void defaultEventHandler(Event&) final;
     void dragDidStart(MouseEvent&);
     void dragDidChange(MouseEvent&);
@@ -245,6 +249,7 @@ private:
     URL m_sourceURL;
     CachedResourceHandle<CachedRawResource> m_resource;
     SharedBufferBuilder m_data;
+    WeakPtr<ModelPlayerProvider> m_modelPlayerProvider;
     RefPtr<Model> m_model;
     UniqueRef<ReadyPromise> m_readyPromise;
     bool m_dataComplete { false };

--- a/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -33,7 +34,7 @@ namespace WebCore {
 class ModelPlayer;
 class ModelPlayerClient;
 
-class WEBCORE_EXPORT ModelPlayerProvider {
+class WEBCORE_EXPORT ModelPlayerProvider : public RefCountedAndCanMakeWeakPtr<ModelPlayerProvider> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ModelPlayerProvider, WEBCORE_EXPORT);
 public:
     virtual ~ModelPlayerProvider();

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.cpp
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.cpp
@@ -33,6 +33,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DummyModelPlayerProvider);
 
+Ref<DummyModelPlayerProvider> DummyModelPlayerProvider::create() { return adoptRef(*new DummyModelPlayerProvider); }
+
 DummyModelPlayerProvider::DummyModelPlayerProvider() = default;
 DummyModelPlayerProvider::~DummyModelPlayerProvider() = default;
 

--- a/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.h
+++ b/Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.h
@@ -33,10 +33,13 @@ namespace WebCore {
 class WEBCORE_EXPORT DummyModelPlayerProvider final : public ModelPlayerProvider {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(DummyModelPlayerProvider, WEBCORE_EXPORT);
 public:
-    DummyModelPlayerProvider();
+    static Ref<DummyModelPlayerProvider> create();
+
     virtual ~DummyModelPlayerProvider();
 
 private:
+    DummyModelPlayerProvider();
+
     // ModelPlayerProvider overrides.
     RefPtr<ModelPlayer> createModelPlayer(ModelPlayerClient&) final;
     void deleteModelPlayer(ModelPlayer&) final;

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1226,7 +1226,7 @@ PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier
         makeUniqueRef<DummySpeechRecognitionProvider>(),
         EmptyBroadcastChannelRegistry::create(),
         makeUniqueRef<DummyStorageProvider>(),
-        makeUniqueRef<DummyModelPlayerProvider>(),
+        DummyModelPlayerProvider::create(),
         EmptyBadgeClient::create(),
         EmptyHistoryItemClient::create(),
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1683,7 +1683,7 @@ private:
     std::optional<std::pair<uint16_t, uint16_t>> m_portsForUpgradingInsecureSchemeForTesting;
 
     const UniqueRef<StorageProvider> m_storageProvider;
-    const UniqueRef<ModelPlayerProvider> m_modelPlayerProvider;
+    const Ref<ModelPlayerProvider> m_modelPlayerProvider;
 
     WeakPtr<KeyboardScrollingAnimator> m_currentKeyboardScrollingAnimator;
 

--- a/Source/WebCore/page/PageConfiguration.cpp
+++ b/Source/WebCore/page/PageConfiguration.cpp
@@ -94,7 +94,7 @@ PageConfiguration::PageConfiguration(
     UniqueRef<SpeechRecognitionProvider>&& speechRecognitionProvider,
     Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry,
     UniqueRef<StorageProvider>&& storageProvider,
-    UniqueRef<ModelPlayerProvider>&& modelPlayerProvider,
+    Ref<ModelPlayerProvider>&& modelPlayerProvider,
     Ref<BadgeClient>&& badgeClient,
     Ref<HistoryItemClient>&& historyItemClient,
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebCore/page/PageConfiguration.h
+++ b/Source/WebCore/page/PageConfiguration.h
@@ -127,7 +127,7 @@ public:
         UniqueRef<SpeechRecognitionProvider>&&,
         Ref<BroadcastChannelRegistry>&&,
         UniqueRef<StorageProvider>&&,
-        UniqueRef<ModelPlayerProvider>&&,
+        Ref<ModelPlayerProvider>&&,
         Ref<BadgeClient>&&,
         Ref<HistoryItemClient>&&,
 #if ENABLE(CONTEXT_MENUS)
@@ -216,7 +216,7 @@ public:
 
     UniqueRef<StorageProvider> storageProvider;
 
-    UniqueRef<ModelPlayerProvider> modelPlayerProvider;
+    Ref<ModelPlayerProvider> modelPlayerProvider;
 #if ENABLE(ATTACHMENT_ELEMENT)
     std::unique_ptr<AttachmentElementClient> attachmentElementClient;
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp
@@ -53,6 +53,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebModelPlayerProvider);
 
+Ref<WebModelPlayerProvider> WebModelPlayerProvider::create(WebPage& webPage)
+{
+    return adoptRef(*new WebModelPlayerProvider(webPage));
+}
+
 WebModelPlayerProvider::WebModelPlayerProvider(WebPage& page)
     : m_page { page }
 {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h
@@ -36,10 +36,13 @@ class WebPage;
 class WebModelPlayerProvider final : public WebCore::ModelPlayerProvider {
     WTF_MAKE_TZONE_ALLOCATED(WebModelPlayerProvider);
 public:
-    WebModelPlayerProvider(WebPage&);
+    static Ref<WebModelPlayerProvider> create(WebPage&);
+
     virtual ~WebModelPlayerProvider();
 
 private:
+    WebModelPlayerProvider(WebPage&);
+
     // WebCore::ModelPlayerProvider overrides.
     RefPtr<WebCore::ModelPlayer> createModelPlayer(WebCore::ModelPlayerClient&) final;
     void deleteModelPlayer(WebCore::ModelPlayer&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -769,7 +769,7 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
         makeUniqueRef<WebSpeechRecognitionProvider>(pageID),
         WebProcess::singleton().broadcastChannelRegistry(),
         makeUniqueRef<WebStorageProvider>(WebProcess::singleton().mediaKeysStorageDirectory(), WebProcess::singleton().mediaKeysStorageSalt()),
-        makeUniqueRef<WebModelPlayerProvider>(*this),
+        WebModelPlayerProvider::create(*this),
         WebProcess::singleton().badgeClient(),
         m_historyItemClient.copyRef(),
 #if ENABLE(CONTEXT_MENUS)

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1526,7 +1526,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         makeUniqueRef<WebCore::DummySpeechRecognitionProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),
         makeUniqueRef<WebCore::DummyStorageProvider>(),
-        makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
+        WebCore::DummyModelPlayerProvider::create(),
         WebCore::EmptyBadgeClient::create(),
         LegacyHistoryItemClient::singleton(),
 #if ENABLE(CONTEXT_MENUS)
@@ -1795,7 +1795,7 @@ static WebCore::ApplicationCacheStorage& webApplicationCacheStorage()
         makeUniqueRef<WebCore::DummySpeechRecognitionProvider>(),
         WebBroadcastChannelRegistry::getOrCreate([[self preferences] privateBrowsingEnabled]),
         makeUniqueRef<WebCore::DummyStorageProvider>(),
-        makeUniqueRef<WebCore::DummyModelPlayerProvider>(),
+        WebCore::DummyModelPlayerProvider::create(),
         WebCore::EmptyBadgeClient::create(),
         LegacyHistoryItemClient::singleton(),
 #if ENABLE(APPLE_PAY)


### PR DESCRIPTION
#### b82b1b09779a98c0183704ec16e01b08518ed5a3
<pre>
Adds WeakPtr&lt;ModelPlayerProvider&gt; to HTMLModelElement for deallocation purposes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288321">https://bugs.webkit.org/show_bug.cgi?id=288321</a>
<a href="https://rdar.apple.com/145434268">rdar://145434268</a>

Reviewed by Ryosuke Niwa.

ModelPlayerProvider is a gateway to communicate with the Model Process.
When an HTMLModelElement is detached from Page/Document that communication
line is gone. To make sure the Model Process is notified when an element&apos;s
destructor is called, WeakPtr&lt;ModelPlayerProvider&gt; is added.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::m_environmentMapReadyPromise):
(WebCore::HTMLModelElement::~HTMLModelElement):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::deleteModelPlayer):
(WebCore::HTMLModelElement::didFinishLoading):
(WebCore::HTMLModelElement::insertedIntoAncestor):
(WebCore::HTMLModelElement::removedFromAncestor):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
Keep track of ModelPlayerProvider when an element attached/detached to/from
document and release resources.

* Source/WebCore/Modules/model-element/ModelPlayerProvider.h:
ModelPlayerProvider is RefCounted and CanMakeWeakPtr now.

* Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.cpp:
(WebCore::DummyModelPlayerProvider::create):
* Source/WebCore/Modules/model-element/dummy/DummyModelPlayerProvider.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::pageConfigurationWithEmptyClients):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageConfiguration.cpp:
(WebCore::PageConfiguration::PageConfiguration):
* Source/WebCore/page/PageConfiguration.h:
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.cpp:
(WebKit::WebModelPlayerProvider::create):
* Source/WebKit/WebProcess/Model/WebModelPlayerProvider.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_textAnimationController):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
(-[WebView initSimpleHTMLDocumentWithStyle:frame:preferences:groupName:]):
UniqueRef is not applicable for RefCounted objects, hence switch to Ref.

Canonical link: <a href="https://commits.webkit.org/291171@main">https://commits.webkit.org/291171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee5981f93c42d895957e57b11ccfcaae1d8ba80a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20001 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70574 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28062 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94983 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9034 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83316 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50902 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/91477 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8764 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/917 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98943 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14121 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79612 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19564 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/687 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12135 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19078 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24287 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18775 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->