### PR TITLE
Improve organization of data and logic for positioned layout

### DIFF
--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -720,14 +720,11 @@ private:
     // Returns true if we did a full repaint.
     bool repaintLayerRectsForImage(WrappedImagePtr, const FillLayer& layers, bool drawingBackground);
 
+    struct PositionedLayoutConstraints;
     void computePositionedLogicalHeight(LogicalExtentComputedValues&) const;
-    void computePositionedLogicalWidthUsing(SizeType, Length logicalWidth, const RenderBoxModelObject& containerBlock, WritingMode containerWritingMode,
-                                            LayoutUnit containerLogicalWidth, LayoutUnit bordersPlusPadding,
-                                            Length logicalLeft, Length logicalRight, Length marginLogicalLeft, Length marginLogicalRight,
+    void computePositionedLogicalWidthUsing(SizeType, Length logicalWidth, const PositionedLayoutConstraints&,
                                             LogicalExtentComputedValues&) const;
-    void computePositionedLogicalHeightUsing(SizeType, Length logicalHeightLength, const RenderBoxModelObject& containerBlock,
-                                             LayoutUnit containerLogicalHeight, LayoutUnit bordersPlusPadding, LayoutUnit logicalHeight,
-                                             Length logicalTop, Length logicalBottom, Length marginLogicalTop, Length marginLogicalBottom,
+    void computePositionedLogicalHeightUsing(SizeType, Length logicalHeightLength, LayoutUnit computedHeight, const PositionedLayoutConstraints&,
                                              LogicalExtentComputedValues&) const;
 
     void computePositionedLogicalHeightReplaced(LogicalExtentComputedValues&) const;
@@ -758,7 +755,7 @@ private:
     ShapeOutsideInfo& ensureShapeOutsideInfo();
     void removeShapeOutsideInfo();
 
-    void computeAnchorCenteredPosition(LogicalExtentComputedValues&, CheckedPtr<const RenderBoxModelObject> defaultAnchorBox, Length logicalLeftLength, Length logicalRightLength, LayoutUnit containerLogicalWidth, bool computeHorizontally) const;
+    void computeAnchorCenteredPosition(const PositionedLayoutConstraints&, LogicalExtentComputedValues&) const;
 
 private:
     // The width/height of the contents + borders + padding.  The x/y location is relative to our container (which is not always our parent).

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -284,6 +284,7 @@ public:
     Overflow effectiveOverflowY() const;
     inline Overflow effectiveOverflowInlineDirection() const;
     inline Overflow effectiveOverflowBlockDirection() const;
+    virtual bool overflowChangesMayAffectLayout() const { return false; }
 
     bool isWritingModeRoot() const { return !parent() || parent()->style().writingMode().computedWritingMode() != style().writingMode().computedWritingMode(); }
 
@@ -302,7 +303,8 @@ public:
     bool renderBoxHasShapeOutsideInfo() const { return m_renderBoxHasShapeOutsideInfo; }
     bool hasCachedSVGResource() const { return m_hasCachedSVGResource; }
 
-    virtual bool overflowChangesMayAffectLayout() const { return false; }
+    const Element* defaultAnchor() const;
+    const RenderElement* defaultAnchorRenderer() const;
 
 protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
@@ -350,9 +352,6 @@ protected:
 
     bool shouldApplyLayoutOrPaintContainment(bool) const;
     inline bool shouldApplySizeOrStyleContainment(bool) const;
-
-    const Element* defaultAnchor() const;
-    const RenderElement* defaultAnchorRenderer() const;
 
 private:
     RenderElement(Type, ContainerNode&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);


### PR DESCRIPTION
#### 6512cb0009b0458ed60644c2d21204add527f532
<pre>
Improve organization of data and logic for positioned layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=288283">https://bugs.webkit.org/show_bug.cgi?id=288283</a>
<a href="https://rdar.apple.com/145348582">rdar://145348582</a>

Reviewed by Alan Baradlay.

Improves the organization of our positioned layout logic by:
* Encapsulating containing block geometry calculations and data, and
  extracting and simplifying coordinate system conversion logic.
* Packaging up cached values into a single struct so they can be passed
  as a single parameter, making it easier to follow what data is being
  passed around and which parameters are being changed from function
  call to function call.
* Better organizing calculations into phases, so that future adjustments
  the containing block (e.g. for position-area) and additions to
  positioning logic (e.g. for the alignment properties) can be more
  easily and correctly integrated.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::LayoutRange::LayoutRange):
(WebCore::LayoutRange::min const):
(WebCore::LayoutRange::max const):
(WebCore::LayoutRange::size const):
(WebCore::LayoutRange::set):
(WebCore::LayoutRange::reset):
(WebCore::LayoutRange::moveBy):
(WebCore::LayoutRange::moveTo):
(WebCore::LayoutRange::shiftMinEdgeBy):
(WebCore::LayoutRange::shiftMaxEdgeBy):
(WebCore::LayoutRange::shiftMinEdgeTo):
(WebCore::LayoutRange::shiftMaxEdgeTo):
(WebCore::RenderBox::PositionedLayoutConstraints::needsAnchor const):
(WebCore::RenderBox::PositionedLayoutConstraints::isOrthogonal const):
(WebCore::RenderBox::PositionedLayoutConstraints::isBlockOpposing const):
(WebCore::RenderBox::PositionedLayoutConstraints::isBlockFlipped const):
(WebCore::RenderBox::PositionedLayoutConstraints::isLogicalLeftInlineStart const):
(WebCore::RenderBox::PositionedLayoutConstraints::containingSize const):
(WebCore::RenderBox::PositionedLayoutConstraints::marginBeforeValue const):
(WebCore::RenderBox::PositionedLayoutConstraints::marginAfterValue const):
(WebCore::RenderBox::PositionedLayoutConstraints::insetBeforeValue const):
(WebCore::RenderBox::PositionedLayoutConstraints::insetAfterValue const):
(WebCore::RenderBox::PositionedLayoutConstraints::PositionedLayoutConstraints):
(WebCore::RenderBox::PositionedLayoutConstraints::computeInlineStaticDistance):
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::PositionedLayoutConstraints::convertLogicalLeftValue const):
(WebCore::RenderBox::computePositionedLogicalWidthUsing const):
(WebCore::RenderBox::PositionedLayoutConstraints::computeBlockStaticDistance):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::PositionedLayoutConstraints::convertLogicalTopValue const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computePositionedLogicalHeightReplaced const):
(WebCore::RenderBox::computeAnchorCenteredPosition const):
(WebCore::computeInlineStaticDistance): Deleted.
(WebCore::computeLogicalLeftPositionedOffset): Deleted.
(WebCore::computeBlockStaticDistance): Deleted.
(WebCore::computeLogicalTopPositionedOffset): Deleted.
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderElement.h:

Canonical link: <a href="https://commits.webkit.org/291088@main">https://commits.webkit.org/291088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95f30219860af83c6506e10bdb2c40320615b465

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42503 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93932 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19901 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70521 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28009 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8983 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/832 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41717 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98853 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79543 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19271 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78767 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23309 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/622 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12062 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14600 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24214 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18697 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22156 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->