### PR TITLE
[IndexedDB] Added records should be removed if transaction aborts

### DIFF
--- a/LayoutTests/storage/indexeddb/resources/transaction-abort-revert-records.js
+++ b/LayoutTests/storage/indexeddb/resources/transaction-abort-revert-records.js
@@ -1,0 +1,96 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Test aborting transaction revert add record");
+
+indexedDBTest(prepareDatabase, onDatabasePrepared);
+
+function prepareDatabase()
+{
+    preamble(event);
+
+    database = event.target.result;
+    store = evalAndLog("store = database.createObjectStore('store')");
+    evalAndLog("store.add('value1', 'key1')");
+    evalAndLog("store.add('value2', 'key2')");
+}
+
+function onDatabasePrepared()
+{
+    preamble(event);
+
+    evalAndLog("database = event.target.result");
+    evalAndLog("database.close()");
+
+    // Upgrade database and add records in versionchange transaction.
+    openRequest = evalAndLog("openRequest = indexedDB.open(dbname, " + (database.version + 1) + ")");
+    openRequest.onupgradeneeded = onDatabaseUpgrade;
+    openRequest.onerror = onDatabaseError;
+    openRequest.onsuccess = unexpectedSuccessCallback;
+}
+
+function onDatabaseUpgrade(event)
+{
+    preamble(event);
+
+    request = event.target;
+    transaction = evalAndLog("transcation = request.transaction");
+    transaction.onabort = onTranactionAbort;
+    evalAndLog("store = transcation.objectStore('store')");
+    evalAndLog("store.delete('key2')");
+    evalAndLog("store.add('value2_new', 'key2')");
+    evalAndLog("store.add('value3', 'key3')");
+    // Adding key again to trigger error that aborts transaction.
+    evalAndLog("store.add('value3_new', 'key3')");
+}
+
+function onTranactionAbort(event)
+{
+    preamble(event);
+
+    // Close database to unblock next open.
+    evalAndLog("event.target.db.close()");
+}
+
+function onDatabaseError(event)
+{
+    preamble(event);
+
+    // Open database again to check saved records.
+    openRequest = evalAndLog("openRequest = indexedDB.open(dbname)");
+    openRequest.onsuccess = onDatabaseOpen;
+    openRequest.onerror = unexpectedErrorCallback;
+}
+
+function onDatabaseOpen(event)
+{
+    preamble(event);
+
+    evalAndLog("database = event.target.result");
+    shouldBe("database.version", "1");
+    evalAndLog("transcation = database.transaction('store')");
+    evalAndLog("store = transcation.objectStore('store')");
+    request = evalAndLog("request = store.getAllKeys()");
+    request.onsuccess = onGetAllKeysSuccess;
+    request.onerror = unexpectedErrorCallback;
+}
+
+function onGetAllKeysSuccess(event)
+{
+    preamble(event);
+
+    shouldBeEqualToString("JSON.stringify(event.target.result)", '["key1","key2"]');
+    request = evalAndLog("request = store.get('key2')");
+    request.onsuccess = onGetSuccess;
+    request.onerror = unexpectedErrorCallback;
+}
+
+function onGetSuccess(event)
+{
+    preamble(event);
+
+    shouldBeEqualToString("event.target.result", "value2");
+    finishJSTest();
+}

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-records-expected.txt
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-records-expected.txt
@@ -1,0 +1,51 @@
+Test aborting transaction revert add record
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+
+prepareDatabase():
+store = database.createObjectStore('store')
+store.add('value1', 'key1')
+store.add('value2', 'key2')
+
+onDatabasePrepared():
+database = event.target.result
+database.close()
+openRequest = indexedDB.open(dbname, 2)
+
+onDatabaseUpgrade():
+transcation = request.transaction
+store = transcation.objectStore('store')
+store.delete('key2')
+store.add('value2_new', 'key2')
+store.add('value3', 'key3')
+store.add('value3_new', 'key3')
+
+onTranactionAbort():
+event.target.db.close()
+
+onDatabaseError():
+openRequest = indexedDB.open(dbname)
+
+onDatabaseOpen():
+database = event.target.result
+PASS database.version is 1
+transcation = database.transaction('store')
+store = transcation.objectStore('store')
+request = store.getAllKeys()
+
+onGetAllKeysSuccess():
+PASS JSON.stringify(event.target.result) is "[\"key1\",\"key2\"]"
+request = store.get('key2')
+
+onGetSuccess():
+PASS event.target.result is "value2"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-records-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-records-private-expected.txt
@@ -1,0 +1,51 @@
+Test aborting transaction revert add record
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+
+prepareDatabase():
+store = database.createObjectStore('store')
+store.add('value1', 'key1')
+store.add('value2', 'key2')
+
+onDatabasePrepared():
+database = event.target.result
+database.close()
+openRequest = indexedDB.open(dbname, 2)
+
+onDatabaseUpgrade():
+transcation = request.transaction
+store = transcation.objectStore('store')
+store.delete('key2')
+store.add('value2_new', 'key2')
+store.add('value3', 'key3')
+store.add('value3_new', 'key3')
+
+onTranactionAbort():
+event.target.db.close()
+
+onDatabaseError():
+openRequest = indexedDB.open(dbname)
+
+onDatabaseOpen():
+database = event.target.result
+PASS database.version is 1
+transcation = database.transaction('store')
+store = transcation.objectStore('store')
+request = store.getAllKeys()
+
+onGetAllKeysSuccess():
+PASS JSON.stringify(event.target.result) is "[\"key1\",\"key2\"]"
+request = store.get('key2')
+
+onGetSuccess():
+PASS event.target.result is "value2"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-records-private.html
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-records-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/transaction-abort-revert-records.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-records.html
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-records.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/transaction-abort-revert-records.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -61,8 +61,7 @@ public:
 
     void addNewObjectStore(MemoryObjectStore&);
     void addExistingObjectStore(MemoryObjectStore&);
-    
-    void recordValueChanged(MemoryObjectStore&, const IDBKeyData&, ThreadSafeDataBuffer*);
+
     void objectStoreDeleted(Ref<MemoryObjectStore>&&);
     void objectStoreCleared(MemoryObjectStore&, std::unique_ptr<KeyValueMap>&&, std::unique_ptr<IDBKeyDataSet>&&);
     void objectStoreRenamed(MemoryObjectStore&, const String& oldName);
@@ -93,12 +92,8 @@ private:
     HashSet<RefPtr<MemoryIndex>> m_indexes;
     HashSet<RefPtr<MemoryIndex>> m_versionChangeAddedIndexes;
 
-    HashMap<MemoryObjectStore*, uint64_t> m_originalKeyGenerators;
     HashMap<String, RefPtr<MemoryObjectStore>> m_deletedObjectStores;
     HashMap<String, RefPtr<MemoryIndex>> m_deletedIndexes;
-    HashMap<MemoryObjectStore*, std::unique_ptr<KeyValueMap>> m_originalValues;
-    HashMap<MemoryObjectStore*, std::unique_ptr<KeyValueMap>> m_clearedKeyValueMaps;
-    HashMap<MemoryObjectStore*, std::unique_ptr<IDBKeyDataSet>> m_clearedOrderedKeys;
     HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
     HashMap<MemoryIndex*, String> m_originalIndexNames;
     HashMap<MemoryIndex*, std::unique_ptr<IndexValueStore>> m_clearedIndexValueStores;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -64,6 +64,7 @@ public:
 
     void writeTransactionStarted(MemoryBackingStoreTransaction&);
     void writeTransactionFinished(MemoryBackingStoreTransaction&);
+    void transactionAborted(MemoryBackingStoreTransaction&);
     MemoryBackingStoreTransaction* writeTransaction();
 
     IDBError addIndex(MemoryBackingStoreTransaction&, const IDBIndexInfo&);
@@ -84,7 +85,6 @@ public:
     void setKeyGeneratorValue(uint64_t value) { m_keyGeneratorValue = value; }
 
     void clear();
-    void replaceKeyValueStore(std::unique_ptr<KeyValueMap>&&, std::unique_ptr<IDBKeyDataSet>&&);
 
     ThreadSafeDataBuffer valueForKey(const IDBKeyData&) const;
     ThreadSafeDataBuffer valueForKeyRange(const IDBKeyRangeData&) const;
@@ -124,12 +124,13 @@ private:
     IDBObjectStoreInfo m_info;
 
     CheckedPtr<MemoryBackingStoreTransaction> m_writeTransaction;
+    uint64_t m_keyGeneratorValueBeforeTransaction { 1 };
     uint64_t m_keyGeneratorValue { 1 };
 
+    KeyValueMap m_transactionModifiedRecords;
     std::unique_ptr<KeyValueMap> m_keyValueStore;
     std::unique_ptr<IDBKeyDataSet> m_orderedKeys;
 
-    void unregisterIndex(MemoryIndex&);
     HashMap<IDBIndexIdentifier, RefPtr<MemoryIndex>> m_indexesByIdentifier;
     HashMap<String, RefPtr<MemoryIndex>> m_indexesByName;
     HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryObjectStoreCursor>> m_cursors;


### PR DESCRIPTION
#### b5d274d82a73a96011e412c2d46d824ba4b42b3e
<pre>
[IndexedDB] Added records should be removed if transaction aborts
<a href="https://bugs.webkit.org/show_bug.cgi?id=288346">https://bugs.webkit.org/show_bug.cgi?id=288346</a>
<a href="https://rdar.apple.com/problem/145501159">rdar://problem/145501159</a>

Reviewed by Brady Eidson.

In current implementation, the memory backend does not roll back added records when transaction aborts. See the new test
for an example: before this patch, transaction-abort-revert-records-private.html would fail for keys added in
versionchnage transaction still present after the transaction is aborted.

The cause is MemoryBackingStoreTransaction only tracks records that are removed from object store during transaction,
but not records that are newly added. To fix that, now MemoryObjectStore tracks both added keys and removed records.
When transaction aborts, MemoryObjectStore deletes added records and re-adds deleted records. By moving the ownership of
changed records from MemoryBackingStoreTransaction to MemoryObjectStore, MemoryObjectStore does not need to notify
MemoryBackingStoreTransaction about changes, which makes the lifetime management more clear.

Tests: storage/indexeddb/transaction-abort-revert-records.html
       storage/indexeddb/transaction-abort-revert-records-private.html

* LayoutTests/storage/indexeddb/resources/transaction-abort-revert-records.js: Added.
(prepareDatabase):
(onDatabasePrepared):
(onDatabaseUpgrade):
(onTranactionAbort):
(onDatabaseError):
(onDatabaseOpen):
(onGetAllKeysSuccess):
(onGetSuccess):
* LayoutTests/storage/indexeddb/transaction-abort-revert-records-expected.txt: Added.
* LayoutTests/storage/indexeddb/transaction-abort-revert-records-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/transaction-abort-revert-records-private.html: Added.
* LayoutTests/storage/indexeddb/transaction-abort-revert-records.html: Added.
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::addExistingObjectStore):
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
(WebCore::IDBServer::MemoryBackingStoreTransaction::objectStoreCleared): Deleted.
(WebCore::IDBServer::MemoryBackingStoreTransaction::recordValueChanged): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::writeTransactionStarted):
(WebCore::IDBServer::MemoryObjectStore::transactionAborted):
(WebCore::IDBServer::MemoryObjectStore::writeTransactionFinished):
(WebCore::IDBServer::MemoryObjectStore::clear):
(WebCore::IDBServer::MemoryObjectStore::deleteRecord):
(WebCore::IDBServer::MemoryObjectStore::addRecord):
(WebCore::IDBServer::MemoryObjectStore::replaceKeyValueStore): Deleted.
(WebCore::IDBServer::MemoryObjectStore::unregisterIndex): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:

Canonical link: <a href="https://commits.webkit.org/291126@main">https://commits.webkit.org/291126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b970dc248adfc237ff49dc378ffb147785bb8f33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1030 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11832 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28039 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94955 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9018 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50883 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8747 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/882 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98918 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19076 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14098 "Found 1 new test failure: ipc/large-vector-allocate-failure-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79585 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78811 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19536 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12114 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19057 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24266 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18754 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->