### PR TITLE
[JSC] Add fast path for `Array#indexOf` searchs int32 from contiguous array

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-indexOf-int32-from-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-indexOf-int32-from-contiguous.js
@@ -1,0 +1,19 @@
+const array = [
+    { value: 0 }, { value: 1 }, { value: 2 }, { value: 3 }, { value: 4 },
+    { value: 5 }, { value: 6 }, { value: 7 }, { value: 8 }, { value: 9 },
+    { value: 10 }, { value: 11 }, { value: 12 }, { value: 13 }, { value: 14 },
+    { value: 15 }, { value: 31 }, { value: 30 }, { value: 29 }, { value: 28 },
+    { value: 27 }, { value: 26 }, { value: 25 }, { value: 24 }, { value: 23 },
+    { value: 22 }, { value: 21 }, { value: 20 }, { value: 19 }, { value: 18 },
+    { value: 17 }, { value: 16 }, { value: 32 }, { value: 33 }, { value: 34 },
+    { value: 35 }, 3, { value: 37 }, { value: 38 }, { value: 39 },
+    { value: 40 }, { value: 41 }, { value: 42 }, { value: 43 }, { value: 44 },
+    { value: 45 }, { value: 46 }, { value: 47 }, { value: 63 }, { value: 62 },
+    { value: 61 }, { value: 60 }, { value: 59 }, { value: 58 }, { value: 57 },
+    { value: 56 }, { value: 55 }, { value: 54 }, { value: 53 }, { value: 52 },
+    { value: 51 }, { value: 50 }, { value: 49 },
+];
+
+for (var i = 0; i < 1e6; ++i) {
+    array.indexOf(3);
+}

--- a/JSTests/stress/array-prototype-indexOf-int32-from-contiguous.js
+++ b/JSTests/stress/array-prototype-indexOf-int32-from-contiguous.js
@@ -1,0 +1,9 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const array = [{}, {}, {}, 3.0, {}, {}, {}];
+
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(array.indexOf(3), 3);

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3889,6 +3889,17 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrict
         OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
     }
 
+    if (searchElement.isInt32()) {
+        for (; index < length; ++index) {
+            JSValue value = data[index].get();
+            if (!value || !value.isNumber())
+                continue;
+            if (searchElement.asInt32() == value.asNumber())
+                OPERATION_RETURN(scope, toUCPUStrictInt32(index));
+        }
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    }
+
     for (; index < length; ++index) {
         JSValue value = data[index].get();
         if (!value)


### PR DESCRIPTION
#### b37512b75772d9e5c8d577984d88cee697acdd00
<pre>
[JSC] Add fast path for `Array#indexOf` searchs int32 from contiguous array
<a href="https://bugs.webkit.org/show_bug.cgi?id=288352">https://bugs.webkit.org/show_bug.cgi?id=288352</a>

Reviewed by Yusuke Suzuki.

This patch adds fast path for `Array#indexOf` searchs
int32 from contiguous array.

                                                  TipOfTree                  Patched

array-prototype-indexOf-int32-from-contiguous
                                               30.5272+-0.7824     ^     18.8472+-1.2090        ^ definitely 1.6197x faster

* JSTests/microbenchmarks/array-prototype-indexOf-int32-from-contiguous.js: Added.
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):

Canonical link: <a href="https://commits.webkit.org/290939@main">https://commits.webkit.org/290939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f2dfbc8a5befa6ef2bfa23687f8c5a92c5f646c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42198 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70271 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27790 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50596 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8480 "Found 5 new test failures: imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/494 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41368 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84315 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78800 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98484 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90260 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18673 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79295 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78499 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19414 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23021 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11798 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18669 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23947 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112844 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18380 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32718 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-eager-jettison, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-eager, wasm.yaml/wasm/v8/multi-value.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20146 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->