### PR TITLE
Media: Sprinkle final, remove unneeded virtual

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -198,7 +198,7 @@ private:
 
     void createAVPlayer() final;
     void createAVPlayerItem() final;
-    virtual void createAVPlayerLayer();
+    void createAVPlayerLayer();
     void createAVAssetForURL(const URL&) final;
     void createAVAssetForURL(const URL&, RetainPtr<NSMutableDictionary>);
     MediaPlayerPrivateAVFoundation::ItemStatus playerItemStatus() const final;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -63,7 +63,7 @@ class VideoLayerManagerObjC;
 class VideoMediaSampleRenderer;
 class VideoTrackPrivate;
 
-class MediaPlayerPrivateMediaSourceAVFObjC
+class MediaPlayerPrivateMediaSourceAVFObjC final
     : public CanMakeWeakPtr<MediaPlayerPrivateMediaSourceAVFObjC>
     , public RefCounted<MediaPlayerPrivateMediaSourceAVFObjC>
     , public MediaPlayerPrivateInterface
@@ -94,8 +94,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void removeVideoTrack(VideoTrackPrivate&);
     void removeTextTrack(InbandTextTrackPrivate&);
 
-    MediaPlayer::NetworkState networkState() const override;
-    MediaPlayer::ReadyState readyState() const override;
+    MediaPlayer::NetworkState networkState() const final;
+    MediaPlayer::ReadyState readyState() const final;
     void setReadyState(MediaPlayer::ReadyState);
     void setNetworkState(MediaPlayer::NetworkState);
 
@@ -103,7 +103,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void maybeCompleteSeek();
     void setLoadingProgresssed(bool flag) { m_loadingProgressed = flag; }
     void setHasAvailableVideoFrame(bool);
-    bool hasAvailableVideoFrame() const override;
+    bool hasAvailableVideoFrame() const final;
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
     void setHasAvailableAudioSample(AVSampleBufferAudioRenderer*, bool);
 ALLOW_NEW_API_WITHOUT_GUARDS_END
@@ -117,21 +117,21 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     void flushPendingSizeChanges();
     void characteristicsChanged();
 
-    MediaTime currentTime() const override;
+    MediaTime currentTime() const final;
     bool timeIsProgressing() const final;
     bool hasVideoRenderer() const;
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-    RetainPtr<PlatformLayer> createVideoFullscreenLayer() override;
-    void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) override;
-    void setVideoFullscreenFrame(FloatRect) override;
+    RetainPtr<PlatformLayer> createVideoFullscreenLayer() final;
+    void setVideoFullscreenLayer(PlatformLayer*, Function<void()>&& completionHandler) final;
+    void setVideoFullscreenFrame(FloatRect) final;
 #endif
 
-    void setTextTrackRepresentation(TextTrackRepresentation*) override;
-    void syncTextTrackBounds() override;
+    void setTextTrackRepresentation(TextTrackRepresentation*) final;
+    void syncTextTrackBounds() final;
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA)
-    void setCDMSession(LegacyCDMSession*) override;
+    void setCDMSession(LegacyCDMSession*) final;
     CDMSessionAVContentKeySession* cdmSession() const;
     void keyAdded() final;
 #endif
@@ -145,8 +145,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 #endif
 
     void outputObscuredDueToInsufficientExternalProtectionChanged(bool);
-    void beginSimulatedHDCPError() override { outputObscuredDueToInsufficientExternalProtectionChanged(true); }
-    void endSimulatedHDCPError() override { outputObscuredDueToInsufficientExternalProtectionChanged(false); }
+    void beginSimulatedHDCPError() final { outputObscuredDueToInsufficientExternalProtectionChanged(true); }
+    void endSimulatedHDCPError() final { outputObscuredDueToInsufficientExternalProtectionChanged(false); }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
     void keyNeeded(const SharedBuffer&);
@@ -167,7 +167,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
-    ASCIILiteral logClassName() const override { return "MediaPlayerPrivateMediaSourceAVFObjC"_s; }
+    ASCIILiteral logClassName() const final { return "MediaPlayerPrivateMediaSourceAVFObjC"_s; }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 
@@ -185,70 +185,70 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 private:
     // MediaPlayerPrivateInterface
-    void load(const String& url) override;
-    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) override;
+    void load(const String& url) final;
+    void load(const URL&, const LoadOptions&, MediaSourcePrivateClient&) final;
 #if ENABLE(MEDIA_STREAM)
-    void load(MediaStreamPrivate&) override;
+    void load(MediaStreamPrivate&) final;
 #endif
-    void cancelLoad() override;
+    void cancelLoad() final;
 
-    void prepareToPlay() override;
-    PlatformLayer* platformLayer() const override;
+    void prepareToPlay() final;
+    PlatformLayer* platformLayer() const final;
 
-    bool supportsPictureInPicture() const override { return true; }
-    bool supportsFullscreen() const override { return true; }
+    bool supportsPictureInPicture() const final { return true; }
+    bool supportsFullscreen() const final { return true; }
 
-    void play() override;
+    void play() final;
     void playInternal(std::optional<MonotonicTime>&& = std::nullopt);
 
-    void pause() override;
+    void pause() final;
     void pauseInternal(std::optional<MonotonicTime>&& = std::nullopt);
 
-    bool paused() const override;
+    bool paused() const final;
 
-    void setVolume(float volume) override;
-    void setMuted(bool) override;
+    void setVolume(float) final;
+    void setMuted(bool) final;
 
-    bool supportsScanning() const override;
+    bool supportsScanning() const final;
 
-    FloatSize naturalSize() const override;
+    FloatSize naturalSize() const final;
 
-    bool hasVideo() const override;
-    bool hasAudio() const override;
+    bool hasVideo() const final;
+    bool hasAudio() const final;
 
     void setPageIsVisible(bool) final;
 
-    MediaTime duration() const override;
-    MediaTime startTime() const override;
-    MediaTime initialTime() const override;
+    MediaTime duration() const final;
+    MediaTime startTime() const final;
+    MediaTime initialTime() const final;
 
     void seekToTarget(const SeekTarget&) final;
     bool seeking() const final;
-    void setRateDouble(double) override;
-    double rate() const override;
-    double effectiveRate() const override;
+    void setRateDouble(double) final;
+    double rate() const final;
+    double effectiveRate() const final;
 
-    void setPreservesPitch(bool) override;
+    void setPreservesPitch(bool) final;
 
-    MediaTime maxTimeSeekable() const override;
-    MediaTime minTimeSeekable() const override;
-    const PlatformTimeRanges& buffered() const override;
+    MediaTime maxTimeSeekable() const final;
+    MediaTime minTimeSeekable() const final;
+    const PlatformTimeRanges& buffered() const final;
 
-    bool didLoadingProgress() const override;
+    bool didLoadingProgress() const final;
 
-    RefPtr<NativeImage> nativeImageForCurrentTime() override;
+    RefPtr<NativeImage> nativeImageForCurrentTime() final;
     bool updateLastPixelBuffer();
     bool updateLastImage();
     void maybePurgeLastImage();
-    void paint(GraphicsContext&, const FloatRect&) override;
-    void paintCurrentFrameInContext(GraphicsContext&, const FloatRect&) override;
+    void paint(GraphicsContext&, const FloatRect&) final;
+    void paintCurrentFrameInContext(GraphicsContext&, const FloatRect&) final;
     RefPtr<VideoFrame> videoFrameForCurrentTime() final;
     DestinationColorSpace colorSpace() final;
 
-    bool supportsAcceleratedRendering() const override;
+    bool supportsAcceleratedRendering() const final;
     // called when the rendering system flips the into or out of accelerated rendering mode.
-    void acceleratedRenderingStateChanged() override;
-    void notifyActiveSourceBuffersChanged() override;
+    void acceleratedRenderingStateChanged() final;
+    void notifyActiveSourceBuffersChanged() final;
 
     void setPresentationSize(const IntSize&) final;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRight&&) final;
@@ -261,25 +261,25 @@ private:
     // NOTE: Because the only way for MSE to recieve data is through an ArrayBuffer provided by
     // javascript running in the page, the video will, by necessity, always be CORS correct and
     // in the page's origin.
-    bool didPassCORSAccessCheck() const override { return true; }
+    bool didPassCORSAccessCheck() const final { return true; }
 
-    MediaPlayer::MovieLoadType movieLoadType() const override;
+    MediaPlayer::MovieLoadType movieLoadType() const final;
 
-    void prepareForRendering() override;
+    void prepareForRendering() final;
 
-    String engineDescription() const override;
+    String engineDescription() const final;
 
-    String languageOfPrimaryAudioTrack() const override;
+    String languageOfPrimaryAudioTrack() const final;
 
-    size_t extraMemoryCost() const override;
+    size_t extraMemoryCost() const final;
 
-    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() override;
+    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    bool isCurrentPlaybackTargetWireless() const override;
-    void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) override;
-    void setShouldPlayToPlaybackTarget(bool) override;
-    bool wirelessVideoPlaybackDisabled() const override { return false; }
+    bool isCurrentPlaybackTargetWireless() const final;
+    void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) final;
+    void setShouldPlayToPlaybackTarget(bool) final;
+    bool wirelessVideoPlaybackDisabled() const final { return false; }
 #endif
 
     bool performTaskAtTime(Function<void()>&&, const MediaTime&) final;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -72,7 +72,7 @@ class VideoMediaSampleRenderer;
 class VideoLayerManagerObjC;
 class VideoTrackPrivateWebM;
 
-class MediaPlayerPrivateWebM
+class MediaPlayerPrivateWebM final
     : public MediaPlayerPrivateInterface
     , public WebMResourceClientParent
     , public WebAVSampleBufferListenerClient


### PR DESCRIPTION
#### 12b318dd4ce5e1c2684f9219f7b0becb663723a8
<pre>
Media: Sprinkle final, remove unneeded virtual
<a href="https://bugs.webkit.org/show_bug.cgi?id=288390">https://bugs.webkit.org/show_bug.cgi?id=288390</a>
<a href="https://rdar.apple.com/145498139">rdar://145498139</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
createAVPlayerLayer doesn&apos;t need to be virtual.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
MediaPlayerPrivateMediaSourceAVFObjC can be final.
Convert non-static function from override to final for consistency.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
MediaPlayerPrivateWebM can be final.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12b318dd4ce5e1c2684f9219f7b0becb663723a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42286 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93662 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11519 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19983 "Failed to checkout and rebase branch from PR 41188") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70344 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27864 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50669 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8559 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/586 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41462 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98585 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18767 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14033 "Exiting early after 60 failures. 50243 tests run. 60 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79370 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78835 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78576 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/452 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11883 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24033 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18470 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21927 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20232 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->