### PR TITLE
[JSC] Enable sm tests in test262

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -45,7 +45,7 @@ skip:
     - test/staging/Intl402
     - test/staging/JSON
     - test/staging/Temporal
-    - test/staging/sm
+    - test/staging/sm/Temporal
   files:
     # https://github.com/claudepache/es-legacy-function-reflection
     - test/built-ins/ThrowTypeError/unique-per-realm-function-proto.js

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1312,3 +1312,141 @@ test/language/statements/with/get-mutable-binding-binding-deleted-in-get-unscopa
   default: "ReferenceError: Can't find variable: binding"
 test/language/statements/with/set-mutable-binding-idref-compound-assign-with-proxy-env.js:
   default: 'Test262Error: Actual [has:p, get:Symbol(Symbol.unscopables), get:p, has:p, set:p, getOwnPropertyDescriptor:p, defineProperty:p] and expected [has:p, get:Symbol(Symbol.unscopables), has:p, get:p, has:p, set:p, getOwnPropertyDescriptor:p, defineProperty:p] should have the same contents. '
+test/staging/sm/Array/change-array-by-copy-errors-from-correct-realm.js:
+  default: "Test262Error: toSpliced - adding elements would exceed max array length didn't throw RangeError from other realm Expected SameValue(«false», «true») to be true"
+test/staging/sm/ArrayBuffer/slice-species.js:
+  default: 'Test262Error: Expected SameValue(«function ArrayBuffer() {'
+test/staging/sm/Date/makeday-year-month-is-infinity.js:
+  default: 'Test262Error: Expected SameValue(«-62167219200000», «NaN») to be true'
+test/staging/sm/Date/non-iso.js:
+  default: 'Test262Error: Expected SameValue(«NaN», «857750461010») to be true'
+test/staging/sm/Date/to-temporal-instant.js:
+  default: "TypeError: min.toZonedDateTimeISO is not a function. (In 'min.toZonedDateTimeISO('UTC')', 'min.toZonedDateTimeISO' is undefined)"
+test/staging/sm/Date/two-digit-years.js:
+  default: 'Test262Error: Expected SameValue(«923583600000», «NaN») to be true'
+test/staging/sm/Function/arguments-parameter-shadowing.js:
+  default: 'Test262Error: Expected SameValue(«true», «false») to be true'
+test/staging/sm/Function/function-bind.js:
+  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
+test/staging/sm/Function/function-name-assignment.js:
+  default: 'Test262Error: Expected SameValue(«"inParen"», «""») to be true'
+test/staging/sm/Function/function-toString-builtin-name.js:
+  default: 'Test262Error: Incorrect match for undefined Expected SameValue(«"fn"», «undefined») to be true'
+test/staging/sm/Iterator/from/modify-return.js:
+  default: 'TypeError: null is not a function'
+test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js:
+  default: 'Test262Error: Actual [get: every, get: return] and expected [get: every] should have the same contents. '
+test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js:
+  default: 'Test262Error: Actual [get: find, get: return] and expected [get: find] should have the same contents. '
+test/staging/sm/Iterator/prototype/forEach/check-fn-after-getting-iterator.js:
+  default: 'Test262Error: Actual [get: forEach, get: return] and expected [get: forEach] should have the same contents. '
+test/staging/sm/Iterator/prototype/reduce/check-fn-after-getting-iterator.js:
+  default: 'Test262Error: Actual [get: reduce, get: return] and expected [get: reduce] should have the same contents. '
+test/staging/sm/Iterator/prototype/some/check-fn-after-getting-iterator.js:
+  default: 'Test262Error: Actual [get: some, get: return] and expected [get: some] should have the same contents. '
+test/staging/sm/Math/cbrt-approx.js:
+  default: 'Error: got 1.39561242508609, expected a number near 1.3956124250860895 (relative error: 2)'
+test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js:
+  default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
+test/staging/sm/RegExp/lastIndex-search.js:
+  default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
+test/staging/sm/RegExp/match-local-tolength-recompilation.js:
+  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
+test/staging/sm/RegExp/replace-local-tolength-recompilation.js:
+  default: 'Test262Error: Expected SameValue(«"b"», «"pass"») to be true'
+test/staging/sm/RegExp/replace-sticky-lastIndex.js:
+  default: 'Test262Error: Expected SameValue(«"b"», «"a"») to be true'
+test/staging/sm/RegExp/replace-sticky.js:
+  default: 'Test262Error: Expected SameValue(«"ABCDEabcdeabcdefghij"», «"abcdeABCDEabcdefghij"») to be true'
+test/staging/sm/RegExp/split-limit.js:
+  default: 'Test262Error: Expected SameValue(«3», «1») to be true'
+test/staging/sm/RegExp/split-trace.js:
+  default: 'Test262Error: Expected SameValue(«"get:constructor,get:species,get:flags,call:constructor,set:lastIndex,get:exec,call:exec,set:lastIndex,get:exec,call:exec,get:lastIndex,get:result[length],get:result[length],get:result[1],get:result[2],set:lastIndex,get:exec,call:exec,"», «"get:constructor,get:species,get:flags,call:constructor,set:lastIndex,get:exec,call:exec,set:lastIndex,get:exec,call:exec,get:lastIndex,get:result[length],get:result[1],get:result[2],set:lastIndex,get:exec,call:exec,"») to be true'
+test/staging/sm/RegExp/unicode-braced.js:
+  default: 'SyntaxError: Invalid regular expression: regular expression too large'
+test/staging/sm/RegExp/unicode-class-braced.js:
+  default: 'SyntaxError: Invalid regular expression: regular expression too large'
+test/staging/sm/RegExp/unicode-class-negated.js:
+  default: 'Test262Error: Actual [�] and expected [�] should have the same contents. '
+test/staging/sm/RegExp/unicode-raw.js:
+  default: 'Test262Error: Expected SameValue(«🐸», «null») to be true'
+test/staging/sm/Set/difference.js:
+  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
+test/staging/sm/Set/symmetric-difference.js:
+  default: 'Test262Error: Expected SameValue(«3», «1») to be true'
+test/staging/sm/Set/union.js:
+  default: 'Test262Error: Expected SameValue(«3», «1») to be true'
+test/staging/sm/String/string-code-point-upper-lower-mapping.js:
+  default: 'Test262Error: Expected SameValue(«68976», «68944») to be true'
+test/staging/sm/String/string-upper-lower-mapping.js:
+  default: 'Test262Error: Expected SameValue(«"ƛ"», «"Ƛ"») to be true'
+test/staging/sm/Symbol/enumeration-order.js:
+  default: 'Test262Error: Expected ["string", "symbol", "string", "symbol", "symbol", "string"] to be structurally equal to ["string", "string", "string", "symbol", "symbol", "symbol"]. '
+test/staging/sm/TypedArray/constructor-buffer-sequence.js:
+  default: 'Error: Assertion failed: expected exception ExpectedError, got Error: Poisoned Value'
+test/staging/sm/TypedArray/iterator-next-with-detached.js:
+  default: 'TypeError: Underlying ArrayBuffer has been detached from the view or out-of-bounds'
+test/staging/sm/TypedArray/set-with-receiver.js:
+  default: 'Test262Error: Expected SameValue(«47», «0») to be true'
+test/staging/sm/TypedArray/slice-memcpy.js:
+  default: 'Test262Error: Actual [1, 2, 1, 2, 3, 4] and expected [1, 2, 1, 2, 1, 2] should have the same contents. '
+test/staging/sm/TypedArray/subarray.js:
+  default: 'Test262Error: Expected SameValue(«0», «1») to be true'
+test/staging/sm/async-functions/await-error.js:
+  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
+test/staging/sm/class/defaultConstructorDerivedSpread.js:
+  default: 'Error: unexpected call'
+test/staging/sm/class/superPropOrdering.js:
+  default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
+test/staging/sm/eval/redeclared-arguments-in-param-expression-eval.js:
+  default: 'Test262Error: Expected SameValue(«true», «false») to be true'
+test/staging/sm/expressions/exponentiation-unparenthesised-unary.js:
+  default: 'Error: Assertion failed: expected exception SyntaxError, no exception thrown - AsyncFunction:await a ** 0'
+test/staging/sm/expressions/object-literal-computed-property-evaluation.js:
+  default: 'Test262Error: Expected SameValue(«undefined», «"abc"») to be true'
+test/staging/sm/expressions/short-circuit-compound-assignment-anon-fns.js:
+  default: 'Test262Error: Expected SameValue(«"a"», «""») to be true'
+test/staging/sm/expressions/short-circuit-compound-assignment-const.js:
+  default: 'Test262Error: Expected SameValue(«true», «function fn() {'
+test/staging/sm/extensions/function-caller-skips-eval-frames.js:
+  default: 'Test262Error: Expected SameValue(«null», «function nest() { return eval("innermost();"); }») to be true'
+test/staging/sm/extensions/inc-dec-functioncall.js:
+  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
+test/staging/sm/extensions/new-cross-compartment.js:
+  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
+test/staging/sm/extensions/regress-469625-01.js:
+  default: "Test262Error: TM: Array prototype and expression closures Expected SameValue(«\"TypeError: [].__proto__ is not a function\"», «\"TypeError: [].__proto__ is not a function. (In '[].__proto__()', '[].__proto__' is an instance of Array)\"») to be true"
+test/staging/sm/fields/await-identifier-module-2.js:
+  module: 'Test262: This statement should not be evaluated.'
+test/staging/sm/generators/delegating-yield-1.js:
+  default: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+test/staging/sm/generators/delegating-yield-3.js:
+  default: 'Test262Error: Expected SameValue(«true», «undefined») to be true'
+test/staging/sm/generators/delegating-yield-5.js:
+  default: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+test/staging/sm/generators/delegating-yield-6.js:
+  default: 'Test262Error: Expected SameValue(«"indvndvndvndvndvndv"», «"indndndndndndv"») to be true'
+test/staging/sm/generators/delegating-yield-7.js:
+  default: 'Test262Error: Expected [Object {value: 1}, Object {value: 34, done: true}] to be structurally equal to [Object {value: 1, done: false}, Object {value: 34, done: true}]. '
+test/staging/sm/generators/syntax.js:
+  default: "Error: Assertion failed: expected SyntaxError, but no exception thrown - function* yield() { 'use strict'; (yield 3) + (yield 4); }"
+test/staging/sm/lexical-environment/block-scoped-functions-annex-b-label.js:
+  default: "TypeError: f1 is not a function. (In 'f1()', 'f1' is undefined)"
+test/staging/sm/lexical-environment/block-scoped-functions-deprecated-redecl.js:
+  default: 'Test262Error: Expected SameValue(«3», «4») to be true'
+test/staging/sm/lexical-environment/for-loop.js:
+  default: "Test262Error: unexpected error for `for (const [z]; ; ) ;`: got Error: didn't throw Expected SameValue(«false», «true») to be true"
+test/staging/sm/misc/future-reserved-words.js:
+  default: 'Test262Error: Implement FutureReservedWords per-spec: implements: function argument retroactively strict Expected SameValue(«"no error"», «"SyntaxError"») to be true'
+test/staging/sm/module/await-restricted-nested.js:
+  module: 'Test262: This statement should not be evaluated.'
+test/staging/sm/module/module-export-name-star.js:
+  module: "ReferenceError: Can't find variable: y"
+test/staging/sm/object/defineProperties-order.js:
+  default: 'Test262Error: Expected SameValue(«"ownKeys,getOwnPropertyDescriptor,getOwnPropertyDescriptor,get,get"», «"ownKeys,getOwnPropertyDescriptor,get,getOwnPropertyDescriptor,get"») to be true'
+test/staging/sm/regress/regress-609617.js:
+  default: 'Error: Assertion failed: expected exception 2, got ReferenceError: Postfix ++ operator applied to value that is not a reference.'
+test/staging/sm/statements/for-of-iterator-close.js:
+  default: 'Error: Assertion failed: expected exception in lhs, got ReferenceError: Left side of for-of statement is not a reference.'
+test/staging/sm/syntax/syntax-parsed-arrow-then-directive.js:
+  default: "Test262Error: stack should contain 'http://example.com/foo.js': block, semi Expected SameValue(«false», «true») to be true"


### PR DESCRIPTION
#### 39e54abe1ea22d4ec83f10f31d11e05c9d414e03
<pre>
[JSC] Enable sm tests in test262
<a href="https://bugs.webkit.org/show_bug.cgi?id=288361">https://bugs.webkit.org/show_bug.cgi?id=288361</a>

Reviewed by Yusuke Suzuki.

This patch enables sm(SpiderMonkey) tests in test262.

In the current JSC, 69 out of 1430 sm tests are failing,
but the rest are passing, so it’s worth testing.

* JSTests/test262/config.yaml:
* JSTests/test262/expectations.yaml:

Canonical link: <a href="https://commits.webkit.org/290946@main">https://commits.webkit.org/290946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46f1094d39562cfda41144e88c5c71ac15d99ee9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/595 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42219 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19479 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70290 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27808 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50614 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8499 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41389 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84335 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78819 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98505 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90281 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18694 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79313 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78767 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78515 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19417 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23040 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11819 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18690 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112865 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18401 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32723 "Found 13 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.no-llint, microbenchmarks/memcpy-wasm.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-collect-continuously, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-slow-memory ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21861 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20167 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->