### PR TITLE
Correct type and serialization of shadowRootCustomElements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative-expected.txt
@@ -3,4 +3,5 @@ PASS A newly attached disconnected ShadowRoot should use the global registry by 
 PASS A newly attached connected ShadowRoot should use the global registry by default
 PASS A newly attached disconnected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
 PASS A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow
+PASS attachShadow() should throw for a null customElements value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
@@ -33,6 +33,11 @@ test(() => {
     assert_equals(shadowRoot.customElements, registry);
 }, 'A newly attached connected ShadowRoot should use the scoped registry if explicitly specified in attachShadow');
 
+test(() => {
+    const host = document.body.appendChild(document.createElement('div'));
+    assert_throws_js(TypeError, () => host.attachShadow({mode: 'closed', customElements: null}));
+}, 'attachShadow() should throw for a null customElements value');
+
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window-expected.txt
@@ -1,0 +1,5 @@
+
+PASS shadowRootCustomElements reflects as string
+PASS Serializing a ShadowRoot with a null registry
+PASS Serializing a ShadowRoot with a registry that differs from its host
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.js
@@ -1,0 +1,25 @@
+test(() => {
+  const template = document.createElement("template");
+  assert_false(template.hasAttribute("shadowrootcustomelements"));
+  assert_equals(template.shadowRootCustomElements, "");
+
+  template.shadowRootCustomElements = "blah";
+  assert_equals(template.getAttribute("shadowrootcustomelements"), "blah");
+  assert_equals(template.shadowRootCustomElements, "blah");
+}, "shadowRootCustomElements reflects as string");
+
+test(() => {
+  const div = document.createElement("div");
+  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootcustomelements shadowrootserializable></template></div>`);
+  assert_equals(div.firstChild.firstChild, null);
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelements=\"\"></template></div>");
+}, "Serializing a ShadowRoot with a null registry");
+
+test(() => {
+  const div = document.createElement("div");
+  div.setHTMLUnsafe(`<div><template shadowrootmode=open shadowrootcustomelements shadowrootserializable></template></div>`);
+  const registry = new CustomElementRegistry();
+  registry.initialize(div.firstChild.shadowRoot);
+  assert_equals(div.firstChild.shadowRoot.customElements, registry);
+  assert_equals(div.getHTML({ serializableShadowRoots: true }), "<div><template shadowrootmode=\"open\" shadowrootserializable=\"\" shadowrootcustomelements=\"\"></template></div>");
+}, "Serializing a ShadowRoot with a registry that differs from its host");

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log
@@ -25,3 +25,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-innerHTML.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-innerHTML.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.js

--- a/Source/WebCore/dom/ShadowRoot.idl
+++ b/Source/WebCore/dom/ShadowRoot.idl
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2015-2024 Apple Inc. All rights reserved.
+* Copyright (C) 2015-2025 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -36,10 +36,9 @@
     [ImplementedAs=isClonable] readonly attribute boolean clonable;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] readonly attribute boolean serializable;
     readonly attribute Element host;
-    attribute EventHandler onslotchange;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled, ImplementedAs=registryForBindings] readonly attribute CustomElementRegistry? customElements;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] attribute [AtomString] DOMString referenceTarget;
-
-    [ImplementedAs=registryForBindings, EnabledBySetting=ScopedCustomElementRegistryEnabled] readonly attribute CustomElementRegistry? customElements;
+    attribute EventHandler onslotchange;
 };
 
 ShadowRoot includes DocumentOrShadowRoot;

--- a/Source/WebCore/dom/ShadowRootInit.idl
+++ b/Source/WebCore/dom/ShadowRootInit.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,6 @@ dictionary ShadowRootInit {
     boolean clonable = false;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled] boolean serializable = false;
     SlotAssignmentMode slotAssignment = "named";
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry customElements = null;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled] CustomElementRegistry customElements;
     [EnabledBySetting=ShadowRootReferenceTargetEnabled] DOMString referenceTarget;
 };

--- a/Source/WebCore/editing/MarkupAccumulator.cpp
+++ b/Source/WebCore/editing/MarkupAccumulator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2009-2022 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -421,7 +421,8 @@ void MarkupAccumulator::startAppendingNode(const Node& node, Namespaces* namespa
             m_markup.append(" shadowrootserializable=\"\""_s);
         if (shadowRoot->isClonable())
             m_markup.append(" shadowrootclonable=\"\""_s);
-        // FIXME: Add shadowrootcustomelements
+        if (shadowRoot->protectedHost()->customElementRegistry() != shadowRoot->registryForBindings())
+            m_markup.append(" shadowrootcustomelements=\"\""_s);
         m_markup.append('>');
     } else
         appendNonElementNode(m_markup, node, namespaces);

--- a/Source/WebCore/html/HTMLTemplateElement.idl
+++ b/Source/WebCore/html/HTMLTemplateElement.idl
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012, Google Inc. All rights reserved.
- * Copyright (c) 2017-2024 Apple Inc. All rights reserved.
+ * Copyright (c) 2012 Google Inc. All rights reserved.
+ * Copyright (c) 2017-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -38,6 +38,6 @@
     [CEReactions=NotNeeded, Reflect=shadowrootdelegatesfocus] attribute boolean shadowRootDelegatesFocus;
     [CEReactions=NotNeeded, Reflect=shadowrootclonable] attribute boolean shadowRootClonable;
     [EnabledBySetting=DeclarativeShadowRootsSerializerAPIsEnabled, CEReactions=NotNeeded, Reflect=shadowrootserializable] attribute boolean shadowRootSerializable;
-    [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=NotNeeded, Reflect=shadowrootcustomelements] attribute boolean shadowRootCustomElements;
-    [CEReactions=NotNeeded, EnabledBySetting=ShadowRootReferenceTargetEnabled, Reflect=shadowrootreferencetarget] attribute DOMString shadowRootReferenceTarget;
+    [EnabledBySetting=ScopedCustomElementRegistryEnabled, CEReactions=NotNeeded, Reflect=shadowrootcustomelements] attribute DOMString shadowRootCustomElements;
+    [EnabledBySetting=ShadowRootReferenceTargetEnabled, CEReactions=NotNeeded, Reflect=shadowrootreferencetarget] attribute DOMString shadowRootReferenceTarget;
 };


### PR DESCRIPTION
#### 9a0b4ad4f70ecb0194d1aa1a8fd172ba6f755b25
<pre>
Correct type and serialization of shadowRootCustomElements
<a href="https://bugs.webkit.org/show_bug.cgi?id=288364">https://bugs.webkit.org/show_bug.cgi?id=288364</a>

Reviewed by Ryosuke Niwa.

The type of the IDL attribute is DOMString for forward compatibility,
according to the HTML PR, not boolean. Also add the missing
serialization logic.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/ShadowRoot-init-customElements.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/template.tentative.window.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log:
* Source/WebCore/dom/ShadowRoot.idl:

Clean up the member order while here and lead with the EnabledBySetting extended attribute.

* Source/WebCore/dom/ShadowRootInit.idl:

Remove an ignored &quot;= null&quot; for clarity. The added test passes either
way and is mainly there to ensure other implementations stay aligned.

* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::MarkupAccumulator::startAppendingNode):
* Source/WebCore/html/HTMLTemplateElement.idl:

Also lead with the EnabledBySetting extended attribute here.

Canonical link: <a href="https://commits.webkit.org/291015@main">https://commits.webkit.org/291015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dcb16627fdb52e9d49ef8458b853f53d136bc73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42225 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70296 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27814 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50620 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8505 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/525 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98511 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18700 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13782 "Found 3 new test failures: fast/mediastream/getUserMedia-to-canvas-1.html fast/mediastream/getUserMedia-to-canvas-2.html imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79319 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78774 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78521 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19467 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11825 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23972 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18407 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->