### PR TITLE
[Interop 2025] Sync `workers/constructors` tests from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin-expected.txt
@@ -1,5 +1,6 @@
 
-PASS unsupported_scheme
+PASS non-parsable URL
+FAIL unsupported_scheme URL of the shared worker is cross-origin
 PASS data_url
 FAIL javascript_url URL of the shared worker is cross-origin
 FAIL about_blank URL of the shared worker is cross-origin

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin.html
@@ -17,7 +17,12 @@ testSharedWorkerHelper = (t, script) => {
 }
 
 test(() => {
-  assert_throws_dom("SecurityError", () => { new SharedWorker('unsupported:', ''); });
+  assert_throws_dom("SyntaxError", () => { new SharedWorker('https://test:test', ''); });
+}, "non-parsable URL");
+
+async_test(t => {
+  // Parses fine as a URL, fails to fetch according to Fetch
+  testSharedWorkerHelper(t, 'unsupported:');
 }, "unsupported_scheme");
 
 async_test(t => {

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin-expected.txt
@@ -1,5 +1,6 @@
 
-PASS unsupported_scheme
+PASS non-parsable URL
+FAIL unsupported_scheme The operation is insecure.
 PASS data_url
 FAIL about_blank The operation is insecure.
 FAIL example_invalid The operation is insecure.

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin.html
@@ -19,7 +19,12 @@ function testWorkerHelper(t, script) {
 }
 
 test(function() {
-  assert_throws_dom("SecurityError", function() { new Worker('unsupported:'); });
+  assert_throws_dom("SyntaxError", function() { new Worker('https://test:test'); });
+}, "non-parsable URL");
+
+async_test(function(t) {
+  // Parses fine as a URL, fails to fetch according to Fetch
+  testWorkerHelper(t, 'unsupported:');
 }, "unsupported_scheme");
 
 async_test(function() {


### PR DESCRIPTION
#### 7e4c841cabbb21d2ac3aaf7a9e60270e601efcac
<pre>
[Interop 2025] Sync `workers/constructors` tests from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=288367">https://bugs.webkit.org/show_bug.cgi?id=288367</a>
<a href="https://rdar.apple.com/145474518">rdar://145474518</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/240b357348202856b077417a3ebf944301776a89">https://github.com/web-platform-tests/wpt/commit/240b357348202856b077417a3ebf944301776a89</a>

* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/SharedWorker/same-origin.html:
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/constructors/Worker/same-origin.html:

Canonical link: <a href="https://commits.webkit.org/290958@main">https://commits.webkit.org/290958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/071ca4f69982f46eb3543db13573a101f5851e3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11080 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42235 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70303 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27824 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50627 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41405 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98522 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18710 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79329 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78784 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78539 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19432 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23054 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/412 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11839 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18417 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->