### PR TITLE
Suppress Safer CPP failures in ArgumentCoders.h

### DIFF
--- a/Source/WebKit/Platform/IPC/ArgumentCoders.h
+++ b/Source/WebKit/Platform/IPC/ArgumentCoders.h
@@ -353,7 +353,7 @@ template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
     static void encode(Encoder& encoder, T&& tuple, std::index_sequence<Indices...>)
     {
         if constexpr (sizeof...(Indices) > 0)
-            (encoder << ... << std::get<Indices>(std::forward<T>(tuple)));
+            SUPPRESS_UNCOUNTED_ARG (encoder << ... << std::get<Indices>(std::forward<T>(tuple)));
     }
 
     template<typename Decoder, typename... DecodedTypes>
@@ -370,7 +370,7 @@ template<typename... Elements> struct ArgumentCoder<std::tuple<Elements...>> {
             return decode(decoder, WTFMove(decodedObjects)..., WTFMove(optional));
         } else {
             static_assert((std::is_same_v<DecodedTypes, Elements> && ...));
-            return std::make_optional<std::tuple<Elements...>>(*WTFMove(decodedObjects)...);
+            SUPPRESS_UNCOUNTED_ARG return std::make_optional<std::tuple<Elements...>>(*WTFMove(decodedObjects)...);
         }
     }
 };

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -23,7 +23,6 @@ NetworkProcess/mac/SecItemShim.cpp
 NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
 NetworkProcess/storage/BackgroundFetchStoreManager.cpp
 NetworkProcess/storage/IDBStorageRegistry.cpp
-Platform/IPC/ArgumentCoders.h
 Shared/API/APIArray.h
 Shared/API/c/WKArray.cpp
 Shared/API/c/WKContextMenuItem.cpp


### PR DESCRIPTION
#### 528c67cfe747c92e938cb30dbd8bd7ca7133c6cf
<pre>
Suppress Safer CPP failures in ArgumentCoders.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=288369">https://bugs.webkit.org/show_bug.cgi?id=288369</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/Platform/IPC/ArgumentCoders.h:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/528c67cfe747c92e938cb30dbd8bd7ca7133c6cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91555 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96524 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42241 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27826 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82955 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50633 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8517 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41411 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98529 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18716 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13875 "Found 60 new test failures: fast/text/glyph-display-lists/glyph-display-list-color.html fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html http/tests/site-isolation/history/add-iframes-and-go-back.html http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html ietestcenter/Javascript/10.4.2-1-1.html imported/w3c/web-platform-tests/content-security-policy/connect-src/shared-worker-connect-src-blocked.sub.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79333 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78793 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78536 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11844 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18712 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/23988 "Found 2 new failures in Platform/IPC/ArgumentCoders.h") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21883 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20189 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->