### PR TITLE
ASSERTION FAILED: isMainThread()

### DIFF
--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h
@@ -49,7 +49,8 @@ private:
 
     const Function<void()> m_callback;
     const RetainPtr<WebEffectiveRateChangedListenerObjCAdapter> m_objcAdapter;
-    RetainPtr<CMTimebaseRef> m_timebase;
+    const RetainPtr<CMTimebaseRef> m_timebase;
+    std::atomic<bool> m_stopped { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
+++ b/Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm
@@ -73,9 +73,7 @@ EffectiveRateChangedListener::EffectiveRateChangedListener(Function<void()>&& ca
     , m_objcAdapter(adoptNS([[WebEffectiveRateChangedListenerObjCAdapter alloc] initWithEffectiveRateChangedListener:*this]))
     , m_timebase(timebase)
 {
-    assertIsMainThread();
     ASSERT(timebase);
-    // Observer removed MediaPlayerPrivateMediaSourceAVFObjC destructor.
     CFNotificationCenterAddObserver(CFNotificationCenterGetLocalCenter(), m_objcAdapter.get(), timebaseEffectiveRateChangedCallback, kCMTimebaseNotification_EffectiveRateChanged, timebase, static_cast<CFNotificationSuspensionBehavior>(_CFNotificationObserverIsObjC));
 }
 
@@ -91,11 +89,9 @@ void EffectiveRateChangedListener::effectiveRateChanged()
 
 void EffectiveRateChangedListener::stop()
 {
-    assertIsMainThread();
-    if (!m_timebase)
+    if (m_stopped.exchange(true))
         return;
     CFNotificationCenterRemoveObserver(CFNotificationCenterGetLocalCenter(), m_objcAdapter.get(), kCMTimebaseNotification_EffectiveRateChanged, m_timebase.get());
-    m_timebase = nullptr;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### 59955e21f6c4839c6f0613a7f3a8007eda03e523
<pre>
ASSERTION FAILED: isMainThread()
<a href="https://bugs.webkit.org/show_bug.cgi?id=288375">https://bugs.webkit.org/show_bug.cgi?id=288375</a>
<a href="https://rdar.apple.com/145483109">rdar://145483109</a>

Reviewed by Simon Fraser.

Remove assertion added in 289922@main.
It did expose an issue in the original code. The observer could take a reference
on a thread other than the main thread which could make multiple concurrent calls to stop().
We make the stop() and destructor operation thread-safe.

* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.h:
* Source/WebCore/platform/cocoa/EffectiveRateChangedListener.mm:
(WebCore::EffectiveRateChangedListener::EffectiveRateChangedListener): Remove out of date comment.
(WebCore::EffectiveRateChangedListener::stop):

Canonical link: <a href="https://commits.webkit.org/291013@main">https://commits.webkit.org/291013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f6bb41f912b11edbbb7d773051372b80ed40e1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70334 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27853 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50658 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8552 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/580 "Found 2 new test failures: http/tests/security/cookie-module-propagate.html http/tests/security/cookie-module.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41450 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98572 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18757 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13823 "Found 2 new test failures: imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/open-features-tokenization-noreferrer.html imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79361 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78829 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78566 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11877 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24025 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18460 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20224 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->