### PR TITLE
[WebGPU] Generated metal does not compile on https://bercon.github.io/roquefort/

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -232,6 +232,8 @@ void RewriteGlobalVariables::visitCallee(const CallGraph::Callee& callee)
 
             for (auto& length : it->value) {
                 auto lengthName = makeString("__"_s, length, "_ArrayLength"_s);
+                if (m_reads.contains(lengthName))
+                    continue;
                 m_shaderModule.append(callee.target->parameters(), m_shaderModule.astBuilder().construct<AST::Parameter>(
                     SourceSpan::empty(),
                     AST::Identifier::make(lengthName),
@@ -280,6 +282,8 @@ void RewriteGlobalVariables::visitCallee(const CallGraph::Callee& callee)
                     result.iterator->value.add(identifier);
 
                     auto lengthName = makeString("__"_s, identifier, "_ArrayLength"_s);
+                    if (m_reads.contains(lengthName))
+                        continue;
                     auto& length = m_shaderModule.astBuilder().construct<AST::IdentifierExpression>(
                         SourceSpan::empty(),
                         AST::Identifier::make(lengthName)

--- a/Source/WebGPU/WGSL/tests/valid/array-length-pointer.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-length-pointer.wgsl
@@ -1,0 +1,16 @@
+// RUN: %metal-compile main
+
+@group(0) @binding(2) var<storage, read> x: array<vec4f>;
+
+fn f1(p: ptr<storage, array<vec4f>, read>) {
+  _ = p[0];
+};
+
+fn f0() {
+  f1(&x);
+}
+
+@compute @workgroup_size(1)
+fn main() {
+    f0();
+}


### PR DESCRIPTION
#### 785d74a7e396b9837a46d355d6704bf68cb7d5b4
<pre>
[WebGPU] Generated metal does not compile on <a href="https://bercon.github.io/roquefort/">https://bercon.github.io/roquefort/</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288356">https://bugs.webkit.org/show_bug.cgi?id=288356</a>
<a href="https://rdar.apple.com/145449315">rdar://145449315</a>

Reviewed by Mike Wyrzykowski.

We use two different mechanisms to track variables that need to be passed to functions:
1. when a function (or any of its callees) use a global, we track that it needs to be
   passed down from the entry point to this function
2. when a runtime-sized array is passed to a callee, we track that we also need to pass
   the array size

However, there were no checks to ensure that the same variable wasn&apos;t being tracked by
both 1 and 2, which could result in duplicate parameters being inserted. The fix is simply
to check if the variable exists in the other HashSet before inserting it.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
* Source/WebGPU/WGSL/tests/valid/array-length-pointer.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/291025@main">https://commits.webkit.org/291025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38fe5d17a002fa110833ad9932f3e7b27dd166c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11489 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/19812 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70322 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27841 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8780 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82971 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50646 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8545 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41433 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18739 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13899 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18993 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78809 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78552 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19471 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23075 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11864 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24010 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18443 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21903 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20209 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->