### PR TITLE
Silence Safer CPP failures in ThreadSafeWeakPtr.h

### DIFF
--- a/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -1,3 +1,2 @@
 wtf/PrintStream.h
 wtf/RunLoop.h
-wtf/ThreadSafeWeakPtr.h

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -2,7 +2,6 @@ wtf/AutomaticThread.cpp
 wtf/MemoryPressureHandler.cpp
 wtf/RecursiveLockAdapter.h
 wtf/Ref.h
-wtf/ThreadSafeWeakPtr.h
 wtf/text/AtomStringImpl.cpp
 wtf/text/CString.cpp
 wtf/text/StringImpl.cpp

--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -70,7 +70,7 @@ public:
     template<typename T, DestructionThread destructionThread>
     void strongDeref() const
     {
-        T* object;
+        SUPPRESS_UNCOUNTED_LOCAL T* object;
         {
             Locker locker { m_lock };
             ASSERT_WITH_SECURITY_IMPLICATION(m_object);
@@ -87,7 +87,7 @@ public:
             m_weakReferenceCount++;
         }
 
-        auto deleteObject = [this, object] {
+        auto deleteObject = [this, object] SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE {
             delete static_cast<const T*>(object);
 
             bool hasOtherWeakRefs;
@@ -239,7 +239,7 @@ public:
         if (didDerefStrongOnly) {
             if (newStrongOnlyRefCount == strongOnlyFlag) {
                 ASSERT(m_bits.exchangeOr(destructionStartedFlag) == newStrongOnlyRefCount);
-                auto deleteObject = [this] {
+                auto deleteObject = [this] SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE {
                     delete static_cast<const T*>(this);
                 };
                 switch (destructionThread) {


### PR DESCRIPTION
#### e54ddae4d6a6eff54058596f26746f08e8914a1f
<pre>
Silence Safer CPP failures in ThreadSafeWeakPtr.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=288377">https://bugs.webkit.org/show_bug.cgi?id=288377</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::ThreadSafeWeakPtrControlBlock::strongDeref const):
(WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e54ddae4d6a6eff54058596f26746f08e8914a1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11117 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42266 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70328 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/571 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41437 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84384 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78861 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98559 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90333 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79353 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/18998 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78820 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78557 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11866 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18738 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24013 "Found 2 new failures in wtf/ThreadSafeWeakPtr.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112918 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18447 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32731 "Found 18 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.default, microbenchmarks/memcpy-wasm-small.js.dfg-eager, stress/string-value-of-error.js.bytecode-cache, stress/v8-typedarray-resizablearraybuffer.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21906 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20212 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->