### PR TITLE
Unreviewed, re-landing 290928@main

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -77,16 +77,21 @@ template<typename T> class RetainPtr;
 template<typename T> constexpr bool IsNSType = std::is_convertible_v<T, id>;
 template<typename T> using RetainPtrType = std::conditional_t<IsNSType<T>, std::remove_pointer_t<T>, T>;
 
-template<typename T> constexpr RetainPtr<T> adoptCF(T CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
-#ifdef __OBJC__
-template<typename T> RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
-#endif
+template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
 template<typename T> class RetainPtr {
 public:
     using ValueType = std::remove_pointer_t<T>;
     using PtrType = ValueType*;
+
+#ifdef __OBJC__
+    using StorageType = PtrType;
+#else
+    // Type pun id to CFTypeRef in C++ files. This is valid because they're ABI equivalent.
+    using StorageType = std::conditional_t<IsNSType<PtrType>, CFTypeRef, PtrType>;
+#endif
 
     RetainPtr() = default;
     RetainPtr(PtrType);
@@ -94,25 +99,26 @@ public:
     RetainPtr(const RetainPtr&);
     template<typename U> RetainPtr(const RetainPtr<U>&);
 
-    constexpr RetainPtr(RetainPtr&& o) : m_ptr(toStorageType(o.leakRef())) { }
-    template<typename U> constexpr RetainPtr(RetainPtr<U>&& o) : m_ptr(toStorageType(checkType(o.leakRef()))) { }
+    constexpr RetainPtr(RetainPtr&& o) : m_ptr(o.leakRef()) { }
+    template<typename U, typename = std::enable_if_t<std::is_convertible_v<typename RetainPtr<RetainPtrType<U>>::PtrType, PtrType>>>
+    constexpr RetainPtr(RetainPtr<U>&& o) : m_ptr(o.leakRef()) { }
 
     // Hash table deleted values, which are only constructed and never copied or destroyed.
-    constexpr RetainPtr(HashTableDeletedValueType) : m_ptr(toStorageType(hashTableDeletedValue())) { }
-    constexpr bool isHashTableDeletedValue() const { return m_ptr == toStorageType(hashTableDeletedValue()); }
+    constexpr RetainPtr(HashTableDeletedValueType) : m_ptr(hashTableDeletedValue()) { }
+    constexpr bool isHashTableDeletedValue() const { return m_ptr == hashTableDeletedValue(); }
 
     ~RetainPtr();
 
     void clear();
 
-    template<typename U = PtrType>
-    std::enable_if_t<IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        return fromStorageType(std::exchange(m_ptr, nullptr));
+    template<typename U = StorageType>
+    std::enable_if_t<IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
+        return std::exchange(m_ptr, nullptr);
     }
 
-    template<typename U = PtrType>
-    std::enable_if_t<!IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
-        return fromStorageType(std::exchange(m_ptr, nullptr));
+    template<typename U = StorageType>
+    std::enable_if_t<!IsNSType<U> && std::is_same_v<U, StorageType>, StorageType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
+        return std::exchange(m_ptr, nullptr);
     }
 
 #if HAVE(CFAUTORELEASE)
@@ -123,9 +129,9 @@ public:
     id bridgingAutorelease();
 #endif
 
-    constexpr PtrType get() const { return fromStorageType(m_ptr); }
-    constexpr PtrType operator->() const { return fromStorageType(m_ptr); }
-    constexpr explicit operator PtrType() const { return fromStorageType(m_ptr); }
+    constexpr PtrType get() const { return m_ptr; }
+    constexpr PtrType operator->() const { return m_ptr; }
+    constexpr explicit operator PtrType() const { return m_ptr; }
     constexpr explicit operator bool() const { return m_ptr; }
 
     constexpr bool operator!() const { return !m_ptr; }
@@ -140,44 +146,44 @@ public:
 
     void swap(RetainPtr&);
 
-    template<typename U> friend constexpr RetainPtr<U> adoptCF(U CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
+    template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptCF(U CF_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
-#ifdef __OBJC__
-    template<typename U> friend RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
-#endif
+    template<typename U> friend constexpr RetainPtr<RetainPtrType<U>> adoptNS(U NS_RELEASES_ARGUMENT) WARN_UNUSED_RETURN;
 
 private:
     enum AdoptTag { Adopt };
-    constexpr RetainPtr(PtrType ptr, AdoptTag) : m_ptr(toStorageType(ptr)) { }
+    constexpr RetainPtr(PtrType ptr, AdoptTag) : m_ptr(ptr) { }
 
-    static constexpr PtrType checkType(PtrType ptr) { return ptr; }
-
-    // ARC will try to retain/release this value, but it looks like a tagged immediate, so retain/release ends up being a no-op -- see _objc_registerTaggedPointerClass.
-    static constexpr PtrType hashTableDeletedValue() { return fromStorageType(reinterpret_cast<CFTypeRef>(-1)); }
-
-#ifdef __OBJC__
+#if __has_feature(objc_arc)
+    // ARC will try to retain/release this value, but it looks like a tagged immediate, so retain/release ends up being a no-op -- see _objc_isTaggedPointer() in <objc-internal.h>.
     template<typename U = PtrType>
-    static constexpr std::enable_if_t<IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> fromStorageTypeHelper(CFTypeRef ptr)
-    {
-        return (__bridge PtrType)const_cast<CF_BRIDGED_TYPE(id) void*>(ptr);
-    }
+    static constexpr std::enable_if_t<IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> hashTableDeletedValue() { return (__bridge PtrType)(void*)-1; }
+
     template<typename U = PtrType>
-    static constexpr std::enable_if_t<!IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> fromStorageTypeHelper(CFTypeRef ptr)
-    {
-        return (PtrType)const_cast<CF_BRIDGED_TYPE(id) void*>(ptr);
-    }
-    static constexpr PtrType fromStorageType(CFTypeRef ptr) { return fromStorageTypeHelper<PtrType>(ptr); }
-    static constexpr CFTypeRef toStorageType(id ptr) { return (__bridge CFTypeRef)ptr; }
-    static constexpr CFTypeRef toStorageType(CFTypeRef ptr) { return ptr; }
+    static constexpr std::enable_if_t<!IsNSType<U> && std::is_same_v<U, PtrType>, PtrType> hashTableDeletedValue() { return reinterpret_cast<PtrType>(-1); }
 #else
-    static constexpr PtrType fromStorageType(CFTypeRef ptr)
-    {
-        return (PtrType)const_cast<CF_BRIDGED_TYPE(id) void*>(ptr);
-    }
-    static constexpr CFTypeRef toStorageType(PtrType ptr) { return (CFTypeRef)ptr; }
+    static constexpr PtrType hashTableDeletedValue() { return reinterpret_cast<PtrType>(-1); }
 #endif
 
-    CFTypeRef m_ptr { nullptr };
+    static inline void retainFoundationPtr(CFTypeRef ptr) { CFRetain(ptr); }
+    static inline void releaseFoundationPtr(CFTypeRef ptr) { CFRelease(ptr); }
+#if HAVE(CFAUTORELEASE)
+    static inline void autoreleaseFoundationPtr(CFTypeRef ptr) { CFAutorelease(ptr); }
+#endif
+
+#ifdef __OBJC__
+#if __has_feature(objc_arc)
+    static inline void retainFoundationPtr(id) { }
+    static inline void releaseFoundationPtr(id) { }
+    static inline void autoreleaseFoundationPtr(id) { }
+#else
+    static inline void retainFoundationPtr(id ptr) { [ptr retain]; }
+    static inline void releaseFoundationPtr(id ptr) { [ptr release]; }
+    static inline void autoreleaseFoundationPtr(id ptr) { [ptr autorelease]; }
+#endif
+#endif
+
+    StorageType m_ptr { nullptr };
 };
 
 template<typename T> RetainPtr(T) -> RetainPtr<RetainPtrType<T>>;
@@ -188,19 +194,21 @@ template<typename T> RetainPtr<RetainPtrType<T>> retainPtr(T) WARN_UNUSED_RETURN
 template<typename T> inline RetainPtr<T>::~RetainPtr()
 {
     if (auto ptr = std::exchange(m_ptr, nullptr))
-        CFRelease(ptr);
+        releaseFoundationPtr(ptr);
 }
 
 template<typename T> inline RetainPtr<T>::RetainPtr(PtrType ptr)
-    : m_ptr(toStorageType(ptr))
+    : m_ptr(ptr)
 {
     if (m_ptr)
-        CFRetain(m_ptr);
+        retainFoundationPtr(m_ptr);
 }
 
 template<typename T> inline RetainPtr<T>::RetainPtr(const RetainPtr& o)
-    : RetainPtr(o.get())
+    : m_ptr(o.m_ptr)
 {
+    if (m_ptr)
+        retainFoundationPtr(m_ptr);
 }
 
 template<typename T> template<typename U> inline RetainPtr<T>::RetainPtr(const RetainPtr<U>& o)
@@ -211,32 +219,27 @@ template<typename T> template<typename U> inline RetainPtr<T>::RetainPtr(const R
 template<typename T> inline void RetainPtr<T>::clear()
 {
     if (auto ptr = std::exchange(m_ptr, nullptr))
-        CFRelease(ptr);
+        releaseFoundationPtr(ptr);
 }
 
 #if HAVE(CFAUTORELEASE)
 template<typename T> inline auto RetainPtr<T>::autorelease() -> PtrType
 {
-#ifdef __OBJC__
-    if constexpr (IsNSType<PtrType>)
-        return CFBridgingRelease(std::exchange(m_ptr, nullptr));
-#endif
-    if (m_ptr)
-        CFAutorelease(m_ptr);
-    return leakRef();
+    auto ptr = std::exchange(m_ptr, nullptr);
+    if (ptr)
+        autoreleaseFoundationPtr(ptr);
+    return ptr;
 }
-#endif // PLATFORM(COCOA)
+#endif // HAVE(CFAUTORELEASE)
 
 #ifdef __OBJC__
-
 // FIXME: It would be better if we could base the return type on the type that is toll-free bridged with T rather than using id.
 template<typename T> inline id RetainPtr<T>::bridgingAutorelease()
 {
     static_assert(!IsNSType<PtrType>, "Don't use bridgingAutorelease for Objective-C pointer types.");
     return CFBridgingRelease(leakRef());
 }
-
-#endif
+#endif // __OBJC__
 
 template<typename T> inline RetainPtr<T>& RetainPtr<T>::operator=(const RetainPtr& o)
 {
@@ -305,25 +308,17 @@ template<typename T, typename U> constexpr bool operator==(T* a, const RetainPtr
     return a == b.get(); 
 }
 
-template<typename T> constexpr RetainPtr<T> adoptCF(T CF_RELEASES_ARGUMENT ptr)
+template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptCF(T CF_RELEASES_ARGUMENT ptr)
 {
-#ifdef __OBJC__
     static_assert(!IsNSType<T>, "Don't use adoptCF with Objective-C pointer types, use adoptNS.");
-#endif
-    return RetainPtr<T>(ptr, RetainPtr<T>::Adopt);
+    return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
 }
 
-#ifdef __OBJC__
-template<typename T> RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT ptr)
+template<typename T> constexpr RetainPtr<RetainPtrType<T>> adoptNS(T NS_RELEASES_ARGUMENT ptr)
 {
     static_assert(IsNSType<T>, "Don't use adoptNS with Core Foundation pointer types, use adoptCF.");
-#if __has_feature(objc_arc)
-    return ptr;
-#else
     return { ptr, RetainPtr<RetainPtrType<T>>::Adopt };
-#endif
 }
-#endif
 
 template<typename T> inline RetainPtr<RetainPtrType<T>> retainPtr(T ptr)
 {

--- a/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
+++ b/Source/WTF/wtf/cocoa/TypeCastsCocoa.h
@@ -35,7 +35,7 @@ namespace WTF {
 
 #if __has_feature(objc_arc)
 #define WTF_CF_TO_NS_BRIDGE_TRANSFER(type, value) ((__bridge_transfer type)value)
-#define WTF_NS_TO_CF_BRIDGE_TRANSFER(type, value) ((type)reinterpret_cast<uintptr_t>(value))
+#define WTF_NS_TO_CF_BRIDGE_TRANSFER(type, value) ((__bridge_retained type)value)
 #else
 #define WTF_CF_TO_NS_BRIDGE_TRANSFER(type, value) ((__bridge type)value)
 #define WTF_NS_TO_CF_BRIDGE_TRANSFER(type, value) ((__bridge type)value)

--- a/Source/WebCore/bridge/objc/objc_runtime.h
+++ b/Source/WebCore/bridge/objc/objc_runtime.h
@@ -81,8 +81,10 @@ public:
     virtual bool setValueAt(JSGlobalObject*, unsigned int index, JSValue aValue) const;
     virtual JSValue valueAt(JSGlobalObject*, unsigned int index) const;
     virtual unsigned int getLength() const;
-    
+
+#ifdef __OBJC__
     ObjectStructPtr getObjcArray() const { return _array.get(); }
+#endif
 
 private:
     RetainPtr<ObjectStructPtr> _array;

--- a/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
+++ b/Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h
@@ -76,7 +76,7 @@ public:
     PlatformSpeechSynthesisUtteranceClient* client() const { return m_client.get(); }
     void setClient(PlatformSpeechSynthesisUtteranceClient* client) { m_client = client; }
 
-#if PLATFORM(COCOA)
+#ifdef __OBJC__
     id wrapper() const { return m_wrapper.get(); }
     void setWrapper(id utterance) { m_wrapper = utterance; }
 #endif

--- a/Source/WebCore/platform/network/cf/AuthenticationChallenge.h
+++ b/Source/WebCore/platform/network/cf/AuthenticationChallenge.h
@@ -40,8 +40,10 @@ public:
 
     WEBCORE_EXPORT AuthenticationChallenge(NSURLAuthenticationChallenge *);
 
+#ifdef __OBJC__
     id sender() const { return m_sender.get(); }
     NSURLAuthenticationChallenge *nsURLAuthenticationChallenge() const { return m_nsChallenge.get(); }
+#endif
 
     WEBCORE_EXPORT void setAuthenticationClient(AuthenticationClient*); // Changes sender to one that invokes client methods.
     WEBCORE_EXPORT AuthenticationClient* authenticationClient() const;

--- a/Tools/DumpRenderTree/AccessibilityUIElement.cpp
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.cpp
@@ -1185,7 +1185,7 @@ static JSValueRef getIsGrabbedCallback(JSContextRef context, JSObjectRef thisObj
 static JSValueRef getIsValidCallback(JSContextRef context, JSObjectRef thisObject, JSStringRef propertyName, JSValueRef* exception)
 {
     AccessibilityUIElement* uiElement = toAXElement(thisObject);
-    if (!uiElement->platformUIElement())
+    if (!uiElement->hasPlatformUIElement())
         return JSValueMakeBoolean(context, false);
     
     // There might be other platform logic that one could check here...
@@ -1720,15 +1720,6 @@ void AccessibilityUIElement::setValue(JSStringRef) { }
 void AccessibilityUIElement::uiElementArrayAttributeValue(JSStringRef, Vector<AccessibilityUIElement>&) const { }
 #endif
 
-#if !PLATFORM(WIN)
-bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)
-{
-    if (!otherElement)
-        return false;
-    return platformUIElement() == otherElement->platformUIElement();
-}
-#endif
-
 #if !PLATFORM(MAC)
 void AccessibilityUIElement::setBoolAttributeValue(JSStringRef, bool) { }
 bool AccessibilityUIElement::isOnScreen() const { return true; }
@@ -1950,7 +1941,7 @@ static void finalize(JSObjectRef thisObject)
 
 JSObjectRef AccessibilityUIElement::makeJSAccessibilityUIElement(JSContextRef context, const AccessibilityUIElement& element)
 {
-    if (!element.platformUIElement())
+    if (!element.hasPlatformUIElement())
         return nullptr;
 
     return JSObjectMake(context, AccessibilityUIElement::getJSClass(), new AccessibilityUIElement(element));

--- a/Tools/DumpRenderTree/AccessibilityUIElement.h
+++ b/Tools/DumpRenderTree/AccessibilityUIElement.h
@@ -57,12 +57,16 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
+#ifdef __OBJC__
     id platformUIElement() const { return m_element.get(); }
+#endif
 #endif
 
 #if !PLATFORM(COCOA)
     PlatformUIElement platformUIElement() const { return m_element; }
 #endif
+
+    bool hasPlatformUIElement() const { return !!m_element; }
 
     static JSObjectRef makeJSAccessibilityUIElement(JSContextRef, const AccessibilityUIElement&);
 

--- a/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm
@@ -149,6 +149,13 @@ static JSRetainPtr<JSStringRef> concatenateAttributeAndValue(NSString *attribute
     return adopt(JSStringCreateWithCharacters(buffer.data(), buffer.size()));
 }
 
+bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)
+{
+    if (!otherElement)
+        return false;
+    return platformUIElement() == otherElement->platformUIElement();
+}
+
 #pragma mark iPhone Attributes
 
 JSRetainPtr<JSStringRef> AccessibilityUIElement::identifier()

--- a/Tools/DumpRenderTree/mac/AccessibilityTextMarkerMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityTextMarkerMac.mm
@@ -38,7 +38,7 @@ AccessibilityTextMarker::AccessibilityTextMarker(id marker)
 }
 
 AccessibilityTextMarker::AccessibilityTextMarker(const AccessibilityTextMarker& marker)
-    : m_textMarker(marker.platformTextMarker())
+    : m_textMarker(marker.m_textMarker)
 {
 }
 

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -294,6 +294,13 @@ static NSDictionary *searchTextParameterizedAttributeForCriteria(JSContextRef co
 }
 #endif
 
+bool AccessibilityUIElement::isEqual(AccessibilityUIElement* otherElement)
+{
+    if (!otherElement)
+        return false;
+    return platformUIElement() == otherElement->platformUIElement();
+}
+
 void AccessibilityUIElement::getLinkedUIElements(Vector<AccessibilityUIElement>& elementVector)
 {
     BEGIN_AX_OBJC_EXCEPTIONS

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm
@@ -59,41 +59,55 @@ static size_t helloWorldCStringLength()
 
 TEST(TypeCastsCocoa, bridge_cast)
 {
-    @autoreleasepool {
-        auto objectNS = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
-        auto objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
+    RetainPtr<NSString> objectNS;
+    uintptr_t objectNSPtr;
 
-        auto objectCF = bridge_cast(WTFMove(objectNS));
-        auto objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
-        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, objectNS.get());
-        EXPECT_EQ(objectNSPtr, objectCFPtr);
-        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
+    RetainPtr<CFStringRef> objectCF;
+    uintptr_t objectCFPtr;
 
-        objectNS = bridge_cast(WTFMove(objectCF));
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        objectNS = adoptNS([[NSString alloc] initWithFormat:@"%s", helloWorldCString]);
         objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
-        EXPECT_EQ(objectCFPtr, objectNSPtr);
-        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
     }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
 
-    @autoreleasepool {
-        auto objectCF = adoptCF(CFStringCreateWithBytes(NULL, (const UInt8*)helloWorldCString, helloWorldCStringLength(), kCFStringEncodingUTF8, false));
-        auto objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
-        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
-
-        auto objectNS = bridge_cast(WTFMove(objectCF));
-        auto objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
-        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
-        EXPECT_EQ(objectCFPtr, objectNSPtr);
-        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
-
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
         objectCF = bridge_cast(WTFMove(objectNS));
         objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
         SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, objectNS.get());
         EXPECT_EQ(objectNSPtr, objectCFPtr);
-        EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
     }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
+
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        objectNS = bridge_cast(WTFMove(objectCF));
+        objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
+        EXPECT_EQ(objectCFPtr, objectNSPtr);
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
+
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        objectCF = adoptCF(CFStringCreateWithBytes(NULL, (const UInt8*)helloWorldCString, helloWorldCStringLength(), kCFStringEncodingUTF8, false));
+        objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
+
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        objectNS = bridge_cast(WTFMove(objectCF));
+        objectNSPtr = reinterpret_cast<uintptr_t>(objectNS.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(NULL, objectCF.get());
+        EXPECT_EQ(objectCFPtr, objectNSPtr);
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectNSPtr));
+
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        objectCF = bridge_cast(WTFMove(objectNS));
+        objectCFPtr = reinterpret_cast<uintptr_t>(objectCF.get());
+        SUPPRESS_USE_AFTER_MOVE EXPECT_EQ(nil, objectNS.get());
+        EXPECT_EQ(objectNSPtr, objectCFPtr);
+    }
+    EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectCFPtr));
 }
 
 TEST(TypeCastsCocoa, bridge_id_cast)

--- a/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm
@@ -27,7 +27,9 @@
  */
 
 #import "config.h"
+#import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/URL.h>
 
 #if __has_feature(objc_arc)
 #ifndef RETAIN_PTR_TEST_NAME
@@ -79,6 +81,8 @@ TEST(RETAIN_PTR_TEST_NAME, AdoptNS)
 
 TEST(RETAIN_PTR_TEST_NAME, ConstructionFromMutableNSType)
 {
+    static_assert(std::is_convertible_v<NSMutableString*, NSString*>, "NSMutableString must convert to NSString");
+
     NSMutableString *string = [NSMutableString stringWithUTF8String:"foo"];
 
     // This should invoke RetainPtr's move constructor.
@@ -124,11 +128,11 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSType)
     // This should invoke RetainPtr's move constructor.
     // FIXME: This doesn't actually test that we moved the value. We should use a mock
     // NSObject that logs -retain and -release calls.
-    RetainPtr<NSString> ptr = RetainPtr<NSString *>(string);
+    RetainPtr<NSString> ptr = RetainPtr<NSString>(string);
 
     EXPECT_EQ(string, ptr);
 
-    RetainPtr<NSString *> temp = string;
+    RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move constructor.
     RetainPtr<NSString> ptr2(WTFMove(temp));
@@ -144,14 +148,14 @@ TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSTypeReversed)
     // This should invoke RetainPtr's move constructor.
     // FIXME: This doesn't actually test that we moved the value. We should use a mock
     // NSObject that logs -retain and -release calls.
-    RetainPtr<NSString *> ptr = RetainPtr<NSString>(string);
+    RetainPtr<NSString> ptr = RetainPtr<NSString>(string);
 
     EXPECT_EQ(string, ptr);
 
     RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move constructor.
-    RetainPtr<NSString *> ptr2(WTFMove(temp));
+    RetainPtr<NSString> ptr2(WTFMove(temp));
 
     EXPECT_EQ(string, ptr2);
     SUPPRESS_USE_AFTER_MOVE EXPECT_EQ((NSString *)nil, temp.get());
@@ -209,12 +213,12 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSType)
     // This should invoke RetainPtr's move assignment operator.
     // FIXME: This doesn't actually test that we moved the value. We should use a mock
     // NSObject that logs -retain and -release calls.
-    ptr = RetainPtr<NSString *>(string);
+    ptr = RetainPtr<NSString>(string);
 
     EXPECT_EQ(string, ptr);
 
     ptr = nil;
-    RetainPtr<NSString *> temp = string;
+    RetainPtr<NSString> temp = string;
 
     // This should invoke RetainPtr's move assignment operator.
     ptr = WTFMove(temp);
@@ -226,7 +230,7 @@ TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSType)
 TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSTypeReversed)
 {
     NSString *string = @"foo";
-    RetainPtr<NSString *> ptr;
+    RetainPtr<NSString> ptr;
 
     // This should invoke RetainPtr's move assignment operator.
     // FIXME: This doesn't actually test that we moved the value. We should use a mock
@@ -344,7 +348,6 @@ TEST(RETAIN_PTR_TEST_NAME, RetainPtrNS)
     EXPECT_EQ(1L, CFGetRetainCount((CFTypeRef)objectPtr3));
 }
 
-/* This test is disabled for now because it fails (!!).
 TEST(RETAIN_PTR_TEST_NAME, LeakRef)
 {
     RetainPtr<NSObject> foo;
@@ -364,6 +367,44 @@ TEST(RETAIN_PTR_TEST_NAME, LeakRef)
 
     (void)adoptNS(object);
 }
-*/
+
+TEST(RETAIN_PTR_TEST_NAME, BridgingAutorelease)
+{
+    NSString *nsString;
+    uintptr_t nsStringPtr;
+
+    AUTORELEASEPOOL_FOR_ARC_DEBUG {
+        RetainPtr<CFStringRef> string = adoptCF(CFStringCreateWithCString(nullptr, "hello world", kCFStringEncodingASCII));
+        nsString = string.bridgingAutorelease();
+        nsStringPtr = reinterpret_cast<uintptr_t>(nsString);
+    }
+
+    EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)nsStringPtr));
+}
+
+TEST(RETAIN_PTR_TEST_NAME, URLBridgeCast)
+{
+    RetainPtr<NSURL> nsURL;
+    uintptr_t nsURLPtr;
+    @autoreleasepool {
+        URL url(""_str);
+        nsURL = static_cast<NSURL *>(url);
+        nsURLPtr = reinterpret_cast<uintptr_t>(nsURL.get());
+    }
+
+    EXPECT_EQ(1, CFGetRetainCount((CFTypeRef)nsURLPtr));
+}
+
+TEST(RETAIN_PTR_TEST_NAME, HashMapCFTypeDeletedValue)
+{
+    HashMap<RetainPtr<CFStringRef>, int> map;
+
+    auto key = adoptCF(CFStringCreateWithCString(nullptr, "hello world", kCFStringEncodingASCII));
+    map.add(key, 1);
+    EXPECT_EQ(true, map.contains(key));
+    map.remove(key);
+
+    EXPECT_EQ(1, CFGetRetainCount(key.get()));
+}
 
 } // namespace TestWebKitAPI

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.cpp
@@ -49,7 +49,7 @@ AccessibilityTextMarker::AccessibilityTextMarker(PlatformTextMarker marker)
 
 AccessibilityTextMarker::AccessibilityTextMarker(const AccessibilityTextMarker& marker)
     : JSWrappable()
-    , m_textMarker(marker.platformTextMarker())
+    , m_textMarker(marker.m_textMarker)
 {
 }
 
@@ -57,15 +57,6 @@ AccessibilityTextMarker::~AccessibilityTextMarker()
 {
 }
 
-PlatformTextMarker AccessibilityTextMarker::platformTextMarker() const
-{
-#if PLATFORM(COCOA)
-    return m_textMarker.get();
-#else
-    return m_textMarker;
-#endif
-}
-    
 JSClassRef AccessibilityTextMarker::wrapperClass()
 {
     return JSAccessibilityTextMarker::accessibilityTextMarkerClass();

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.h
@@ -69,4 +69,18 @@ private:
 inline bool AccessibilityTextMarker::isEqual(AccessibilityTextMarker*) { return false; }
 #endif
 
+#if PLATFORM(COCOA)
+#ifdef __OBJC__
+inline PlatformTextMarker AccessibilityTextMarker::platformTextMarker() const
+{
+    return m_textMarker.get();
+}
+#endif
+#else
+inline PlatformTextMarker AccessibilityTextMarker::platformTextMarker() const
+{
+    return m_textMarker;
+}
+#endif
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp
@@ -49,7 +49,7 @@ AccessibilityTextMarkerRange::AccessibilityTextMarkerRange(PlatformTextMarkerRan
 
 AccessibilityTextMarkerRange::AccessibilityTextMarkerRange(const AccessibilityTextMarkerRange& markerRange)
     : JSWrappable()
-    , m_textMarkerRange(markerRange.platformTextMarkerRange())
+    , m_textMarkerRange(markerRange.m_textMarkerRange)
 {
 }
 
@@ -57,15 +57,6 @@ AccessibilityTextMarkerRange::~AccessibilityTextMarkerRange()
 {
 }
 
-PlatformTextMarkerRange AccessibilityTextMarkerRange::platformTextMarkerRange() const
-{
-#if PLATFORM(COCOA)
-    return m_textMarkerRange.get();
-#else
-    return m_textMarkerRange;
-#endif
-}
-    
 JSClassRef AccessibilityTextMarkerRange::wrapperClass()
 {
     return JSAccessibilityTextMarkerRange::accessibilityTextMarkerRangeClass();

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h
@@ -62,9 +62,23 @@ private:
     PlatformTextMarkerRange m_textMarkerRange;
 #endif
 };
-    
+
 #if !PLATFORM(COCOA)
 inline bool AccessibilityTextMarkerRange::isEqual(AccessibilityTextMarkerRange*) { return false; }
+#endif
+
+#if PLATFORM(COCOA)
+#ifdef __OBJC__
+inline PlatformTextMarkerRange AccessibilityTextMarkerRange::platformTextMarkerRange() const
+{
+    return m_textMarkerRange.get();
+}
+#endif
+#else
+inline PlatformTextMarkerRange AccessibilityTextMarkerRange::platformTextMarkerRange() const
+{
+    return m_textMarkerRange;
+}
 #endif
     
 #ifdef __OBJC__


### PR DESCRIPTION
#### 0ee109c50d1f7066d48f5957e0b644dad2092a92
<pre>
Unreviewed, re-landing 290928@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=288379">https://bugs.webkit.org/show_bug.cgi?id=288379</a>
<a href="https://rdar.apple.com/145490867">rdar://145490867</a>

Fixed the Safari build.

Re-landed changeset:

&quot;RetainPtr’s leakRef() and move constructors are incorrect when ARC is enabled&quot;

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr::RetainPtr):
(WTF::RetainPtr::isHashTableDeletedValue const):
(WTF::RetainPtr::get const):
(WTF::RetainPtr::operator-&gt; const):
(WTF::RetainPtr::operator PtrType const):
(WTF::RetainPtr::hashTableDeletedValue):
(WTF::RetainPtr::retainFoundationPtr):
(WTF::RetainPtr::releaseFoundationPtr):
(WTF::RetainPtr::autoreleaseFoundationPtr):
(WTF::RetainPtr&lt;T&gt;::~RetainPtr):
(WTF::RetainPtr&lt;T&gt;::RetainPtr):
(WTF::RetainPtr&lt;T&gt;::clear):
(WTF::RetainPtr&lt;T&gt;::autorelease):
(WTF::adoptCF):
(WTF::adoptNS):
(WTF::RetainPtr::checkType): Deleted.
(WTF::RetainPtr::fromStorageTypeHelper): Deleted.
(WTF::RetainPtr::fromStorageType): Deleted.
(WTF::RetainPtr::toStorageType): Deleted.
* Source/WTF/wtf/cocoa/TypeCastsCocoa.h:
* Source/WebCore/bridge/objc/objc_runtime.h:
* Source/WebCore/platform/PlatformSpeechSynthesisUtterance.h:
* Source/WebCore/platform/network/cf/AuthenticationChallenge.h:
* Tools/DumpRenderTree/AccessibilityUIElement.cpp:
(getIsValidCallback):
(AccessibilityUIElement::makeJSAccessibilityUIElement):
(AccessibilityUIElement::isEqual): Deleted.
* Tools/DumpRenderTree/AccessibilityUIElement.h:
(AccessibilityUIElement::hasPlatformUIElement const):
* Tools/DumpRenderTree/ios/AccessibilityUIElementIOS.mm:
(AccessibilityUIElement::isEqual):
* Tools/DumpRenderTree/mac/AccessibilityTextMarkerMac.mm:
(AccessibilityTextMarker::AccessibilityTextMarker):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::isEqual):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/TypeCastsCocoa.mm:
(TestWebKitAPI::TEST(TypeCastsCocoa, bridge_cast)):
* Tools/TestWebKitAPI/Tests/WTF/ns/RetainPtr.mm:
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, ConstructionFromMutableNSType)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSType)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, ConstructionFromSimilarNSTypeReversed)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSType)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, MoveAssignmentFromSimilarNSTypeReversed)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, BridgingAutorelease)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, URLBridgeCast)):
(TestWebKitAPI::TEST(RETAIN_PTR_TEST_NAME, HashMapCFTypeDeletedValue)):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.cpp:
(WTR::AccessibilityTextMarker::AccessibilityTextMarker):
(WTR::AccessibilityTextMarker::platformTextMarker const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarker.h:
(WTR::AccessibilityTextMarker::platformTextMarker const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.cpp:
(WTR::AccessibilityTextMarkerRange::AccessibilityTextMarkerRange):
(WTR::AccessibilityTextMarkerRange::platformTextMarkerRange const): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityTextMarkerRange.h:
(WTR::AccessibilityTextMarkerRange::platformTextMarkerRange const):

Canonical link: <a href="https://commits.webkit.org/290967@main">https://commits.webkit.org/290967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2f83d937c36419bda5eab0578dec0c23aaa260a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96556 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42271 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94592 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8782 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50654 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8547 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/579 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41442 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84389 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78865 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98564 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90338 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18749 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79358 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78828 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78563 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23088 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14509 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18743 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24018 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112923 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18452 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32732 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->