### PR TITLE
[WebGPU] MTLBuffer may not be resident in some GPUExternalTexture bind groups

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-288383-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-288383-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-288383.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-288383.html
@@ -1,0 +1,172 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter({});
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-etc2',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'float32-blendable',
+  ],
+});
+// START
+veryExplicitBindGroupLayout0 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage', }
+    },
+    {
+      binding : 3,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage' }},
+    {
+      binding : 11,
+      visibility : GPUShaderStage.COMPUTE,
+      externalTexture : {}}]});
+veryExplicitBindGroupLayout2 = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage', }
+    },
+    {
+      binding : 3,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage' }},
+    {
+      binding : 11,
+      visibility : GPUShaderStage.COMPUTE,
+      externalTexture : {}}]});
+pipelineLayout2 = device0.createPipelineLayout({
+  bindGroupLayouts :
+      [ veryExplicitBindGroupLayout0, ]
+});
+veryExplicitBindGroupLayout3 = device0.createBindGroupLayout({
+  entries : []});
+buffer10 = device0.createBuffer(
+    {size : 84, usage : GPUBufferUsage.STORAGE});
+videoFrame0 = new VideoFrame(new ArrayBuffer(16), {
+  codedWidth : 2,
+  codedHeight : 2,
+  format : 'BGRX',
+  timestamp : 0,
+  });
+shaderModule1 = device0.createShaderModule({
+  code : ` ;
+              @group(0) @binding(3) var<storage, read_write> buffer16: T4;
+              struct T4 {
+              f0: atomic<i32>}
+              @compute @workgroup_size(41, ) fn compute1() {
+              atomicOr(&buffer16.f0, (586128435));
+            }
+             `});
+pipeline3 = await device0.createComputePipelineAsync({
+  layout : pipelineLayout2,
+  compute : {module : shaderModule1, }
+});
+externalTexture1 = device0.importExternalTexture(
+    {source : videoFrame0, });
+buffer33 = device0.createBuffer(
+    {size : 176, usage : GPUBufferUsage.STORAGE});
+{
+}
+bindGroup9 = device0.createBindGroup({
+  layout : veryExplicitBindGroupLayout2,
+  entries : [
+    {binding : 3, resource : {buffer : buffer33, }},
+    {binding : 11, resource : externalTexture1},
+    {binding : 0, resource : {buffer : buffer10}}]});
+{
+}
+commandEncoder35 = device0.createCommandEncoder();
+device0.createBindGroup({
+  layout : veryExplicitBindGroupLayout3,
+  entries : [
+    {binding : 3, resource : {buffer : buffer33}},
+    {binding : 11, resource : externalTexture1},
+    {binding : 0, resource : {buffer : buffer10}}]});
+computePassEncoder18 = commandEncoder35.beginComputePass();
+try {
+  computePassEncoder18.setPipeline(pipeline3);
+  computePassEncoder18.setBindGroup(0, bindGroup9)} catch {
+}
+try {
+  computePassEncoder18.dispatchWorkgroups(21)} catch {
+}
+try {
+  computePassEncoder18.end()} catch {
+}
+commandBuffer0 = commandEncoder35.finish();
+try {
+  device0.queue.submit([ commandBuffer0 ])} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -1214,8 +1214,9 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
             auto renderStage = metalRenderStage(stage);
             auto &v = stageResources[renderStage][i];
             auto &u = stageResourceUsages[renderStage][i];
+            static_assert(MTLResourceUsageRead == 1 && !BindGroupLayout::BindingAccessReadOnly);
             if (v.size()) {
-                if (stage != ShaderStage::Undefined)
+                if (stage != ShaderStage::Undefined && i == BindGroupLayout::BindingAccessReadOnly)
                     externalTextureIndices[stage].containerIndex = resources.size();
                 resources.append(BindableResources {
                     .mtlResources = WTFMove(v),


### PR DESCRIPTION
#### a6e77b92e6418f7d3178d8a23dd2be87eaf71ef8
<pre>
[WebGPU] MTLBuffer may not be resident in some GPUExternalTexture bind groups
<a href="https://bugs.webkit.org/show_bug.cgi?id=288383">https://bugs.webkit.org/show_bug.cgi?id=288383</a>
<a href="https://rdar.apple.com/145446959">rdar://145446959</a>

Reviewed by Tadeu Zagallo.

GPUExternalTextures are always read-only, but in a bind group which
had mixed read, read+write, and write-only usages, we could end
up over-writing the wrong MTLResource leading to a read / write
from a non-resident resource.

* LayoutTests/fast/webgpu/nocrash/fuzz-288383-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-288383.html: Added.
Add regression test.

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
External textures are always read only.

Canonical link: <a href="https://commits.webkit.org/291006@main">https://commits.webkit.org/291006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eaf94e62bc405eed34c8015fa950b56baed5dbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42281 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70338 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27858 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94605 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8792 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/82996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50663 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/585 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41454 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18761 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13827 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79391 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78834 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78601 "Found 1 new API test failure: /WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19459 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/451 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11878 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24028 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18464 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->