### PR TITLE
Add axis-flipping methods for BoxAxis and LogicalBoxAxis

### DIFF
--- a/Source/WebCore/platform/BoxSides.h
+++ b/Source/WebCore/platform/BoxSides.h
@@ -47,8 +47,10 @@ enum class BoxAxis : uint8_t {
     Vertical
 };
 
-constexpr BoxAxis mapAxisLogicalToPhysical(WritingMode, LogicalBoxAxis);
-constexpr LogicalBoxAxis mapAxisPhysicalToLogical(WritingMode, BoxAxis);
+constexpr BoxAxis mapAxisLogicalToPhysical(const WritingMode, const LogicalBoxAxis);
+constexpr LogicalBoxAxis mapAxisPhysicalToLogical(const WritingMode, const BoxAxis);
+constexpr LogicalBoxAxis oppositeAxis(LogicalBoxAxis axis) { return axis == LogicalBoxAxis::Inline ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline; }
+constexpr BoxAxis oppositeAxis(BoxAxis axis) { return axis == BoxAxis::Horizontal ? BoxAxis::Vertical : BoxAxis::Horizontal; }
 
 /* Sides */
 
@@ -92,8 +94,8 @@ constexpr std::array<BoxSide, 4> allBoxSides = {
 
 using BoxSideSet = OptionSet<BoxSideFlag>;
 
-constexpr BoxSide mapSideLogicalToPhysical(WritingMode, LogicalBoxSide);
-constexpr LogicalBoxSide mapSidePhysicalToLogical(WritingMode, BoxSide);
+constexpr BoxSide mapSideLogicalToPhysical(const WritingMode, const LogicalBoxSide);
+constexpr LogicalBoxSide mapSidePhysicalToLogical(const WritingMode, const BoxSide);
 
 /* Corners */
 
@@ -114,26 +116,26 @@ enum class BoxCorner : uint8_t {
 
 // Numeric values used below for bit-hacking; don't change without adjusting mapping methods.
 
-constexpr BoxCorner mapCornerLogicalToPhysical(WritingMode, LogicalBoxCorner);
-constexpr LogicalBoxCorner mapCornerPhysicalToLogical(WritingMode, BoxCorner);
+constexpr BoxCorner mapCornerLogicalToPhysical(const WritingMode, const LogicalBoxCorner);
+constexpr LogicalBoxCorner mapCornerPhysicalToLogical(const WritingMode, const BoxCorner);
 
 /** Implementation Below **********************************************/
 
-constexpr BoxAxis mapAxisLogicalToPhysical(WritingMode writingMode, LogicalBoxAxis logicalAxis)
+constexpr BoxAxis mapAxisLogicalToPhysical(const WritingMode writingMode, const LogicalBoxAxis logicalAxis)
 {
     bool isBlock = logicalAxis == LogicalBoxAxis::Block;
     bool isVertical = isBlock != writingMode.isVertical();
     return isVertical ? BoxAxis::Vertical : BoxAxis::Horizontal;
 }
 
-constexpr LogicalBoxAxis mapAxisPhysicalToLogical(WritingMode writingMode, BoxAxis axis)
+constexpr LogicalBoxAxis mapAxisPhysicalToLogical(const WritingMode writingMode, const BoxAxis axis)
 {
     bool isVertical = axis == BoxAxis::Vertical;
     bool isBlock = isVertical != writingMode.isVertical();
     return isBlock ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
 }
 
-constexpr BoxSide mapSideLogicalToPhysical(WritingMode writingMode, LogicalBoxSide logicalSide)
+constexpr BoxSide mapSideLogicalToPhysical(const WritingMode writingMode, const LogicalBoxSide logicalSide)
 {
     switch (logicalSide) {
     case LogicalBoxSide::BlockStart:
@@ -188,7 +190,7 @@ constexpr BoxSide mapSideLogicalToPhysical(WritingMode writingMode, LogicalBoxSi
     return BoxSide::Top;
 }
 
-constexpr LogicalBoxSide mapSidePhysicalToLogical(WritingMode writingMode, BoxSide side)
+constexpr LogicalBoxSide mapSidePhysicalToLogical(const WritingMode writingMode, const BoxSide side)
 {
     switch (side) {
     case BoxSide::Top:
@@ -255,7 +257,7 @@ constexpr LogicalBoxSide mapSidePhysicalToLogical(WritingMode writingMode, BoxSi
     return LogicalBoxSide::BlockStart;
 }
 
-constexpr BoxCorner mapCornerLogicalToPhysical(WritingMode writingMode, LogicalBoxCorner logicalBoxCorner)
+constexpr BoxCorner mapCornerLogicalToPhysical(const WritingMode writingMode, const LogicalBoxCorner logicalBoxCorner)
 {
     bool isBlockStart = !(static_cast<uint8_t>(logicalBoxCorner) & 2);
     bool isInlineStart = !(static_cast<uint8_t>(logicalBoxCorner) & 1);
@@ -274,7 +276,7 @@ constexpr BoxCorner mapCornerLogicalToPhysical(WritingMode writingMode, LogicalB
     return isLeft ? BoxCorner::BottomLeft : BoxCorner::BottomRight;
 }
 
-constexpr LogicalBoxCorner mapCornerPhysicalToLogical(WritingMode writingMode, BoxCorner boxCorner)
+constexpr LogicalBoxCorner mapCornerPhysicalToLogical(const WritingMode writingMode, const BoxCorner boxCorner)
 {
     bool isTop = !(static_cast<uint8_t>(boxCorner) & 2);
     bool isLeft = !(static_cast<uint8_t>(boxCorner) & 1);


### PR DESCRIPTION
#### 5535d11237a2abc59d3c04e66c71e108d612a4fe
<pre>
Add axis-flipping methods for BoxAxis and LogicalBoxAxis
<a href="https://bugs.webkit.org/show_bug.cgi?id=288398">https://bugs.webkit.org/show_bug.cgi?id=288398</a>
<a href="https://rdar.apple.com/145502631">rdar://145502631</a>

Reviewed by Alan Baradlay.

Also mark const parameters const while we&apos;re here.

* Source/WebCore/platform/BoxSides.h:
(WebCore::oppositeAxis): Add helper methods.
(WebCore::mapAxisLogicalToPhysical): Make const parameters const.
(WebCore::mapAxisPhysicalToLogical): Make const parameters const.
(WebCore::mapSideLogicalToPhysical): Make const parameters const.
(WebCore::mapSidePhysicalToLogical): Make const parameters const.
(WebCore::mapCornerLogicalToPhysical): Make const parameters const.
(WebCore::mapCornerPhysicalToLogical): Make const parameters const.

Canonical link: <a href="https://commits.webkit.org/290997@main">https://commits.webkit.org/290997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef497aa413d745912337ce443e6c3c39711371b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96604 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42305 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19606 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70363 "Failure limit exceed. At least found 21 new test failures: imported/w3c/web-platform-tests/css/css-transforms/animation/transform-non-invertible-discrete-interpolation.html imported/w3c/web-platform-tests/css/css-transforms/transform-box/cssbox-content-box-002.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-left-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/massive-element-on-top-of-viewport-offscreen-new.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-exit.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-ident.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple-wildcard.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-multiple.html imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-with-classes-match-wildcard-no-star.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27871 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50689 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8579 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/615 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41490 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19044 "Failed to checkout and rebase branch from PR 41224") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78602 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11899 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18783 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21948 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->