### PR TITLE
[Yarr] Improve processing of an alternation of strings

### DIFF
--- a/JSTests/microbenchmarks/regexp-keyword-parsing.js
+++ b/JSTests/microbenchmarks/regexp-keyword-parsing.js
@@ -1,0 +1,175 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+let re = /^(?:break|case|catch|continue|debugger|default|do|else|finally|for|function|if|return|switch|throw|try|var|while|with|null|true|false|instanceof|typeof|void|delete|new|in|this)/;
+
+for (i = 0; i < 1000000; i++) {
+    testRegExp(re, "function", ["function"]);
+    testRegExp(re, "return", ["return"]);
+    testRegExp(re, "let", null);
+}
+
+let re1 = /^(?:break|case|catch|continue|debugger|default|do|else|finally|for|function|if|return|switch|throw|try|var|while|with|null|true|false|instanceof|typeof|void|delete|new|in|this)$/;
+
+for (i = 0; i < 1000000; i++) {
+    testRegExp(re1, "throw", ["throw"]);
+    testRegExp(re1, "while", ["while"]);
+}

--- a/JSTests/stress/regexp-parsing-tokens.js
+++ b/JSTests/stress/regexp-parsing-tokens.js
@@ -1,0 +1,253 @@
+// With verbose set to false, this test is successful if there is no output.  Set verbose to true to see expected matches.
+let verbose = false;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function objectToString(obj)
+{
+    let str = "";
+
+    firstEntry = true;
+
+    for (const [key, value] of Object.entries(obj)) {
+        if (!firstEntry)
+            str += ", ";
+
+        str += key + ": " + dumpValue(value);
+
+        firstEntry = false;
+    }
+
+    return "{ " + str + " }";
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    if (v.groups) {
+        groupStr = objectToString(v.groups);
+
+        if (str.length) {
+            if ( groupStr.length)
+                str += ", " + groupStr;
+        } else
+            str = groupStr;
+    }
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function compareGroups(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected group is null, actual group is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected group is not null, actual group is null");
+        return false;
+    }
+
+    for (const key in expected) {
+        if (expected[key] !== actual[key]) {
+            print("### expected." + key + ": " + dumpValue(expected[key]) + " !== actual." + key + ": " + dumpValue(actual[key]));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+let testNumber = 0;
+
+function testRegExp(re, str, exp, groups)
+{
+    testNumber++;
+
+    if (groups)
+        exp.groups = groups;
+
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);;
+
+    if (exp && exp.groups) {
+        if (!compareGroups(exp.groups, actual.groups))
+            result = false;
+    }
+
+    if (result) {
+        if (verbose)
+            print(re.toString() + ".exec(" + dumpValue(str) + "), passed ", dumpValue(exp));
+    } else
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED test #" + testNumber + ", Expected ", dumpValue(exp), " got ", dumpValue(actual));
+}
+
+function testRegExpSyntaxError(reString, flags, expError)
+{
+    testNumber++;
+
+
+    try {
+        let re = new RegExp(reString, flags);
+        print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\", but it didn't");
+    } catch (e) {
+        if (e != expError)
+            print("FAILED test #" + testNumber + ", Expected /" + reString + "/" + flags + " to throw \"" + expError + "\" got \"" + e + "\"");
+        else if (verbose)
+            print("/" + reString + "/" + flags + " passed, it threw \"" + expError + "\" as expected");
+    }
+}
+
+// Test 1
+let re1 = /^(?:break|case|which|do|for)/i;
+
+testRegExp(re1, "case", ["case"]);
+testRegExp(re1, "FOR", ["FOR"]);
+testRegExp(re1, "throw", null);
+
+// Test 4
+// ЛЕВЫЙ | ПРАВЫЙ | left | right  note: ЛЕВЫЙ is Russian for left and ПРАВЫЙ is Russian for right
+let re2 = /^(?:\u{041b}\u{0415}\u{0412}\u{042b}\u{0419}|\u{041f}\u{0420}\u{0410}\u{0412}\u{042b}\u{0419}|left|right)$/u;
+
+testRegExp(re2, "\u{041f}\u{0420}\u{0410}\u{0412}\u{042b}\u{0419}", ["\u{041f}\u{0420}\u{0410}\u{0412}\u{042b}\u{0419}"]);
+testRegExp(re2, "\u{041b}\u{0415}\u{0412}\u{042b} ", null);
+testRegExp(re2, "left", ["left"]);
+testRegExp(re2, "center", null);
+
+// Test 8
+let re3 = /^(?:something|everything|anything)$/;
+testRegExp(re3, "something", ["something"]);
+testRegExp(re3, "anything", ["anything"]);
+testRegExp(re3, "everything", ["everything"]);
+testRegExp(re3, "anything but", null);
+
+// Test 12
+let re4 = /^(?:break|case|catch|continue|debugger|default|do|else|finally|for|function|if|return|switch|throw|try|var|while|with|null|true|false|instanceof|typeof|void|delete|new|in|this)/;
+
+testRegExp(re4, "break", ["break"]);
+testRegExp(re4, "catch", ["catch"]);
+testRegExp(re4, "throw", ["throw"]);
+testRegExp(re4, " throw", null);
+testRegExp(re4, "return", ["return"]);
+testRegExp(re4, "until", null);
+
+// Test 18
+let re5 = /^(?:break|case|catch|continue|debugger|default|do|else|finally|for|function|if|return|switch|throw|try|var|while|with|null|true|false|instanceof|typeof|void|delete|new|in|this)$/;
+
+testRegExp(re5, "throw", ["throw"]);
+testRegExp(re5, " throw", null);
+testRegExp(re5, "function", ["function"]);
+testRegExp(re5, "return", ["return"]);
+testRegExp(re5, "let", null);
+testRegExp(re5, "until", null);
+
+// Test 24
+let re6 = /^(?:a*|b*|c*)/;
+
+testRegExp(re6, "", [""]);
+testRegExp(re6, "a", ["a"]);
+testRegExp(re6, "aa", ["aa"]);
+testRegExp(re6, "b", [""]);
+testRegExp(re6, "bbb", [""]);
+testRegExp(re6, "c", [""]);
+testRegExp(re6, "cc", [""]);
+
+// Test 31
+let re7 = /^(?:a+|b+|c+)/;
+
+testRegExp(re7, "a", ["a"]);
+testRegExp(re7, "aaa", ["aaa"]);
+testRegExp(re7, "aa", ["aa"]);
+testRegExp(re7, "b", ["b"]);
+testRegExp(re7, "bb", ["bb"]);
+testRegExp(re7, "bbb", ["bbb"]);
+testRegExp(re7, "c", ["c"]);
+testRegExp(re7, "cc", ["cc"]);
+testRegExp(re7, "ccc", ["ccc"]);
+
+// Test 40
+let re8 = /^(?:a{1,}|b{1,}|c{1,})/;
+
+testRegExp(re8, "a", ["a"]);
+testRegExp(re8, "aa", ["aa"]);
+testRegExp(re8, "aaa", ["aaa"]);
+testRegExp(re8, "b", ["b"]);
+testRegExp(re8, "bb", ["bb"]);
+testRegExp(re8, "bbb", ["bbb"]);
+testRegExp(re8, "c", ["c"]);
+testRegExp(re8, "cc", ["cc"]);
+testRegExp(re8, "ccc", ["ccc"]);
+
+// Test 49
+let re9 = /^(?:a{2}|b{2}|c{2})/;
+
+testRegExp(re9, "a", null);
+testRegExp(re9, "aa", ["aa"]);
+testRegExp(re9, "aaa", ["aa"]);
+testRegExp(re9, "b", null);
+testRegExp(re9, "bb", ["bb"]);
+testRegExp(re9, "bbb", ["bb"]);
+testRegExp(re9, "c", null);
+testRegExp(re9, "cc", ["cc"]);
+testRegExp(re9, "ccc", ["cc"]);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1417,14 +1417,17 @@ public:
 
         PatternTerm& lastTerm = m_alternative->lastTerm();
 
-        unsigned numParenAlternatives = parenthesesDisjunction->m_alternatives.size();
         unsigned numBOLAnchoredAlts = 0;
+        unsigned numParenAlternatives = parenthesesDisjunction->m_alternatives.size();
+        ASSERT(numParenAlternatives);
 
         for (unsigned i = 0; i < numParenAlternatives; i++) {
             // Bubble up BOL flags
             if (parenthesesDisjunction->m_alternatives[i]->m_startsWithBOL)
                 numBOLAnchoredAlts++;
         }
+
+        parenthesesDisjunction->m_alternatives.last()->m_isLastAlternative = true;
 
         if (numBOLAnchoredAlts) {
             m_alternative->m_containsBOL = true;
@@ -1857,6 +1860,12 @@ public:
     //     alternatives of the main body disjunction).
     //   * where the parens are non-capturing, and quantified unbounded greedy (*).
     //   * where the parens do not contain any capturing subpatterns.
+    //   * Where the parens contains a BOL anchored non-captured subpattern with a single
+    //     alternative of fixed strings, e.g. /^(?:foo|bar|baz).
+    //     In such a case we can simplify matching a little more by stopping at the first
+    //     matched string alternative, without jumping to backtracking doe to fixup offests.
+    //     Instead we fixup the offsets, if needed, at the top of the next alternative's
+    //     matching JIT code.
     void checkForTerminalParentheses()
     {
         // This check is much too crude; should be just checking whether the candidate
@@ -1865,8 +1874,49 @@ public:
             return;
 
         Vector<std::unique_ptr<PatternAlternative>>& alternatives = m_pattern.m_body->m_alternatives;
-        for (size_t i = 0; i < alternatives.size(); ++i) {
-            Vector<PatternTerm>& terms = alternatives[i]->m_terms;
+        alternatives.last()->m_isLastAlternative = true;
+
+        if (alternatives.size() == 1 && alternatives[0]->m_startsWithBOL) {
+            Vector<PatternTerm>& terms = alternatives[0]->m_terms;
+
+            bool isStringList = false;
+
+            if (terms.size() >= 2
+                && terms[0].type == PatternTerm::Type::AssertionBOL
+                && terms[1].type == PatternTerm::Type::ParenthesesSubpattern
+                && terms[1].quantityType == QuantifierType::FixedCount
+                && terms[1].quantityMaxCount == 1
+                && (terms.size() == 2
+                    || (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL))) {
+                // We start assuming this is a string list and then prove the negative.
+                isStringList = true;
+
+                PatternTerm& term = terms[1];
+
+                PatternDisjunction* nestedDisjunction = term.parentheses.disjunction;
+                for (unsigned alt = 0; isStringList && alt < nestedDisjunction->m_alternatives.size(); ++alt) {
+                    Vector<PatternTerm>& innerTerms = nestedDisjunction->m_alternatives[alt]->m_terms;
+
+                    for (size_t termIndex = 0; termIndex < innerTerms.size(); ++termIndex) {
+                        PatternTerm& innerTerm = innerTerms[termIndex];
+                        if (innerTerm.type != PatternTerm::Type::PatternCharacter
+                            || innerTerm.quantityType != QuantifierType::FixedCount
+                            || innerTerm.quantityMaxCount != 1) {
+                            isStringList = false;
+                            break;
+                        }
+                    }
+                }
+
+                term.parentheses.isStringList = isStringList;
+            }
+
+            if (isStringList)
+                return;
+        }
+
+        for (auto& alternative : alternatives) {
+            auto& terms = alternative->m_terms;
             if (terms.size()) {
                 PatternTerm& term = terms.last();
                 if (term.type == PatternTerm::Type::ParenthesesSubpattern
@@ -2440,6 +2490,8 @@ void PatternAlternative::dump(PrintStream& out, YarrPattern* thisPattern, unsign
         out.print(",starts with ^");
     if (m_containsBOL)
         out.print(",contains ^");
+    if (m_isLastAlternative)
+        out.print(", last alternative");
     out.print("\n");
 
     for (size_t i = 0; i < m_terms.size(); ++i)
@@ -2562,6 +2614,9 @@ void PatternTerm::dump(PrintStream& out, YarrPattern* thisPattern, unsigned nest
 
         if (parentheses.isTerminal)
             out.print(",terminal");
+
+        if (parentheses.isStringList)
+            out.print(",string-list");
 
         out.println(",frame location ", frameLocation);
 

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -234,6 +234,7 @@ struct PatternTerm {
             unsigned lastSubpatternId;
             bool isCopy : 1;
             bool isTerminal : 1;
+            bool isStringList : 1;
         } parentheses;
         struct {
             bool bolAnchor : 1;
@@ -278,6 +279,7 @@ struct PatternTerm {
         parentheses.subpatternId = subpatternId;
         parentheses.isCopy = false;
         parentheses.isTerminal = false;
+        parentheses.isStringList = false;
         quantityType = QuantifierType::FixedCount;
         quantityMinCount = quantityMaxCount = 1;
     }
@@ -426,6 +428,7 @@ public:
         , m_hasFixedSize(false)
         , m_startsWithBOL(false)
         , m_containsBOL(false)
+        , m_isLastAlternative(false)
     {
     }
 
@@ -491,6 +494,7 @@ public:
     bool m_hasFixedSize : 1;
     bool m_startsWithBOL : 1;
     bool m_containsBOL : 1;
+    bool m_isLastAlternative : 1;
 };
 
 struct PatternDisjunction {


### PR DESCRIPTION
#### 5d4feeaef67a95a369beb8242abd28bf64bc4251
<pre>
[Yarr] Improve processing of an alternation of strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=288102">https://bugs.webkit.org/show_bug.cgi?id=288102</a>
<a href="https://rdar.apple.com/145222010">rdar://145222010</a>

Reviewed by Yusuke Suzuki.

Added the notion of a string list to a parsed RegExp that is in the form of
  /^(?:break|case|which|do|for)/ with an optional trailing $.
Such a RegExp will not backtrack and therefore we can streamline the code we emit for such a pattern.

This change involves recognizing beginning of string anchored alternations of strings while parsing and
then treating the generation of JIT code differently for these patterns.  This includes changing how
conditional branching works, specifically that instead of the &quot;fall through on match&quot; for each term,
to a &quot;jump on match&quot; for the whole alternation.

Fixed a bug in the original version where we weren&apos;t properly checking the nested alternatives to see
if they only contain fixed single count PatternCharacter terms.

The current code generated for the &quot;case&quot; elternative is:
   8:Term PatternCharacter checked-offset:(3) &apos;c&apos;
               &lt;156&gt; 0x11381430c:    add      w1, w1, #2
               &lt;160&gt; 0x113814310:    cmp      w1, w2
               &lt;164&gt; 0x113814314:    b.hi     0x113814444 -&gt; &lt;468&gt;
  10:Term PatternCharacter checked-offset:(4) &apos;c&apos;
               &lt;168&gt; 0x113814318:    sub      x17, x0, #4
               &lt;172&gt; 0x11381431c:    ldr      w17, [x17, x1]
               &lt;176&gt; 0x113814320:    movz     w16, #0x6163
               &lt;180&gt; 0x113814324:    movk     w16, #0x6573, lsl #16 -&gt; 0x65736163
               &lt;184&gt; 0x113814328:    cmp      w17, w16
               &lt;188&gt; 0x11381432c:    b.ne     0x113814444 -&gt; &lt;468&gt;
  11:Term PatternCharacter checked-offset:(4) &apos;a&apos; already handled
  12:Term PatternCharacter checked-offset:(4) &apos;s&apos; already handled
  13:Term PatternCharacter checked-offset:(4) &apos;e&apos; already handled
  14:NestedAlternativeNext minimum-size:(5),checked-offset:(5)
               &lt;192&gt; 0x113814330:    movz     x16, #0x4444
               &lt;196&gt; 0x113814334:    movk     x16, #0x1381, lsl #16
               &lt;200&gt; 0x113814338:    movk     x16, #0x8001, lsl #32
               &lt;204&gt; 0x11381433c:    movk     x16, #0xc973, lsl #48 -&gt; 0x113814444 JIT PC
               &lt;208&gt; 0x113814340:    stur     x16, [sp, #8]
               &lt;212&gt; 0x113814344:    b        0x113814404 -&gt; &lt;404&gt;
With some additional backtracking code:
   9:NestedAlternativeNext minimum-size:(4),checked-offset:(4)
               &lt;468&gt; 0x113814444:    sub      w1, w1, #2
               &lt;472&gt; 0x113814448:    b        0x113814348 -&gt; &lt;216&gt;

With this change, the processing of &quot;case&quot; becomes:
   9:StringListAlternativeNext minimum-size:(4),checked-offset:(4)
               &lt;132&gt; 0x12a8285c4:    sub      w1, w1, #1
               &lt;136&gt; 0x12a8285c8:    cmp      w1, w2
               &lt;140&gt; 0x12a8285cc:    b.hi     0x12a8285e8 -&gt; &lt;168&gt;
  10:Term PatternCharacter checked-offset:(4) &apos;c&apos;
               &lt;144&gt; 0x12a8285d0:    sub      x17, x0, #4
               &lt;148&gt; 0x12a8285d4:    ldr      w17, [x17, x1]
               &lt;152&gt; 0x12a8285d8:    movz     w16, #0x6163
               &lt;156&gt; 0x12a8285dc:    movk     w16, #0x6573, lsl #16 -&gt; 0x65736163
               &lt;160&gt; 0x12a8285e0:    cmp      w17, w16
               &lt;164&gt; 0x12a8285e4:    b.eq     0x12a82866c -&gt; &lt;300&gt;
  11:Term PatternCharacter checked-offset:(4) &apos;a&apos; already handled
  12:Term PatternCharacter checked-offset:(4) &apos;s&apos; already handled
  13:Term PatternCharacter checked-offset:(4) &apos;e&apos; already handled
  14:StringListAlternativeNext minimum-size:(5),checked-offset:(5)
With no backtracking code.

We are able to eliminate one branch and the saving of the continuation PC for backtracking.
The code size to process these string list RegExp is reduces.  For the example RegExp above,
the prior version created 1940 bytes (485 instructions) of code while the code created with this
1392 bytes (345 instructions) of code, a nearly 30% reduction in code.

This change is a ~18% progression on the new regexp-keyword-parsing microbenchmark:

                                 Baseline               YarrStringList

regexp-keyword-parsing      136.7065+-0.9807     ^    116.0161+-1.1791        ^ definitely 1.1783x faster

&lt;geometric&gt;                 136.7065+-0.9807     ^    116.0161+-1.1791        ^ definitely 1.1783x faster

* JSTests/microbenchmarks/regexp-keyword-parsing.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
(let.re.break.case.catch.continue.debugger.default.else.finally.if):
(let.re1.break.case.catch.continue.debugger.default.else.finally.if):
* JSTests/stress/regexp-parsing-tokens.js: Added.
(arrayToString):
(objectToString):
(dumpValue):
(compareArray):
(compareGroups):
(testRegExp):
(testRegExpSyntaxError):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomParenthesesEnd):
(JSC::Yarr::YarrPatternConstructor::checkForTerminalParentheses):
(JSC::Yarr::PatternAlternative::dump):
(JSC::Yarr::PatternTerm::dump):
* Source/JavaScriptCore/yarr/YarrPattern.h:
(JSC::Yarr::PatternTerm::PatternTerm):
(JSC::Yarr::PatternAlternative::PatternAlternative):

Canonical link: <a href="https://commits.webkit.org/290982@main">https://commits.webkit.org/290982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f23d121a020796064af34b8b6f46a46084131125

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91632 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96597 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42300 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19598 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94633 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83023 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41482 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84430 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98605 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90379 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18784 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78596 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23110 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18777 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/112964 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18486 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32735 "Found 14 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, stress/new-largeish-contiguous-array-with-size.js.ram-size-10000000, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21942 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->