### PR TITLE
NEW-TEST(290390@main): [ iOS ] TestWebKitAPI.UnifiedPDF.SelectionClearsOnAnchorLinkTap(api-test) is a constant crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -521,6 +521,7 @@ UNIFIED_PDF_TEST(MouseDidMoveOverPDF)
     TestWebKitAPI::Util::run(&done);
 }
 
+#if ENABLE(IOS_TOUCH_EVENTS)
 UNIFIED_PDF_TEST(SelectionClearsOnAnchorLinkTap)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
@@ -542,6 +543,7 @@ UNIFIED_PDF_TEST(SelectionClearsOnAnchorLinkTap)
     [webView waitForNextPresentationUpdate];
     EXPECT_WK_STREQ("", [contentView selectedText]);
 }
+#endif
 
 #endif
 


### PR DESCRIPTION
#### 2f9c119b986a52177fb403226f4175d9e3e2e7c5
<pre>
NEW-TEST(290390@main): [ iOS ] TestWebKitAPI.UnifiedPDF.SelectionClearsOnAnchorLinkTap(api-test) is a constant crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=288400">https://bugs.webkit.org/show_bug.cgi?id=288400</a>
<a href="https://rdar.apple.com/145503896">rdar://145503896</a>

Reviewed by Wenson Hsieh.

This test is crashing like this:

```
CRASH:
 TestWebKitAPI.UnifiedPDF.SelectionClearsOnAnchorLinkTap
        SHOULD NEVER BE REACHED
        /Volumes/Data/worker/Apple-iOS-18-Simulator-Debug-Build/build/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm(137) : WebCore::MouseEventPolicy WebKit::coreMouseEventPolicy(_WKWebsiteMouseEventPolicy)
        1   0x14c30e084 WebKit::coreMouseEventPolicy(unsigned long)
        2   0x14c30dff4 -[WKWebpagePreferences _setMouseEventPolicy:]
        3   0x101d13628 TestWebKitAPI::UnifiedPDF_SelectionClearsOnAnchorLinkTap_Test::TestBody()
```

The crash happens in open source iOS configurations because we are not
able to handle _WKWebsiteMouseEventPolicySynthesizeTouchEvents, since
ENABLE_IOS_TOUCH_EVENTS==0 in these configurations.

As such, let us gate this test behind ENABLE(IOS_TOUCH_EVENTS).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:

Canonical link: <a href="https://commits.webkit.org/290983@main">https://commits.webkit.org/290983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7643664a79dd575036dbba7b126b97c87c5c7a08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96600 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11539 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19601 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50683 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/616 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41485 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/620 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98608 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18786 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79383 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19040 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78593 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23111 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18779 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18488 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21944 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->