### PR TITLE
Non-unified source build fix of February 2025 (part 9)

### DIFF
--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp
@@ -23,10 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #include "config.h"
 #include "FileSystemStorageConnection.h"
+
+#include "FileSystemWritableFileStream.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -27,6 +27,7 @@
 #include "InternalWritableStream.h"
 
 #include "Exception.h"
+#include "JSDOMExceptionHandling.h"
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "HTMLSlotElement.h"
 
+#include "AXObjectCache.h"
 #include "ElementInlines.h"
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "Color.h"
+#include "LayoutSize.h"
 #include "LayoutUnit.h"
 #include "RectEdges.h"
 #include "RenderObjectEnums.h"

--- a/Source/WebCore/rendering/RenderBlockInlines.h
+++ b/Source/WebCore/rendering/RenderBlockInlines.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "RenderBlock.h"
+#include "RenderBoxInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderStyleInlines.h"
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -33,6 +33,7 @@
 #include "MessageSenderInlines.h"
 #include "RemotePageFullscreenManagerProxy.h"
 #include "WebAutomationSession.h"
+#include "WebFrameProxy.h"
 #include "WebFullScreenManagerMessages.h"
 #include "WebFullScreenManagerProxyMessages.h"
 #include "WebPageProxy.h"
@@ -41,6 +42,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/ScreenOrientationType.h>
+#include <wtf/CallbackAggregator.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -53,7 +53,7 @@ void WebFileSystemStorageConnection::errorWritable(WebCore::ScriptExecutionConte
         return;
 
     WebCore::ScriptExecutionContext::postTaskTo(contextIdentifier, [writableIdentifier, protectedThis = Ref { *this }](auto& context) mutable {
-        RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(context);
+        RefPtr globalScope = dynamicDowncast<WebCore::WorkerGlobalScope>(context);
         RefPtr connection = globalScope ? globalScope->fileSystemStorageConnection() : nullptr;
         if (connection)
             connection->errorFileSystemWritable(writableIdentifier);


### PR DESCRIPTION
#### 36a8f4813835e0ec865a59aff8b500a682443134
<pre>
Non-unified source build fix of February 2025 (part 9)
<a href="https://bugs.webkit.org/show_bug.cgi?id=286904">https://bugs.webkit.org/show_bug.cgi?id=286904</a>

Unreviewed non-unified build fix.

* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp:
* Source/WebCore/bindings/js/InternalWritableStream.cpp:
* Source/WebCore/html/HTMLSlotElement.cpp:
* Source/WebCore/rendering/BorderEdge.h:
* Source/WebCore/rendering/RenderBlockInlines.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::errorWritable):

Canonical link: <a href="https://commits.webkit.org/290994@main">https://commits.webkit.org/290994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c28cfe3e7f395b11da8a9e07e52d40258ae32cf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96606 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70362 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/27875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50688 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/613 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41492 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78895 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98615 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79390 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78600 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23114 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14534 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18785 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->