### PR TITLE
Address Safer CPP failures in JSContext

### DIFF
--- a/Source/JavaScriptCore/API/JSContextRef.cpp
+++ b/Source/JavaScriptCore/API/JSContextRef.cpp
@@ -97,20 +97,20 @@ void JSContextGroupSetExecutionTimeLimit(JSContextGroupRef group, double limit, 
 {
     VM& vm = *toJS(group);
     JSLockHolder locker(&vm);
-    Watchdog& watchdog = vm.ensureWatchdog();
+    Ref watchdog = vm.ensureWatchdog();
     if (callback) {
         void* callbackPtr = reinterpret_cast<void*>(callback);
-        watchdog.setTimeLimit(Seconds { limit }, internalScriptTimeoutCallback, callbackPtr, callbackData);
+        watchdog->setTimeLimit(Seconds { limit }, internalScriptTimeoutCallback, callbackPtr, callbackData);
     } else
-        watchdog.setTimeLimit(Seconds { limit });
+        watchdog->setTimeLimit(Seconds { limit });
 }
 
 void JSContextGroupClearExecutionTimeLimit(JSContextGroupRef group)
 {
     VM& vm = *toJS(group);
     JSLockHolder locker(&vm);
-    if (vm.watchdog())
-        vm.watchdog()->setTimeLimit(Watchdog::noTimeLimit);
+    if (RefPtr watchdog = vm.watchdog())
+        watchdog->setTimeLimit(Watchdog::noTimeLimit);
 }
 
 // From the API's perspective, a global context remains alive iff it has been JSGlobalContextRetained.
@@ -455,7 +455,7 @@ void JSGlobalContextSetDebuggerRunLoop(JSGlobalContextRef ctx, CFRunLoopRef runL
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
 
-    globalObject->inspectorDebuggable().setTargetRunLoop(runLoop);
+    globalObject->protectedInspectorDebuggable()->setTargetRunLoop(runLoop);
 #else
     UNUSED_PARAM(ctx);
     UNUSED_PARAM(runLoop);

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -3,8 +3,6 @@ API/JSCallbackConstructor.cpp
 API/JSCallbackObject.h
 API/JSCallbackObjectFunctions.h
 API/JSClassRef.cpp
-API/JSContext.mm
-API/JSContextRef.cpp
 API/JSObjectRef.cpp
 API/JSRetainPtr.h
 API/JSScript.mm
@@ -168,10 +166,8 @@ runtime/TypeProfiler.cpp
 runtime/TypeProfilerLog.cpp
 runtime/TypeSet.cpp
 runtime/VMTraps.cpp
-runtime/WaiterListManager.cpp
 runtime/Watchdog.cpp
 tools/FunctionOverrides.cpp
-tools/HeapVerifier.cpp
 tools/JSDollarVM.cpp
 wasm/WasmBBQJIT.cpp
 wasm/WasmBBQJIT64.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,6 +1,4 @@
 API/JSCallbackObjectFunctions.h
-API/JSContext.mm
-API/JSContextRef.cpp
 API/JSValue.mm
 API/JSWrapperMap.mm
 API/tests/testapi.cpp
@@ -62,7 +60,6 @@ ftl/FTLPatchpointExceptionHandle.cpp
 heap/ConservativeRoots.cpp
 heap/HeapHelperPool.cpp
 heap/JITStubRoutineSet.cpp
-heap/MachineStackMarker.cpp
 inspector/AsyncStackTrace.cpp
 inspector/InspectorBackendDispatcher.cpp
 inspector/JSJavaScriptCallFrame.cpp
@@ -94,13 +91,11 @@ runtime/FileBasedFuzzerAgent.cpp
 runtime/HasOwnPropertyCache.h
 runtime/HashMapHelper.h
 runtime/InferredValue.h
-runtime/InitializeThreading.cpp
 runtime/JSCJSValue.cpp
 runtime/JSCJSValueInlines.h
 runtime/JSFinalizationRegistry.cpp
 runtime/JSFunction.cpp
 runtime/JSGlobalObject.cpp
-runtime/JSLock.cpp
 runtime/JSObject.cpp
 runtime/JSRunLoopTimer.cpp
 runtime/JSString.cpp
@@ -117,7 +112,6 @@ runtime/StructureInlines.h
 runtime/SymbolConstructor.cpp
 runtime/SymbolTable.h
 runtime/TypeSet.cpp
-runtime/VMEntryScope.cpp
 runtime/VMTraps.cpp
 runtime/WaiterListManager.h
 tools/JSDollarVM.cpp

--- a/Source/JavaScriptCore/assembler/ProbeStack.h
+++ b/Source/JavaScriptCore/assembler/ProbeStack.h
@@ -151,7 +151,7 @@ class Stack {
     WTF_MAKE_TZONE_ALLOCATED(Stack);
 public:
     Stack()
-        : m_stackBounds(Thread::current().stack())
+        : m_stackBounds(Thread::currentSingleton().stack())
     { }
     Stack(Stack&& other);
 

--- a/Source/JavaScriptCore/heap/BlockDirectory.cpp
+++ b/Source/JavaScriptCore/heap/BlockDirectory.cpp
@@ -517,7 +517,7 @@ void BlockDirectory::assertIsMutatorOrMutatorIsStopped() const
     auto& heap = markedSpace().heap();
     if (!heap.worldIsStopped()) {
         if (auto owner = heap.vm().apiLock().ownerThread())
-            ASSERT(owner->get() == &Thread::current());
+            ASSERT(owner->get() == &Thread::currentSingleton());
         else {
             // FIXME: It feels like heap access should be tied to holding the API lock.
             ASSERT(heap.hasAccess());

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1351,7 +1351,7 @@ auto Heap::runCurrentPhase(GCConductor conn, CurrentThreadState* currentThreadSt
 {
     checkConn(conn);
     m_currentThreadState = currentThreadState;
-    m_currentThread = &Thread::current();
+    m_currentThread = &Thread::currentSingleton();
     
     if (conn == GCConductor::Mutator)
         sanitizeStackForVM(vm());
@@ -1684,9 +1684,9 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
     }
         
     {
-        auto* previous = Thread::current().setCurrentAtomStringTable(nullptr);
+        auto* previous = Thread::currentSingleton().setCurrentAtomStringTable(nullptr);
         auto scopeExit = makeScopeExit([&] {
-            Thread::current().setCurrentAtomStringTable(previous);
+            Thread::currentSingleton().setCurrentAtomStringTable(previous);
         });
 
         if (vm().typeProfiler())
@@ -2282,7 +2282,7 @@ Heap::Ticket Heap::requestCollection(GCRequest request)
     stopIfNecessary();
     
     ASSERT(vm().currentThreadIsHoldingAPILock());
-    RELEASE_ASSERT(vm().atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm().atomStringTable() == Thread::currentSingleton().atomStringTable());
     
     Locker locker { *m_threadLock };
     // We may be able to steal the conn. That only works if the collector is definitely not running

--- a/Source/JavaScriptCore/heap/MachineStackMarker.cpp
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.cpp
@@ -143,7 +143,7 @@ bool MachineThreads::tryCopyOtherThreadStacks(const AbstractLocker& locker, void
 
     *size = 0;
 
-    Thread& currentThread = Thread::current();
+    auto& currentThread = Thread::currentSingleton();
     const ListHashSet<Ref<Thread>>& threads = m_threadGroup->threads(locker);
     BitVector isSuspended(threads.size());
 

--- a/Source/JavaScriptCore/heap/MachineStackMarker.h
+++ b/Source/JavaScriptCore/heap/MachineStackMarker.h
@@ -66,7 +66,7 @@ private:
 #define DECLARE_AND_COMPUTE_CURRENT_THREAD_STATE(stateName) \
     CurrentThreadState stateName; \
     stateName.stackTop = &stateName; \
-    stateName.stackOrigin = Thread::current().stack().origin(); \
+    stateName.stackOrigin = Thread::currentSingleton().stack().origin(); \
     ALLOCATE_AND_GET_REGISTER_STATE(stateName ## _registerState); \
     stateName.registerState = &stateName ## _registerState
 

--- a/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp
+++ b/Source/JavaScriptCore/inspector/remote/socket/RemoteInspectorSocketEndpoint.cpp
@@ -66,7 +66,7 @@ RemoteInspectorSocketEndpoint::RemoteInspectorSocketEndpoint()
 
 RemoteInspectorSocketEndpoint::~RemoteInspectorSocketEndpoint()
 {
-    ASSERT(m_workerThread.get() != &Thread::current());
+    ASSERT(m_workerThread.get() != &Thread::currentSingleton());
 
     m_shouldAbortWorkerThread = true;
     wakeupWorkerThread();

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -3256,7 +3256,7 @@ JSC_DEFINE_HOST_FUNCTION(functionSamplingProfilerStackTraces, (JSGlobalObject* g
 JSC_DEFINE_HOST_FUNCTION(functionMaxArguments, (JSGlobalObject* globalObject, CallFrame*))
 {
     VM& vm = globalObject->vm();
-    unsigned result = std::min<unsigned>(JSC::maxArguments, static_cast<unsigned>((std::bit_cast<uint8_t*>(Thread::current().stack().origin()) - std::bit_cast<uint8_t*>(vm.softStackLimit())) / sizeof(EncodedJSValue)));
+    unsigned result = std::min<unsigned>(JSC::maxArguments, static_cast<unsigned>((std::bit_cast<uint8_t*>(Thread::currentSingleton().stack().origin()) - std::bit_cast<uint8_t*>(vm.softStackLimit())) / sizeof(EncodedJSValue)));
     return JSValue::encode(jsNumber(result));
 }
 

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -233,7 +233,7 @@ extern "C" UGPRPair SYSV_ABI llint_trace_operand(CallFrame* callFrame, const JSI
     LLINT_BEGIN();
     dataLogF(
         "<%p> %p / %p: executing bc#%zu, op#%u: Trace(%d): %d\n",
-        &Thread::current(),
+        &Thread::currentSingleton(),
         callFrame->codeBlock(),
         globalObject,
         static_cast<intptr_t>(callFrame->codeBlock()->bytecodeOffset(pc)),
@@ -259,7 +259,7 @@ extern "C" UGPRPair SYSV_ABI llint_trace_value(CallFrame* callFrame, const JSIns
     u.asValue = JSValue::encode(value);
     dataLogF(
         "<%p> %p / %p: executing bc#%zu, op#%u: Trace(%d): %d: %08x:%08x: %s\n",
-        &Thread::current(),
+        &Thread::currentSingleton(),
         callFrame->codeBlock(),
         callFrame,
         static_cast<intptr_t>(callFrame->codeBlock()->bytecodeOffset(pc)),
@@ -278,7 +278,7 @@ LLINT_SLOW_PATH_DECL(trace_prologue)
         LLINT_END_IMPL();
 
     CodeBlock* codeBlock = callFrame->codeBlock();
-    dataLogF("<%p> %p / %p: in prologue of ", &Thread::current(), codeBlock, callFrame);
+    dataLogF("<%p> %p / %p: in prologue of ", &Thread::currentSingleton(), codeBlock, callFrame);
     dataLog(codeBlock, "\n");
     LLINT_END_IMPL();
 }
@@ -291,7 +291,7 @@ static void traceFunctionPrologue(CallFrame* callFrame, const char* comment, Cod
     JSFunction* callee = jsCast<JSFunction*>(callFrame->jsCallee());
     FunctionExecutable* executable = callee->jsExecutable();
     CodeBlock* codeBlock = executable->codeBlockFor(kind);
-    dataLogF("<%p> %p / %p: in %s of ", &Thread::current(), codeBlock, callFrame, comment);
+    dataLogF("<%p> %p / %p: in %s of ", &Thread::currentSingleton(), codeBlock, callFrame, comment);
     dataLog(codeBlock);
     dataLogF(" function %p, executable %p; numVars = %u, numParameters = %u, numCalleeLocals = %u, caller = %p.\n",
         callee, executable, codeBlock->numVars(), codeBlock->numParameters(), codeBlock->numCalleeLocals(), callFrame->callerFrame());
@@ -329,7 +329,7 @@ LLINT_SLOW_PATH_DECL(trace)
     CodeBlock* codeBlock = callFrame->codeBlock();
     OpcodeID opcodeID = pc->opcodeID();
     dataLogF("<%p> %p / %p: executing bc#%zu, %s, pc = %p\n",
-            &Thread::current(),
+            &Thread::currentSingleton(),
             codeBlock,
             callFrame,
             static_cast<intptr_t>(codeBlock->bytecodeOffset(pc)),

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -53,7 +53,7 @@ bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 
     ParserError error;
     if (checkSyntaxInternal(vm, source, error))
@@ -67,7 +67,7 @@ bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 bool checkSyntax(VM& vm, const SourceCode& source, ParserError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     return checkSyntaxInternal(vm, source, error);
 }
 
@@ -75,7 +75,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     std::unique_ptr<ModuleProgramNode> moduleProgramNode = parseRootNode<ModuleProgramNode>(
         vm, source, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         StrictModeLexicallyScopedFeature, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, error);
@@ -90,7 +90,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source, FileSystem::PlatformFileHandle fd, BytecodeCacheError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 
     LexicallyScopedFeatures lexicallyScopedFeatures = NoLexicallyScopedFeatures;
     JSParserScriptMode scriptMode = JSParserScriptMode::Classic;
@@ -109,7 +109,7 @@ RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source,
 RefPtr<CachedBytecode> generateModuleBytecode(VM& vm, const SourceCode& source, FileSystem::PlatformFileHandle fd, BytecodeCacheError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 
     LexicallyScopedFeatures lexicallyScopedFeatures = StrictModeLexicallyScopedFeature;
     JSParserScriptMode scriptMode = JSParserScriptMode::Module;
@@ -129,7 +129,7 @@ JSValue evaluate(JSGlobalObject* globalObject, const SourceCode& source, JSValue
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_CATCH_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     if (!thisValue || thisValue.isUndefinedOrNull())
@@ -188,7 +188,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, Symbol* m
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadAndEvaluateModule(globalObject, moduleId, parameters, scriptFetcher);
@@ -198,7 +198,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const Str
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadAndEvaluateModule(globalObject, identifierToJSValue(vm, Identifier::fromString(vm, moduleName)), parameters, scriptFetcher);
@@ -209,7 +209,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const Sou
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Symbol* key = createSymbolForEntryPointModule(vm);
@@ -224,7 +224,7 @@ JSInternalPromise* loadModule(JSGlobalObject* globalObject, const Identifier& mo
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadModule(globalObject, identifierToJSValue(vm, moduleKey), parameters, scriptFetcher);
@@ -235,7 +235,7 @@ JSInternalPromise* loadModule(JSGlobalObject* globalObject, const SourceCode& so
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Symbol* key = createSymbolForEntryPointModule(vm);
@@ -251,7 +251,7 @@ JSValue linkAndEvaluateModule(JSGlobalObject* globalObject, const Identifier& mo
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->linkAndEvaluateModule(globalObject, identifierToJSValue(vm, moduleKey), scriptFetcher);
@@ -261,7 +261,7 @@ JSInternalPromise* importModule(JSGlobalObject* globalObject, const Identifier& 
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::current().atomStringTable());
+    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->requestImportModule(globalObject, moduleName, referrer, parameters, scriptFetcher);

--- a/Source/JavaScriptCore/runtime/ExceptionScope.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionScope.cpp
@@ -55,7 +55,7 @@ CString ExceptionScope::unexpectedExceptionMessage()
 {
     StringPrintStream out;
 
-    out.println("Unexpected exception observed on thread ", Thread::current(), " at:");
+    out.println("Unexpected exception observed on thread ", Thread::currentSingleton(), " at:");
     auto currentStack = StackTrace::captureStackTrace(Options::unexpectedExceptionStackTraceLimit(), 1);
     out.print(StackTracePrinter { *currentStack, "    " });
 

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -74,7 +74,7 @@ void Identifier::checkCurrentAtomStringTable(VM& vm)
 {
     // Check the identifier table accessible through the threadspecific matches the
     // vm's identifier table.
-    ASSERT_UNUSED(vm, vm.atomStringTable() == Thread::current().atomStringTable());
+    ASSERT_UNUSED(vm, vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
 }
 
 #else

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -119,7 +119,7 @@ void initialize()
         AssertNoGC::initialize();
 
         initializeSuperSampler();
-        Thread& thread = Thread::current();
+        auto& thread = Thread::currentSingleton();
         thread.setSavedLastStackTop(thread.stack().origin());
 
         NativeCalleeRegistry::initialize();

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -3467,4 +3467,11 @@ void JSGlobalObject::cachedFunctionExecutableForFunctionConstructor(FunctionExec
     m_executableForCachedFunctionExecutableForFunctionConstructor.set(vm(), executable);
 }
 
+#if ENABLE(REMOTE_INSPECTOR)
+Ref<JSGlobalObjectDebuggable> JSGlobalObject::protectedInspectorDebuggable()
+{
+    return inspectorDebuggable();
+}
+#endif
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -966,6 +966,7 @@ public:
     // FIXME: <http://webkit.org/b/246237> Local inspection should be controlled by `inspectable` API.
     Inspector::JSGlobalObjectInspectorController& inspectorController() const { return *m_inspectorController.get(); }
     JSGlobalObjectDebuggable& inspectorDebuggable() { return *m_inspectorDebuggable; }
+    Ref<JSGlobalObjectDebuggable> protectedInspectorDebuggable();
 #endif
 
     void bumpGlobalLexicalBindingEpoch(VM&);

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -59,7 +59,7 @@ struct JSGlobalObject::GlobalPropertyInfo {
         , value(v)
         , attributes(a)
     {
-        ASSERT(Thread::current().stack().contains(this));
+        ASSERT(Thread::currentSingleton().stack().contains(this));
     }
 
     const Identifier identifier;

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -104,7 +104,7 @@ void JSLock::lock(intptr_t lockCount) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
         m_lock.lock();
     }
 
-    m_ownerThread = &Thread::current();
+    m_ownerThread = &Thread::currentSingleton();
     WTF::storeStoreFence();
     m_hasOwnerThread = true;
     ASSERT(!m_lockCount);
@@ -119,7 +119,7 @@ void JSLock::didAcquireLock()
     if (!m_vm)
         return;
     
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     ASSERT(!m_entryAtomStringTable);
     m_entryAtomStringTable = thread.setCurrentAtomStringTable(m_vm->atomStringTable());
     ASSERT(m_entryAtomStringTable);
@@ -210,7 +210,7 @@ void JSLock::willReleaseLock()
     }
 
     if (m_entryAtomStringTable) {
-        Thread::current().setCurrentAtomStringTable(m_entryAtomStringTable);
+        Thread::currentSingleton().setCurrentAtomStringTable(m_entryAtomStringTable);
         m_entryAtomStringTable = nullptr;
     }
 }
@@ -235,7 +235,7 @@ unsigned JSLock::dropAllLocks(DropAllLocks* dropper)
 
     dropper->setDropDepth(m_lockDropDepth);
 
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     thread.setSavedStackPointerAtVMEntry(m_vm->stackPointerAtVMEntry());
     thread.setSavedLastStackTop(m_vm->lastStackTop());
 
@@ -262,7 +262,7 @@ void JSLock::grabAllLocks(DropAllLocks* dropper, unsigned droppedLockCount)
 
     --m_lockDropDepth;
 
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     m_vm->setStackPointerAtVMEntry(thread.savedStackPointerAtVMEntry());
     m_vm->setLastStackTop(thread);
 }

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -92,7 +92,7 @@ public:
             return m_ownerThread;
         return std::nullopt;
     }
-    bool currentThreadIsHoldingLock() { return m_hasOwnerThread && m_ownerThread.get() == &Thread::current(); }
+    bool currentThreadIsHoldingLock() { return m_hasOwnerThread && m_ownerThread.get() == &Thread::currentSingleton(); }
 
     void willDestroyVM(VM*);
 

--- a/Source/JavaScriptCore/runtime/JSONObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSONObject.cpp
@@ -868,7 +868,7 @@ inline unsigned FastStringifier<CharType, bufferMode>::usableBufferSize(unsigned
     //    side here is potential loss of some performance opportunity when we encounter
     //    a workload that recurses deeply. We expect such workloads to be rare.
 
-    auto& stack = Thread::current().stack();
+    auto& stack = Thread::currentSingleton().stack();
     uint8_t* stackPointer = std::bit_cast<uint8_t*>(currentStackPointer());
     uint8_t* stackLimit = std::bit_cast<uint8_t*>(stack.recursionLimit());
     size_t stackCapacityForRecursion = stackPointer - stackLimit;

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.cpp
@@ -766,7 +766,7 @@ void SamplingProfiler::pause()
 void SamplingProfiler::noticeCurrentThreadAsJSCExecutionThreadWithLock()
 {
     ASSERT(m_lock.isLocked());
-    m_jscExecutionThread = &Thread::current();
+    m_jscExecutionThread = &Thread::currentSingleton();
 }
 
 void SamplingProfiler::noticeCurrentThreadAsJSCExecutionThread()

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -293,7 +293,7 @@ public:
     // WebCore has a one-to-one mapping of threads to VMs;
     // create() should only be called once
     // on a thread, this is the 'default' VM (it uses the
-    // thread's default string uniquing table from Thread::current()).
+    // thread's default string uniquing table from Thread::currentSingleton()).
     enum class VMType { Default, APIContextGroup };
 
     struct ClientData {

--- a/Source/JavaScriptCore/runtime/VMEntryScope.cpp
+++ b/Source/JavaScriptCore/runtime/VMEntryScope.cpp
@@ -41,7 +41,7 @@ void VMEntryScope::setUpSlow()
 {
     m_vm.entryScope = this;
 
-    auto& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     if (UNLIKELY(!thread.isJSThread())) {
         Thread::registerJSThread(thread);
 

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -75,7 +75,7 @@ WaiterListManager& WaiterListManager::singleton()
 template <typename ValueType>
 WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueType* ptr, ValueType expectedValue, Seconds timeout)
 {
-    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> waitSyncImpl starts totalWaiterCount=", totalWaiterCount());
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> waitSyncImpl starts totalWaiterCount=", totalWaiterCount());
 
     Ref<Waiter> syncWaiter = vm.syncWaiter();
     Ref<WaiterList> list = findOrCreateList(ptr);
@@ -87,7 +87,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
             return WaitSyncResult::NotEqual;
 
         list->addLast(listLocker, syncWaiter);
-        dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> added a new SyncWaiter=", syncWaiter.get(), " to a waiterList for ptr ", RawPointer(ptr));
+        dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> added a new SyncWaiter=", syncWaiter.get(), " to a waiterList for ptr ", RawPointer(ptr));
 
         while (syncWaiter->isOnList() && time.now() < time && !vm.hasTerminationRequest())
             syncWaiter->condition().waitUntil(list->lock, time.approximateWallTime());
@@ -106,7 +106,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
 template <typename ValueType>
 JSValue WaiterListManager::waitAsyncImpl(JSGlobalObject* globalObject, VM& vm, ValueType* ptr, ValueType expectedValue, Seconds timeout)
 {
-    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> waitAsyncImpl starts totalWaiterCount=", totalWaiterCount());
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> waitAsyncImpl starts totalWaiterCount=", totalWaiterCount());
 
     JSObject* object = constructEmptyObject(globalObject);
 
@@ -135,7 +135,7 @@ JSValue WaiterListManager::waitAsyncImpl(JSGlobalObject* globalObject, VM& vm, V
                 waiter->setTimer(listLocker, WTFMove(timer));
             }
 
-            dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> added a new AsyncWaiter=", *waiter.ptr(), " to a waiterList for ptr ", RawPointer(ptr));
+            dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> added a new AsyncWaiter=", *waiter.ptr(), " to a waiterList for ptr ", RawPointer(ptr));
             value = promise;
         }
     }
@@ -167,7 +167,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSync(VM& vm, int64_t* p
 
 void WaiterListManager::timeoutAsyncWaiter(void* ptr, Ref<Waiter>&& waiter)
 {
-    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> timeoutAsyncWaiter ", waiter.get(), ") for ptr ", RawPointer(ptr));
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> timeoutAsyncWaiter ", waiter.get(), ") for ptr ", RawPointer(ptr));
     if (RefPtr<WaiterList> list = findList(ptr)) {
         Locker listLocker { list->lock };
         if (waiter->isOnList()) {
@@ -195,7 +195,7 @@ unsigned WaiterListManager::notifyWaiter(void* ptr, unsigned count)
         }
     }
 
-    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::current(), "> notified waiters (count ", notified, ") for ptr ", RawPointer(ptr));
+    dataLogLnIf(WaiterListsManagerInternal::verbose, "<WaiterListManager> <Thread:", Thread::currentSingleton(), "> notified waiters (count ", notified, ") for ptr ", RawPointer(ptr));
     return notified;
 }
 
@@ -270,7 +270,7 @@ void WaiterListManager::unregister(VM* vm)
         list->removeIf(listLocker, [&](Waiter* waiter) {
             if (waiter->vm() == vm) {
                 dataLogLnIf(WaiterListsManagerInternal::verbose,
-                    "<WaiterListManager> <Thread:", Thread::current(),
+                    "<WaiterListManager> <Thread:", Thread::currentSingleton(),
                     "> unregister VM is cancelling waiter=", *waiter,
                     " in WaiterList for ptr ", RawPointer(entry.key));
 
@@ -295,7 +295,7 @@ void WaiterListManager::unregister(JSGlobalObject* globalObject)
             if (waiter->isAsync()) {
                 if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->target()->globalObject() == globalObject) {
                     dataLogLnIf(WaiterListsManagerInternal::verbose,
-                        "<WaiterListManager> <Thread:", Thread::current(),
+                        "<WaiterListManager> <Thread:", Thread::currentSingleton(),
                         "> unregister JSGlobalObject is cancelling waiter=", *waiter,
                         " in WaiterList for ptr ", RawPointer(entry.key));
 
@@ -317,7 +317,7 @@ void WaiterListManager::unregister(uint8_t* arrayPtr, size_t size)
             Locker listLocker { list->lock };
             list->removeIf(listLocker, [&](Waiter* waiter) {
                 dataLogLnIf(WaiterListsManagerInternal::verbose,
-                    "<WaiterListManager> <Thread:", Thread::current(),
+                    "<WaiterListManager> <Thread:", Thread::currentSingleton(),
                     "> unregister SAB is cancelling waiter=", *waiter,
                     " in WaiterList for ptr ", RawPointer(entry.key));
 

--- a/Source/JavaScriptCore/tools/HeapVerifier.cpp
+++ b/Source/JavaScriptCore/tools/HeapVerifier.cpp
@@ -147,7 +147,7 @@ void HeapVerifier::printVerificationHeader()
     RELEASE_ASSERT(m_heap->collectionScope());
     CollectionScope scope = currentCycle().scope;
     MonotonicTime gcCycleTimestamp = currentCycle().timestamp;
-    dataLog("Verifying heap in [p", getCurrentProcessID(), ", ", Thread::current(), "] vm ",
+    dataLog("Verifying heap in [p", getCurrentProcessID(), ", ", Thread::currentSingleton(), "] vm ",
         RawPointer(&m_heap->vm()), " on ", scope, " GC @ ", gcCycleTimestamp, "\n");
 }
 

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -3057,7 +3057,7 @@ JSC_DEFINE_HOST_FUNCTION_WITH_ATTRIBUTES(functionCallWithStackSize, SUPPRESS_ASA
 
     size_t desiredStackSize = arg1.asNumber();
 
-    const StackBounds& bounds = Thread::current().stack();
+    const StackBounds& bounds = Thread::currentSingleton().stack();
     uint8_t* currentStackPosition = std::bit_cast<uint8_t*>(currentStackPointer());
     uint8_t* end = std::bit_cast<uint8_t*>(bounds.end());
     uint8_t* desiredStart = end + desiredStackSize;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -5283,7 +5283,7 @@ bool OMGIRGenerator::canInline(FunctionSpaceIndex functionIndexSpace) const
     if (m_inlineRoot->m_inlinedBytes.value() >= Options::maximumWasmCallerSizeForInlining())
         return false;
 
-    if (m_inlineDepth > 1 && !StackCheck(Thread::current().stack(), StackBounds::DefaultReservedZone * 2).isSafeToRecurse())
+    if (m_inlineDepth > 1 && !StackCheck(Thread::currentSingleton().stack(), StackBounds::DefaultReservedZone * 2).isSafeToRecurse())
         return false;
 
     // FIXME: There's no fundamental reason we can't inline these including imports.

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -5635,7 +5635,7 @@ bool OMGIRGenerator::canInline(FunctionSpaceIndex functionIndexSpace) const
     if (m_inlineRoot->m_inlinedBytes.value() >= Options::maximumWasmCallerSizeForInlining())
         return false;
 
-    if (m_inlineDepth > 1 && !StackCheck(Thread::current().stack(), StackBounds::DefaultReservedZone * 2).isSafeToRecurse())
+    if (m_inlineDepth > 1 && !StackCheck(Thread::currentSingleton().stack(), StackBounds::DefaultReservedZone * 2).isSafeToRecurse())
         return false;
 
     // FIXME: There's no fundamental reason we can't inline these including imports.

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -375,7 +375,7 @@ WASM_SLOW_PATH_DECL(trace)
 
     WasmOpcodeID opcodeID = pc->opcodeID();
     dataLogF("<%p> %p / %p: executing bc#%zu, %s, pc = %p\n",
-        &Thread::current(),
+        &Thread::currentSingleton(),
         CALLEE(),
         callFrame,
         static_cast<intptr_t>(CALLEE()->bytecodeOffset(pc)),

--- a/Source/JavaScriptCore/yarr/YarrMatchingContextHolder.h
+++ b/Source/JavaScriptCore/yarr/YarrMatchingContextHolder.h
@@ -67,7 +67,7 @@ inline MatchingContextHolder::MatchingContextHolder(VM& vm, bool usesPatternCont
         m_stackLimit = vm.softStackLimit();
         vm.m_executingRegExp = regExp;
     } else {
-        StackBounds stack = Thread::current().stack();
+        StackBounds stack = Thread::currentSingleton().stack();
         m_stackLimit = stack.recursionLimit(Options::reservedZoneSize());
     }
 

--- a/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -3,7 +3,6 @@ wtf/JSONValues.cpp
 wtf/MemoryPressureHandler.cpp
 wtf/ParallelHelperPool.cpp
 wtf/PrintStream.h
-wtf/ThreadGroup.cpp
 wtf/WorkerPool.cpp
 wtf/text/AtomStringImpl.cpp
 wtf/text/WTFString.cpp

--- a/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,6 +1,5 @@
 wtf/AutomaticThread.cpp
 wtf/MemoryPressureHandler.cpp
-wtf/RecursiveLockAdapter.h
 wtf/Ref.h
 wtf/ThreadSafeWeakPtr.h
 wtf/text/AtomStringImpl.cpp

--- a/Source/WTF/benchmarks/ConditionSpeedTest.cpp
+++ b/Source/WTF/benchmarks/ConditionSpeedTest.cpp
@@ -107,7 +107,7 @@ void runTest(
                             emptyCondition, lock, locker,
                             [&] () {
                                 if (verbose)
-                                    dataLog(toString(Thread::current(), ": Checking consumption predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
+                                    dataLog(toString(Thread::currentSingleton(), ": Checking consumption predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
                                 return !shouldContinue || !queue.isEmpty();
                             });
                         if (!shouldContinue && queue.isEmpty())
@@ -137,7 +137,7 @@ void runTest(
                             fullCondition, lock, locker,
                             [&] () {
                                 if (verbose)
-                                    dataLog(toString(Thread::current(), ": Checking production predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
+                                    dataLog(toString(Thread::currentSingleton(), ": Checking production predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
                                 return queue.size() < maxQueueSize;
                             });
                         mustNotify = queue.isEmpty();

--- a/Source/WTF/wtf/CompilationThread.cpp
+++ b/Source/WTF/wtf/CompilationThread.cpp
@@ -33,7 +33,7 @@ namespace WTF {
 
 bool isCompilationThread()
 {
-    return Thread::current().isCompilationThread();
+    return Thread::currentSingleton().isCompilationThread();
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/DataMutex.h
+++ b/Source/WTF/wtf/DataMutex.h
@@ -122,11 +122,11 @@ private:
 
     void lock() WTF_ACQUIRES_LOCK(m_dataMutex.m_mutex)
     {
-        DATA_MUTEX_CHECK(m_dataMutex.m_currentMutexHolder != &Thread::current()); // Thread attempted recursive lock on non-recursive lock.
+        DATA_MUTEX_CHECK(m_dataMutex.m_currentMutexHolder != &Thread::currentSingleton()); // Thread attempted recursive lock on non-recursive lock.
         mutex().lock();
         m_isLocked = true;
 #if ENABLE_DATA_MUTEX_CHECKS
-        m_dataMutex.m_currentMutexHolder = &Thread::current();
+        m_dataMutex.m_currentMutexHolder = &Thread::currentSingleton();
 #endif
     }
 

--- a/Source/WTF/wtf/MainThread.cpp
+++ b/Source/WTF/wtf/MainThread.cpp
@@ -55,7 +55,7 @@ void initializeMainThread()
 #if !USE(WEB_THREAD)
 bool canCurrentThreadAccessThreadLocalData(Thread& thread)
 {
-    return &thread == &Thread::current();
+    return &thread == &Thread::currentSingleton();
 }
 #endif
 

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -47,7 +47,7 @@ template<typename... Types>
 static void dataLogForCurrentThread(const Types&... values)
 {
     StringPrintStream stream;
-    SUPPRESS_UNCOUNTED_ARG stream.print(Thread::current());
+    SUPPRESS_UNCOUNTED_ARG stream.print(Thread::currentSingleton());
     stream.print(values...);
     dataLog(stream.toString());
 }
@@ -423,7 +423,7 @@ void ensureHashtableSize(unsigned numThreads)
 }
 
 ThreadData::ThreadData()
-    : thread(Thread::current())
+    : thread(Thread::currentSingleton())
 {
     unsigned currentNumThreads;
     for (;;) {

--- a/Source/WTF/wtf/RecursiveLockAdapter.h
+++ b/Source/WTF/wtf/RecursiveLockAdapter.h
@@ -40,7 +40,7 @@ public:
     // which doesn't support analysis.
     void lock() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     {
-        Thread& me = Thread::current();
+        auto& me = Thread::currentSingleton();
         if (&me == m_owner) {
             m_recursionCount++;
             return;
@@ -69,7 +69,7 @@ public:
     // which doesn't support analysis.
     bool tryLock() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
     {
-        Thread& me = Thread::current();
+        auto& me = Thread::currentSingleton();
         if (&me == m_owner) {
             m_recursionCount++;
             return true;
@@ -90,7 +90,7 @@ public:
         return m_lock.isLocked();
     }
 
-    bool isOwner() const { return m_owner == &Thread::current(); }
+    bool isOwner() const { return m_owner == &Thread::currentSingleton(); }
     
 private:
     Thread* m_owner { nullptr }; // Use Thread* instead of RefPtr<Thread> since m_owner thread is always alive while m_onwer is set.

--- a/Source/WTF/wtf/SingleThreadIntegralWrapper.h
+++ b/Source/WTF/wtf/SingleThreadIntegralWrapper.h
@@ -51,7 +51,7 @@ public:
 
 private:
 #if ASSERT_ENABLED && !USE(WEB_THREAD)
-    void assertThread() const { ASSERT(m_thread.ptr() == &Thread::current()); }
+    void assertThread() const { ASSERT(m_thread.ptr() == &Thread::currentSingleton()); }
 #else
     constexpr void assertThread() const { }
 #endif
@@ -66,7 +66,7 @@ template <typename IntegralType>
 inline SingleThreadIntegralWrapper<IntegralType>::SingleThreadIntegralWrapper(IntegralType value)
     : m_value { value }
 #if ASSERT_ENABLED && !USE(WEB_THREAD)
-    , m_thread { Thread::current() }
+    , m_thread { Thread::currentSingleton() }
 #endif
 { }
 

--- a/Source/WTF/wtf/StackCheck.h
+++ b/Source/WTF/wtf/StackCheck.h
@@ -55,7 +55,7 @@ public:
             : m_checker(checker)
         {
 #if VERIFY_STACK_CHECK_RESERVED_ZONE_SIZE
-            RELEASE_ASSERT(checker.m_ownerThread == &Thread::current());
+            RELEASE_ASSERT(checker.m_ownerThread == &Thread::currentSingleton());
 
             // Make sure that the stack interval between checks never exceed the
             // reservedZone size. If the interval exceeds the reservedZone size,
@@ -101,10 +101,10 @@ public:
 #endif
     };
 
-    StackCheck(const StackBounds& bounds = Thread::current().stack(), size_t minReservedZone = StackBounds::DefaultReservedZone)
+    StackCheck(const StackBounds& bounds = Thread::currentSingleton().stack(), size_t minReservedZone = StackBounds::DefaultReservedZone)
         : m_stackLimit(bounds.recursionLimit(minReservedZone))
 #if VERIFY_STACK_CHECK_RESERVED_ZONE_SIZE
-        , m_ownerThread(&Thread::current())
+        , m_ownerThread(&Thread::currentSingleton())
         , m_lastStackCheckpoint(static_cast<uint8_t*>(currentStackPointer()))
         , m_reservedZone(minReservedZone)
 #endif

--- a/Source/WTF/wtf/StackStats.cpp
+++ b/Source/WTF/wtf/StackStats.cpp
@@ -58,7 +58,7 @@ int StackStats::s_maxLayoutReentryDepth = 0;
 
 StackStats::PerThreadStats::PerThreadStats()
 {
-    const StackBounds& stack = Thread::current().stack();
+    const StackBounds& stack = Thread::currentSingleton().stack();
     m_reentryDepth = 0;
     m_stackStart = (char*)stack.origin();
     m_currentCheckPoint = 0;
@@ -69,7 +69,7 @@ StackStats::PerThreadStats::PerThreadStats()
 StackStats::CheckPoint::CheckPoint()
 {
     Locker locker { StackStats::s_sharedMutex };
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     StackStats::PerThreadStats& t = thread.stackStats();
     const StackBounds& stack = thread.stack();
 
@@ -122,7 +122,7 @@ StackStats::CheckPoint::CheckPoint()
 StackStats::CheckPoint::~CheckPoint()
 {
     Locker locker { StackStats::s_sharedMutex };
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     StackStats::PerThreadStats& t = thread.stackStats();
 
     // Pop to previous checkpoint:
@@ -149,7 +149,7 @@ StackStats::CheckPoint::~CheckPoint()
 void StackStats::probe()
 {
     Locker locker { StackStats::s_sharedMutex };
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     StackStats::PerThreadStats& t = thread.stackStats();
     const StackBounds& stack = thread.stack();
 
@@ -204,7 +204,7 @@ StackStats::LayoutCheckPoint::LayoutCheckPoint()
     StackStats::probe();
 
     Locker locker { StackStats::s_sharedMutex };
-    Thread& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     StackStats::PerThreadStats& t = thread.stackStats();
     const StackBounds& stack = thread.stack();
 

--- a/Source/WTF/wtf/ThreadGroup.cpp
+++ b/Source/WTF/wtf/ThreadGroup.cpp
@@ -48,7 +48,7 @@ ThreadGroupAddResult ThreadGroup::add(Thread& thread)
 
 ThreadGroupAddResult ThreadGroup::addCurrentThread()
 {
-    auto result = add(Thread::current());
+    auto result = add(Thread::currentSingleton());
     ASSERT(result != ThreadGroupAddResult::NotAdded);
     return result;
 }

--- a/Source/WTF/wtf/ThreadSpecific.h
+++ b/Source/WTF/wtf/ThreadSpecific.h
@@ -159,7 +159,7 @@ inline ThreadSpecific<T, canBeGCThread>::ThreadSpecific()
 template<typename T, CanBeGCThread canBeGCThread>
 inline T* ThreadSpecific<T, canBeGCThread>::get()
 {
-    auto data = static_cast<Data*>(Thread::current().specificStorage().get(m_key));
+    auto data = static_cast<Data*>(Thread::currentSingleton().specificStorage().get(m_key));
     if (!data)
         return nullptr;
     return data->storagePointer();
@@ -168,7 +168,7 @@ inline T* ThreadSpecific<T, canBeGCThread>::get()
 template<typename T, CanBeGCThread canBeGCThread>
 inline void ThreadSpecific<T, canBeGCThread>::setInTLS(Data* data)
 {
-    return Thread::current().specificStorage().set(m_key, data);
+    return Thread::currentSingleton().specificStorage().set(m_key, data);
 }
 
 #else

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -149,7 +149,7 @@ uint32_t ThreadLike::currentSequence()
     if (uint32_t uid = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(dispatch_get_specific(&s_uid))))
         return uid;
 #endif
-    return Thread::current().uid();
+    return Thread::currentSingleton().uid();
 }
 
 struct Thread::NewThreadContext : public ThreadSafeRefCounted<NewThreadContext> {
@@ -264,7 +264,7 @@ void Thread::entryPoint(NewThreadContext* newThreadContext)
 #endif
     }
 
-    ASSERT(!Thread::current().stack().isEmpty());
+    ASSERT(!Thread::currentSingleton().stack().isEmpty());
     function();
 }
 
@@ -389,26 +389,26 @@ unsigned Thread::numberOfThreadGroups()
 
 bool Thread::exchangeIsCompilationThread(bool newValue)
 {
-    Ref thread = Thread::current();
-    bool oldValue = thread->m_isCompilationThread;
-    thread->m_isCompilationThread = newValue;
+    auto& thread = Thread::currentSingleton();
+    bool oldValue = thread.m_isCompilationThread;
+    thread.m_isCompilationThread = newValue;
     return oldValue;
 }
 
 void Thread::registerGCThread(GCThreadType gcThreadType)
 {
-    Thread::current().m_gcThreadType = static_cast<unsigned>(gcThreadType);
+    Thread::currentSingleton().m_gcThreadType = static_cast<unsigned>(gcThreadType);
 }
 
 bool Thread::mayBeGCThread()
 {
     // TODO: FIX THIS
-    return Thread::current().gcThreadType() != GCThreadType::None || Thread::current().m_isCompilationThread;
+    return Thread::currentSingleton().gcThreadType() != GCThreadType::None || Thread::currentSingleton().m_isCompilationThread;
 }
 
 void Thread::registerJSThread(Thread& thread)
 {
-    ASSERT(&thread == &Thread::current());
+    ASSERT(&thread == &Thread::currentSingleton());
     thread.m_isJSThread = true;
 }
 
@@ -422,7 +422,7 @@ void Thread::setCurrentThreadIsUserInteractive(int relativePriority)
     // We don't allow to make the main thread real time. This is used by secondary processes to match the
     // UI process, but in linux the UI process is not real time.
     if (!isMainThread())
-        RealTimeThreads::singleton().registerThread(current());
+        RealTimeThreads::singleton().registerThread(currentSingleton());
     UNUSED_PARAM(relativePriority);
 #else
     UNUSED_PARAM(relativePriority);

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -141,7 +141,7 @@ public:
     WTF_EXPORT_PRIVATE static Ref<Thread> create(ASCIILiteral threadName, Function<void()>&&, ThreadType = ThreadType::Unknown, QOS = QOS::UserInitiated, SchedulingPolicy = SchedulingPolicy::Other);
 
     // Returns Thread object.
-    static Thread& current();
+    static Thread& currentSingleton();
 
     // Set of all WTF::Thread created threads.
     WTF_EXPORT_PRIVATE static UncheckedKeyHashSet<Thread*>& allThreads() WTF_REQUIRES_LOCK(allThreadsLock());
@@ -154,7 +154,7 @@ public:
 #if OS(WINDOWS)
     // Returns ThreadIdentifier directly. It is useful if the user only cares about identity
     // of threads. At that time, users should know that holding this ThreadIdentifier does not ensure
-    // that the thread information is alive. While Thread::current() is not safe if it is called
+    // that the thread information is alive. While Thread::currentSingleton() is not safe if it is called
     // from the destructor of the other TLS data, currentID() always returns meaningful thread ID.
     WTF_EXPORT_PRIVATE static ThreadIdentifier currentID();
 
@@ -427,10 +427,10 @@ inline Thread* Thread::currentMayBeNull()
 }
 #endif
 
-inline Thread& Thread::current()
+inline Thread& Thread::currentSingleton()
 {
     // WRT WebCore:
-    //    Thread::current() is used on main thread before it could possibly be used
+    //    Thread::currentSingleton() is used on main thread before it could possibly be used
     //    on secondary ones, so there is no need for synchronization here.
     // WRT JavaScriptCore:
     //    Thread::initializeTLSKey() is initially called from initialize(), ensuring

--- a/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MainThreadCocoa.mm
@@ -117,7 +117,7 @@ bool isWebThread()
 void initializeApplicationUIThread()
 {
     ASSERT(pthread_main_np());
-    s_applicationUIThread = &Thread::current();
+    s_applicationUIThread = &Thread::currentSingleton();
 }
 
 void initializeWebThread()
@@ -126,14 +126,14 @@ void initializeWebThread()
     std::call_once(initializeKey, [] {
         ASSERT(!pthread_main_np());
         s_webThreadPthread = pthread_self();
-        s_webThread = &Thread::current();
+        s_webThread = &Thread::currentSingleton();
         RunLoop::initializeWeb();
     });
 }
 
 bool canCurrentThreadAccessThreadLocalData(Thread& thread)
 {
-    Thread& currentThread = Thread::current();
+    auto& currentThread = Thread::currentSingleton();
     if (&thread == &currentThread)
         return true;
 

--- a/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
+++ b/Source/WTF/wtf/generic/WorkQueueGeneric.cpp
@@ -45,7 +45,7 @@ void WorkQueueBase::platformInitialize(ASCIILiteral name, Type, QOS qos)
     m_runLoop = RunLoop::create(name, ThreadType::Unknown, qos).ptr();
     BinarySemaphore semaphore;
     m_runLoop->dispatch([&] {
-        m_threadID = Thread::current().uid();
+        m_threadID = Thread::currentSingleton().uid();
         semaphore.signal();
     });
     semaphore.wait();

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -450,7 +450,7 @@ bool Thread::signal(int signalNumber)
 
 auto Thread::suspend(const ThreadSuspendLocker&) -> Expected<void, PlatformSuspendError>
 {
-    RELEASE_ASSERT_WITH_MESSAGE(this != &Thread::current(), "We do not support suspending the current thread itself.");
+    RELEASE_ASSERT_WITH_MESSAGE(this != &Thread::currentSingleton(), "We do not support suspending the current thread itself.");
 #if OS(DARWIN)
     kern_return_t result = thread_suspend(m_platformThread);
     if (result != KERN_SUCCESS)
@@ -603,8 +603,8 @@ void Thread::destructTLS(void* data)
     _pthread_setspecific_direct(WTF_THREAD_DATA_KEY, thread);
     pthread_key_init_np(WTF_THREAD_DATA_KEY, &destructTLS);
 #endif
-    // Destructor of ClientData can rely on Thread::current() (e.g. AtomStringTable).
-    // We destroy it after re-setting Thread::current() so that we can ensure destruction
+    // Destructor of ClientData can rely on Thread::currentSingleton() (e.g. AtomStringTable).
+    // We destroy it after re-setting Thread::currentSingleton() so that we can ensure destruction
     // can still access to it.
     thread->m_clientData = nullptr;
 }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -66,7 +66,7 @@ using StringTableImpl = AtomStringTable::StringTableImpl;
 
 static ALWAYS_INLINE StringTableImpl& stringTable()
 {
-    return Thread::current().atomStringTable()->table();
+    return Thread::currentSingleton().atomStringTable()->table();
 }
 
 template<typename T, typename HashTranslator>

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -207,7 +207,7 @@ void Thread::detach()
 
 auto Thread::suspend(const ThreadSuspendLocker&) -> Expected<void, PlatformSuspendError>
 {
-    RELEASE_ASSERT_WITH_MESSAGE(this != &Thread::current(), "We do not support suspending the current thread itself.");
+    RELEASE_ASSERT_WITH_MESSAGE(this != &Thread::currentSingleton(), "We do not support suspending the current thread itself.");
     DWORD result = SuspendThread(m_handle);
     if (result != (DWORD)-1)
         return { };

--- a/Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h
+++ b/Source/WebCore/Modules/indexeddb/IDBActiveDOMObject.h
@@ -86,7 +86,7 @@ protected:
     }
 
 private:
-    Ref<Thread> m_originThread { Thread::current() };
+    Ref<Thread> m_originThread { Thread::currentSingleton() };
     Lock m_scriptExecutionContextLock;
 };
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -602,7 +602,7 @@ void removeItemsMatchingCurrentThread(HashMap<KeyType, ValueType>& map, Function
 {
     // FIXME: Revisit when introducing WebThread aware thread comparison.
     // https://bugs.webkit.org/show_bug.cgi?id=204345
-    map.removeIf([currentThread = &Thread::current(), cleanupFunction = WTFMove(cleanupFunction)](auto& entry) {
+    map.removeIf([currentThread = &Thread::currentSingleton(), cleanupFunction = WTFMove(cleanupFunction)](auto& entry) {
         if (&entry.value->originThread() == currentThread) {
             cleanupFunction(entry.value);
             return true;
@@ -616,7 +616,7 @@ void setMatchingItemsContextSuspended(ScriptExecutionContext& currentContext, Ha
 {
     // FIXME: Revisit when introducing WebThread aware thread comparison.
     // https://bugs.webkit.org/show_bug.cgi?id=204345
-    auto& currentThread = Thread::current();
+    auto& currentThread = Thread::currentSingleton();
     for (auto& iterator : map) {
         if (&iterator.value->originThread() != &currentThread)
             continue;
@@ -659,7 +659,7 @@ void IDBConnectionProxy::abortActivitiesForCurrentThread()
     {
         Locker locker { m_transactionOperationLock };
         for (auto& operation : m_activeOperations.values()) {
-            if (&operation->originThread() == &Thread::current())
+            if (&operation->originThread() == &Thread::currentSingleton())
                 activeOperationsForThread.add(operation);
         }
         for (auto& operation : activeOperationsForThread)

--- a/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
+++ b/Source/WebCore/Modules/indexeddb/client/TransactionOperation.h
@@ -139,7 +139,7 @@ private:
     std::optional<IDBResourceIdentifier> cursorIdentifier() const { return m_cursorIdentifier; }
     IndexedDB::IndexRecordType indexRecordType() const { return m_indexRecordType; }
 
-    Ref<Thread> m_originThread { Thread::current() };
+    Ref<Thread> m_originThread { Thread::currentSingleton() };
     RefPtr<IDBRequest> m_idbRequest;
     bool m_nextRequestCanGoToServer { true };
     bool m_didComplete { false };

--- a/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioDestinationNode.cpp
@@ -65,7 +65,7 @@ void AudioDestinationNode::renderQuantum(AudioBus* destinationBus, size_t number
     // This will take care of all AudioNodes because they all process within this scope.
     DenormalDisabler denormalDisabler;
     
-    context().setAudioThread(Thread::current());
+    context().setAudioThread(Thread::currentSingleton());
 
     // For performance reasons, we forbid heap allocations while doing rendering on the audio thread.
     // Heap allocations that cannot be avoided or have not been fixed yet can be allowed using
@@ -88,7 +88,7 @@ void AudioDestinationNode::renderQuantum(AudioBus* destinationBus, size_t number
 
     RefPtr<AudioWorkletGlobalScope> workletGlobalScope;
     if (RefPtr audioWorkletProxy = context().audioWorklet().proxy()) {
-        if (Ref workletThread = audioWorkletProxy->workletThread(); workletThread->thread() == &Thread::current())
+        if (Ref workletThread = audioWorkletProxy->workletThread(); workletThread->thread() == &Thread::currentSingleton())
             workletGlobalScope = workletThread->globalScope();
     }
     if (workletGlobalScope)

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -186,7 +186,7 @@ void AudioWorkletNode::setProcessor(RefPtr<AudioWorkletProcessor>&& processor)
     if (processor) {
         Locker locker { m_processLock };
         m_processor = WTFMove(processor);
-        m_workletThread = &Thread::current();
+        m_workletThread = &Thread::currentSingleton();
     } else
         fireProcessorErrorOnMainThread(ProcessorError::ConstructorError);
 }
@@ -205,7 +205,7 @@ void AudioWorkletNode::process(size_t framesToProcess)
         return;
     }
     Locker locker { AdoptLock, m_processLock };
-    if (!m_processor || &Thread::current() != m_workletThread.get()) {
+    if (!m_processor || &Thread::currentSingleton() != m_workletThread.get()) {
         // We're not ready yet or we are getting destroyed. In this case, we output silence.
         zeroOutput();
         return;

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -185,7 +185,7 @@ public:
     //
     
     void setAudioThread(Thread& thread) { m_audioThread = &thread; } // FIXME: check either not initialized or the same
-    bool isAudioThread() const { return m_audioThread == &Thread::current(); }
+    bool isAudioThread() const { return m_audioThread == &Thread::currentSingleton(); }
 
     // Returns true only after the audio thread has been started and then shutdown.
     bool isAudioThreadFinished() const { return m_isAudioThreadFinished; }

--- a/Source/WebCore/Modules/webdatabase/Database.cpp
+++ b/Source/WebCore/Modules/webdatabase/Database.cpp
@@ -277,7 +277,7 @@ void Database::close()
 
 void Database::performClose()
 {
-    ASSERT(databaseThread().getThread() == &Thread::current());
+    ASSERT(databaseThread().getThread() == &Thread::currentSingleton());
 
     {
         Locker locker { m_transactionInProgressLock };
@@ -772,7 +772,7 @@ SecurityOriginData Database::securityOrigin()
 {
     if (isMainThread())
         return m_contextThreadSecurityOrigin->data();
-    if (databaseThread().getThread() == &Thread::current())
+    if (databaseThread().getThread() == &Thread::currentSingleton())
         return m_databaseThreadSecurityOrigin->data();
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
+++ b/Source/WebCore/Modules/webdatabase/DatabaseDetails.h
@@ -94,7 +94,7 @@ private:
     Markable<WallTime> m_creationTime;
     Markable<WallTime> m_modificationTime;
 #if ASSERT_ENABLED
-    Ref<Thread> m_thread { Thread::current() };
+    Ref<Thread> m_thread { Thread::currentSingleton() };
 #endif
 };
 

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -257,7 +257,7 @@ DatabaseDetails DatabaseManager::detailsForNameAndOrigin(const String& name, Sec
         Locker locker { m_proposedDatabasesLock };
         for (auto* proposedDatabase : m_proposedDatabases) {
             if (proposedDatabase->details().name() == name && proposedDatabase->origin().equal(origin)) {
-                ASSERT(&proposedDatabase->details().thread() == &Thread::current() || isMainThread());
+                ASSERT(&proposedDatabase->details().thread() == &Thread::currentSingleton() || isMainThread());
                 return proposedDatabase->details();
             }
         }

--- a/Source/WebCore/Modules/webdatabase/DatabaseThread.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseThread.cpp
@@ -136,7 +136,7 @@ void DatabaseThread::recordDatabaseOpen(Database& database)
 {
     Locker locker { m_openDatabaseSetLock };
 
-    ASSERT(m_thread == &Thread::current());
+    ASSERT(m_thread == &Thread::currentSingleton());
     ASSERT(!m_openDatabaseSet.contains(&database));
     m_openDatabaseSet.add(&database);
 }
@@ -145,7 +145,7 @@ void DatabaseThread::recordDatabaseClosed(Database& database)
 {
     Locker locker { m_openDatabaseSetLock };
 
-    ASSERT(m_thread == &Thread::current());
+    ASSERT(m_thread == &Thread::currentSingleton());
     ASSERT(m_queue.killed() || m_openDatabaseSet.contains(&database));
     m_openDatabaseSet.remove(&database);
 }

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -201,7 +201,7 @@ void SQLTransaction::checkAndHandleClosedDatabase()
     m_errorCallbackWrapper.clear();
 
     // The next steps should be executed only if we're on the DB thread.
-    if (m_database->databaseThread().getThread() != &Thread::current())
+    if (m_database->databaseThread().getThread() != &Thread::currentSingleton())
         return;
 
     // The current SQLite transaction should be stopped, as well

--- a/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransactionBackend.cpp
@@ -353,7 +353,7 @@ SQLTransactionBackend::~SQLTransactionBackend()
 
 void SQLTransactionBackend::doCleanup()
 {
-    ASSERT(m_frontend.database().databaseThread().getThread() == &Thread::current());
+    ASSERT(m_frontend.database().databaseThread().getThread() == &Thread::currentSingleton());
 
     m_frontend.releaseOriginLockIfNeeded();
 
@@ -465,7 +465,7 @@ void SQLTransactionBackend::computeNextStateAndCleanupIfNeeded()
 
 void SQLTransactionBackend::notifyDatabaseThreadIsShuttingDown()
 {
-    ASSERT(m_frontend.database().databaseThread().getThread() == &Thread::current());
+    ASSERT(m_frontend.database().databaseThread().getThread() == &Thread::currentSingleton());
 
     // If the transaction is in progress, we should roll it back here, since this
     // is our last opportunity to do something related to this transaction on the

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -531,14 +531,14 @@ class IDBSerializationContext {
 public:
     IDBSerializationContext()
 #if ASSERT_ENABLED
-        : m_threadUID(Thread::current().uid())
+        : m_threadUID(Thread::currentSingleton().uid())
 #endif
     {
     }
 
     ~IDBSerializationContext()
     {
-        ASSERT(m_threadUID == Thread::current().uid());
+        ASSERT(m_threadUID == Thread::currentSingleton().uid());
         if (!m_vm)
             return;
 
@@ -549,7 +549,7 @@ public:
 
     JSC::JSGlobalObject& globalObject()
     {
-        ASSERT(m_threadUID == Thread::current().uid());
+        ASSERT(m_threadUID == Thread::currentSingleton().uid());
 
         initializeVM();
         return *m_globalObject.get();

--- a/Source/WebCore/bindings/js/JSCallbackData.h
+++ b/Source/WebCore/bindings/js/JSCallbackData.h
@@ -58,7 +58,7 @@ public:
     ~JSCallbackData()
     {
 #if !PLATFORM(IOS_FAMILY)
-        ASSERT(m_thread.ptr() == &Thread::current());
+        ASSERT(m_thread.ptr() == &Thread::currentSingleton());
 #endif
     }
 
@@ -93,7 +93,7 @@ private:
     JSC::Weak<JSC::JSObject> m_callback;
 
 #if ASSERT_ENABLED
-    Ref<Thread> m_thread { Thread::current() };
+    Ref<Thread> m_thread { Thread::currentSingleton() };
 #endif
 };
 

--- a/Source/WebCore/bindings/js/ScheduledAction.cpp
+++ b/Source/WebCore/bindings/js/ScheduledAction.cpp
@@ -151,7 +151,7 @@ void ScheduledAction::execute(Document& document)
 void ScheduledAction::execute(WorkerGlobalScope& workerGlobalScope)
 {
     // In a Worker, the execution should always happen on a worker thread.
-    ASSERT(workerGlobalScope.thread().thread() == &Thread::current());
+    ASSERT(workerGlobalScope.thread().thread() == &Thread::currentSingleton());
 
     auto* scriptController = workerGlobalScope.script();
 

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -158,7 +158,7 @@ private:
     uint64_t m_pendingActivityInstanceCount { 0 };
 #if ASSERT_ENABLED
     bool m_suspendIfNeededWasCalled { false };
-    Ref<Thread> m_creationThread { Thread::current() };
+    Ref<Thread> m_creationThread { Thread::currentSingleton() };
 #endif
 
     friend class ActiveDOMObjectEventDispatchTask;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -923,7 +923,7 @@ public:
 private:
     explicit ScriptExecutionContextDispatcher(ScriptExecutionContext& context)
         : m_identifier(context.identifier())
-        , m_threadId(context.isWorkerGlobalScope() ? Thread::current().uid() : 1)
+        , m_threadId(context.isWorkerGlobalScope() ? Thread::currentSingleton().uid() : 1)
     {
     }
 
@@ -936,7 +936,7 @@ private:
         }
         ScriptExecutionContext::postTaskTo(m_identifier, WTFMove(callback));
     }
-    bool isCurrent() const final { return m_threadId == Thread::current().uid(); }
+    bool isCurrent() const final { return m_threadId == Thread::currentSingleton().uid(); }
 
     ScriptExecutionContextIdentifier m_identifier;
     const uint32_t m_threadId { 1 };

--- a/Source/WebCore/platform/Supplementable.h
+++ b/Source/WebCore/platform/Supplementable.h
@@ -119,7 +119,7 @@ private:
     using SupplementMap = UncheckedKeyHashMap<ASCIILiteral, std::unique_ptr<Supplement<T>>>;
     SupplementMap m_supplements;
 #if ASSERT_ENABLED
-    Ref<Thread> m_thread { Thread::current() };
+    Ref<Thread> m_thread { Thread::currentSingleton() };
 #endif
 };
 

--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -69,14 +69,14 @@ void ThreadGlobalData::setWebCoreThreadData()
     ASSERT(&threadGlobalData() != sharedMainThreadStaticData);
 
     // Set WebThread's ThreadGlobalData object to be the same as the main UI thread.
-    Thread::current().m_clientData = adoptRef(sharedMainThreadStaticData);
+    Thread::currentSingleton().m_clientData = adoptRef(sharedMainThreadStaticData);
 
     ASSERT(&threadGlobalData() == sharedMainThreadStaticData);
 }
 
 ThreadGlobalData& threadGlobalDataSlow()
 {
-    auto& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     auto* clientData = thread.m_clientData.get();
     if (UNLIKELY(clientData))
         return *static_cast<ThreadGlobalData*>(clientData);
@@ -96,7 +96,7 @@ ThreadGlobalData& threadGlobalDataSlow()
 
 ThreadGlobalData& threadGlobalDataSlow()
 {
-    auto& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     auto* clientData = thread.m_clientData.get();
     if (UNLIKELY(clientData))
         return *static_cast<ThreadGlobalData*>(clientData);

--- a/Source/WebCore/platform/ThreadGlobalData.h
+++ b/Source/WebCore/platform/ThreadGlobalData.h
@@ -151,7 +151,7 @@ inline PURE_FUNCTION ThreadGlobalData& threadGlobalData()
             return *static_cast<ThreadGlobalData*>(clientData);
     }
 #else
-    auto& thread = Thread::current();
+    auto& thread = Thread::currentSingleton();
     auto* clientData = thread.m_clientData.get();
     if (LIKELY(clientData))
         return *static_cast<ThreadGlobalData*>(clientData);

--- a/Source/WebCore/platform/Timer.h
+++ b/Source/WebCore/platform/Timer.h
@@ -135,7 +135,7 @@ private:
     Seconds m_repeatInterval; // 0 if not repeating
 
     CompactRefPtrTuple<ThreadTimerHeapItem, uint8_t> m_heapItemWithBitfields;
-    Ref<Thread> m_thread { Thread::current() };
+    Ref<Thread> m_thread { Thread::currentSingleton() };
 
     friend class ThreadTimers;
     friend class TimerHeapLessThanFunction;
@@ -211,9 +211,9 @@ inline bool TimerBase::isActive() const
 {
     // FIXME: Write this in terms of USE(WEB_THREAD) instead of PLATFORM(IOS_FAMILY).
 #if !PLATFORM(IOS_FAMILY)
-    ASSERT(m_thread.ptr() == &Thread::current());
+    ASSERT(m_thread.ptr() == &Thread::currentSingleton());
 #else
-    ASSERT(WebThreadIsCurrent() || pthread_main_np() || m_thread.ptr() == &Thread::current());
+    ASSERT(WebThreadIsCurrent() || pthread_main_np() || m_thread.ptr() == &Thread::currentSingleton());
 #endif // PLATFORM(IOS_FAMILY)
     return static_cast<bool>(nextFireTime());
 }

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -111,7 +111,7 @@ FontCascadeFonts::FontCascadeFonts(RefPtr<FontSelector>&& fontSelector)
 {
 #if ASSERT_ENABLED
     if (!isMainThread())
-        m_thread = Thread::current();
+        m_thread = Thread::currentSingleton();
 #endif
 }
 
@@ -534,7 +534,7 @@ static RefPtr<GlyphPage> glyphPageFromFontRanges(unsigned pageNumber, const Font
 
 GlyphData FontCascadeFonts::glyphDataForCharacter(char32_t c, const FontCascadeDescription& description, FontVariant variant, ResolvedEmojiPolicy resolvedEmojiPolicy)
 {
-    ASSERT(m_thread ? m_thread->ptr() == &Thread::current() : isMainThread());
+    ASSERT(m_thread ? m_thread->ptr() == &Thread::currentSingleton() : isMainThread());
     ASSERT(variant != AutoVariant);
 
     if (variant != NormalVariant)

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -151,7 +151,7 @@ inline bool FontCascadeFonts::canTakeFixedPitchFastContentMeasuring(const FontCa
 
 inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& description)
 {
-    ASSERT(m_thread ? m_thread->ptr() == &Thread::current() : isMainThread());
+    ASSERT(m_thread ? m_thread->ptr() == &Thread::currentSingleton() : isMainThread());
     if (!m_cachedPrimaryFont) {
         auto& primaryRanges = realizeFallbackRangesAt(description, 0);
         m_cachedPrimaryFont = primaryRanges.glyphDataForCharacter(' ', ExternalResourceDownloadPolicy::Allow).font.get();

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -271,7 +271,7 @@ void AppendPipeline::handleErrorSyncMessage([[maybe_unused]] GstMessage* message
 GstPadProbeReturn AppendPipeline::appsrcEndOfAppendCheckerProbe(GstPadProbeInfo* padProbeInfo)
 {
     ASSERT(!isMainThread());
-    m_streamingThread = &Thread::current();
+    m_streamingThread = &Thread::currentSingleton();
 
     GstBuffer* buffer = GST_BUFFER(padProbeInfo->data);
     ASSERT(GST_IS_BUFFER(buffer));
@@ -665,7 +665,7 @@ void AppendPipeline::pushNewBuffer(GRefPtr<GstBuffer>&& buffer)
 void AppendPipeline::handleAppsinkNewSampleFromStreamingThread(GstElement*)
 {
     ASSERT(!isMainThread());
-    if (&Thread::current() != m_streamingThread) {
+    if (&Thread::currentSingleton() != m_streamingThread) {
         // m_streamingThreadId has been initialized in appsrcEndOfAppendCheckerProbe().
         // For a buffer to reach the appsink, a buffer must have passed through appsrcEndOfAppendCheckerProbe() first.
         // This error will only raise if someone modifies the pipeline to include more than one streaming thread or

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -327,7 +327,7 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger
     , m_settings(m_sourceObserver->source().settings())
     , m_capabilities(m_sourceObserver->source().capabilities())
 #if ASSERT_ENABLED
-    , m_creationThreadId(isMainThread() ? 0 : Thread::current().uid())
+    , m_creationThreadId(isMainThread() ? 0 : Thread::currentSingleton().uid())
 #endif
 {
     UNUSED_PARAM(trackLogger);
@@ -361,7 +361,7 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& logger, Uni
     , m_settings(WTFMove(dataHolder->settings))
     , m_capabilities(WTFMove(dataHolder->capabilities))
 #if ASSERT_ENABLED
-    , m_creationThreadId(isMainThread() ? 0 : Thread::current().uid())
+    , m_creationThreadId(isMainThread() ? 0 : Thread::currentSingleton().uid())
 #endif
 {
 }
@@ -383,7 +383,7 @@ MediaStreamTrackPrivate::~MediaStreamTrackPrivate()
 #if ASSERT_ENABLED
 bool MediaStreamTrackPrivate::isOnCreationThread()
 {
-    return m_creationThreadId ? m_creationThreadId == Thread::current().uid() : isMainThread();
+    return m_creationThreadId ? m_creationThreadId == Thread::currentSingleton().uid() : isMainThread();
 }
 #endif
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -177,7 +177,7 @@ bool SQLiteDatabase::open(const String& filename, OpenMode openMode, OptionSet<O
 
     overrideUnauthorizedFunctions();
 
-    m_openingThread = &Thread::current();
+    m_openingThread = &Thread::currentSingleton();
     if (sqlite3_extended_result_codes(m_db, 1) != SQLITE_OK)
         return false;
 
@@ -296,7 +296,7 @@ void SQLiteDatabase::close()
         ASSERT_WITH_MESSAGE(!m_statementCount, "All SQLiteTransaction objects should be destroyed before closing the database");
 
         // FIXME: This is being called on the main thread during JS GC. <rdar://problem/5739818>
-        // ASSERT(m_openingThread == &Thread::current());
+        // ASSERT(m_openingThread == &Thread::currentSingleton());
         sqlite3* db = m_db;
         {
             Locker locker { m_databaseClosingMutex };

--- a/Source/WebCore/platform/sql/SQLiteDatabase.h
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.h
@@ -132,7 +132,7 @@ public:
     sqlite3* sqlite3Handle() const
     {
 #if !PLATFORM(IOS_FAMILY)
-        ASSERT(m_sharable || m_openingThread == &Thread::current() || !m_db);
+        ASSERT(m_sharable || m_openingThread == &Thread::currentSingleton() || !m_db);
 #endif
         return m_db;
     }

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -142,7 +142,7 @@ WorkerGlobalScope::WorkerGlobalScope(WorkerThreadType type, const WorkerParamete
 
 WorkerGlobalScope::~WorkerGlobalScope()
 {
-    ASSERT(thread().thread() == &Thread::current());
+    ASSERT(thread().thread() == &Thread::currentSingleton());
 
     {
         Locker locker { allWorkerGlobalScopeIdentifiersLock };

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -113,7 +113,7 @@ WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject)
     , m_workerObject(&workerObject)
 {
     ASSERT((is<Document>(*m_scriptExecutionContext) && isMainThread())
-        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread().thread() == &Thread::current()));
+        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread().thread() == &Thread::currentSingleton()));
 
     // Nobody outside this class ref counts this object. The original ref
     // is balanced by the deref in workerGlobalScopeDestroyedInternal.
@@ -124,7 +124,7 @@ WorkerMessagingProxy::~WorkerMessagingProxy()
     ASSERT(!m_workerObject);
     ASSERT(!m_scriptExecutionContext
         || (is<Document>(*m_scriptExecutionContext) && isMainThread())
-        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread().thread() == &Thread::current()));
+        || (is<WorkerGlobalScope>(*m_scriptExecutionContext) && downcast<WorkerGlobalScope>(*m_scriptExecutionContext).thread().thread() == &Thread::currentSingleton()));
 
     if (m_workerThread)
         m_workerThread->clearProxies();

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -128,7 +128,7 @@ EventLoopTaskGroup& WorkerOrWorkletGlobalScope::eventLoop()
 bool WorkerOrWorkletGlobalScope::isContextThread() const
 {
     auto* thread = workerOrWorkletThread();
-    return thread && thread->thread() ? thread->thread() == &Thread::current() : isMainThread();
+    return thread && thread->thread() ? thread->thread() == &Thread::currentSingleton() : isMainThread();
 }
 
 void WorkerOrWorkletGlobalScope::postTask(Task&& task)

--- a/Source/WebCore/workers/WorkerOrWorkletThread.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.cpp
@@ -83,7 +83,7 @@ void WorkerOrWorkletThread::dispatch(Function<void()>&& func)
 
 bool WorkerOrWorkletThread::isCurrent() const
 {
-    return thread() ? thread()->uid() == Thread::current().uid() : false;
+    return thread() ? thread()->uid() == Thread::currentSingleton().uid() : false;
 }
 
 void WorkerOrWorkletThread::startRunningDebuggerTasks()

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -181,7 +181,7 @@ bool WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalScope* context, cons
 MessageQueueWaitResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalScope* context, const ModePredicate& predicate)
 {
     ASSERT(context);
-    ASSERT(context->workerOrWorkletThread()->thread() == &Thread::current());
+    ASSERT(context->workerOrWorkletThread()->thread() == &Thread::currentSingleton());
 
     AutodrainedPool pool;
 
@@ -258,7 +258,7 @@ MessageQueueWaitResult WorkerDedicatedRunLoop::runInMode(WorkerOrWorkletGlobalSc
 void WorkerDedicatedRunLoop::runCleanupTasks(WorkerOrWorkletGlobalScope* context)
 {
     ASSERT(context);
-    ASSERT(context->workerOrWorkletThread()->thread() == &Thread::current());
+    ASSERT(context->workerOrWorkletThread()->thread() == &Thread::currentSingleton());
     ASSERT(m_messageQueue.killed());
 
     while (true) {

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -148,7 +148,7 @@ Ref<Thread> WorkerThread::createThread()
             protectedThis->workerOrWorkletThread();
         });
         ASSERT(isMainThread());
-        return Thread::current();
+        return Thread::currentSingleton();
     }
 
     return Thread::create(threadName(), [this] {
@@ -221,7 +221,7 @@ SocketProvider* WorkerThread::socketProvider()
 
 WorkerGlobalScope* WorkerThread::globalScope()
 {
-    ASSERT(!thread() || thread() == &Thread::current());
+    ASSERT(!thread() || thread() == &Thread::currentSingleton());
     return downcast<WorkerGlobalScope>(WorkerOrWorkletThread::globalScope());
 }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -99,7 +99,7 @@ ServiceWorkerContainer::ServiceWorkerContainer(ScriptExecutionContext* context, 
 
 ServiceWorkerContainer::~ServiceWorkerContainer()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 }
 
 void ServiceWorkerContainer::refEventTarget()
@@ -293,7 +293,7 @@ void ServiceWorkerContainer::updateRegistration(const URL& scopeURL, const URL& 
 
 void ServiceWorkerContainer::scheduleJob(std::unique_ptr<ServiceWorkerJob>&& job)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(m_swConnection);
     ASSERT(!isStopped());
 
@@ -393,7 +393,7 @@ void ServiceWorkerContainer::startMessages()
 
 void ServiceWorkerContainer::jobFailedWithException(ServiceWorkerJob& job, const Exception& exception)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT_WITH_MESSAGE(job.hasPromise() || job.data().type == ServiceWorkerJobType::Update, "Only soft updates have no promise");
 
     auto guard = makeScopeExit([this, &job] {
@@ -416,7 +416,7 @@ void ServiceWorkerContainer::jobFailedWithException(ServiceWorkerJob& job, const
 
 void ServiceWorkerContainer::queueTaskToFireUpdateFoundEvent(ServiceWorkerRegistrationIdentifier identifier)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 
     if (auto* registration = m_registrations.get(identifier))
         registration->queueTaskToFireUpdateFoundEvent();
@@ -424,7 +424,7 @@ void ServiceWorkerContainer::queueTaskToFireUpdateFoundEvent(ServiceWorkerRegist
 
 void ServiceWorkerContainer::jobResolvedWithRegistration(ServiceWorkerJob& job, ServiceWorkerRegistrationData&& data, ShouldNotifyWhenResolved shouldNotifyWhenResolved)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT_WITH_MESSAGE(job.hasPromise() || job.data().type == ServiceWorkerJobType::Update, "Only soft updates have no promise");
 
     if (job.data().type == ServiceWorkerJobType::Register) {
@@ -514,7 +514,7 @@ void ServiceWorkerContainer::notifyRegistrationIsSettled(const ServiceWorkerRegi
 
 void ServiceWorkerContainer::jobResolvedWithUnregistrationResult(ServiceWorkerJob& job, bool unregistrationResult)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(job.hasPromise());
 
     auto guard = makeScopeExit([this, &job] {
@@ -536,7 +536,7 @@ void ServiceWorkerContainer::jobResolvedWithUnregistrationResult(ServiceWorkerJo
 
 void ServiceWorkerContainer::startScriptFetchForJob(ServiceWorkerJob& job, FetchOptions::Cache cachePolicy)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 
     CONTAINER_RELEASE_LOG("startScriptFetchForJob: Starting script fetch for job %" PRIu64, job.identifier().toUInt64());
 
@@ -553,7 +553,7 @@ void ServiceWorkerContainer::startScriptFetchForJob(ServiceWorkerJob& job, Fetch
 
 void ServiceWorkerContainer::jobFinishedLoadingScript(ServiceWorkerJob& job, WorkerFetchResult&& fetchResult)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 
     CONTAINER_RELEASE_LOG("jobFinishedLoadingScript: Successfuly finished fetching script for job %" PRIu64, job.identifier().toUInt64());
 
@@ -562,7 +562,7 @@ void ServiceWorkerContainer::jobFinishedLoadingScript(ServiceWorkerJob& job, Wor
 
 void ServiceWorkerContainer::jobFailedLoadingScript(ServiceWorkerJob& job, const ResourceError& error, Exception&& exception)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT_WITH_MESSAGE(job.hasPromise() || job.data().type == ServiceWorkerJobType::Update, "Only soft updates have no promise");
 
     CONTAINER_RELEASE_LOG_ERROR("jobFinishedLoadingScript: Failed to fetch script for job %" PRIu64 ", error: %s", job.identifier().toUInt64(), error.localizedDescription().utf8().data());
@@ -587,7 +587,7 @@ void ServiceWorkerContainer::notifyFailedFetchingScript(ServiceWorkerJob& job, c
 
 void ServiceWorkerContainer::destroyJob(ServiceWorkerJob& job)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(m_jobMap.contains(job.identifier()));
     m_jobMap.remove(job.identifier());
 }
@@ -612,7 +612,7 @@ Ref<SWClientConnection> ServiceWorkerContainer::ensureProtectedSWClientConnectio
 
 void ServiceWorkerContainer::addRegistration(ServiceWorkerRegistration& registration)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 
     ensureSWClientConnection().addServiceWorkerRegistrationInServer(registration.identifier());
     m_registrations.add(registration.identifier(), registration);
@@ -620,7 +620,7 @@ void ServiceWorkerContainer::addRegistration(ServiceWorkerRegistration& registra
 
 void ServiceWorkerContainer::removeRegistration(ServiceWorkerRegistration& registration)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 
     m_swConnection->removeServiceWorkerRegistrationInServer(registration.identifier());
     m_registrations.remove(registration.identifier());
@@ -695,7 +695,7 @@ void ServiceWorkerContainer::getNotifications(const URL& serviceWorkerRegistrati
 
 void ServiceWorkerContainer::queueTaskToDispatchControllerChangeEvent()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 
     queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().controllerchangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
@@ -718,7 +718,7 @@ void ServiceWorkerContainer::stop()
 
 ServiceWorkerOrClientIdentifier ServiceWorkerContainer::contextIdentifier()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(scriptExecutionContext());
     if (RefPtr serviceWorkerGlobal = dynamicDowncast<ServiceWorkerGlobalScope>(*scriptExecutionContext()))
         return serviceWorkerGlobal->thread().identifier();

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -168,7 +168,7 @@ private:
     HashMap<ServiceWorkerRegistrationIdentifier, WeakRef<ServiceWorkerRegistration, WeakPtrImplWithEventTargetData>> m_registrations;
 
 #if ASSERT_ENABLED
-    Ref<Thread> m_creationThread { Thread::current() };
+    Ref<Thread> m_creationThread { Thread::currentSingleton() };
 #endif
 
     uint64_t m_lastOngoingSettledRegistrationIdentifier { 0 };

--- a/Source/WebCore/workers/service/ServiceWorkerJob.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.cpp
@@ -54,7 +54,7 @@ ServiceWorkerJob::ServiceWorkerJob(ServiceWorkerJobClient& client, RefPtr<Deferr
 
 ServiceWorkerJob::~ServiceWorkerJob()
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
 }
 
 RefPtr<DeferredPromise> ServiceWorkerJob::takePromise()
@@ -64,7 +64,7 @@ RefPtr<DeferredPromise> ServiceWorkerJob::takePromise()
 
 void ServiceWorkerJob::failedWithException(const Exception& exception)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(!m_completed);
 
     m_completed = true;
@@ -73,7 +73,7 @@ void ServiceWorkerJob::failedWithException(const Exception& exception)
 
 void ServiceWorkerJob::resolvedWithRegistration(ServiceWorkerRegistrationData&& data, ShouldNotifyWhenResolved shouldNotifyWhenResolved)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(!m_completed);
 
     m_completed = true;
@@ -82,7 +82,7 @@ void ServiceWorkerJob::resolvedWithRegistration(ServiceWorkerRegistrationData&& 
 
 void ServiceWorkerJob::resolvedWithUnregistrationResult(bool unregistrationResult)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(!m_completed);
 
     m_completed = true;
@@ -91,7 +91,7 @@ void ServiceWorkerJob::resolvedWithUnregistrationResult(bool unregistrationResul
 
 void ServiceWorkerJob::startScriptFetch(FetchOptions::Cache cachePolicy)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(!m_completed);
 
     m_client.startScriptFetchForJob(*this, cachePolicy);
@@ -117,7 +117,7 @@ static FetchOptions scriptFetchOptions(FetchOptions::Cache cachePolicy, FetchOpt
 
 void ServiceWorkerJob::fetchScriptWithContext(ScriptExecutionContext& context, FetchOptions::Cache cachePolicy)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(!m_completed);
 
     auto source = m_jobData.workerType == WorkerType::Module ? WorkerScriptLoader::Source::ModuleScript : WorkerScriptLoader::Source::ClassicWorkerScript;
@@ -156,7 +156,7 @@ ResourceError ServiceWorkerJob::validateServiceWorkerResponse(const ServiceWorke
 
 void ServiceWorkerJob::didReceiveResponse(ScriptExecutionContextIdentifier, std::optional<ResourceLoaderIdentifier>, const ResourceResponse& response)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(!m_completed);
     ASSERT(m_scriptLoader);
 
@@ -173,7 +173,7 @@ void ServiceWorkerJob::didReceiveResponse(ScriptExecutionContextIdentifier, std:
 
 void ServiceWorkerJob::notifyFinished(std::optional<ScriptExecutionContextIdentifier>)
 {
-    ASSERT(m_creationThread.ptr() == &Thread::current());
+    ASSERT(m_creationThread.ptr() == &Thread::currentSingleton());
     ASSERT(m_scriptLoader);
 
     auto scriptLoader = std::exchange(m_scriptLoader, { });

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -89,7 +89,7 @@ private:
     RefPtr<WorkerScriptLoader> m_scriptLoader;
 
 #if ASSERT_ENABLED
-    Ref<Thread> m_creationThread { Thread::current() };
+    Ref<Thread> m_creationThread { Thread::currentSingleton() };
 #endif
 };
 

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -398,7 +398,7 @@ static int matchFunc(const char*)
 {
     // Only match loads initiated due to uses of libxml2 from within XMLDocumentParser to avoid
     // interfering with client applications that also use libxml2.  http://bugs.webkit.org/show_bug.cgi?id=17353
-    return XMLDocumentParserScope::currentCachedResourceLoader() && libxmlLoaderThread == &Thread::current();
+    return XMLDocumentParserScope::currentCachedResourceLoader() && libxmlLoaderThread == &Thread::currentSingleton();
 }
 
 class OffsetBuffer {
@@ -503,7 +503,7 @@ static bool shouldAllowExternalLoad(const URL& url)
 static void* openFunc(const char* uri)
 {
     ASSERT(XMLDocumentParserScope::currentCachedResourceLoader());
-    ASSERT(libxmlLoaderThread == &Thread::current());
+    ASSERT(libxmlLoaderThread == &Thread::currentSingleton());
 
     RefPtr cachedResourceLoader = XMLDocumentParserScope::currentCachedResourceLoader().get();
     if (!cachedResourceLoader)
@@ -601,7 +601,7 @@ void initializeXMLParser()
         xmlRegisterOutputCallbacks(matchFunc, openFunc, writeFunc, closeFunc);
         defaultEntityLoader = xmlGetExternalEntityLoader();
         RELEASE_ASSERT_WITH_MESSAGE(defaultEntityLoader != WebCore::externalEntityLoader, "XMLDocumentParserScope was created too early");
-        libxmlLoaderThread = &Thread::current();
+        libxmlLoaderThread = &Thread::currentSingleton();
     });
 }
 

--- a/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
+++ b/Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp
@@ -99,7 +99,7 @@ void StreamConnectionWorkQueue::stopAndWaitForCompletion(NOESCAPE WTF::Function<
     }
     if (!processingThread)
         return;
-    ASSERT(Thread::current().uid() != processingThread->uid());
+    ASSERT(Thread::currentSingleton().uid() != processingThread->uid());
     wakeUp();
     processingThread->waitForCompletion();
     {
@@ -163,7 +163,7 @@ void StreamConnectionWorkQueue::processStreams()
 bool StreamConnectionWorkQueue::isCurrent() const
 {
     Locker locker { m_lock };
-    return m_processingThread ? m_processingThread->uid() == Thread::current().uid() : false;
+    return m_processingThread ? m_processingThread->uid() == Thread::currentSingleton().uid() : false;
 }
 
 }

--- a/Tools/DumpRenderTree/JavaScriptThreading.cpp
+++ b/Tools/DumpRenderTree/JavaScriptThreading.cpp
@@ -104,7 +104,7 @@ void runJavaScriptThread()
             continue;
 
         Locker locker { javaScriptThreadsLock };
-        Thread& thread = Thread::current();
+        auto& thread = Thread::currentSingleton();
         thread.detach();
         javaScriptThreads().remove(&thread);
         javaScriptThreads().add(Thread::create("JavaScript Thread"_s, &runJavaScriptThread));

--- a/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/IPC/ConnectionTests.cpp
@@ -469,7 +469,7 @@ public:
         // FIXME: Cannot wait for RunLoop to really exit.
         for (auto& runLoop : std::exchange(m_runLoops, { })) {
             dispatchSync(runLoop, [&] {
-                threadsToWait.append(Thread::current());
+                threadsToWait.append(Thread::currentSingleton());
                 RunLoop::current().stop();
             });
         }

--- a/Tools/TestWebKitAPI/Tests/WTF/Condition.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Condition.cpp
@@ -109,7 +109,7 @@ void runTest(
                             emptyCondition,
                             [&] () {
                                 if (verbose)
-                                    dataLog(toString(Thread::current(), ": Checking consumption predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
+                                    dataLog(toString(Thread::currentSingleton(), ": Checking consumption predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
                                 return !shouldContinue || !queue.isEmpty();
                             },
                             timeout);
@@ -142,7 +142,7 @@ void runTest(
                             fullCondition,
                             [&] () {
                                 if (verbose)
-                                    dataLog(toString(Thread::current(), ": Checking production predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
+                                    dataLog(toString(Thread::currentSingleton(), ": Checking production predicate with shouldContinue = ", shouldContinue, ", queue.size() == ", queue.size(), "\n"));
                                 return queue.size() < maxQueueSize;
                             },
                             timeout);

--- a/Tools/TestWebKitAPI/Tests/WTF/ParkingLot.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ParkingLot.cpp
@@ -52,8 +52,8 @@ struct SingleLatchTest {
                         down();
 
                         std::scoped_lock<std::mutex> locker(lock);
-                        awake.add(Thread::current());
-                        lastAwoken = &Thread::current();
+                        awake.add(Thread::currentSingleton());
+                        lastAwoken = &Thread::currentSingleton();
                         condition.notify_one();
                     }));
         }

--- a/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RunLoop.cpp
@@ -268,7 +268,7 @@ TEST(WTF_RunLoop, Create)
     {
         BinarySemaphore semaphore;
         runLoop->dispatch([&] {
-            runLoopThread = &Thread::current();
+            runLoopThread = &Thread::currentSingleton();
             semaphore.signal();
         });
         semaphore.wait();

--- a/Tools/TestWebKitAPI/Tests/WTF/Threading.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Threading.cpp
@@ -41,14 +41,14 @@ TEST(WTF, ThreadingThreadIdentity)
     // Imitate 'foreign' threads that are not created by WTF.
     pthread_t pthread;
     pthread_create(&pthread, nullptr, [] (void*) -> void* {
-        thread1 = &Thread::current();
+        thread1 = &Thread::currentSingleton();
         thread1->ref();
         return nullptr;
     }, nullptr);
     pthread_join(pthread, nullptr);
 
     pthread_create(&pthread, nullptr, [] (void*) -> void* {
-        thread2 = &Thread::current();
+        thread2 = &Thread::currentSingleton();
         thread2->ref();
         return nullptr;
     }, nullptr);
@@ -57,8 +57,8 @@ TEST(WTF, ThreadingThreadIdentity)
     // Now create another thread using WTF. On OSX, it may have the same pthread handle
     // but should get a different RefPtr<Thread> if the previous RefPtr<Thread> is held.
     Thread::create("DumpRenderTree: test"_s, [] {
-        EXPECT_TRUE(thread1 != &Thread::current());
-        EXPECT_TRUE(thread2 != &Thread::current());
+        EXPECT_TRUE(thread1 != &Thread::currentSingleton());
+        EXPECT_TRUE(thread2 != &Thread::currentSingleton());
         EXPECT_TRUE(thread1 != thread2);
         thread1->deref();
         thread2->deref();

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/TestGraphicsContextGLCocoa.mm
@@ -607,12 +607,12 @@ TEST_P(AnyContextAttributeTest, FinishIsSignaled)
     std::atomic<uint32_t> signalThreadUID = 0;
     context->prepareForDisplayWithFinishedSignal([&signalled, &signalThreadUID] {
         signalled = true;
-        signalThreadUID = Thread::current().uid();
+        signalThreadUID = Thread::currentSingleton().uid();
     });
     while (!signalled)
         sleep(.1_s);
     EXPECT_TRUE(signalled);
-    EXPECT_NE(Thread::current().uid(), signalThreadUID);
+    EXPECT_NE(Thread::currentSingleton().uid(), signalThreadUID);
 }
 
 INSTANTIATE_TEST_SUITE_P(GraphicsContextGLCocoaTest,

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
@@ -191,7 +191,7 @@ AXThread::AXThread()
 
 bool AXThread::isCurrentThread()
 {
-    return AXThread::singleton().m_thread == &Thread::current();
+    return AXThread::singleton().m_thread == &Thread::currentSingleton();
 }
 
 void AXThread::dispatch(Function<void()>&& function)


### PR DESCRIPTION
#### 4903b29014c50616d45cb769528d8cfe6938d3bd
<pre>
Address Safer CPP failures in JSContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=288409">https://bugs.webkit.org/show_bug.cgi?id=288409</a>

Reviewed by Darin Adler.

* Source/JavaScriptCore/API/JSContext.mm:
(+[JSContext currentContext]):
(+[JSContext currentThis]):
(+[JSContext currentCallee]):
(+[JSContext currentArguments]):
(-[JSContext name]):
(-[JSContext beginCallbackWithData:calleeValue:thisValue:argumentCount:arguments:]):
(-[JSContext endCallbackWithData:]):
* Source/JavaScriptCore/API/JSContextRef.cpp:
(JSContextGroupSetExecutionTimeLimit):
(JSContextGroupClearExecutionTimeLimit):
(JSGlobalContextSetDebuggerRunLoop):
* Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::protectedInspectorDebuggable):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:

Canonical link: <a href="https://commits.webkit.org/291186@main">https://commits.webkit.org/291186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3b125ca14b19077c517dd0a0bcef44982acc35f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92259 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1353 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94309 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20268 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95260 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/84998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/12103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/90949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19588 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19571 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113575 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->