### PR TITLE
REGRESSION (iOS 18): Loading is blocked when trying to load localhost content from HTTPS website

### DIFF
--- a/LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent-expected.txt
@@ -1,3 +1,5 @@
 CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-localhost-image.html requested insecure content from http://localhost:8080/security/resources/compass.jpg. This content was not upgraded to HTTPS and must be served from the local host.
 
+CONSOLE MESSAGE: The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-localhost-image.html requested insecure content from http://127.0.0.1:8080/security/resources/compass.jpg. This content was not upgraded to HTTPS and must be served from the local host.
+
 This test opens a window that loads an insecure image from localhost. We should trigger a mixed content callback because the main frame in the window is HTTPS but is displaying insecure content.

--- a/LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-localhost-image.html
+++ b/LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-localhost-image.html
@@ -1,4 +1,5 @@
 <img src="http://localhost:8080/security/resources/compass.jpg">
+<img src="http://127.0.0.1:8080/security/resources/compass.jpg">
 <script>
 window.onload = function() {
     if (window.opener)

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -95,7 +95,7 @@ static void logConsoleWarning(const LocalFrame& frame, bool allowed, ASCIILitera
 
 static void logConsoleWarningForUpgrade(const LocalFrame& frame, bool blocked, const URL& target, bool isUpgradingIPAddressAndLocalhostEnabled)
 {
-    auto isUpgradingLocalhostDisabled = !isUpgradingIPAddressAndLocalhostEnabled && SecurityOrigin::isLocalhostAddress(target.host());
+    auto isUpgradingLocalhostDisabled = !isUpgradingIPAddressAndLocalhostEnabled && shouldTreatAsPotentiallyTrustworthy(target);
     ASCIILiteral errorString = [&] {
     if (blocked)
         return "blocked and must"_s;
@@ -193,20 +193,20 @@ bool MixedContentChecker::shouldUpgradeInsecureContent(LocalFrame& frame, IsUpgr
     auto shouldUpgradeIPAddressAndLocalhostForTesting = document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled();
 
     // 4.1 The request's URL is not upgraded in the following cases.
-    if (!canModifyRequest(url, destination, initiator, shouldUpgradeIPAddressAndLocalhostForTesting))
+    if (!canModifyRequest(url, destination, initiator))
         return false;
 
     logConsoleWarningForUpgrade(frame, /* blocked */ false, url, shouldUpgradeIPAddressAndLocalhostForTesting);
     return true;
 }
 
-bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator, bool shouldUpgradeIPAddressAndLocalhostForTesting)
+bool MixedContentChecker::canModifyRequest(const URL& url, FetchOptions::Destination destination, Initiator initiator)
 {
     // 4.1.1 request’s URL is a potentially trustworthy URL.
     if (url.protocolIs("https"_s))
         return false;
     // 4.1.2 request’s URL’s host is an IP address.
-    if (!shouldUpgradeIPAddressAndLocalhostForTesting && URL::hostIsIPAddress(url.host()))
+    if (URL::hostIsIPAddress(url.host()) && !shouldTreatAsPotentiallyTrustworthy(url))
         return false;
     // 4.1.4 request’s destination is not "image", "audio", or "video".
     if (!destinationIsImageAudioOrVideo(destination))
@@ -225,7 +225,7 @@ static bool shouldBlockInsecureContent(LocalFrame& frame, const URL& url, MixedC
         return false;
     if (!foundMixedContentInFrameTree(frame, url))
         return false;
-    if ((LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || SecurityOrigin::isLocalhostAddress(url.host())) && isUpgradable == MixedContentChecker::IsUpgradable::Yes)
+    if ((LegacySchemeRegistry::schemeIsHandledBySchemeHandler(url.protocol()) || shouldTreatAsPotentiallyTrustworthy(url)) && isUpgradable == MixedContentChecker::IsUpgradable::Yes)
         return false;
     logConsoleWarningForUpgrade(frame, /* blocked */ true, url, document->settings().iPAddressAndLocalhostMixedContentUpgradeTestingEnabled());
     return true;

--- a/Source/WebCore/loader/MixedContentChecker.h
+++ b/Source/WebCore/loader/MixedContentChecker.h
@@ -56,7 +56,7 @@ bool shouldBlockRequestForDisplayableContent(LocalFrame&, const URL&, ContentTyp
 bool shouldBlockRequestForRunnableContent(LocalFrame&, SecurityOrigin&, const URL&, ShouldLogWarning = ShouldLogWarning::Yes);
 void checkFormForMixedContent(LocalFrame&, const URL&);
 
-WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator, bool shouldUpgradeIPAddressAndLocalhostForTesting);
+WEBCORE_EXPORT bool canModifyRequest(const URL&, FetchOptions::Destination, Initiator);
 
 } // namespace MixedContentChecker
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp
@@ -37,68 +37,64 @@ TEST(MixedContentChecker, CanModifyRequest)
     URL url { "http://example.com/cat.jpg"_s };
     FetchOptions::Destination destination = FetchOptions::Destination::Image;
     Initiator initiator = Initiator::EmptyString;
-    bool shouldUpgradeIPAddressAndLocalhostForTesting = false;
 
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         url,
         destination,
-        initiator,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        initiator
     ));
 
     // 4.1.1 request’s URL is a potentially trustworthy URL.
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "https://example.com/cat.jpg"_s },
         destination,
-        initiator,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        initiator
     ));
 
     // 4.1.2 request’s URL’s host is an IP address.
-    URL ipAddressURL { "http://192.0.1.36"_s };
-
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
-        ipAddressURL,
+        URL { "http://192.0.1.36"_s },
         destination,
-        initiator,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        initiator
+    ));
+
+    // Exception for 4.1.2 potentially truthworthy address
+    ASSERT_TRUE(MixedContentChecker::canModifyRequest(
+        URL { "http://127.0.0.1"_s },
+        destination,
+        initiator
     ));
 
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
-        ipAddressURL,
+        URL { "http://localhost"_s },
         destination,
-        initiator,
-        true
+        initiator
     ));
 
     // 4.1.4 request’s destination is not "image", "audio", or "video".
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         url,
         FetchOptions::Destination::Audio,
-        initiator,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        initiator
     ));
 
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         url,
         FetchOptions::Destination::Video,
-        initiator,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        initiator
     ));
 
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         url,
         FetchOptions::Destination::Font,
-        initiator,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        initiator
     ));
 
     // 4.1.5 request’s destination is "image" and request’s initiator is "imageset".
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         url,
         destination,
-        Initiator::Imageset,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        Initiator::Imageset
     ));
 
     // But if the scheme is handled by the handler, it is modifiable even if the initiator is "imageset".
@@ -109,8 +105,7 @@ TEST(MixedContentChecker, CanModifyRequest)
     ASSERT_TRUE(MixedContentChecker::canModifyRequest(
         URL { "custom://example.com/cat.jpg"_s },
         destination,
-        Initiator::Imageset,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        Initiator::Imageset
     ));
 
     // This exception won't apply if the cheme is not registered.
@@ -119,8 +114,7 @@ TEST(MixedContentChecker, CanModifyRequest)
     ASSERT_FALSE(MixedContentChecker::canModifyRequest(
         URL { "custom2://example.com/cat.jpg"_s },
         destination,
-        Initiator::Imageset,
-        shouldUpgradeIPAddressAndLocalhostForTesting
+        Initiator::Imageset
     ));
 }
 


### PR DESCRIPTION
#### 93b599ee4b957ae9f803c133528d4bc33c88b02e
<pre>
REGRESSION (iOS 18): Loading is blocked when trying to load localhost content from HTTPS website
<a href="https://bugs.webkit.org/show_bug.cgi?id=279249">https://bugs.webkit.org/show_bug.cgi?id=279249</a>
<a href="https://rdar.apple.com/135479521">rdar://135479521</a>

Reviewed by Matthew Finkel.

Those are treated as potentially trustworthy origin. It is defined in secure context.
<a href="https://w3c.github.io/webappsec-secure-contexts/#is-url-trustworthy">https://w3c.github.io/webappsec-secure-contexts/#is-url-trustworthy</a>

* LayoutTests/http/tests/security/mixedContent/insecure-localhost-image-in-main-frame-UpgradeMixedContent-expected.txt:
* LayoutTests/http/tests/security/mixedContent/resources/frame-with-insecure-localhost-image.html:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::logConsoleWarningForUpgrade):
(WebCore::MixedContentChecker::shouldUpgradeInsecureContent):
(WebCore::MixedContentChecker::canModifyRequest):
(WebCore::shouldBlockInsecureContent):
* Source/WebCore/loader/MixedContentChecker.h:
* Tools/TestWebKitAPI/Tests/WebCore/MixedContentChecker.cpp:
(TestWebKitAPI::TEST(MixedContentChecker, CanModifyRequest)):

Canonical link: <a href="https://commits.webkit.org/291988@main">https://commits.webkit.org/291988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c417c90382b92fee8229042f00140ac05cbd22e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14038 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22466 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72078 "Found 1 new test failure: fast/css/view-transitions-nested-transparency-layers.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29401 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85276 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2968 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44288 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101509 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21500 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15686 "Found 1 new test failure: html5lib/generated/run-entities01-data.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81078 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20100 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24998 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14725 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26631 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21161 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24621 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->