### PR TITLE
Begin using C++ coroutines for WebFullScreenManagerProxy IPC functions

### DIFF
--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "APIFullscreenClient.h"
 #include "APIPageConfiguration.h"
+#include "CoroutineUtilities.h"
 #include "MessageSenderInlines.h"
 #include "RemotePageFullscreenManagerProxy.h"
 #include "WebAutomationSession.h"
@@ -191,7 +192,7 @@ bool WebFullScreenManagerProxy::blocksReturnToFullscreenFromPictureInPicture() c
     return m_blocksReturnToFullscreenFromPictureInPicture;
 }
 
-void WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& connection, FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&& mediaDetails, CompletionHandler<void(bool)>&& completionHandler)
+Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& connection, FrameIdentifier frameID, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails mediaDetails)
 {
     m_fullScreenProcess = dynamicDowncast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
     m_blocksReturnToFullscreenFromPictureInPicture = blocksReturnToFullscreenFromPictureInPicture;
@@ -211,19 +212,24 @@ void WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& connection, Fra
 
     CheckedPtr client = m_client;
     if (!client)
-        return completionHandler(false);
+        co_return false;
 
-    client->enterFullScreen(mediaDetails.mediaDimensions, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), frameID, logIdentifier = LOGIDENTIFIER] (bool success) mutable {
-        ALWAYS_LOG(logIdentifier);
-        if (!success)
-            return completionHandler(false);
-        m_fullscreenState = FullscreenState::EnteringFullscreen;
-        if (RefPtr page = m_page.get())
-            page->fullscreenClient().willEnterFullscreen(page.get());
-        enterFullScreenForOwnerElementsInOtherProcesses(frameID, [completionHandler = WTFMove(completionHandler)] mutable {
-            completionHandler(true);
-        });
-    });
+    bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
+        client->enterFullScreen(mediaDetails.mediaDimensions, WTFMove(completionHandler));
+    } };
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+    if (!success)
+        co_return false;
+    m_fullscreenState = FullscreenState::EnteringFullscreen;
+    if (RefPtr page = m_page.get())
+        page->fullscreenClient().willEnterFullscreen(page.get());
+
+    co_await AwaitableFromCompletionHandler<void> { [this, protectedThis = Ref { *this }, frameID] (auto completionHandler) {
+        enterFullScreenForOwnerElementsInOtherProcesses(frameID, WTFMove(completionHandler));
+    } };
+
+    co_return true;
 }
 
 void WebFullScreenManagerProxy::enterFullScreenForOwnerElementsInOtherProcesses(FrameIdentifier frameID, CompletionHandler<void()>&& completionHandler)
@@ -265,20 +271,22 @@ void WebFullScreenManagerProxy::updateImageSource(FullScreenMediaDetails&& media
 }
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 
-void WebFullScreenManagerProxy::exitFullScreen(CompletionHandler<void()>&& completionHandler)
+Awaitable<void> WebFullScreenManagerProxy::exitFullScreen()
 {
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     m_imageBuffer = nullptr;
 #endif
-    if (CheckedPtr client = m_client)
-        client->exitFullScreen([this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler)] mutable {
-            m_fullscreenState = FullscreenState::ExitingFullscreen;
-            if (RefPtr page = m_page.get())
-                page->fullscreenClient().willExitFullscreen(page.get());
-            completionHandler();
-        });
-    else
-        completionHandler();
+    CheckedPtr client = m_client;
+    if (!client)
+        co_return;
+
+    co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
+        client->exitFullScreen(WTFMove(completionHandler));
+    } };
+
+    m_fullscreenState = FullscreenState::ExitingFullscreen;
+    if (RefPtr page = m_page.get())
+        page->fullscreenClient().willExitFullscreen(page.get());
 }
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
@@ -303,45 +311,56 @@ void WebFullScreenManagerProxy::prepareQuickLookImageURL(CompletionHandler<void(
 }
 #endif
 
-void WebFullScreenManagerProxy::beganEnterFullScreen(const IntRect& initialFrame, const IntRect& finalFrame, CompletionHandler<void(bool)>&& completionHandler)
+Awaitable<bool> WebFullScreenManagerProxy::beganEnterFullScreen(IntRect initialFrame, IntRect finalFrame)
 {
     RefPtr page = m_page.get();
     if (!page)
-        return completionHandler(false);
+        co_return false;
 
-    page->callAfterNextPresentationUpdate([weakThis = WeakPtr { *this }, initialFrame, finalFrame, completionHandler = WTFMove(completionHandler)] mutable {
-        if (CheckedPtr client = weakThis ? weakThis->m_client : nullptr)
-            client->beganEnterFullScreen(initialFrame, finalFrame, [weakThis = WTFMove(weakThis), completionHandler = WTFMove(completionHandler)] (bool success) mutable {
-                if (weakThis && success)
-                    weakThis->didEnterFullScreen(WTFMove(completionHandler));
-                else
-                    completionHandler(false);
-            });
-        else
-            completionHandler(false);
-    });
+    co_await page->nextPresentationUpdate();
+
+    CheckedPtr client = m_client;
+    if (!client)
+        co_return false;
+
+    bool success = co_await AwaitableFromCompletionHandler<bool> { [=] (auto completionHandler) {
+        client->beganEnterFullScreen(initialFrame, finalFrame, WTFMove(completionHandler));
+    } };
+    if (!success)
+        co_return false;
+
+    co_return co_await AwaitableFromCompletionHandler<bool> { [this, protectedThis = Ref { *this }] (auto completionHandler) {
+        didEnterFullScreen(WTFMove(completionHandler));
+    } };
 }
 
-void WebFullScreenManagerProxy::beganExitFullScreen(FrameIdentifier frameID, const IntRect& initialFrame, const IntRect& finalFrame, CompletionHandler<void()>&& completionHandler)
+Awaitable<void> WebFullScreenManagerProxy::beganExitFullScreen(FrameIdentifier frameID, IntRect initialFrame, IntRect finalFrame)
 {
     CheckedPtr client = m_client;
     if (!client)
-        return completionHandler();
-    client->beganExitFullScreen(initialFrame, finalFrame, [this, protectedThis = Ref { *this }, completionHandler = WTFMove(completionHandler), frameID, logIdentifier = LOGIDENTIFIER] mutable {
-        m_fullscreenState = FullscreenState::NotInFullscreen;
-        RefPtr page = m_page.get();
-        if (!page)
-            return completionHandler();
-        ALWAYS_LOG(logIdentifier);
-        page->fullscreenClient().didExitFullscreen(page.get());
-        exitFullScreenInOtherProcesses(frameID, WTFMove(completionHandler));
+        co_return;
 
-        if (page->isControlledByAutomation()) {
-            if (RefPtr automationSession = page->configuration().processPool().automationSession())
-                automationSession->didExitFullScreenForPage(*page);
-        }
-        callCloseCompletionHandlers();
-    });
+    co_await AwaitableFromCompletionHandler<void> { [=] (auto completionHandler) {
+        client->beganExitFullScreen(initialFrame, finalFrame, WTFMove(completionHandler));
+    } };
+
+    m_fullscreenState = FullscreenState::NotInFullscreen;
+    RefPtr page = m_page.get();
+    if (!page)
+        co_return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
+    page->fullscreenClient().didExitFullscreen(page.get());
+
+    co_await AwaitableFromCompletionHandler<void> { [this, protectedThis = Ref { *this }, frameID] (auto completionHandler) {
+        exitFullScreenInOtherProcesses(frameID, WTFMove(completionHandler));
+    } };
+
+    if (page->isControlledByAutomation()) {
+        if (RefPtr automationSession = page->configuration().processPool().automationSession())
+            automationSession->didExitFullScreenForPage(*page);
+    }
+    callCloseCompletionHandlers();
 }
 
 void WebFullScreenManagerProxy::exitFullScreenInOtherProcesses(FrameIdentifier frameID, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -55,6 +55,7 @@ class WebFullScreenManagerProxy;
 class WebPageProxy;
 class WebProcessProxy;
 struct SharedPreferencesForWebProcess;
+template<typename> class Awaitable;
 
 class WebFullScreenManagerProxyClient : public CanMakeCheckedPtr<WebFullScreenManagerProxyClient> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -125,14 +126,14 @@ public:
 private:
     WebFullScreenManagerProxy(WebPageProxy&, WebFullScreenManagerProxyClient&);
 
-    void enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails&&, CompletionHandler<void(bool)>&&);
+    Awaitable<bool> enterFullScreen(IPC::Connection&, WebCore::FrameIdentifier, bool blocksReturnToFullscreenFromPictureInPicture, FullScreenMediaDetails);
     void didEnterFullScreen(CompletionHandler<void(bool)>&&);
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     void updateImageSource(FullScreenMediaDetails&&);
 #endif
-    void exitFullScreen(CompletionHandler<void()>&&);
-    void beganEnterFullScreen(const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void(bool)>&&);
-    void beganExitFullScreen(WebCore::FrameIdentifier, const WebCore::IntRect& initialFrame, const WebCore::IntRect& finalFrame, CompletionHandler<void()>&&);
+    Awaitable<void> exitFullScreen();
+    Awaitable<bool> beganEnterFullScreen(WebCore::IntRect initialFrame, WebCore::IntRect finalFrame);
+    Awaitable<void> beganExitFullScreen(WebCore::FrameIdentifier, WebCore::IntRect initialFrame, WebCore::IntRect finalFrame);
     void callCloseCompletionHandlers();
     template<typename M> void sendToWebProcess(M&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13962,6 +13962,13 @@ void WebPageProxy::didChangeBackgroundColor()
         pageClient->didChangeBackgroundColor();
 }
 
+Awaitable<void> WebPageProxy::nextPresentationUpdate()
+{
+    co_return co_await AwaitableFromCompletionHandler<void> { [this, protectedThis = Ref { *this }] (auto completionHandler) {
+        callAfterNextPresentationUpdate(WTFMove(completionHandler));
+    } };
+}
+
 #if !PLATFORM(GTK) && !PLATFORM(WPE)
 void WebPageProxy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& callback)
 {

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -617,6 +617,7 @@ enum class WebEventModifier : uint8_t;
 enum class WebEventType : uint8_t;
 enum class WindowKind : uint8_t;
 
+template<typename> class Awaitable;
 template<typename> class MonotonicObjectIdentifier;
 
 using ActivityStateChangeID = uint64_t;
@@ -2039,6 +2040,7 @@ public:
     void didLayoutForCustomContentProvider();
 
     void callAfterNextPresentationUpdate(CompletionHandler<void()>&&);
+    Awaitable<void> nextPresentationUpdate();
 
     void didReachLayoutMilestone(OptionSet<WebCore::LayoutMilestone>, WallTime timestamp);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9443,23 +9443,23 @@ WebCore::HighlightRequestOriginatedInApp WebPage::highlightRequestOriginatedInAp
     return m_internals->highlightRequestOriginatedInApp;
 }
 
-bool WebPage::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight createNewGroup, WebCore::HighlightRequestOriginatedInApp requestOriginatedInApp, CompletionHandler<void(WebCore::AppHighlight&&)>&& completionHandler)
+void WebPage::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight createNewGroup, WebCore::HighlightRequestOriginatedInApp requestOriginatedInApp, CompletionHandler<void(WebCore::AppHighlight&&)>&& completionHandler)
 {
     SetForScope highlightIsNewGroupScope { m_internals->highlightIsNewGroup, createNewGroup };
     SetForScope highlightRequestOriginScope { m_internals->highlightRequestOriginatedInApp, requestOriginatedInApp };
 
     RefPtr focusedOrMainFrame = protectedCorePage()->checkedFocusController()->focusedOrMainFrame();
     if (!focusedOrMainFrame)
-        return false;
+        return;
     RefPtr document = focusedOrMainFrame->document();
 
     RefPtr frame = document->frame();
     if (!frame)
-        return false;
+        return;
 
     auto selectionRange = frame->selection().selection().toNormalizedRange();
     if (!selectionRange)
-        return false;
+        return;
 
     document->protectedAppHighlightRegistry()->addAnnotationHighlightWithRange(StaticRange::create(selectionRange.value()));
     document->appHighlightStorage().storeAppHighlight(StaticRange::create(selectionRange.value()), [completionHandler = WTFMove(completionHandler), protectedThis = Ref { *this }, this] (WebCore::AppHighlight&& highlight) mutable {
@@ -9467,8 +9467,6 @@ bool WebPage::createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighli
         highlight.requestOriginatedInApp = m_internals->highlightRequestOriginatedInApp;
         completionHandler(WTFMove(highlight));
     });
-
-    return true;
 }
 
 void WebPage::restoreAppHighlightsAndScrollToIndex(Vector<SharedMemory::Handle>&& memoryHandles, const std::optional<unsigned> index)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1795,7 +1795,7 @@ public:
     WebCore::HighlightRequestOriginatedInApp highlightRequestOriginatedInApp() const;
     WebCore::HighlightVisibility appHighlightsVisiblility() const { return m_appHighlightsVisible; }
 
-    bool createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight, WebCore::HighlightRequestOriginatedInApp, CompletionHandler<void(WebCore::AppHighlight&&)>&&);
+    void createAppHighlightInSelectedRange(WebCore::CreateNewGroupForHighlight, WebCore::HighlightRequestOriginatedInApp, CompletionHandler<void(WebCore::AppHighlight&&)>&&);
     void restoreAppHighlightsAndScrollToIndex(Vector<WebCore::SharedMemoryHandle>&&, const std::optional<unsigned> index);
     void setAppHighlightsVisibility(const WebCore::HighlightVisibility);
 #endif

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -187,6 +187,11 @@ if (COMPILER_IS_GCC_OR_CLANG)
         WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-uninitialized)
     endif ()
 
+    # GCC < 14.0 gives false warnings for subobject-linkage <https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70413>
+    if ((CMAKE_CXX_COMPILER_ID MATCHES "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14.0.0"))
+        WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-subobject-linkage)
+    endif ()
+
     WEBKIT_PREPEND_GLOBAL_CXX_FLAGS(-Wno-noexcept-type)
 
     # These GCC warnings produce too many false positives to be useful. We'll

--- a/Tools/TestWebKitAPI/CoroutineUtilities.h
+++ b/Tools/TestWebKitAPI/CoroutineUtilities.h
@@ -25,17 +25,7 @@
 
 #pragma once
 
-#if (_LIBCPP_VERSION >= 14000) && !defined(_LIBCPP_HAS_NO_CXX20_COROUTINES)
 #import <coroutine>
-#else
-// FIXME: Remove this once all supported toolchains have non-experimental coroutine support.
-#import <experimental/coroutine>
-namespace std {
-using std::experimental::coroutine_handle;
-using std::experimental::suspend_never;
-using std::experimental::suspend_always;
-}
-#endif
 
 namespace TestWebKitAPI {
 


### PR DESCRIPTION
#### afd0493af45e56cf1005c046ca57af404a96d59d
<pre>
Begin using C++ coroutines for WebFullScreenManagerProxy IPC functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=288413">https://bugs.webkit.org/show_bug.cgi?id=288413</a>
<a href="https://rdar.apple.com/145511185">rdar://145511185</a>

Reviewed by Abrar Rahman Protyasha.

I tried this in 278995@main but it got reverted because it leaked a call frame every time we called a coroutine.
I fixed that by making Task::final_suspend return std::suspend_never because when we call a coroutine
and give it a CompletionHandler, the caller has no more business suspending it.  The coroutine should continue
until it calls the CompletionHandler.  My technique of using a class CoroutineCaller to try to destroy the call
frame from the caller is also not needed.  You just call a coroutine that returns a Task like you do any function,
and it takes care of itself and returns at the first co_await or co_return or the end, whichever comes first.

I made Lazy and Awaitable [[nodiscard]] to prevent bugs where the result isn&apos;t co_awaited.

This makes adding async tasks simpler.  Instead of indenting everything another layer and explicitly copying all
the parameters needed into yet another lambda capture, we just add a co_await doSomethingAsync() call and it just works.
It also makes it so the code won&apos;t compile if we forget to co_return a value, instead of the status quo where
we can forget to call a CompletionHandler in a branch.

WebPage::createAppHighlightInSelectedRange had an unused return value, and I changed it to void because I now
use sfinae to detect if the return value is void when determining which version of callMemberFunction to call.

* Source/WebKit/Platform/CoroutineUtilities.h:
(WebKit::Task::promise_type::get_return_object):
(WebKit::Lazy::PromiseBase::initial_suspend): Deleted.
(WebKit::Lazy::PromiseBase::unhandled_exception): Deleted.
(WebKit::Lazy::PromiseBase::setHandle): Deleted.
(WebKit::Lazy::PromiseBase::handle): Deleted.
(WebKit::Lazy::Promise&lt;U&gt;::get_return_object): Deleted.
(WebKit::Lazy::Promise&lt;U&gt;::return_void): Deleted.
(WebKit::Lazy::Promise&lt;U&gt;::result): Deleted.
(WebKit::Lazy::Awaitable::Awaitable): Deleted.
(WebKit::Lazy::Awaitable::await_ready const): Deleted.
(WebKit::Lazy::Awaitable::await_suspend): Deleted.
(WebKit::Lazy::Awaitable::await_resume): Deleted.
(WebKit::Lazy::Lazy): Deleted.
(WebKit::Lazy::operator co_await const): Deleted.
(WebKit::CoroutineCaller::setCoroutine): Deleted.
(WebKit::callCoroutine): Deleted.
(WebKit::AwaitableTaskWithCompletionHandler::AwaitableTaskWithCompletionHandler): Deleted.
(WebKit::AwaitableTaskWithCompletionHandler::await_ready): Deleted.
(WebKit::AwaitableTaskWithCompletionHandler::await_suspend): Deleted.
(WebKit::AwaitableTaskWithCompletionHandler::await_resume): Deleted.
* Source/WebKit/Platform/IPC/HandleMessage.h:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::prepareQuickLookImageURL const):
(WebKit::WebFullScreenManagerProxy::beganEnterFullScreen):
(WebKit::WebFullScreenManagerProxy::beganExitFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::nextPresentationUpdate):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/CoroutineUtilities.h:

Canonical link: <a href="https://commits.webkit.org/291846@main">https://commits.webkit.org/291846@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f991f1953b5e8b255a2b0879b9c36ab979e41ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92211 "11 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12055 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70728 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28184 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95212 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83745 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51058 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1382 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42087 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84956 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99274 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90907 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19295 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79740 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19547 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78998 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23526 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/965 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12299 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15107 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24448 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113530 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18968 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32846 "Found 309 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22426 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->