### PR TITLE
[HDR] Scan the render layer tree for HDR content only if the document has at least one HDR image or canvas

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7684,6 +7684,22 @@ bool Document::hasSVGRootNode() const
     return documentElement() && documentElement()->hasTagName(SVGNames::svgTag);
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+bool Document::canDrawHDRContent() const
+{
+    if (!(settings().supportHDRDisplayEnabled() || settings().canvasPixelFormatEnabled()))
+        return false;
+
+    if (!hasPaintedHDRContent())
+        return false;
+
+    if (RefPtr frameView = view())
+        return screenSupportsHighDynamicRange(frameView.get());
+
+    return false;
+}
+#endif
+
 template <CollectionType collectionType>
 Ref<HTMLCollection> Document::ensureCachedCollection()
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -629,6 +629,12 @@ public:
     bool hasSVGRootNode() const;
     virtual bool isFrameSet() const { return false; }
 
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    void setHasPaintedHDRContent() { m_hasPaintedHDRContent = true; }
+    bool hasPaintedHDRContent() const { return m_hasPaintedHDRContent; }
+    bool canDrawHDRContent() const;
+#endif
+
     static constexpr ptrdiff_t documentClassesMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentClasses); }
     static auto isHTMLDocumentClassFlag() { return enumToUnderlyingType(DocumentClass::HTML); }
 
@@ -2659,6 +2665,10 @@ private:
 
 #if ENABLE(MEDIA_STREAM)
     bool m_hasHadCaptureMediaStreamTrack { false };
+#endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    bool m_hasPaintedHDRContent { false };
 #endif
 
     bool m_hasViewTransitionPseudoElementTree { false };

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -365,6 +365,13 @@ CanvasRenderingContext2D* HTMLCanvasElement::createContext2d(const String& type,
     ASSERT(!m_context);
 
     m_context = CanvasRenderingContext2D::create(*this, WTFMove(settings), document().inQuirksMode());
+    if (!m_context)
+        return nullptr;
+
+#if ENABLE(PIXEL_FORMAT_RGBA16F) && HAVE(SUPPORT_HDR_DISPLAY)
+    if (m_context->pixelFormat() == ImageBufferPixelFormat::RGBA16F)
+        document().setHasPaintedHDRContent();
+#endif
 
 #if USE(CA) || USE(SKIA)
     // Need to make sure a RenderLayer and compositing layer get created for the Canvas.

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4223,16 +4223,6 @@ void Page::setFullscreenAutoHideDuration(Seconds duration)
     });
 }
 
-#if HAVE(SUPPORT_HDR_DISPLAY)
-bool Page::canDrawHDRContent() const
-{
-    if (!(m_settings->supportHDRDisplayEnabled() || m_settings->canvasPixelFormatEnabled()))
-        return false;
-
-    return screenSupportsHighDynamicRange();
-}
-#endif
-
 Document* Page::outermostFullscreenDocument() const
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -664,10 +664,6 @@ public:
 
     Document* outermostFullscreenDocument() const;
 
-#if HAVE(SUPPORT_HDR_DISPLAY)
-    bool canDrawHDRContent() const;
-#endif
-
     bool shouldSuppressScrollbarAnimations() const { return m_suppressScrollbarAnimations; }
     WEBCORE_EXPORT void setShouldSuppressScrollbarAnimations(bool suppressAnimations);
     void lockAllOverlayScrollbarsToHidden(bool lockOverlayScrollbars);

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -431,8 +431,15 @@ void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetr
         contentChanged(ContentChangeType::Image);
     }
 
-    if (RefPtr image = dynamicDowncast<HTMLImageElement>(element()))
+    if (RefPtr image = dynamicDowncast<HTMLImageElement>(element())) {
         page().didFinishLoadingImageForElement(*image);
+#if HAVE(SUPPORT_HDR_DISPLAY)
+        if (!document().hasPaintedHDRContent()) {
+            if (cachedImage() && cachedImage()->isHDR())
+                document().setHasPaintedHDRContent();
+        }
+#endif
+    }
 
     RenderReplaced::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -406,7 +406,7 @@ RenderLayer::~RenderLayer()
 RenderLayer::PaintedContentRequest::PaintedContentRequest(const RenderLayer& owningLayer)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (owningLayer.page().canDrawHDRContent())
+    if (owningLayer.renderer().document().canDrawHDRContent())
         makePaintedHDRContentUnknown();
 #else
     UNUSED_PARAM(owningLayer);
@@ -5870,13 +5870,8 @@ void RenderLayer::determineNonLayerDescendantsPaintedContent(PaintedContentReque
 #if HAVE(SUPPORT_HDR_DISPLAY)
 bool RenderLayer::isReplacedElementWithHDR() const
 {
-    if (auto* imageDocument = dynamicDowncast<ImageDocument>(renderer().document())) {
-        if (RefPtr imageElement = imageDocument->imageElement()) {
-            if (auto* cachedImage = imageElement->cachedImage())
-                return cachedImage->isHDR();
-        }
-        return false;
-    }
+    if (auto* imageDocument = dynamicDowncast<ImageDocument>(renderer().document()))
+        return imageDocument->hasPaintedHDRContent();
     return WebCore::isReplacedElementWithHDR(renderer());
 }
 #endif

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -151,7 +151,7 @@ public:
         : m_backing(inBacking)
     {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        if (m_backing.renderer().page().canDrawHDRContent()) {
+        if (m_backing.renderer().document().canDrawHDRContent()) {
             m_hdrContent = RequestState::Unknown;
             m_isReplacedElementWithHDR = RequestState::Unknown;
         }


### PR DESCRIPTION
#### c392d3b6bf926955abc7b2037e6c3b1f379ff53f
<pre>
[HDR] Scan the render layer tree for HDR content only if the document has at least one HDR image or canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=288419">https://bugs.webkit.org/show_bug.cgi?id=288419</a>
<a href="https://rdar.apple.com/145515241">rdar://145515241</a>

Reviewed by Simon Fraser.

Scanning the renderer of a render layer and its descendants for HDR contents is
costly. To optimize the PLT, the traversal for HDR content can be disabled until
an HDR image is loaded or an HDR canvas context is created.

A flag can be kept on the Document to tell whether it hasPaintedHDRContent() or
not. This flag can be used by Document::canDrawHDRContent() which is consulted
for before starting the traversal for HDR content.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::canDrawHDRContent const):
Pass the view of the main frame as the widget to screenSupportsHighDynamicRange().
This way, the screen properties which was sent from the UIP to the WebP, can be
be used instead of recalculating them.

* Source/WebCore/dom/Document.h:
(WebCore::Document::setHasPaintedHDRContent):
(WebCore::Document::hasPaintedHDRContent const):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContext2d):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::canDrawHDRContent const): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::notifyFinished):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::PaintedContentRequest::PaintedContentRequest):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::PaintedContentsInfo):

Canonical link: <a href="https://commits.webkit.org/291179@main">https://commits.webkit.org/291179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b524c35ac4a0381bfa856e10328b82bb9e264c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11663 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1230 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42696 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70680 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28145 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83455 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51009 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8854 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1067 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41914 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79173 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1040 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99087 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19235 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14222 "Build is in progress. Recent messages:") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79698 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79317 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78952 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19567 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23486 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12243 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24391 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18908 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->