### PR TITLE
objectIsRelayoutBoundary doesn't account for baseline changes across the boundary.

### DIFF
--- a/LayoutTests/fast/layout/relayout-boundary-inside-flex-expected.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-flex-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+</head>
+<body>
+
+<div style="display: flex; align-items: baseline">
+  <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+    <div id="target" style="background: green; width: 100px; height: 50px;"></div>
+  </div>
+  <div style="background: blue; height: 70px; width: 100px;"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/layout/relayout-boundary-inside-flex.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-flex.html
@@ -1,0 +1,21 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<head>
+</head>
+<body>
+
+<div style="display: flex; align-items: baseline">
+  <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+    <div id="target" style="background: green; width: 100px; height: 150px;"></div>
+  </div>
+  <div style="background: blue; height: 70px; width: 100px;"></div>
+</div>
+</body>
+<script>
+function doTest() {
+    document.getElementById("target").style.height = "50px";
+    document.documentElement.classList.remove("reftest-wait");
+}
+window.addEventListener('load', doTest, false);
+</script>
+</html>

--- a/LayoutTests/fast/layout/relayout-boundary-inside-inline-expected.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-inline-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+</head>
+<body>
+
+<div style="display: inline-grid">
+  <div style="display: grid">
+    <div style="display: inline-flex">
+      <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+        <div id="target" style="background: green; width: 100px; height: 50px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<div style="background: blue; height: 70px; width: 100px; display: inline-block;"></div>
+</body>
+</html>

--- a/LayoutTests/fast/layout/relayout-boundary-inside-inline.html
+++ b/LayoutTests/fast/layout/relayout-boundary-inside-inline.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<html class="reftest-wait">
+<head>
+</head>
+<body>
+
+<div style="display: inline-grid">
+  <div style="display: grid">
+    <div style="display: inline-flex">
+      <div style="display: flex; height: 100px; width: 100px; overflow: hidden;">
+        <div id="target" style="background: green; width: 100px; height: 150px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<div style="background: blue; height: 70px; width: 100px; display: inline-block;"></div>
+</body>
+<script>
+function doTest() {
+    document.getElementById("target").style.height = "50px";
+    document.documentElement.classList.remove("reftest-wait");
+}
+window.addEventListener('load', doTest, false);
+</script>
+</html>


### PR DESCRIPTION
#### 6dd21dc9f928997631d9ee4165db98be40001af3
<pre>
objectIsRelayoutBoundary doesn&apos;t account for baseline changes across the boundary.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288421">https://bugs.webkit.org/show_bug.cgi?id=288421</a>
&lt;<a href="https://rdar.apple.com/145515762">rdar://145515762</a>&gt;

Reviewed by Alan Baradlay.

Being an independent formatting context isn&apos;t sufficient to be a layout
boundary, as placement within the formatting context can affect the baseline
positioning of things outside.

We need to prevent these being treated as boundaries if they are inside an
formatting context that uses baselines.

Caches the lookup of nearest ancestor baseline formatting context to prevent extra
ancestor walks during markContainingBlocksForLayout.

* LayoutTests/fast/layout/relayout-boundary-inside-flex-expected.html: Added.
* LayoutTests/fast/layout/relayout-boundary-inside-flex.html: Added.
* LayoutTests/fast/layout/relayout-boundary-inside-inline-expected.html: Added.
* LayoutTests/fast/layout/relayout-boundary-inside-inline.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::nearestBaselineContextAncestor):
(WebCore::objectIsRelayoutBoundary):
(WebCore::RenderObject::markContainingBlocksForLayout):

Canonical link: <a href="https://commits.webkit.org/291150@main">https://commits.webkit.org/291150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4ee962bcc2e44c835afd80cae05a1001b616720

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70578 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28056 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94991 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9035 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50906 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/909 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98951 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19104 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14128 "Found 1 new test failure: ipc/large-vector-allocate-failure-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79608 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78836 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12142 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19085 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24294 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18782 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20533 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->