### PR TITLE
[HDR] Brightness fade in and fade out

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -155,6 +155,7 @@ typedef struct _CARenderContext CARenderContext;
 @property BOOL needsLayoutOnGeometryChange;
 @property BOOL shadowPathIsBounds;
 @property BOOL continuousCorners;
+@property CGFloat contentsEDRStrength;
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
 @property (getter=isSeparated) BOOL separated;
 #endif

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1183,7 +1183,9 @@ void PlatformCALayerCocoa::updateContentsFormat()
             [m_layer setContentsFormat:formatString];
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         if (contentsFormat == ContentsFormat::RGBA16F) {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [m_layer setWantsExtendedDynamicRangeContent:true];
+            ALLOW_DEPRECATED_DECLARATIONS_END
             [m_layer setToneMapMode:CAToneMapModeIfSupported];
         }
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm
@@ -545,7 +545,9 @@ void RemoteLayerTreePropertyApplier::applyPropertiesToLayer(CALayer *layer, Remo
             [layer setContentsFormat:formatString];
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
         if (contentsFormat == ContentsFormat::RGBA16F) {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             [layer setWantsExtendedDynamicRangeContent:true];
+            ALLOW_DEPRECATED_DECLARATIONS_END
             [layer setToneMapMode:CAToneMapModeIfSupported];
         }
 #endif

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -328,6 +328,9 @@ public:
     void screenDidChangeColorSpace();
     bool shouldDelayWindowOrderingForEvent(NSEvent *);
     bool windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint);
+    void applicationShouldSuppressHDR();
+    void applicationShouldAllowHDR();
+    void updateHDRState();
 
     void accessibilitySettingsDidChange();
 
@@ -1066,6 +1069,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     bool m_inlinePredictionsEnabled { false };
 #endif
+    bool m_hdrAllowed { true };
 };
     
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -360,6 +360,8 @@ static void* keyValueObservingContext = &keyValueObservingContext;
     [defaultNotificationCenter addObserver:self selector:@selector(_windowWillClose:) name:NSWindowWillCloseNotification object:window];
 
     [defaultNotificationCenter addObserver:self selector:@selector(_screenDidChangeColorSpace:) name:NSScreenColorSpaceDidChangeNotification object:nil];
+    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldSuppressHDR:) name:@"NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification" object:NSApp];
+    [defaultNotificationCenter addObserver:self selector:@selector(_applicationShouldAllowHDR:) name:@"NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification" object:NSApp];
 
     if (_shouldObserveFontPanel) {
         ASSERT(!_isObservingFontPanel);
@@ -535,6 +537,18 @@ static void* keyValueObservingContext = &keyValueObservingContext;
 {
     if (_impl)
         _impl->screenDidChangeColorSpace();
+}
+
+- (void)_applicationShouldSuppressHDR:(NSNotification *)notification
+{
+    if (_impl)
+        _impl->applicationShouldSuppressHDR();
+}
+
+- (void)_applicationShouldAllowHDR:(NSNotification *)notification
+{
+    if (_impl)
+        _impl->applicationShouldAllowHDR();
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
@@ -1237,6 +1251,42 @@ static RetainPtr<_WKWebViewTextInputNotifications> subscribeToTextInputNotificat
 static bool isInRecoveryOS()
 {
     return os_variant_is_basesystem("WebKit");
+}
+
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+static void setEDRStrengthRecursive(CALayer* layer, float strength, bool animate)
+{
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    if ([layer wantsExtendedDynamicRangeContent] && [layer respondsToSelector:@selector(setContentsEDRStrength:)]) {
+    ALLOW_DEPRECATED_DECLARATIONS_END
+        if (animate) {
+            CASpringAnimation* animation = [[CASpringAnimation alloc] initWithPerceptualDuration:3.f bounce:0];
+            float edrStrength = allow ? 1.f : 0.f;
+            animation.keyPath = @"contentsEDRStrength";
+            animation.fromValue = @([layer contentsEDRStrength]);
+            animation.toValue = @(edrStrength);
+            [layer addAnimation:animation forKey:@"contentsEDRStrength"];
+            [animation release];
+        }
+        [layer setContentsEDRStrength:edrStrength];
+    }
+    for (CALayer* sublayer in [layer sublayers])
+        setEDRStrengthRecursive(sublayer, strength, animate);
+}
+#endif
+
+static void setEDRStrength(CALayer* layer, float strength, bool animate)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    setEDRStrengthRecursive(layer, strength, animate);
+    [CATransaction commit];
+#else
+    UNUSED_PARAM(layer);
+    UNUSED_PARAM(strength);
+    UNUSED_PARAM(animate);
+#endif
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewImpl);
@@ -2054,6 +2104,7 @@ void WebViewImpl::windowDidOrderOnScreen()
 
 void WebViewImpl::windowDidBecomeKey(NSWindow *keyWindow)
 {
+    updateHDRState();
     if (keyWindow == [m_view window] || keyWindow == [m_view window].attachedSheet) {
 #if ENABLE(GAMEPAD)
         UIGamepadProvider::singleton().viewBecameActive(m_page.get());
@@ -2065,6 +2116,7 @@ void WebViewImpl::windowDidBecomeKey(NSWindow *keyWindow)
 
 void WebViewImpl::windowDidResignKey(NSWindow *formerKeyWindow)
 {
+    updateHDRState();
     if (formerKeyWindow == [m_view window] || formerKeyWindow == [m_view window].attachedSheet) {
 #if ENABLE(GAMEPAD)
         UIGamepadProvider::singleton().viewBecameInactive(m_page.get());
@@ -2138,6 +2190,23 @@ void WebViewImpl::windowWillClose()
 void WebViewImpl::screenDidChangeColorSpace()
 {
     m_page->configuration().processPool().screenPropertiesChanged();
+}
+
+void WebViewImpl::updateHDRState()
+{
+    setEDRStrength(m_rootLayer.get(), (m_hdrAllowed && m_page->isViewWindowActive()) ? 1.f : 0.f, true);
+}
+
+void WebViewImpl::applicationShouldSuppressHDR()
+{
+    m_hdrAllowed = false;
+    updateHDRState();
+}
+
+void WebViewImpl::applicationShouldAllowHDR()
+{
+    m_hdrAllowed = true;
+    updateHDRState();
 }
 
 bool WebViewImpl::mightBeginDragWhileInactive()


### PR DESCRIPTION
#### 9cb124f4e9b97528c8ee21700e5d10e9f6aa61e1
<pre>
[HDR] Brightness fade in and fade out
<a href="https://bugs.webkit.org/show_bug.cgi?id=283314">https://bugs.webkit.org/show_bug.cgi?id=283314</a>
<a href="https://rdar.apple.com/140139174">rdar://140139174</a>

Reviewed by Simon Fraser.

Update the contentsEDRStrength when the view changes key state
or is otherwise informed by the system.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayerCocoa::updateContentsFormat):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreePropertyApplier.mm:
(WebKit::RemoteLayerTreePropertyApplier::applyPropertiesToLayer):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKWindowVisibilityObserver startObserving:]):
(-[WKWindowVisibilityObserver _applicationShouldSuppressHDR:]):
(-[WKWindowVisibilityObserver _applicationShouldAllowHDR:]):
(WebKit::setEDRStrengthRecursive):
(WebKit::setEDRStrength):
(WebKit::WebViewImpl::windowDidBecomeKey):
(WebKit::WebViewImpl::windowDidResignKey):
(WebKit::WebViewImpl::updateHDRState):
(WebKit::WebViewImpl::applicationShouldSuppressHDR):
(WebKit::WebViewImpl::applicationShouldAllowHDR):

Canonical link: <a href="https://commits.webkit.org/291153@main">https://commits.webkit.org/291153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88879b7d8304154a79cac8a7e7b3f622a7d9530f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96916 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42585 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70577 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9030 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1063 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41800 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79081 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99036 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79667 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79313 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19549 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23368 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24292 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18780 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20531 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->