### PR TITLE
REGRESSION(290753@main): TestWebKitAPI.WKPreferencesPrivate.DisableRichJavaScriptFeatures(api-test) is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm
@@ -76,12 +76,6 @@ TEST(WKPreferencesPrivate, DisableRichJavaScriptFeatures)
     result = (NSString *)[getNextMessage() body];
     EXPECT_WK_STREQ(@"WebGPU Disabled", result.get());
 
-    [webView evaluateJavaScript:@"log(navigator.xr ? 'WebXR Enabled' : 'WebXR Disabled');" completionHandler:^(id, NSError *error) {
-        EXPECT_NULL(error);
-    }];
-    result = (NSString *)[getNextMessage() body];
-    EXPECT_WK_STREQ(@"WebXR Disabled", result.get());
-
     [webView evaluateJavaScript:@"log(window.AudioContext ? 'Web Audio Enabled' : 'Web Audio Disabled');" completionHandler:^(id, NSError *error) {
         EXPECT_NULL(error);
     }];
@@ -123,12 +117,6 @@ TEST(WKPreferencesPrivate, DisableRichJavaScriptFeatures)
     }];
     result = (NSString *)[getNextMessage() body];
     EXPECT_WK_STREQ(@"ApplePay Disabled", result.get());
-
-    [webView evaluateJavaScript:@"log(navigator.credentials ? 'Web Authentication Enabled' : 'Web Authentication Disabled');" completionHandler:^(id, NSError *error) {
-        EXPECT_NULL(error);
-    }];
-    result = (NSString *)[getNextMessage() body];
-    EXPECT_WK_STREQ(@"Web Authentication Disabled", result.get());
 
     [webView evaluateJavaScript:@"log(navigator.setAppBadge ? 'Badging Enabled' : 'Badging Disabled');" completionHandler:^(id, NSError *error) {
         EXPECT_NULL(error);


### PR DESCRIPTION
#### 1ab3effd62fc46618e828f1aa1f756ed856055c6
<pre>
REGRESSION(290753@main): TestWebKitAPI.WKPreferencesPrivate.DisableRichJavaScriptFeatures(api-test) is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=288396">https://bugs.webkit.org/show_bug.cgi?id=288396</a>
<a href="https://rdar.apple.com/145501620">rdar://145501620</a>

Reviewed by Ryosuke Niwa.

290753@main changed the behavior of _disableRichJavaScriptFeatures, that but didn&apos;t update test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPreferences.mm:
(DisableRichJavaScriptFeatures)):

Canonical link: <a href="https://commits.webkit.org/291003@main">https://commits.webkit.org/291003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40ac5df404bef02dd3e1ae9ee648dc947fe0e55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91701 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96658 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94702 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/8855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50724 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41544 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/78933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98670 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18846 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78644 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19455 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23164 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/11943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18836 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18541 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/21998 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->