### PR TITLE
[layout-test-worker-parser] Doesn't work with S3 logs.

### DIFF
--- a/Tools/Scripts/layout-test-worker-parser
+++ b/Tools/Scripts/layout-test-worker-parser
@@ -27,6 +27,7 @@ import webkitpy
 from webkitcorepy import arguments, Terminal
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -34,6 +35,7 @@ import sys
 import re
 import requests
 from urllib.parse import urlparse
+from typing import Optional
 
 
 def init():
@@ -41,7 +43,7 @@ def init():
 
     # data source
     parser.add_argument('input_source',
-                        help='Specifies the source to query for layout test results data. Can be a file or URL.',
+                        help='Specifies the source to query for layout test results data. Can be a file or URL (URL being a build or step w/ stdio from buildbot, or link ending in .txt).',
                         type=str)
 
     # optional flags
@@ -67,9 +69,14 @@ def init():
                         action='store_true',
                         help='Exports one file containing all tests in the order they were run (regardless of worker number).',
                         required=False)
+    parser.add_argument('--buildbot-step',
+                        dest='buildbot_step_name',
+                        help='If input is a buildbot link and the user isn\'t specifying stdio input, this allows the user to choose a specific buildbot step from which to take layout tests run data. Only needed if using --no-warn.',
+                        default=None,
+                        required=False)
     parser.add_argument('--no-warn',
                         action='store_true',
-                        help='Does not warn or prompt the user before performing any actions. Potentially destructive due to bypassing file overwrite prompts. Good for automation. Will cause the script to quit if user input required.',
+                        help='Does not warn or prompt the user before performing any actions. Potentially destructive due to bypassing file overwrite prompts. Good for automation. Will cause the script to quit if user input required. If input is a buildbot link and --buildbot-step isn\'t specified, using this option will take the first layout tests run step.',
                         required=False)
 
     # logging
@@ -190,8 +197,12 @@ def parse_raw_stdio_into_test_names(raw, target_test='', long=False):
             if not long and test_name == target_test:
                 info(f'Found requested test (last of {i}), skipping remaining tests.')
                 break
-    info(f'Processed {i} tests total.')
-    return "\n".join(tests)
+    if i > 0:
+        info(f'Processed {i} tests total.')
+        return "\n".join(tests)
+    else:
+        error(f'No tests found. Quitting.')
+        graceful_exit(os.EX_DATAERR)
 
 
 # Parses a raw stdio log into a dict of lists containing test lists.
@@ -217,8 +228,12 @@ def parse_raw_stdio_into_workers(raw, target_test='', long=False):
                     info(f'Continuing to sort tests by worker (--long).')
                     continue
                 break
-    info(f'Finished parsing tests ({i} total).')
-    return (workers, int(target_worker))
+    if i > 0:
+        info(f'Finished parsing tests ({i} total).')
+        return (workers, int(target_worker))
+    else:
+        error(f'No tests found. Quitting.')
+        graceful_exit(os.EX_DATAERR)
 
 
 # Loads the stdio input for analysis from a file.
@@ -237,22 +252,70 @@ def load_from_file(path):
 
 # Loads the stdio input for analysis from a build URL.
 # Returns a str with the contents of the stdio log.
-def load_from_buildbot(url):
-    url = url.replace('/#/', '/api/v2/') + ("/raw" if "/logs/stdio" in url else "/steps/layout-test/logs/stdio/raw")
-    try: # validation
+def load_from_url(base_url: str, step_name: Optional[str] = None, no_warn: bool = False) -> str:
+    '''Takes a build URL and analyzes the steps to determine which log to return. Can also take a step stdio link ("/steps/<step-name>/logs/stdio") or a .txt file URL.'''
+
+    url = base_url
+    if not url.endswith('.txt'):
+        url = url.replace('/#/', '/api/v2/').strip('/')
+        # Don't analyze steps if user specifically asked for stdio
+        if '/logs/stdio' not in url:
+            url += '/steps'
+        elif not url.endswith('/raw'):
+            url += '/raw'
+
+    info('Loading from URL (this may take a moment)...')
+
+    try:
         uobj = urlparse(url)
         if not all([uobj.scheme, uobj.netloc]):
             raise IOError()
-    except:
-        error("Invalid URL specified: %s.", url)
+        data = requests.get(uobj.geturl())
+    except (TypeError, requests.RequestException) as e:
+        error(f'Unable to load data: {e.args[0]}. Check your spelling and try again.')
         graceful_exit(os.EX_DATAERR)
 
-    info("Loading from URL (this may take a moment)...")
+    # Early return for stdio/txt result
+    if url.endswith('/raw') or url.endswith('.txt'):
+        return data.text
 
-    try: # more validation
-        data = requests.get(url)
+    # Analyze steps
+    candidate_steps = {}
+    layout_test_step = {}
+    build_data = json.loads(data.text)
+    for step in build_data['steps']:
+        if step['name'] == 'layout-test':
+            layout_test_step = step
+        for url_data in step['urls']:
+            # This is fragile, but it works
+            if 'layout-test' in url_data['url'] and url_data['url'].endswith('.txt') and (step_name is None or step_name == step['name']):
+                candidate_steps[step['name']] = url_data['url']
+                break
+
+    cstep_names = list(candidate_steps.keys())
+    if len(cstep_names) == 0:
+        # Not all buildbot instances upload results to S3
+        if layout_test_step != {}: 
+            info('No S3 URLs found. Retrying and querying stdio of the "layout-test" step.\n')
+            return load_from_url(f'{base_url}/layout-test/logs/stdio/raw', step_name, no_warn)
+        elif step_name:
+            err = f'Step "{step_name}" is either not a step in this run or doesn\'t contain layout test run data.'
+        else:
+            err = 'No layout tests runs in this buildbot run have data uploaded to S3.'
+        error(err)
+        graceful_exit(os.EX_DATAERR)
+
+    if not step_name:
+        if len(cstep_names) == 1 or no_warn:
+            step_name = cstep_names[0]
+        else:
+            step_name = Terminal.choose(prompt='Choose a step from which to get layout test run data (enter a number)', options=cstep_names, numbered=True, default=cstep_names[0], strict=True)
+
+    info(f'Retrieving data from the "{step_name}" step...')
+    try:
+        data = requests.get(candidate_steps[step_name])
     except Exception as e:
-        error('Unable to load data: ' + e.args[0] + '. Check your spelling and try again.')
+        error(f'Unable to load data: {e.args[0]}. Check your spelling and try again.')
         graceful_exit(os.EX_DATAERR)
 
     return data.text
@@ -263,7 +326,7 @@ def main():
     info()
 
     if options.input_source.find('https://') == 0 or options.input_source.find('http://') == 0: # user entered url
-        stdio_text = load_from_buildbot(options.input_source)
+        stdio_text = load_from_url(options.input_source, options.buildbot_step_name, options.no_warn)
         if options.stdio_export_path is not None: # export raw stdio [--stdio-export-path]
             ex_path = export_file(options.stdio_export_path, stdio_text, options.no_warn)
             info(f'Exported stdio file to "{ex_path}".')


### PR DESCRIPTION
#### 68e07e8029ac0f9a39a10d02cfafdd0584594f17
<pre>
[layout-test-worker-parser] Doesn&apos;t work with S3 logs.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288434">https://bugs.webkit.org/show_bug.cgi?id=288434</a>
<a href="https://rdar.apple.com/145524609">rdar://145524609</a>

Reviewed by Jonathan Bedard.

The layout-test-worker-parser script doesn&apos;t work with S3 logs. In practice,
this means that layout test runs that have their logs uploaded to S3 won&apos;t
parse the desired logs.

This change adds support for runs with layout test logs in S3, as well as runs
with multiple steps containing layout test results.

* Tools/Scripts/layout-test-worker-parser:
    -&gt; (load_from_url): Renamed from load_from_buildbot, add handling for S3 log links.
    -&gt; (main): Add new parameters to load_from_url function.
    -&gt; (init): Add new argument --buildbot-step.
    -&gt; (parse_raw_stdio_into_test_names): Bail if no tests found in data.
    -&gt; (parse_raw_stdio_into_workers): Ditto.

Canonical link: <a href="https://commits.webkit.org/302679@main">https://commits.webkit.org/302679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a0eae078ffd51f084e3c446f5d9291ee29d803

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/129897 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/2158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/40755 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/81386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/131768 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/2111 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/2049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/137290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/81386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/132844 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/1591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/116338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/137290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/1502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/34467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/80560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/110009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/34972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/139771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/1952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/2049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/139771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/1997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/112686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/139771 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/31159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/54754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/20260 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/2025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/1839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/1874 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/1948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->