### PR TITLE
[Site Isolation] Back navigation breaks after the main frame is redirected to a new process

### DIFF
--- a/LayoutTests/http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back-expected.txt
@@ -1,0 +1,9 @@
+Verifies that history.back() works correctly after the main frame is redirected into a new process.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back.html
+++ b/LayoutTests/http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back.html
@@ -1,0 +1,18 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Verifies that history.back() works correctly after the main frame is redirected into a new process.");
+jsTestIsAsync = true;
+
+onload = () => {
+    if (sessionStorage.didNavigate) {
+        delete sessionStorage.didNavigate;
+        finishJSTest();
+    } else {
+        sessionStorage.didNavigate = true;
+        setTimeout(() => {
+            location.href = 'http://localhost:8000/site-isolation/history/resources/navigate-to-url.html?url=https://localhost:8443/site-isolation/history/resources/go-back.html';
+        }, 0);
+    }
+}
+</script>

--- a/LayoutTests/http/tests/site-isolation/history/resources/navigate-to-url.html
+++ b/LayoutTests/http/tests/site-isolation/history/resources/navigate-to-url.html
@@ -1,0 +1,5 @@
+<script>
+onload = () => {
+    location.href = new URLSearchParams(location.search).get('url');
+}
+</script>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3812,7 +3812,7 @@ void WebPage::setNeedsFontAttributes(bool needsFontAttributes)
 
 void WebPage::setCurrentHistoryItemForReattach(Ref<FrameState>&& mainFrameState)
 {
-    if (RefPtr localMainFrame = this->localMainFrame())
+    if (RefPtr localMainFrame = m_mainFrame->provisionalFrame() ? m_mainFrame->provisionalFrame() : m_mainFrame->coreLocalFrame())
         localMainFrame->loader().protectedHistory()->setCurrentItem(toHistoryItem(m_historyItemClient, mainFrameState));
 }
 


### PR DESCRIPTION
#### 5da7cad5615eda2184ad92f729925512e79fe3a8
<pre>
[Site Isolation] Back navigation breaks after the main frame is redirected to a new process
<a href="https://bugs.webkit.org/show_bug.cgi?id=288436">https://bugs.webkit.org/show_bug.cgi?id=288436</a>
<a href="https://rdar.apple.com/145526678">rdar://145526678</a>

Reviewed by Alex Christensen.

During a provisional main frame navigation, the current history item needs to be set in the web process
so that it can determine whether the back/forward list should be updated on redirection. With site
isolation, the main frame will be in a provisional state, but we should still set the current history
item on its HistoryController.

* LayoutTests/http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/history/redirect-main-frame-into-new-process-then-go-back.html: Added.
* LayoutTests/http/tests/site-isolation/history/resources/navigate-to-url.html: Added.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setCurrentHistoryItemForReattach):

Canonical link: <a href="https://commits.webkit.org/291035@main">https://commits.webkit.org/291035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7139c2ec4ede428e8d4bd1a59cb49d716b8c128

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91708 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42357 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70405 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27907 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94709 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50730 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/674 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41549 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98773 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18853 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/13989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79501 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19105 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78724 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11947 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14553 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18843 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24099 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18546 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22003 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20302 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->