### PR TITLE
Use BorderShape for rendering inner box shadows

### DIFF
--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -223,11 +223,13 @@ bool BorderShape::innerShapeIsRectangular() const
 void BorderShape::move(LayoutSize offset)
 {
     m_borderRect.move(offset);
+    m_innerEdgeRect.move(offset);
 }
 
 void BorderShape::inflate(LayoutUnit amount)
 {
     m_borderRect.inflateWithRadii(amount);
+    m_innerEdgeRect = computeInnerEdgeRoundedRect(m_borderRect, m_borderWidths);
 }
 
 static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path)
@@ -344,6 +346,14 @@ void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, f
         context.fillRect(pixelSnappedRect.rect(), color);
 }
 
+void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const LayoutRect& outerRect, const Color& color, float deviceScaleFactor) const
+{
+    auto pixelSnappedOuterRect = snapRectToDevicePixels(outerRect, deviceScaleFactor);
+    auto innerSnappedRoundedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(innerSnappedRoundedRect.isRenderable());
+    context.fillRectWithRoundedHole(pixelSnappedOuterRect, innerSnappedRoundedRect, color);
+}
+
 RoundedRect BorderShape::computeInnerEdgeRoundedRect(const RoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths)
 {
     auto borderRect = borderRoundedRect.rect();
@@ -367,11 +377,6 @@ RoundedRect BorderShape::computeInnerEdgeRoundedRect(const RoundedRect& borderRo
     }
 
     return innerEdgeRect;
-}
-
-LayoutRect BorderShape::innerEdgeRect() const
-{
-    return m_innerEdgeRect.rect();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -62,6 +62,8 @@ public:
     BorderShape shapeWithBorderWidths(const RectEdges<LayoutUnit>&) const;
 
     LayoutRect borderRect() const { return m_borderRect.rect(); }
+    LayoutRect innerEdgeRect() const { return m_innerEdgeRect.rect(); }
+
     // Takes `closedEdges` into account.
     const RectEdges<LayoutUnit>& borderWidths() const { return m_borderWidths; }
 
@@ -109,8 +111,9 @@ public:
     void fillOuterShape(GraphicsContext&, const Color&, float deviceScaleFactor) const;
     void fillInnerShape(GraphicsContext&, const Color&, float deviceScaleFactor) const;
 
+    void fillRectWithInnerHoleShape(GraphicsContext&, const LayoutRect& outerRect, const Color&, float deviceScaleFactor) const;
+
 private:
-    LayoutRect innerEdgeRect() const;
     static RoundedRect computeInnerEdgeRoundedRect(const RoundedRect& borderRoundedRect, const RectEdges<LayoutUnit>& borderWidths);
 
     RoundedRect m_borderRect;


### PR DESCRIPTION
#### dd8b5e641c8aa32d1af442bd8a1eaf5141de7b2e
<pre>
Use BorderShape for rendering inner box shadows
<a href="https://bugs.webkit.org/show_bug.cgi?id=288443">https://bugs.webkit.org/show_bug.cgi?id=288443</a>
<a href="https://rdar.apple.com/145532909">rdar://145532909</a>

Reviewed by Antti Koivisto.

Inset box-shadow painting had some assumptions about shapes being rounded rects that get broken
with `corner-shape`, so migrate it to using BorderShape.

The code computes a new BorderShape where the outer rect is the border box, and the inner rect
represents the size of the shadow &quot;hole&quot; (i.e. the edge of the blurred area). It expands out
the non-present edges so that shadows on those edges get clipped out (this expanding used to
be done on the hole rect, but we can equivalently do it on the outer rect).

Finally we add BorderShape::fillRectWithRoundedHole() in preparation to later deal with
non-rounded-rect holes.

* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintBoxShadow const):
(WebCore::areaCastingShadowInHole): Deleted.
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::move): Drive-by fix: if we move the outer rect, we need to move the cached inner rect.
(WebCore::BorderShape::inflate): Drive-by fix: if we inflate the outer rect, we need to recompute the inner rect.
(WebCore::BorderShape::fillRectWithInnerHoleShape const):
(WebCore::BorderShape::innerEdgeRect const): Deleted.
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::innerEdgeRect const):

Canonical link: <a href="https://commits.webkit.org/291055@main">https://commits.webkit.org/291055@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f729cfaaaf67e309559cb01fe6e03084352af708

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93775 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70420 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27919 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94726 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50746 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/690 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41566 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98694 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18869 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79444 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/78942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78665 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19491 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/528 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11957 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18860 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24109 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18563 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->