### PR TITLE
[SwiftUI] Provide ability for clients to enable or disable magnification gestures

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -562,6 +562,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     _allowsLinkPreview = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::LinkPreviewEnabledByDefault);
     _findInteractionEnabled = NO;
     _needsToPresentLockdownModeMessage = YES;
+    _allowsMagnification = YES;
 
     auto fastClickingEnabled = []() {
         if (NSNumber *enabledValue = [[NSUserDefaults standardUserDefaults] objectForKey:@"WebKitFastClickingDisabled"])

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -429,6 +429,8 @@ struct PerWebProcessState {
     WebCore::FixedContainerEdges _fixedContainerEdges;
 
     RetainPtr<WKScrollGeometry> _currentScrollGeometry;
+
+    BOOL _allowsMagnification;
 }
 
 - (BOOL)_isValid;
@@ -567,6 +569,10 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails&)
 @property (nonatomic, setter=_setAlwaysBounceHorizontal:) BOOL _alwaysBounceHorizontal;
 
 - (void)_setContentOffset:(CGPoint)contentOffset animated:(BOOL)animated;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+@property (nonatomic, setter=_setAllowsMagnification:) BOOL _allowsMagnification;
 #endif
 
 @end

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -102,6 +102,12 @@ extension WebPageWebView {
         get { scrollView.bouncesHorizontally }
         set { scrollView.bouncesHorizontally = newValue }
     }
+
+    @_spi(CrossImportOverlay)
+    public var allowsMagnification: Bool {
+        get { self._allowsMagnification }
+        set { self._allowsMagnification = newValue }
+    }
 #else
     @_spi(CrossImportOverlay)
     public var alwaysBounceVertical: Bool {

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -982,7 +982,7 @@ static void changeContentOffsetBoundedInValidRange(UIScrollView *scrollView, Web
 
     [_scrollView setMinimumZoomScale:minimumScaleFactor];
     [_scrollView setMaximumZoomScale:maximumScaleFactor];
-    [_scrollView _setZoomEnabledInternal:allowsUserScaling];
+    [_scrollView _setZoomEnabledInternal:allowsUserScaling && self._allowsMagnification];
     if ([_scrollView showsHorizontalScrollIndicator] && [_scrollView showsVerticalScrollIndicator]) {
         [_scrollView setShowsHorizontalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None)];
         [_scrollView setShowsVerticalScrollIndicator:(_page->scrollingCoordinatorProxy()->mainFrameScrollbarWidth() != WebCore::ScrollbarWidth::None)];
@@ -3888,12 +3888,23 @@ static bool isLockdownModeWarningNeeded()
     _overriddenZoomScaleParameters = { minimumZoomScale, maximumZoomScale, allowUserScaling };
     [_scrollView setMinimumZoomScale:minimumZoomScale];
     [_scrollView setMaximumZoomScale:maximumZoomScale];
-    [_scrollView _setZoomEnabledInternal:allowUserScaling];
+    [_scrollView _setZoomEnabledInternal:allowUserScaling && self._allowsMagnification];
 }
 
 - (void)_clearOverrideZoomScaleParameters
 {
     _overriddenZoomScaleParameters = std::nullopt;
+}
+
+- (BOOL)_allowsMagnification
+{
+    return _allowsMagnification;
+}
+
+- (void)_setAllowsMagnification:(BOOL)allowsMagnification
+{
+    _allowsMagnification = allowsMagnification;
+    [_contentView _updateDoubleTapGestureRecognizerEnablement];
 }
 
 #if ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -579,6 +579,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _isHandlingActivePressesEvent;
     BOOL _isDeferringKeyEventsToInputMethod;
     BOOL _isUpdatingAccessoryView;
+    BOOL _doubleTapGesturesAreDisabledTemporarilyForFastTap;
 
     BOOL _focusRequiresStrongPasswordAssistance;
     BOOL _waitingForEditDragSnapshot;
@@ -983,6 +984,8 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (ScopeExit<Function<void()>>)makeTextSelectionViewsNonInteractiveForScope;
 
 - (BOOL)_shouldHideSelectionDuringOverflowScroll:(UIScrollView *)scrollView;
+
+- (void)_updateDoubleTapGestureRecognizerEnablement;
 
 @property (nonatomic, readonly) BOOL shouldUseAsyncInteractions;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2331,7 +2331,7 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
     if (gestureRecognizer == [_webView scrollView].pinchGestureRecognizer)
         return YES;
 
-    // The gesture recognizer is another UIPichGestureRecognizer known to lead to pinch-to-zoom.
+    // The gesture recognizer is another UIPinchGestureRecognizer known to lead to pinch-to-zoom.
     if ([gestureRecognizer isKindOfClass:[UIPinchGestureRecognizer class]]) {
         if (auto uiDelegate = static_cast<id<WKUIDelegatePrivate>>(self.webView.UIDelegate)) {
             if ([uiDelegate respondsToSelector:@selector(_webView:gestureRecognizerCouldPinch:)])
@@ -6130,8 +6130,14 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
     if (_showDebugTapHighlightsForFastClicking && !enabled)
         _tapHighlightInformation.color = [self _tapHighlightColorForFastClick:YES];
 
-    [_doubleTapGestureRecognizer setEnabled:enabled];
-    [_nonBlockingDoubleTapGestureRecognizer setEnabled:!enabled];
+    _doubleTapGesturesAreDisabledTemporarilyForFastTap = !enabled;
+    [self _updateDoubleTapGestureRecognizerEnablement];
+}
+
+- (void)_updateDoubleTapGestureRecognizerEnablement
+{
+    [_doubleTapGestureRecognizer setEnabled:!_doubleTapGesturesAreDisabledTemporarilyForFastTap && [_webView _allowsMagnification]];
+    [_nonBlockingDoubleTapGestureRecognizer setEnabled:_doubleTapGesturesAreDisabledTemporarilyForFastTap && [_webView _allowsMagnification]];
     [self _resetIsDoubleTapPending];
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
@@ -30,6 +30,9 @@ extension EnvironmentValues {
     var webViewAllowsBackForwardNavigationGestures = WebView.BackForwardNavigationGesturesBehavior.automatic
 
     @Entry
+    var webViewMagnificationGestures = WebView.MagnificationGesturesBehavior.automatic
+
+    @Entry
     var webViewAllowsLinkPreview = WebView.LinkPreviewBehavior.automatic
 
     @Entry
@@ -58,6 +61,11 @@ extension View {
     @available(tvOS, unavailable)
     public func webViewBackForwardNavigationGestures(_ value: WebView.BackForwardNavigationGesturesBehavior = .automatic) -> some View {
         environment(\.webViewAllowsBackForwardNavigationGestures, value)
+    }
+
+    @_spi(Private)
+    public func webViewMagnificationGestures(_ value: WebView.MagnificationGesturesBehavior) -> some View {
+        environment(\.webViewMagnificationGestures, value)
     }
 
     /// Determines whether pressing a link displays a preview of the destination for the link.

--- a/Source/WebKit/_WebKit_SwiftUI/WebView.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebView.swift
@@ -72,6 +72,27 @@ extension WebView {
         let value: Value
     }
 
+    @_spi(Private)
+    public struct MagnificationGesturesBehavior: Sendable {
+        enum Value {
+            case automatic
+            case enabled
+            case disabled
+        }
+
+        public static let automatic: Self = .init(.automatic)
+
+        public static let enabled: Self = .init(.enabled)
+
+        public static let disabled: Self = .init(.disabled)
+
+        init(_ value: Value) {
+            self.value = value
+        }
+
+        let value: Value
+    }
+
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @available(watchOS, unavailable)
     @available(tvOS, unavailable)

--- a/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift
@@ -51,6 +51,13 @@ struct WebViewRepresentable {
         webView.allowsBackForwardNavigationGestures = environment.webViewAllowsBackForwardNavigationGestures.value != .disabled
         webView.allowsLinkPreview = environment.webViewAllowsLinkPreview.value != .disabled
 
+
+#if os(macOS)
+        webView.allowsMagnification = environment.webViewMagnificationGestures.value == .enabled // automatic -> false
+#else
+        webView.allowsMagnification = environment.webViewMagnificationGestures.value != .disabled // automatic -> true
+#endif
+
         let isOpaque = environment.webViewContentBackground != .hidden
 
 #if os(macOS)

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -231,6 +231,7 @@ struct ContentView: View {
 
             WebView(viewModel.page)
                 .webViewBackForwardNavigationGestures(.enabled)
+                .webViewMagnificationGestures(.enabled)
                 .webViewLinkPreviews(.enabled)
                 .webViewTextSelection(.enabled)
                 .webViewAllowsElementFullscreen()


### PR DESCRIPTION
#### 42aebba2a97bea8fe82fb7f77c10008b2097fb3b
<pre>
[SwiftUI] Provide ability for clients to enable or disable magnification gestures
<a href="https://bugs.webkit.org/show_bug.cgi?id=288450">https://bugs.webkit.org/show_bug.cgi?id=288450</a>
<a href="https://rdar.apple.com/145534365">rdar://145534365</a>

Reviewed by Abrar Rahman Protyasha and Tim Horton.

Add a `webViewMagnificationGestures` view modifier to WebView.

* Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift:
(View.webViewMagnificationGestures(_:)):
* Source/WebKit/_WebKit_SwiftUI/WebView.swift:
* Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
* Tools/SwiftBrowser/Source/Views/ContentView.swift:
(ContentView.body):

Canonical link: <a href="https://commits.webkit.org/291142@main">https://commits.webkit.org/291142@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e94d98c0182d7d4174c24c0af0242a286a1d075a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42599 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94059 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70592 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28073 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50920 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/935 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79103 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19119 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79621 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79186 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78853 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19545 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23382 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12154 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24306 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->