### PR TITLE
Web Inspector: Console: show source code location for bound functions

### DIFF
--- a/LayoutTests/inspector/debugger/getFunctionDetails-expected.txt
+++ b/LayoutTests/inspector/debugger/getFunctionDetails-expected.txt
@@ -1,0 +1,40 @@
+Tests for Debugger.getFunctionDetails command.
+
+
+== Running test suite: Debugger.getFunctionDetails
+-- Running test case: Debugger.getFunctionDetails.Regular
+PASS: Should have source code line.
+PASS: Should have source code column.
+PASS: Should have name.
+PASS: Should have displayName.
+
+-- Running test case: Debugger.getFunctionDetails.Regular.Bound.Once
+PASS: Should have source code line.
+PASS: Should have source code column.
+PASS: Should have name.
+PASS: Should have displayName.
+
+-- Running test case: Debugger.getFunctionDetails.Regular.Bound.Twice
+PASS: Should have source code line.
+PASS: Should have source code column.
+PASS: Should have name.
+PASS: Should not have displayName.
+
+-- Running test case: Debugger.getFunctionDetails.Arrow
+PASS: Should have source code line.
+PASS: Should have source code column.
+PASS: Should not have name.
+PASS: Should have displayName.
+
+-- Running test case: Debugger.getFunctionDetails.Arrow.Bound.Once
+PASS: Should have source code line.
+PASS: Should have source code column.
+PASS: Should have name.
+PASS: Should have displayName.
+
+-- Running test case: Debugger.getFunctionDetails.Arrow.Bound.Twice
+PASS: Should have source code line.
+PASS: Should have source code column.
+PASS: Should have name.
+PASS: Should not have displayName.
+

--- a/LayoutTests/inspector/debugger/getFunctionDetails.html
+++ b/LayoutTests/inspector/debugger/getFunctionDetails.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function regular() {}
+regular.displayName = "Regular";
+
+let regularBoundOnce = regular.bind();
+regularBoundOnce.displayName = "RegularBound";
+
+let regularBoundTwice = regularBoundOnce.bind();
+
+let arrow = () => {};
+arrow.displayName = "Arrow";
+
+let arrowBoundOnce = arrow.bind();
+arrowBoundOnce.displayName = "ArrowBound";
+
+let arrowBoundTwice = arrowBoundOnce.bind();
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Debugger.getFunctionDetails");
+
+    suite.addTestCase({
+        name: "Debugger.getFunctionDetails.Regular",
+        async test() {
+            let remoteObject = await InspectorTest.evaluateInPage(`regular`, {remoteObjectOnly: true});
+            let {details} = await DebuggerAgent.getFunctionDetails(remoteObject.objectId);
+            InspectorTest.assert(details, "Should get function details.");
+            InspectorTest.expectEqual(details.location.lineNumber, 5, "Should have source code line.");
+            InspectorTest.expectEqual(details.location.columnNumber, 16, "Should have source code column.");
+            InspectorTest.expectEqual(details.name, "regular", "Should have name.");
+            InspectorTest.expectEqual(details.displayName, "Regular", "Should have displayName.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.getFunctionDetails.Regular.Bound.Once",
+        async test() {
+            let remoteObject = await InspectorTest.evaluateInPage(`regularBoundOnce`, {remoteObjectOnly: true});
+            let {details} = await DebuggerAgent.getFunctionDetails(remoteObject.objectId);
+            InspectorTest.assert(details, "Should get function details.");
+            InspectorTest.expectEqual(details.location.lineNumber, 5, "Should have source code line.");
+            InspectorTest.expectEqual(details.location.columnNumber, 16, "Should have source code column.");
+            InspectorTest.expectEqual(details.name, "regular", "Should have name.");
+            InspectorTest.expectEqual(details.displayName, "RegularBound", "Should have displayName.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.getFunctionDetails.Regular.Bound.Twice",
+        async test() {
+            let remoteObject = await InspectorTest.evaluateInPage(`regularBoundTwice`, {remoteObjectOnly: true});
+            let {details} = await DebuggerAgent.getFunctionDetails(remoteObject.objectId);
+            InspectorTest.assert(details, "Should get function details.");
+            InspectorTest.expectEqual(details.location.lineNumber, 5, "Should have source code line.");
+            InspectorTest.expectEqual(details.location.columnNumber, 16, "Should have source code column.");
+            InspectorTest.expectEqual(details.name, "bound regular", "Should have name.");
+            InspectorTest.expectEqual(details.displayName, undefined, "Should not have displayName.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.getFunctionDetails.Arrow",
+        async test() {
+            let remoteObject = await InspectorTest.evaluateInPage(`arrow`, {remoteObjectOnly: true});
+            let {details} = await DebuggerAgent.getFunctionDetails(remoteObject.objectId);
+            InspectorTest.assert(details, "Should get function details.");
+            InspectorTest.expectEqual(details.location.lineNumber, 13, "Should have source code line.");
+            InspectorTest.expectEqual(details.location.columnNumber, 12, "Should have source code column.");
+            InspectorTest.expectEqual(details.name, undefined, "Should not have name.");
+            InspectorTest.expectEqual(details.displayName, "Arrow", "Should have displayName.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.getFunctionDetails.Arrow.Bound.Once",
+        async test() {
+            let remoteObject = await InspectorTest.evaluateInPage(`arrowBoundOnce`, {remoteObjectOnly: true});
+            let {details} = await DebuggerAgent.getFunctionDetails(remoteObject.objectId);
+            InspectorTest.assert(details, "Should get function details.");
+            InspectorTest.expectEqual(details.location.lineNumber, 13, "Should have source code line.");
+            InspectorTest.expectEqual(details.location.columnNumber, 12, "Should have source code column.");
+            InspectorTest.expectEqual(details.name, "arrow", "Should have name.");
+            InspectorTest.expectEqual(details.displayName, "ArrowBound", "Should have displayName.");
+        },
+    });
+
+    suite.addTestCase({
+        name: "Debugger.getFunctionDetails.Arrow.Bound.Twice",
+        async test() {
+            let remoteObject = await InspectorTest.evaluateInPage(`arrowBoundTwice`, {remoteObjectOnly: true});
+            let {details} = await DebuggerAgent.getFunctionDetails(remoteObject.objectId);
+            InspectorTest.assert(details, "Should get function details.");
+            InspectorTest.expectEqual(details.location.lineNumber, 13, "Should have source code line.");
+            InspectorTest.expectEqual(details.location.columnNumber, 12, "Should have source code column.");
+            InspectorTest.expectEqual(details.name, "bound arrow", "Should have name.");
+            InspectorTest.expectEqual(details.displayName, undefined, "Should not have displayName.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests for Debugger.getFunctionDetails command.</p>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -253,9 +253,15 @@ JSValue JSInjectedScriptHost::functionDetails(JSGlobalObject* globalObject, Call
 
     // FIXME: <https://webkit.org/b/87192> Web Inspector: Expose function scope / closure data
 
-    // FIXME: This should provide better details for JSBoundFunctions.
+    auto* targetFunction = function;
+    while (auto* boundFunction = jsDynamicCast<JSBoundFunction*>(targetFunction)) {
+        auto* nextTargetFunction = jsDynamicCast<JSFunction*>(boundFunction->targetFunction());
+        if (UNLIKELY(!nextTargetFunction))
+            break;
+        targetFunction = nextTargetFunction;
+    }
 
-    const SourceCode* sourceCode = function->sourceCode();
+    const SourceCode* sourceCode = targetFunction->sourceCode();
     if (!sourceCode)
         return jsUndefined();
 

--- a/Source/WebInspectorUI/UserInterface/Test/FrontendTestHarness.js
+++ b/Source/WebInspectorUI/UserInterface/Test/FrontendTestHarness.js
@@ -79,6 +79,11 @@ FrontendTestHarness = class FrontendTestHarness extends TestHarness
 
     evaluateInPage(expression, callback, options = {})
     {
+        if (arguments.length === 2 && typeof callback !== "function") {
+            options = callback;
+            callback = undefined;
+        }
+
         let remoteObjectOnly = !!options.remoteObjectOnly;
         let target = WI.assumingMainTarget();
 


### PR DESCRIPTION
#### 07fdedc0b2dabaf8ddd285aaebd62dc37421c4cc
<pre>
Web Inspector: Console: show source code location for bound functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=288454">https://bugs.webkit.org/show_bug.cgi?id=288454</a>

Reviewed by BJ Burg.

This allow help developers to quickly jump to the source code location of the original function instead of having to search for it by name.

* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::functionDetails):

* Source/WebInspectorUI/UserInterface/Test/FrontendTestHarness.js:
(FrontendTestHarness.prototype.evaluateInPage):
Drive-by: allow `options` to be provided without a `callback` (i.e. to return a `Promise` for use with `await`).

* LayoutTests/inspector/debugger/getFunctionDetails.html: Added.
* LayoutTests/inspector/debugger/getFunctionDetails-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/291073@main">https://commits.webkit.org/291073@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/740a92256c42d4079279528b4dfea4906c027f66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1027 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19968 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94952 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/84731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98915 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90681 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78810 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19507 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113273 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->