### PR TITLE
[IndexedDB] Cache in-memory index records for rollback

### DIFF
--- a/LayoutTests/storage/indexeddb/resources/transaction-abort-revert-index-records.js
+++ b/LayoutTests/storage/indexeddb/resources/transaction-abort-revert-index-records.js
@@ -1,0 +1,183 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+    importScripts('shared.js');
+}
+
+description("Test aborting transaction reverts changes maded to index records");
+
+indexedDBTest(prepareDatabase, onDatabaseOpen);
+
+var recordsCount, indexRecordKey, indexRecordValue;
+
+const originalIndexRecords = [
+    { 
+        name: "timestampIndex", count: 4, records: [
+            { key: 101, values: ["key1"] }, 
+            { key: 102, values: ["key2"] }, 
+            { key: 103, values: ["key3"] }, 
+            { key: 104, values: ["key4"] }
+        ]
+    },
+    { 
+        name: "groupIndex", count: 3, records: [
+            { key: "a", values: ["key1"] }, 
+            { key: "b", values: ["key2", "key3"] }
+        ] 
+    },
+    { 
+        name: "groupCountIndex", count: 3, records: [
+            { key: ["a", 1], values: ["key1"] }, 
+            { key: ["b", 2], values: ["key2", "key3"] }
+        ]
+    },
+    { 
+        name: "categoriesIndex", count: 6, 
+        records: [
+            { key: "xx", values: ["key1", "key4"] }, 
+            { key: "yy", values: ["key2", "key4"] }, 
+            { key: "zz", values: ["key3", "key4"] }
+        ] 
+    }
+];
+
+const updatedIndexRecords = [
+    { 
+        name: "timestampIndex", count: 4, records: [
+            { key: 101, values: ["key1"] }, 
+            { key: 102, values: ["key2"] }, 
+            { key: 105, values: ["key5"] },
+            { key: 106, values: ["key3"] },
+        ]
+    },
+    { 
+        name: "groupIndex", count: 4, records: [
+            { key: "a", values: ["key1"] }, 
+            { key: "b", values: ["key2"] },
+            { key: "c", values: ["key3", "key5"] },
+        ] 
+    },
+    { 
+        name: "groupCountIndex", count: 4, records: [
+            { key: ["a", 1], values: ["key1"] }, 
+            { key: ["b", 2], values: ["key2"] },
+            { key: ["c", 3], values: ["key3", "key5"] }
+        ] 
+    },
+    { 
+        name: "categoriesIndex", count: 5, 
+        records: [
+            { key: "ww", values: ["key3", "key5"] },
+            { key: "xx", values: ["key1"] }, 
+            { key: "yy", values: ["key2", "key3"] }
+        ] 
+    }
+];
+
+async function getAllKeys(index, key)
+{
+    promise = new Promise((resolve, reject) => {
+        if (!index)
+            reject('index is not valid.');
+        else {
+            request = index.getAllKeys(key);
+            request.onsuccess = (event) => { resolve(event.target.result); }
+            request.onerror = (event) => { reject(event.target.error); }
+        }
+    });
+    result = await promise;
+    return result;
+}
+
+async function getIndexCount(index)
+{
+    promise = new Promise((resolve, reject) => {
+        if (!index)
+            reject('index is not valid.');
+        else {
+            request = index.count();
+            request.onsuccess = (event) => { resolve(event.target.result); }
+            request.onerror = (event) => { reject(event.target.error); }
+        }
+    });
+    count = await promise;
+    return count;
+}
+
+async function validateIndexRecords(indexName, expectdRecordsCount, expectedRecords)
+{
+    debug("");
+    debug("Validating records for: " + indexName);
+
+    index = evalAndLog("index = store.index('" + indexName + "')");
+    recordsCount = await getIndexCount(index);
+    shouldBe("recordsCount", expectdRecordsCount + "");
+
+    for (const record of expectedRecords) {
+        indexRecordKey = record.key;
+        debug("will getAllKeys");
+        result = await getAllKeys(index, indexRecordKey);
+        debug("done getAllKeys");
+        indexRecordValues = JSON.stringify(result);
+        debug("Getting index record with key: " + indexRecordKey);
+        shouldBeEqualToString("indexRecordValues", JSON.stringify(record.values));
+    }
+}
+
+async function validateAllIndexRecords(indexes, callback)
+{
+    for (const index of indexes)
+        await validateIndexRecords(index.name, index.count, index.records);
+
+    if (callback)
+        callback();
+}
+
+function prepareDatabase()
+{
+    preamble(event);
+
+    database = event.target.result;
+    evalAndLog("store = database.createObjectStore('store')");
+    evalAndLog("store.createIndex('timestampIndex', 'timestamp', { unique: true })");
+    evalAndLog("store.createIndex('groupIndex', 'group', { unique: false })");
+    evalAndLog("store.createIndex('groupCountIndex', ['group', 'count'])");
+    evalAndLog("store.createIndex('categoriesIndex', 'categories', { multiEntry: true })");
+
+    evalAndLog("store.add({ timestamp: 101, group: 'a', count: 1, categories: 'xx' }, 'key1')");
+    evalAndLog("store.add({ timestamp: 102, group: 'b', count: 2, categories: 'yy' }, 'key2')");
+    evalAndLog("store.add({ timestamp: 103, group: 'b', count: 2, categories: 'zz' }, 'key3')");
+    evalAndLog("store.add({ timestamp: 104, categories: ['xx', 'yy', 'zz'] }, 'key4')");
+
+    validateAllIndexRecords(originalIndexRecords);
+}
+
+function onDatabaseOpen()
+{
+    preamble(event);
+
+    // Start a new transaction to modify index records.
+    database = event.target.result;
+    transaction = evalAndLog("transcation = database.transaction('store', 'readwrite')");
+    transaction.onabort = onTransactionAbort;
+    evalAndLog("store = transcation.objectStore('store')");
+    evalAndLog("store.add({ timestamp: 105, group: 'c', count: 3, categories: 'ww' }, 'key5')");
+    evalAndLog("store.put({ timestamp: 106, group: 'c', count: 3, categories: ['ww', 'yy'] }, 'key3')");
+    evalAndLog("store.delete('key4')");
+
+    validateAllIndexRecords(updatedIndexRecords, abortTransaction);
+}
+
+function abortTransaction()
+{
+    // Adding a record with existing key will cause request to fail and transaction to abort.
+    evalAndLog("store.add({ timestamp: 107 }, 'key1')");
+}
+
+function onTransactionAbort()
+{
+    preamble(event);
+
+    transaction = evalAndLog("transcation = database.transaction('store', 'readwrite')");
+    evalAndLog("store = transcation.objectStore('store')");
+    validateAllIndexRecords(originalIndexRecords, finishJSTest);
+}

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-expected.txt
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-expected.txt
@@ -1,0 +1,224 @@
+Test aborting transaction reverts changes maded to index records
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+
+prepareDatabase():
+store = database.createObjectStore('store')
+store.createIndex('timestampIndex', 'timestamp', { unique: true })
+store.createIndex('groupIndex', 'group', { unique: false })
+store.createIndex('groupCountIndex', ['group', 'count'])
+store.createIndex('categoriesIndex', 'categories', { multiEntry: true })
+store.add({ timestamp: 101, group: 'a', count: 1, categories: 'xx' }, 'key1')
+store.add({ timestamp: 102, group: 'b', count: 2, categories: 'yy' }, 'key2')
+store.add({ timestamp: 103, group: 'b', count: 2, categories: 'zz' }, 'key3')
+store.add({ timestamp: 104, categories: ['xx', 'yy', 'zz'] }, 'key4')
+
+Validating records for: timestampIndex
+index = store.index('timestampIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: 101
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 102
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 103
+PASS indexRecordValues is "[\"key3\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 104
+PASS indexRecordValues is "[\"key4\"]"
+
+Validating records for: groupIndex
+index = store.index('groupIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: groupCountIndex
+index = store.index('groupCountIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a,1
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b,2
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: categoriesIndex
+index = store.index('categoriesIndex')
+PASS recordsCount is 6
+will getAllKeys
+done getAllKeys
+Getting index record with key: xx
+PASS indexRecordValues is "[\"key1\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: yy
+PASS indexRecordValues is "[\"key2\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: zz
+PASS indexRecordValues is "[\"key3\",\"key4\"]"
+
+onDatabaseOpen():
+transcation = database.transaction('store', 'readwrite')
+store = transcation.objectStore('store')
+store.add({ timestamp: 105, group: 'c', count: 3, categories: 'ww' }, 'key5')
+store.put({ timestamp: 106, group: 'c', count: 3, categories: ['ww', 'yy'] }, 'key3')
+store.delete('key4')
+
+Validating records for: timestampIndex
+index = store.index('timestampIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: 101
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 102
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 105
+PASS indexRecordValues is "[\"key5\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 106
+PASS indexRecordValues is "[\"key3\"]"
+
+Validating records for: groupIndex
+index = store.index('groupIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: a
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: c
+PASS indexRecordValues is "[\"key3\",\"key5\"]"
+
+Validating records for: groupCountIndex
+index = store.index('groupCountIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: a,1
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b,2
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: c,3
+PASS indexRecordValues is "[\"key3\",\"key5\"]"
+
+Validating records for: categoriesIndex
+index = store.index('categoriesIndex')
+PASS recordsCount is 5
+will getAllKeys
+done getAllKeys
+Getting index record with key: ww
+PASS indexRecordValues is "[\"key3\",\"key5\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: xx
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: yy
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+store.add({ timestamp: 107 }, 'key1')
+
+onTransactionAbort():
+transcation = database.transaction('store', 'readwrite')
+store = transcation.objectStore('store')
+
+Validating records for: timestampIndex
+index = store.index('timestampIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: 101
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 102
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 103
+PASS indexRecordValues is "[\"key3\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 104
+PASS indexRecordValues is "[\"key4\"]"
+
+Validating records for: groupIndex
+index = store.index('groupIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: groupCountIndex
+index = store.index('groupCountIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a,1
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b,2
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: categoriesIndex
+index = store.index('categoriesIndex')
+PASS recordsCount is 6
+will getAllKeys
+done getAllKeys
+Getting index record with key: xx
+PASS indexRecordValues is "[\"key1\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: yy
+PASS indexRecordValues is "[\"key2\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: zz
+PASS indexRecordValues is "[\"key3\",\"key4\"]"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private-expected.txt
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private-expected.txt
@@ -1,0 +1,224 @@
+Test aborting transaction reverts changes maded to index records
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+indexedDB = self.indexedDB || self.webkitIndexedDB || self.mozIndexedDB || self.msIndexedDB || self.OIndexedDB;
+
+indexedDB.deleteDatabase(dbname)
+indexedDB.open(dbname)
+
+prepareDatabase():
+store = database.createObjectStore('store')
+store.createIndex('timestampIndex', 'timestamp', { unique: true })
+store.createIndex('groupIndex', 'group', { unique: false })
+store.createIndex('groupCountIndex', ['group', 'count'])
+store.createIndex('categoriesIndex', 'categories', { multiEntry: true })
+store.add({ timestamp: 101, group: 'a', count: 1, categories: 'xx' }, 'key1')
+store.add({ timestamp: 102, group: 'b', count: 2, categories: 'yy' }, 'key2')
+store.add({ timestamp: 103, group: 'b', count: 2, categories: 'zz' }, 'key3')
+store.add({ timestamp: 104, categories: ['xx', 'yy', 'zz'] }, 'key4')
+
+Validating records for: timestampIndex
+index = store.index('timestampIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: 101
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 102
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 103
+PASS indexRecordValues is "[\"key3\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 104
+PASS indexRecordValues is "[\"key4\"]"
+
+Validating records for: groupIndex
+index = store.index('groupIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: groupCountIndex
+index = store.index('groupCountIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a,1
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b,2
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: categoriesIndex
+index = store.index('categoriesIndex')
+PASS recordsCount is 6
+will getAllKeys
+done getAllKeys
+Getting index record with key: xx
+PASS indexRecordValues is "[\"key1\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: yy
+PASS indexRecordValues is "[\"key2\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: zz
+PASS indexRecordValues is "[\"key3\",\"key4\"]"
+
+onDatabaseOpen():
+transcation = database.transaction('store', 'readwrite')
+store = transcation.objectStore('store')
+store.add({ timestamp: 105, group: 'c', count: 3, categories: 'ww' }, 'key5')
+store.put({ timestamp: 106, group: 'c', count: 3, categories: ['ww', 'yy'] }, 'key3')
+store.delete('key4')
+
+Validating records for: timestampIndex
+index = store.index('timestampIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: 101
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 102
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 105
+PASS indexRecordValues is "[\"key5\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 106
+PASS indexRecordValues is "[\"key3\"]"
+
+Validating records for: groupIndex
+index = store.index('groupIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: a
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: c
+PASS indexRecordValues is "[\"key3\",\"key5\"]"
+
+Validating records for: groupCountIndex
+index = store.index('groupCountIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: a,1
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b,2
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: c,3
+PASS indexRecordValues is "[\"key3\",\"key5\"]"
+
+Validating records for: categoriesIndex
+index = store.index('categoriesIndex')
+PASS recordsCount is 5
+will getAllKeys
+done getAllKeys
+Getting index record with key: ww
+PASS indexRecordValues is "[\"key3\",\"key5\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: xx
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: yy
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+store.add({ timestamp: 107 }, 'key1')
+
+onTransactionAbort():
+transcation = database.transaction('store', 'readwrite')
+store = transcation.objectStore('store')
+
+Validating records for: timestampIndex
+index = store.index('timestampIndex')
+PASS recordsCount is 4
+will getAllKeys
+done getAllKeys
+Getting index record with key: 101
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 102
+PASS indexRecordValues is "[\"key2\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 103
+PASS indexRecordValues is "[\"key3\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: 104
+PASS indexRecordValues is "[\"key4\"]"
+
+Validating records for: groupIndex
+index = store.index('groupIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: groupCountIndex
+index = store.index('groupCountIndex')
+PASS recordsCount is 3
+will getAllKeys
+done getAllKeys
+Getting index record with key: a,1
+PASS indexRecordValues is "[\"key1\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: b,2
+PASS indexRecordValues is "[\"key2\",\"key3\"]"
+
+Validating records for: categoriesIndex
+index = store.index('categoriesIndex')
+PASS recordsCount is 6
+will getAllKeys
+done getAllKeys
+Getting index record with key: xx
+PASS indexRecordValues is "[\"key1\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: yy
+PASS indexRecordValues is "[\"key2\",\"key4\"]"
+will getAllKeys
+done getAllKeys
+Getting index record with key: zz
+PASS indexRecordValues is "[\"key3\",\"key4\"]"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private.html
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private.html
@@ -1,0 +1,10 @@
+<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/transaction-abort-revert-index-records.js"></script>
+</body>
+</html>

--- a/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records.html
+++ b/LayoutTests/storage/indexeddb/transaction-abort-revert-index-records.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="resources/shared.js"></script>
+</head>
+<body>
+<script src="resources/transaction-abort-revert-index-records.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp
@@ -77,6 +77,14 @@ bool IndexValueEntry::removeKey(const IDBKeyData& key)
     return m_orderedKeys->erase(key);
 }
 
+bool IndexValueEntry::contains(const IDBKeyData& key)
+{
+    if (m_unique)
+        return m_key && *m_key == key;
+
+    return m_orderedKeys && m_orderedKeys->count(key);
+}
+
 const IDBKeyData* IndexValueEntry::getLowest() const
 {
     if (m_unique)
@@ -226,6 +234,19 @@ IndexValueEntry::Iterator IndexValueEntry::reverseFind(const IDBKeyData& key, Cu
     return { *this, iterator };
 }
 
+Vector<IDBKeyData> IndexValueEntry::keys() const
+{
+    Vector<IDBKeyData> result;
+    if (m_unique) {
+        if (m_key)
+            result.append(*m_key);
+    } else if (m_orderedKeys) {
+        for (auto& key : *m_orderedKeys)
+            result.append(key);
+    }
+
+    return result;
+}
 
 } // namespace IDBServer
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h
@@ -46,6 +46,7 @@ public:
 
     // Returns true if a key was actually removed.
     bool removeKey(const IDBKeyData&);
+    bool contains(const IDBKeyData&);
 
     const IDBKeyData* getLowest() const;
 
@@ -85,6 +86,7 @@ public:
     Iterator reverseFind(const IDBKeyData&, CursorDuplicity);
 
     bool unique() const { return m_unique; }
+    Vector<IDBKeyData> keys() const;
 
 private:
     union {

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp
@@ -85,6 +85,24 @@ bool IndexValueStore::contains(const IDBKeyData& key) const
     return true;
 }
 
+std::optional<Vector<IDBKeyData>> IndexValueStore::valueKeys(const IDBKeyData& key) const
+{
+    auto* entry = m_records.get(key);
+    if (!entry)
+        return std::nullopt;
+
+    return entry->keys();
+}
+
+Vector<IDBKeyData> IndexValueStore::allKeys() const
+{
+    Vector<IDBKeyData> result;
+    for (auto& key : m_records.keys())
+        result.append(key);
+
+    return result;
+}
+
 IDBError IndexValueStore::addRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey)
 {
     auto result = m_records.add(indexKey, nullptr);
@@ -113,6 +131,12 @@ void IndexValueStore::removeRecord(const IDBKeyData& indexKey, const IDBKeyData&
     }
 }
 
+void IndexValueStore::removeRecord(const IDBKeyData& indexKey)
+{
+    m_records.remove(indexKey);
+    m_orderedKeys.erase(indexKey);
+}
+
 void IndexValueStore::removeEntriesWithValueKey(MemoryIndex& index, const IDBKeyData& valueKey)
 {
     Vector<IDBKeyData> entryKeysToRemove;
@@ -129,6 +153,17 @@ void IndexValueStore::removeEntriesWithValueKey(MemoryIndex& index, const IDBKey
         m_orderedKeys.erase(entry);
         m_records.remove(entry);
     }
+}
+
+Vector<IDBKeyData> IndexValueStore::findKeysWithValueKey(const IDBKeyData& valueKey)
+{
+    Vector<IDBKeyData> keys;
+    for (auto& [key, entry] : m_records) {
+        if (entry->contains(valueKey))
+            keys.append(key);
+    }
+
+    return keys;
 }
 
 IDBKeyData IndexValueStore::lowestKeyWithRecordInRange(const IDBKeyRangeData& range) const

--- a/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/IndexValueStore.h
@@ -55,11 +55,15 @@ public:
     uint64_t countForKey(const IDBKeyData&) const;
     IDBKeyData lowestKeyWithRecordInRange(const IDBKeyRangeData&) const;
     bool contains(const IDBKeyData&) const;
+    std::optional<Vector<IDBKeyData>> valueKeys(const IDBKeyData&) const;
+    Vector<IDBKeyData> allKeys() const;
 
     IDBError addRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey);
     void removeRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey);
+    void removeRecord(const IDBKeyData& indexKey);
 
     void removeEntriesWithValueKey(MemoryIndex&, const IDBKeyData& valueKey);
+    Vector<IDBKeyData> findKeysWithValueKey(const IDBKeyData& valueKey);
 
     class Iterator {
         friend class IndexValueStore;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h
@@ -66,7 +66,6 @@ public:
     void objectStoreCleared(MemoryObjectStore&, std::unique_ptr<KeyValueMap>&&, std::unique_ptr<IDBKeyDataSet>&&);
     void objectStoreRenamed(MemoryObjectStore&, const String& oldName);
     void indexRenamed(MemoryIndex&, const String& oldName);
-    void indexCleared(MemoryIndex&, std::unique_ptr<IndexValueStore>&&);
 
     void addNewIndex(MemoryIndex&);
     void removeNewIndex(MemoryIndex&);
@@ -75,6 +74,8 @@ public:
 
     void abort();
     void commit();
+
+    IDBTransactionInfo info() const { return m_info; }
 
 private:
     void finish();
@@ -96,7 +97,6 @@ private:
     HashMap<String, RefPtr<MemoryIndex>> m_deletedIndexes;
     HashMap<MemoryObjectStore*, String> m_originalObjectStoreNames;
     HashMap<MemoryIndex*, String> m_originalIndexNames;
-    HashMap<MemoryIndex*, std::unique_ptr<IndexValueStore>> m_clearedIndexValueStores;
 };
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -75,10 +75,16 @@ void MemoryIndex::cursorDidBecomeDirty(MemoryIndexCursor& cursor)
 
 void MemoryIndex::objectStoreCleared()
 {
-    auto transaction = m_objectStore->writeTransaction();
-    ASSERT(transaction);
+    if (m_records) {
+        for (auto& key : m_records->allKeys()) {
+            if (m_transactionModifiedRecords.contains(key))
+                continue;
+            if (auto valueKeys = m_records->valueKeys(key))
+                m_transactionModifiedRecords.add(key, WTFMove(*valueKeys));
+        }
 
-    transaction->indexCleared(*this, WTFMove(m_records));
+        m_records = nullptr;
+    }
 
     notifyCursorsOfAllRecordsChanged();
 }
@@ -95,22 +101,6 @@ void MemoryIndex::notifyCursorsOfAllRecordsChanged()
         cursor->indexRecordsAllChanged();
 
     ASSERT(m_cleanCursors.isEmpty());
-}
-
-void MemoryIndex::clearIndexValueStore()
-{
-    ASSERT(m_objectStore->writeTransaction());
-    ASSERT(m_objectStore->writeTransaction()->isAborting());
-
-    m_records = nullptr;
-}
-
-void MemoryIndex::replaceIndexValueStore(std::unique_ptr<IndexValueStore>&& valueStore)
-{
-    ASSERT(m_objectStore->writeTransaction());
-    ASSERT(m_objectStore->writeTransaction()->isAborting());
-
-    m_records = WTFMove(valueStore);
 }
 
 IDBGetResult MemoryIndex::getResultForKeyRange(IndexedDB::IndexRecordType type, const IDBKeyRangeData& range) const
@@ -196,7 +186,6 @@ void MemoryIndex::getAllRecords(const IDBKeyRangeData& keyRangeData, std::option
     }
 }
 
-
 IDBError MemoryIndex::putIndexKey(const IDBKeyData& valueKey, const IndexKey& indexKey)
 {
     LOG(IndexedDB, "MemoryIndex::provisionalPutIndexKey");
@@ -208,7 +197,7 @@ IDBError MemoryIndex::putIndexKey(const IDBKeyData& valueKey, const IndexKey& in
 
     if (!m_info.multiEntry()) {
         IDBKeyData key = indexKey.asOneKey();
-        IDBError result = m_records->addRecord(key, valueKey);
+        auto result = addIndexRecord(key, valueKey);
         notifyCursorsOfValueChange(key, valueKey);
         return result;
     }
@@ -223,7 +212,7 @@ IDBError MemoryIndex::putIndexKey(const IDBKeyData& valueKey, const IndexKey& in
     }
 
     for (auto& key : keys) {
-        auto error = m_records->addRecord(key, valueKey);
+        auto error = addIndexRecord(key, valueKey);
         ASSERT_UNUSED(error, error.isNull());
         notifyCursorsOfValueChange(key, valueKey);
     }
@@ -239,14 +228,14 @@ void MemoryIndex::removeRecord(const IDBKeyData& valueKey, const IndexKey& index
 
     if (!m_info.multiEntry()) {
         IDBKeyData key = indexKey.asOneKey();
-        m_records->removeRecord(key, valueKey);
+        removeIndexRecord(key, valueKey);
         notifyCursorsOfValueChange(key, valueKey);
         return;
     }
 
     Vector<IDBKeyData> keys = indexKey.multiEntry();
     for (auto& key : keys) {
-        m_records->removeRecord(key, valueKey);
+        removeIndexRecord(key, valueKey);
         notifyCursorsOfValueChange(key, valueKey);
     }
 }
@@ -257,6 +246,16 @@ void MemoryIndex::removeEntriesWithValueKey(const IDBKeyData& valueKey)
 
     if (!m_records)
         return;
+
+    RELEASE_ASSERT(m_writeTransaction);
+    if (!m_writeTransaction->isAborting()) {
+        for (auto& indexKey : m_records->findKeysWithValueKey(valueKey)) {
+            if (m_transactionModifiedRecords.contains(indexKey))
+                continue;
+            if (auto valueKeys = m_records->valueKeys(indexKey))
+                m_transactionModifiedRecords.add(indexKey, WTFMove(*valueKeys));
+        }
+    }
 
     m_records->removeEntriesWithValueKey(*this, valueKey);
 }
@@ -269,6 +268,71 @@ MemoryIndexCursor* MemoryIndex::maybeOpenCursor(const IDBCursorInfo& info)
 
     result.iterator->value = makeUnique<MemoryIndexCursor>(*this, info);
     return result.iterator->value.get();
+}
+
+IDBError MemoryIndex::addIndexRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey)
+{
+    RELEASE_ASSERT(m_writeTransaction);
+
+    if (!m_records)
+        m_records = makeUnique<IndexValueStore>(m_info.unique());
+
+    if (!m_writeTransaction->isAborting() && !m_transactionModifiedRecords.contains(indexKey)) {
+        if (!m_records->contains(indexKey))
+            m_transactionModifiedRecords.add(indexKey, Vector<IDBKeyData> { });
+        else if (auto valueKeys = m_records->valueKeys(indexKey))
+            m_transactionModifiedRecords.add(indexKey, WTFMove(*valueKeys));
+    }
+
+    return m_records->addRecord(indexKey, valueKey);
+}
+
+void MemoryIndex::removeIndexRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey)
+{
+    if (!m_records)
+        return;
+
+    RELEASE_ASSERT(m_writeTransaction);
+    if (!m_writeTransaction->isAborting() && !m_transactionModifiedRecords.contains(indexKey)) {
+        if (auto valueKeys = m_records->valueKeys(indexKey))
+            m_transactionModifiedRecords.add(indexKey, WTFMove(*valueKeys));
+    }
+
+    return m_records->removeRecord(indexKey, valueKey);
+}
+
+void MemoryIndex::removeIndexRecord(const IDBKeyData& indexKey)
+{
+    if (m_records)
+        m_records->removeRecord(indexKey);
+}
+
+void MemoryIndex::writeTransactionStarted(MemoryBackingStoreTransaction& transaction)
+{
+    ASSERT(!m_writeTransaction);
+
+    m_writeTransaction = &transaction;
+}
+
+void MemoryIndex::writeTransactionFinished(MemoryBackingStoreTransaction& transaction)
+{
+    ASSERT_UNUSED(transaction, m_writeTransaction == &transaction);
+
+    m_writeTransaction = nullptr;
+    m_transactionModifiedRecords.clear();
+}
+
+void MemoryIndex::transactionAborted(MemoryBackingStoreTransaction& transaction)
+{
+    if (m_writeTransaction != &transaction)
+        return;
+
+    auto transactionModifiedRecords = std::exchange(m_transactionModifiedRecords, { });
+    for (auto& [key, valueKeys] : transactionModifiedRecords) {
+        removeIndexRecord(key);
+        for (auto valueKey : valueKeys)
+            addIndexRecord(key, valueKey);
+    }
 }
 
 } // namespace IDBServer

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -77,8 +77,6 @@ public:
     void removeRecord(const IDBKeyData&, const IndexKey&);
 
     void objectStoreCleared();
-    void clearIndexValueStore();
-    void replaceIndexValueStore(std::unique_ptr<IndexValueStore>&&);
 
     MemoryIndexCursor* maybeOpenCursor(const IDBCursorInfo&);
 
@@ -92,16 +90,25 @@ public:
 
     void notifyCursorsOfValueChange(const IDBKeyData& indexKey, const IDBKeyData& primaryKey);
 
+    void writeTransactionStarted(MemoryBackingStoreTransaction&);
+    void writeTransactionFinished(MemoryBackingStoreTransaction&);
+    void transactionAborted(MemoryBackingStoreTransaction&);
+
 private:
     MemoryIndex(const IDBIndexInfo&, MemoryObjectStore&);
 
     uint64_t recordCountForKey(const IDBKeyData&) const;
 
     void notifyCursorsOfAllRecordsChanged();
+    IDBError addIndexRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey);
+    void removeIndexRecord(const IDBKeyData& indexKey, const IDBKeyData& valueKey);
+    void removeIndexRecord(const IDBKeyData& indexKey);
 
     IDBIndexInfo m_info;
     WeakPtr<MemoryObjectStore> m_objectStore;
 
+    CheckedPtr<MemoryBackingStoreTransaction> m_writeTransaction;
+    HashMap<IDBKeyData, Vector<IDBKeyData>, IDBKeyDataHash, IDBKeyDataHashTraits> m_transactionModifiedRecords;
     std::unique_ptr<IndexValueStore> m_records;
 
     HashMap<IDBResourceIdentifier, std::unique_ptr<MemoryIndexCursor>> m_cursors;

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -78,7 +78,6 @@ public:
     bool containsRecord(const IDBKeyData&);
     void deleteRecord(const IDBKeyData&);
     void deleteRange(const IDBKeyRangeData&);
-    IDBError addRecord(MemoryBackingStoreTransaction&, const IDBKeyData&, const IDBValue&);
     IDBError addRecord(MemoryBackingStoreTransaction&, const IDBKeyData&, const IndexIDToIndexKeyMap&, const IDBValue&);
 
     uint64_t currentKeyGeneratorValue() const { return m_keyGeneratorValue; }
@@ -115,11 +114,11 @@ private:
 
     IDBKeyDataSet::iterator lowestIteratorInRange(const IDBKeyRangeData&, bool reverse) const;
 
-    IDBError populateIndexWithExistingRecords(MemoryIndex&);
     IDBError updateIndexesForPutRecord(const IDBKeyData&, const IndexIDToIndexKeyMap&);
     void updateIndexesForDeleteRecord(const IDBKeyData& value);
     void updateCursorsForPutRecord(IDBKeyDataSet::iterator);
     void updateCursorsForDeleteRecord(const IDBKeyData&);
+    void addRecordWithoutUpdatingIndexes(MemoryBackingStoreTransaction&, const IDBKeyData&, const IDBValue&);
 
     IDBObjectStoreInfo m_info;
 


### PR DESCRIPTION
#### 239b3c11cd8c79f0945fdcd8dd6947c418cd4c46
<pre>
[IndexedDB] Cache in-memory index records for rollback
<a href="https://bugs.webkit.org/show_bug.cgi?id=288457">https://bugs.webkit.org/show_bug.cgi?id=288457</a>
<a href="https://rdar.apple.com/145541402">rdar://145541402</a>

Reviewed by Brady Eidson.

When transaction aborts, index records modified during transaction need to be rolled back. In existing implementation of
in-memory backend, instead of rolling back index records to previous state, it rolls back the object store records, and
re-populate index records by generating index keys from original object store records. Index key generation requires to
deserialize SerializedScriptValue, which should be avoided on server side. This patch makes MemoryIndex cache the
original state of index records that are modified during transaction, so that these records can directly roll back to
previous state when transaction aborts.

Test: LayoutTests/storage/indexeddb/transaction-abort-revert-index-records.html
      LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private.html

* LayoutTests/storage/indexeddb/resources/transaction-abort-revert-index-records.js: Added.
(async getAllKeys):
(async getIndexCount):
(async validateIndexRecords):
(async validateAllIndexRecords):
(prepareDatabase):
(onDatabaseOpen):
(abortTransaction):
(onTransactionAbort):
* LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-expected.txt: Added.
* LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private-expected.txt: Added.
* LayoutTests/storage/indexeddb/transaction-abort-revert-index-records-private.html: Added.
* LayoutTests/storage/indexeddb/transaction-abort-revert-index-records.html: Added.
* Source/WebCore/Modules/indexeddb/server/IndexValueEntry.cpp:
(WebCore::IDBServer::IndexValueEntry::contains):
(WebCore::IDBServer::IndexValueEntry::keys const):
* Source/WebCore/Modules/indexeddb/server/IndexValueEntry.h:
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.cpp:
(WebCore::IDBServer::IndexValueStore::valueKeys const):
(WebCore::IDBServer::IndexValueStore::allKeys const):
(WebCore::IDBServer::IndexValueStore::removeRecord):
(WebCore::IDBServer::IndexValueStore::findKeysWithValueKey):
* Source/WebCore/Modules/indexeddb/server/IndexValueStore.h:
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
(WebCore::IDBServer::MemoryBackingStoreTransaction::indexCleared): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::objectStoreCleared):
(WebCore::IDBServer::MemoryIndex::putIndexKey):
(WebCore::IDBServer::MemoryIndex::removeRecord):
(WebCore::IDBServer::MemoryIndex::removeEntriesWithValueKey):
(WebCore::IDBServer::MemoryIndex::addIndexRecord):
(WebCore::IDBServer::MemoryIndex::removeIndexRecord):
(WebCore::IDBServer::MemoryIndex::writeTransactionStarted):
(WebCore::IDBServer::MemoryIndex::writeTransactionFinished):
(WebCore::IDBServer::MemoryIndex::transactionAborted):
(WebCore::IDBServer::MemoryIndex::clearIndexValueStore): Deleted.
(WebCore::IDBServer::MemoryIndex::replaceIndexValueStore): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.cpp:
(WebCore::IDBServer::MemoryObjectStore::writeTransactionStarted):
(WebCore::IDBServer::MemoryObjectStore::transactionAborted):
(WebCore::IDBServer::MemoryObjectStore::writeTransactionFinished):
(WebCore::IDBServer::MemoryObjectStore::addIndex):
(WebCore::IDBServer::MemoryObjectStore::maybeRestoreDeletedIndex):
(WebCore::IDBServer::MemoryObjectStore::addRecordWithoutUpdatingIndexes):
(WebCore::IDBServer::MemoryObjectStore::populateIndexWithExistingRecords): Deleted.
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:

Canonical link: <a href="https://commits.webkit.org/291234@main">https://commits.webkit.org/291234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91d1694c46b5a2f6ce1eccf1dc5c07c32af3dd38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97315 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20326 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70760 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28223 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95323 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9223 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1224 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42169 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79283 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99339 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19380 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79033 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19600 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23577 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12381 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24532 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19054 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22511 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->