### PR TITLE
[GStreamer][MediaStream] Basic support for track configurationchange events

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2214,9 +2214,6 @@ webkit.org/b/265860 imported/w3c/web-platform-tests/webrtc-stats/supported-stats
 
 webkit.org/b/262989 imported/w3c/web-platform-tests/webrtc-stats/hardware-capability-stats.https.html [ Failure ]
 
-# This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
-fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
-
 fast/mediastream/video-rotation2.html [ Failure Pass Timeout ]
 
 # Regressions introduced by https://commits.webkit.org/263750@main
@@ -2246,6 +2243,7 @@ webkit.org/b/256758 fast/mediastream/captureStream/canvas3d.html [ Failure ]
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 
+# These tests are macOS-specific. In Linux changing the PipeWire capture source on the fly is not supported.
 fast/mediastream/getDisplayMedia-max-constraints4.html [ Skip ]
 fast/mediastream/getDisplayMedia-max-constraints5.html [ Skip ]
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -1505,6 +1505,13 @@ std::pair<GstClockTime, GstClockTime> RealtimeMediaSource::queryCaptureLatency()
 }
 #endif
 
+void RealtimeMediaSource::configurationChanged()
+{
+    forEachObserver([](auto& observer) {
+        observer.sourceConfigurationChanged();
+    });
+}
+
 #if !RELEASE_LOG_DISABLED
 void RealtimeMediaSource::setLogger(const Logger& newLogger, uint64_t newLogIdentifier)
 {

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -306,6 +306,8 @@ public:
     virtual std::pair<GstClockTime, GstClockTime> queryCaptureLatency() const;
 #endif
 
+    virtual void configurationChanged();
+
 protected:
     RealtimeMediaSource(const CaptureDevice&, MediaDeviceHashSalts&& hashSalts = { }, std::optional<PageIdentifier> = std::nullopt);
 

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp
@@ -111,6 +111,13 @@ void GStreamerAudioCaptureSource::captureEnded()
     captureFailed();
 }
 
+void GStreamerAudioCaptureSource::captureDeviceUpdated(const GStreamerCaptureDevice& device)
+{
+    setName(AtomString { device.label() });
+    setPersistentId(device.persistentId());
+    configurationChanged();
+}
+
 std::pair<GstClockTime, GstClockTime> GStreamerAudioCaptureSource::queryCaptureLatency() const
 {
     if (!m_capturer)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h
@@ -47,7 +47,8 @@ public:
     virtual ~GStreamerAudioCaptureSource();
 
     // GStreamerCapturerObserver
-    void captureEnded()final;
+    void captureEnded() final;
+    void captureDeviceUpdated(const GStreamerCaptureDevice&) final;
 
 protected:
     GStreamerAudioCaptureSource(GStreamerCaptureDevice&&, MediaDeviceHashSalts&&);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h
@@ -64,8 +64,11 @@ public:
 private:
     void addDevice(GRefPtr<GstDevice>&&);
     void removeDevice(GRefPtr<GstDevice>&&);
+    void updateDevice(GRefPtr<GstDevice>&& newDevice, GRefPtr<GstDevice>&& oldDevice);
     void stopMonitor();
     void refreshCaptureDevices();
+
+    std::optional<GStreamerCaptureDevice> captureDeviceFromGstDevice(GRefPtr<GstDevice>&&);
 
     GRefPtr<GstDeviceMonitor> m_deviceMonitor;
     Vector<GStreamerCaptureDevice> m_gstreamerDevices;
@@ -73,6 +76,7 @@ private:
     Vector<RefPtr<GStreamerCapturer>> m_capturers;
     bool m_isTearingDown { false };
     Vector<CaptureDevice> m_speakerDevices;
+    RefPtr<GStreamerCapturer> m_defaultCapturer;
 };
 
 class GStreamerAudioCaptureDeviceManager final : public GStreamerCaptureDeviceManager {

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h
@@ -47,6 +47,7 @@ public:
 
     virtual void sourceCapsChanged(const GstCaps*) { }
     virtual void captureEnded() { }
+    virtual void captureDeviceUpdated(const GStreamerCaptureDevice&) { }
 };
 
 class GStreamerCapturer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<GStreamerCapturer> {
@@ -56,6 +57,8 @@ public:
     virtual ~GStreamerCapturer();
 
     void tearDown(bool disconnectSignals = true);
+
+    void setDevice(std::optional<GStreamerCaptureDevice>&&);
 
     void addObserver(GStreamerCapturerObserver&);
     void removeObserver(GStreamerCapturerObserver&);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp
@@ -35,7 +35,7 @@ struct _GStreamerMockDevicePrivate {
 GST_DEBUG_CATEGORY_STATIC(webkitGstMockDeviceDebug);
 #define GST_CAT_DEFAULT webkitGstMockDeviceDebug
 
-WEBKIT_DEFINE_TYPE_WITH_CODE(GStreamerMockDevice, webkit_mock_device, GST_TYPE_DEVICE, GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceDebug, "webkitmockdevice", 0, "Mock Device"))
+WEBKIT_DEFINE_TYPE(GStreamerMockDevice, webkit_mock_device, GST_TYPE_DEVICE)
 
 static GstElement* webkitMockDeviceCreateElement([[maybe_unused]] GstDevice* device, const char* name)
 {
@@ -53,6 +53,8 @@ static void webkit_mock_device_class_init(GStreamerMockDeviceClass* klass)
 
 GstDevice* webkitMockDeviceCreate(const CaptureDevice& captureDevice)
 {
+    GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceDebug, "webkitmockdevice", 0, "Mock Device");
+
     const char* deviceClass;
     GRefPtr<GstCaps> caps;
 
@@ -75,7 +77,8 @@ GstDevice* webkitMockDeviceCreate(const CaptureDevice& captureDevice)
 
     auto displayName = captureDevice.label();
     GUniquePtr<GstStructure> properties(gst_structure_new("webkit-mock-device", "persistent-id", G_TYPE_STRING, captureDevice.persistentId().ascii().data(), "is-default", G_TYPE_BOOLEAN, captureDevice.isDefault(), nullptr));
-    auto* device = WEBKIT_MOCK_DEVICE_CAST(g_object_new(GST_TYPE_MOCK_DEVICE, "display-name", displayName.ascii().data(), "device-class", deviceClass, "caps", caps.get(), "properties", properties.get(), nullptr));
+    GST_DEBUG("Creating mock device with name %s and properties %" GST_PTR_FORMAT, displayName.utf8().data(), properties.get());
+    auto* device = WEBKIT_MOCK_DEVICE_CAST(g_object_new(GST_TYPE_MOCK_DEVICE, "display-name", displayName.utf8().data(), "device-class", deviceClass, "caps", caps.get(), "properties", properties.get(), nullptr));
     gst_object_ref_sink(device);
     return GST_DEVICE_CAST(device);
 }

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.h
@@ -47,4 +47,10 @@ struct _GStreamerMockDeviceProviderClass {
 
 GType webkit_mock_device_provider_get_type(void);
 
+namespace WebCore {
+class CaptureDevice;
+};
+
+void webkitGstMockDeviceProviderSwitchDefaultDevice(const WebCore::CaptureDevice&, const WebCore::CaptureDevice&);
+
 #endif // ENABLE(MEDIA_STREAM) && USE(GSTREAMER)

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -181,6 +181,13 @@ void GStreamerVideoCaptureSource::captureEnded()
     m_capturer->stop();
 }
 
+void GStreamerVideoCaptureSource::captureDeviceUpdated(const GStreamerCaptureDevice& device)
+{
+    setName(AtomString { device.label() });
+    setPersistentId(device.persistentId());
+    configurationChanged();
+}
+
 std::pair<GstClockTime, GstClockTime> GStreamerVideoCaptureSource::queryCaptureLatency() const
 {
     if (!m_capturer)
@@ -251,6 +258,14 @@ const RealtimeMediaSourceSettings& GStreamerVideoCaptureSource::settings()
     m_currentSettings->setFrameRate(frameRate());
     m_currentSettings->setFacingMode(facingMode());
     return m_currentSettings.value();
+}
+
+void GStreamerVideoCaptureSource::configurationChanged()
+{
+    m_currentSettings = { };
+    m_capabilities = { };
+
+    RealtimeMediaSource::configurationChanged();
 }
 
 void GStreamerVideoCaptureSource::generatePresets()

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 using NodeAndFD = GStreamerVideoCapturer::NodeAndFD;
 
-class GStreamerVideoCaptureSource : public RealtimeVideoCaptureSource, GStreamerCapturerObserver {
+class GStreamerVideoCaptureSource final : public RealtimeVideoCaptureSource, GStreamerCapturerObserver {
 public:
     static CaptureSourceOrError create(String&& deviceID, MediaDeviceHashSalts&&, const MediaConstraints*);
     static CaptureSourceOrError createPipewireSource(String&& deviceID, const NodeAndFD&, MediaDeviceHashSalts&&, const MediaConstraints*, CaptureDevice::DeviceType);
@@ -41,14 +41,17 @@ public:
 
     WEBCORE_EXPORT static DisplayCaptureFactory& displayFactory();
 
-    const RealtimeMediaSourceCapabilities& capabilities() override;
-    const RealtimeMediaSourceSettings& settings() override;
+    const RealtimeMediaSourceCapabilities& capabilities() final;
+    const RealtimeMediaSourceSettings& settings() final;
+    void configurationChanged() final;
+
     GstElement* pipeline() { return m_capturer->pipeline(); }
     GStreamerCapturer* capturer() { return m_capturer.get(); }
 
     // GStreamerCapturerObserver
     void sourceCapsChanged(const GstCaps*) final;
     void captureEnded() final;
+    void captureDeviceUpdated(const GStreamerCaptureDevice&) final;
 
     std::pair<GstClockTime, GstClockTime> queryCaptureLatency() const final;
 
@@ -56,15 +59,15 @@ protected:
     GStreamerVideoCaptureSource(String&& deviceID, AtomString&& name, MediaDeviceHashSalts&&, const gchar* source_factory, CaptureDevice::DeviceType, const NodeAndFD&);
     GStreamerVideoCaptureSource(GStreamerCaptureDevice&&, MediaDeviceHashSalts&&);
     virtual ~GStreamerVideoCaptureSource();
-    void startProducingData() override;
-    void stopProducingData() override;
+    void startProducingData() final;
+    void stopProducingData() final;
     bool canResizeVideoFrames() const final { return true; }
-    void generatePresets() override;
-    void setSizeFrameRateAndZoom(const VideoPresetConstraints&) override;
+    void generatePresets() final;
+    void setSizeFrameRateAndZoom(const VideoPresetConstraints&) final;
 
     mutable std::optional<RealtimeMediaSourceCapabilities> m_capabilities;
     mutable std::optional<RealtimeMediaSourceSettings> m_currentSettings;
-    CaptureDevice::DeviceType deviceType() const override { return m_deviceType; }
+    CaptureDevice::DeviceType deviceType() const final { return m_deviceType; }
 
 private:
     bool isCaptureSource() const final { return true; }

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp
@@ -132,6 +132,14 @@ void MockRealtimeAudioSourceGStreamer::captureEnded()
     captureFailed();
 }
 
+void MockRealtimeAudioSourceGStreamer::captureDeviceUpdated(const GStreamerCaptureDevice& device)
+{
+    setName(AtomString { device.label() });
+    setPersistentId(device.persistentId());
+
+    configurationChanged();
+}
+
 std::pair<GstClockTime, GstClockTime> MockRealtimeAudioSourceGStreamer::queryCaptureLatency() const
 {
     if (!m_capturer)

--- a/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h
@@ -41,6 +41,7 @@ public:
 
     // GStreamerCapturerObserver
     void captureEnded() final;
+    void captureDeviceUpdated(const GStreamerCaptureDevice&) final;
 
     std::pair<GstClockTime, GstClockTime> queryCaptureLatency() const final;
 

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h
@@ -79,7 +79,7 @@ public:
     void captureDeviceSuspendedDidChange();
     void captureOutputDidFinishProcessingPhoto(RetainPtr<AVCapturePhotoOutput>, RetainPtr<AVCapturePhoto>, RetainPtr<NSError>);
 
-    void configurationChanged();
+    void configurationChanged() final;
 
 private:
     AVVideoCaptureSource(AVCaptureDevice*, const CaptureDevice&, MediaDeviceHashSalts&&, std::optional<PageIdentifier>);

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -440,9 +440,7 @@ void AVVideoCaptureSource::configurationChanged()
     m_currentSettings = { };
     m_capabilities = { };
 
-    forEachObserver([](auto& observer) {
-        observer.sourceConfigurationChanged();
-    });
+    RealtimeMediaSource::configurationChanged();
 }
 
 static bool isZoomSupported(const Vector<VideoPreset>& presets)

--- a/Source/WebCore/platform/mock/MockMediaDevice.h
+++ b/Source/WebCore/platform/mock/MockMediaDevice.h
@@ -77,16 +77,16 @@ struct MockMediaDevice {
     CaptureDevice captureDevice() const
     {
         if (isMicrophone())
-            return CaptureDevice { persistentId, CaptureDevice::DeviceType::Microphone, label, persistentId, true, false, true, flags.contains(Flag::Ephemeral) };
+            return CaptureDevice { persistentId, CaptureDevice::DeviceType::Microphone, label, persistentId, true, isDefault, true, flags.contains(Flag::Ephemeral) };
 
         if (isSpeaker())
-            return CaptureDevice { persistentId, CaptureDevice::DeviceType::Speaker, label, speakerProperties()->relatedMicrophoneId, true, false, true, flags.contains(Flag::Ephemeral) };
+            return CaptureDevice { persistentId, CaptureDevice::DeviceType::Speaker, label, speakerProperties()->relatedMicrophoneId, true, isDefault, true, flags.contains(Flag::Ephemeral) };
 
         if (isCamera())
-            return CaptureDevice { persistentId, CaptureDevice::DeviceType::Camera, label, persistentId, true, false, true, flags.contains(Flag::Ephemeral) };
+            return CaptureDevice { persistentId, CaptureDevice::DeviceType::Camera, label, persistentId, true, isDefault, true, flags.contains(Flag::Ephemeral) };
 
         ASSERT(isDisplay());
-        return CaptureDevice { persistentId, std::get<MockDisplayProperties>(properties).type, label, emptyString(), true, false, true, flags.contains(Flag::Ephemeral) };
+        return CaptureDevice { persistentId, std::get<MockDisplayProperties>(properties).type, label, emptyString(), true, isDefault, true, flags.contains(Flag::Ephemeral) };
     }
 
     CaptureDevice::DeviceType type() const
@@ -115,6 +115,7 @@ struct MockMediaDevice {
     String persistentId;
     String label;
     Flags flags;
+    bool isDefault;
     std::variant<MockMicrophoneProperties, MockSpeakerProperties, MockCameraProperties, MockDisplayProperties> properties;
 };
 

--- a/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp
@@ -53,6 +53,7 @@
 #endif
 
 #if USE(GSTREAMER)
+#include "GStreamerMockDeviceProvider.h"
 #include "MockDisplayCaptureSourceGStreamer.h"
 #include "MockRealtimeVideoSourceGStreamer.h"
 #endif
@@ -62,15 +63,15 @@ namespace WebCore {
 static inline Vector<MockMediaDevice> defaultDevices()
 {
     return Vector<MockMediaDevice> {
-        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, { }, MockMicrophoneProperties { 44100 , { } } },
-        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, { },  MockMicrophoneProperties { 48000, { false } } },
-        MockMediaDevice { "239c24b1-3b15-11e3-8224-0800200c9a66"_s, "Mock audio device 3"_s, { },  MockMicrophoneProperties { 96000, { true } } },
+        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 1"_s, { }, true, MockMicrophoneProperties { 44100 , { } } },
+        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, "Mock audio device 2"_s, { }, false, MockMicrophoneProperties { 48000, { false } } },
+        MockMediaDevice { "239c24b1-3b15-11e3-8224-0800200c9a66"_s, "Mock audio device 3"_s, { }, false, MockMicrophoneProperties { 96000, { true } } },
 
-        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 1"_s, { },  MockSpeakerProperties { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, 44100 } },
-        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 2"_s, { },  MockSpeakerProperties { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, 48000 } },
-        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 3"_s, { },  MockSpeakerProperties { String { }, 48000 } },
+        MockMediaDevice { "239c24b0-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 1"_s, { }, true, MockSpeakerProperties { "239c24b0-2b15-11e3-8224-0800200c9a66"_s, 44100 } },
+        MockMediaDevice { "239c24b1-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 2"_s, { }, false, MockSpeakerProperties { "239c24b1-2b15-11e3-8224-0800200c9a66"_s, 48000 } },
+        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a67"_s, "Mock speaker device 3"_s, { }, false, MockSpeakerProperties { String { }, 48000 } },
 
-        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 1"_s, { },
+        MockMediaDevice { "239c24b2-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 1"_s, { }, true,
             MockCameraProperties {
                 30,
                 VideoFacingMode::User, {
@@ -85,7 +86,7 @@ static inline Vector<MockMediaDevice> defaultDevices()
                 false, // background blur enabled
             } },
 
-        MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, { },
+        MockMediaDevice { "239c24b3-2b15-11e3-8224-0800200c9a66"_s, "Mock video device 2"_s, { }, false,
             MockCameraProperties {
                 15,
                 VideoFacingMode::Environment, {
@@ -104,11 +105,11 @@ static inline Vector<MockMediaDevice> defaultDevices()
                 true, // background blur enabled
             } },
 
-        MockMediaDevice { "SCREEN-1"_s, "Mock screen device 1"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::lightGray, { 1920, 1080 } } },
-        MockMediaDevice { "SCREEN-2"_s, "Mock screen device 2"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::yellow, { 3840, 2160 } } },
+        MockMediaDevice { "SCREEN-1"_s, "Mock screen device 1"_s, { }, true, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::lightGray, { 1920, 1080 } } },
+        MockMediaDevice { "SCREEN-2"_s, "Mock screen device 2"_s, { }, false, MockDisplayProperties { CaptureDevice::DeviceType::Screen, Color::yellow, { 3840, 2160 } } },
 
-        MockMediaDevice { "WINDOW-1"_s, "Mock window device 1"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 241, 181 }, { 640, 480 } } },
-        MockMediaDevice { "WINDOW-2"_s, "Mock window device 2"_s, { }, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 208, 181 }, { 1280, 600 } } },
+        MockMediaDevice { "WINDOW-1"_s, "Mock window device 1"_s, { }, true, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 241, 181 }, { 640, 480 } } },
+        MockMediaDevice { "WINDOW-2"_s, "Mock window device 2"_s, { }, false, MockDisplayProperties { CaptureDevice::DeviceType::Window, SRGBA<uint8_t> { 255, 208, 181 }, { 1280, 600 } } },
     };
 }
 
@@ -450,6 +451,13 @@ void MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange(bool f
         if (auto capturer = MockRealtimeDisplaySourceFactory::singleton().latestCapturer())
             capturer->triggerMockCaptureConfigurationChange();
     }
+#elif USE(GSTREAMER)
+    if (forMicrophone) {
+        auto devices = audioCaptureDeviceManager().captureDevices();
+        if (devices.size() > 1)
+            webkitGstMockDeviceProviderSwitchDefaultDevice(devices[0], devices[1]);
+    }
+    UNUSED_PARAM(forDisplay);
 #else
     UNUSED_PARAM(forMicrophone);
     UNUSED_PARAM(forDisplay);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6522,6 +6522,7 @@ header: <WebCore/MockMediaDevice.h>
     String persistentId;
     String label;
     OptionSet<WebCore::MockMediaDevice::Flag> flags;
+    bool isDefault;
     std::variant<WebCore::MockMicrophoneProperties, WebCore::MockSpeakerProperties, WebCore::MockCameraProperties, WebCore::MockDisplayProperties> properties;
 };
 

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp
@@ -72,7 +72,8 @@ void WKAddMockMediaDevice(WKContextRef context, WKStringRef persistentId, WKStri
         }
     }
 
-    toImpl(context)->addMockMediaDevice({ WebKit::toImpl(persistentId)->string(), WebKit::toImpl(label)->string(), flags, WTFMove(deviceProperties) });
+    bool isDefault = false;
+    toImpl(context)->addMockMediaDevice({ WebKit::toImpl(persistentId)->string(), WebKit::toImpl(label)->string(), flags, isDefault, WTFMove(deviceProperties) });
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3377,7 +3377,11 @@ void WKPageTriggerMockCaptureConfigurationChange(WKPageRef pageRef, bool forCame
 {
     CRASH_IF_SUSPENDED;
 #if ENABLE(MEDIA_STREAM)
+#if USE(GSTREAMER)
+    toImpl(pageRef)->triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
+#else
     MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
+#endif // USE(GSTREAMER)
 
 #if ENABLE(GPU_PROCESS)
     auto preferences = toImpl(pageRef)->protectedPreferences();

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14985,6 +14985,11 @@ void WebPageProxy::setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bo
 {
     send(Messages::WebPage::SetMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted));
 }
+
+void WebPageProxy::triggerMockCaptureConfigurationChange(bool forCamera, bool forMicrophone, bool forDisplay)
+{
+    send(Messages::WebPage::TriggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay));
+}
 #endif
 
 void WebPageProxy::getLoadedSubresourceDomains(CompletionHandler<void(Vector<RegistrableDomain>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2240,6 +2240,7 @@ public:
 
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
+    void triggerMockCaptureConfigurationChange(bool forCamera, bool forMicrophone, bool forDisplay);
 #endif
 
     bool isHandlingPreventableTouchStart() const { return m_handlingPreventableTouchStartCount; }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5953,6 +5953,11 @@ void WebPage::setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool is
 {
     MockRealtimeMediaSourceCenter::setMockCaptureDevicesInterrupted(isCameraInterrupted, isMicrophoneInterrupted);
 }
+
+void WebPage::triggerMockCaptureConfigurationChange(bool forCamera, bool forMicrophone, bool forDisplay)
+{
+    MockRealtimeMediaSourceCenter::singleton().triggerMockCaptureConfigurationChange(forCamera, forMicrophone, forDisplay);
+}
 #endif // USE(GSTREAMER)
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1497,6 +1497,7 @@ public:
 #if ENABLE(MEDIA_STREAM) && USE(GSTREAMER)
     void setOrientationForMediaCapture(uint64_t rotation);
     void setMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted);
+    void triggerMockCaptureConfigurationChange(bool forCamera, bool forMicrophone, bool forDisplay);
 #endif
 
     void addUserScript(String&& source, InjectedBundleScriptWorld&, WebCore::UserContentInjectedFrames, WebCore::UserScriptInjectionTime);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -436,6 +436,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #if USE(GSTREAMER)
     SetOrientationForMediaCapture(uint64_t rotation)
     SetMockCaptureDevicesInterrupted(bool isCameraInterrupted, bool isMicrophoneInterrupted)
+    TriggerMockCaptureConfigurationChange(bool forCamera, bool forMicrophone, bool forDisplay)
 #endif
 #endif
 

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
@@ -108,10 +108,8 @@ void RemoteRealtimeMediaSource::configurationChanged(String&& persistentID, WebC
     setSettings(WTFMove(settings));
     setCapabilities(WTFMove(capabilities));
     setName(m_settings.label());
-    
-    forEachObserver([](auto& observer) {
-        observer.sourceConfigurationChanged();
-    });
+
+    RealtimeMediaSource::configurationChanged();
 }
 
 void RemoteRealtimeMediaSource::applyConstraintsSucceeded(WebCore::RealtimeMediaSourceSettings&& settings)

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSource.h
@@ -56,6 +56,7 @@ public:
     void captureStopped(bool didFail);
     void sourceMutedChanged(bool value, bool interrupted);
 
+    using RealtimeMediaSource::configurationChanged;
     void configurationChanged(String&& persistentID, WebCore::RealtimeMediaSourceSettings&&, WebCore::RealtimeMediaSourceCapabilities&&);
 
 #if ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### 70b217d22d3a08d4eec2767e2029cf3d673fc97d
<pre>
[GStreamer][MediaStream] Basic support for track configurationchange events
<a href="https://bugs.webkit.org/show_bug.cgi?id=288466">https://bugs.webkit.org/show_bug.cgi?id=288466</a>

Reviewed by Xabier Rodriguez-Calvar.

If we are capturing a default microphone or camera and the user changes the default device in the OS
session settings, we should keep capture the new default device. This is now supported, excepted for
screen capture. The GstDeviceProvider emits device-changed messages on the bus, so by monitoring
those we can propagate changes in the CaptureDeviceManager and notify observing RealtimeMediaSources
which then notify the MediaStreamTrackPrivate which relays the notification to the MediaStreamTrack
which emits the configurationchange event. On the GStreamer capturer side, when the default device
changes the pipeline is partly teared down and a new one is spun up, using the new GstDevice.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::configurationChanged):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.cpp:
(WebCore::GStreamerAudioCaptureSource::captureDeviceUpdated):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerAudioCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::captureDeviceFromGstDevice):
(WebCore::GStreamerCaptureDeviceManager::addDevice):
(WebCore::GStreamerCaptureDeviceManager::removeDevice):
(WebCore::GStreamerCaptureDeviceManager::updateDevice):
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.cpp:
(WebCore::GStreamerCapturer::tearDown):
(WebCore::GStreamerCapturer::setDevice):
(WebCore::GStreamerCapturer::setupPipeline):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCapturer.h:
(WebCore::GStreamerCapturerObserver::captureDeviceUpdated):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDevice.cpp:
(webkitMockDeviceCreate):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
(webkitMockDeviceProviderProbe):
(webkitGstMockDeviceProviderSingleton):
(findDeviceWithID):
(webkitGstMockDeviceProviderSwitchDefaultDevice):
(webkitMockDeviceProviderConstructed):
(webkitMockDeviceProviderFinalize):
(webkit_mock_device_provider_class_init):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::captureDeviceUpdated):
(WebCore::GStreamerVideoCaptureSource::configurationChanged):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.cpp:
(WebCore::MockRealtimeAudioSourceGStreamer::captureDeviceUpdated):
* Source/WebCore/platform/mediastream/gstreamer/MockRealtimeAudioSourceGStreamer.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.h:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::configurationChanged):
* Source/WebCore/platform/mock/MockMediaDevice.h:
(WebCore::MockMediaDevice::captureDevice const):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::defaultDevices):
(WebCore::MockRealtimeMediaSourceCenter::triggerMockCaptureConfigurationChange):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp:
(WKAddMockMediaDevice):
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageTriggerMockCaptureConfigurationChange):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::triggerMockCaptureConfigurationChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::triggerMockCaptureConfigurationChange):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/291112@main">https://commits.webkit.org/291112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a97c2f914ddd4c21e7a8bb6794d4ab858987917

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96994 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42652 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11945 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20101 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95076 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83401 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50975 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1009 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41870 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99034 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19184 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19436 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78916 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19525 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23442 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19165 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18860 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20603 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->