### PR TITLE
Fix createElement[NS]'s customElements handling

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative-expected.txt
@@ -1,8 +1,9 @@
 
 PASS createElement should use the global registry by default
 PASS createElement should use the specified scoped registry
-PASS createElement should create a builtin element regardles of a custom element registry specified
+PASS createElement should create a builtin element regardless of a custom element registry specified
 PASS createElement should use the specified global registry
 PASS createElement should create an upgrade candidate when there is no matching definition in the specified registry
 PASS createElement should create an upgrade candidate and the candidate should be upgraded when the element is defined
+PASS createElement on a non-HTML document should still handle registries correctly
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative-expected.txt
@@ -1,0 +1,9 @@
+
+PASS createElementNS should use the global registry by default
+PASS createElementNS should use the specified scoped registry
+PASS createElementNS should create a builtin element regardless of a custom element registry specified
+PASS createElementNS should use the specified global registry
+PASS createElementNS should create an upgrade candidate when there is no matching definition in the specified registry
+PASS createElementNS should create an upgrade candidate and the candidate should be upgraded when the element is defined
+PASS createElementNS on a non-HTML document should still handle registries correctly
+

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative.html
@@ -1,14 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
-<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
 <link rel="help" href="https://github.com/whatwg/html/issues/10854">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>
-// Keep this ~synchronized with Document-createElementNS
+// Keep this ~synchronized with Document-createElement
 "use strict";
 
 const scopedRegistry = new CustomElementRegistry();
@@ -19,12 +18,12 @@ customElements.define('a-b', GlobalABElement);
 scopedRegistry.define('a-b', ScopedABElement);
 
 test(() => {
-    assert_true(document.createElement('a-b') instanceof GlobalABElement);
-}, 'createElement should use the global registry by default');
+    assert_true(document.createElementNS('http://www.w3.org/1999/xhtml', 'a-b') instanceof GlobalABElement);
+}, 'createElementNS should use the global registry by default');
 
 test(() => {
-    assert_true(document.createElement('a-b', {customElements: scopedRegistry}) instanceof ScopedABElement);
-}, 'createElement should use the specified scoped registry');
+    assert_true(document.createElementNS('http://www.w3.org/1999/xhtml', 'a-b', {customElements: scopedRegistry}) instanceof ScopedABElement);
+}, 'createElementNS should use the specified scoped registry');
 
 test(() => {
     const elements = {
@@ -35,33 +34,33 @@ test(() => {
         unknown: HTMLUnknownElement,
     };
     for (const localName in elements) {
-        const scopedElement = document.createElement(localName, {customElements: scopedRegistry});
+        const scopedElement = document.createElementNS('http://www.w3.org/1999/xhtml', localName, {customElements: scopedRegistry});
         assert_true(scopedElement instanceof elements[localName], localName);
         assert_equals(scopedElement.customElements, scopedRegistry);
 
-        const globalExplicitElement = document.createElement(localName, {customElements: window.customElements});
+        const globalExplicitElement = document.createElementNS('http://www.w3.org/1999/xhtml', localName, {customElements: window.customElements});
         assert_true(globalExplicitElement instanceof elements[localName], localName);
         assert_equals(globalExplicitElement.customElements, window.customElements);
 
-        const globalImplicitElement = document.createElement(localName);
+        const globalImplicitElement = document.createElementNS('http://www.w3.org/1999/xhtml', localName);
         assert_true(globalImplicitElement instanceof elements[localName], localName);
         assert_equals(globalImplicitElement.customElements, window.customElements);
     }
-}, 'createElement should create a builtin element regardless of a custom element registry specified');
+}, 'createElementNS should create a builtin element regardless of a custom element registry specified');
 
 test(() => {
-    assert_true(document.createElement('a-b', {customElements: window.customElements}) instanceof GlobalABElement);
-}, 'createElement should use the specified global registry');
+    assert_true(document.createElementNS('http://www.w3.org/1999/xhtml', 'a-b', {customElements: window.customElements}) instanceof GlobalABElement);
+}, 'createElementNS should use the specified global registry');
 
 test(() => {
-    const element = document.createElement('a-b', {customElements: otherScopedRegistry});
+    const element = document.createElementNS('http://www.w3.org/1999/xhtml', 'a-b', {customElements: otherScopedRegistry});
     assert_equals(element.__proto__.constructor.name, 'HTMLElement');
-}, 'createElement should create an upgrade candidate when there is no matching definition in the specified registry');
+}, 'createElementNS should create an upgrade candidate when there is no matching definition in the specified registry');
 
 test(() => {
     class CDElement extends HTMLElement { }
     const registry = new CustomElementRegistry;
-    const cdElement = document.createElement('c-d', {customElements: registry});
+    const cdElement = document.createElementNS('http://www.w3.org/1999/xhtml', 'c-d', {customElements: registry});
     assert_false(cdElement instanceof CDElement);
     assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
     registry.define('c-d', CDElement);
@@ -69,19 +68,19 @@ test(() => {
     assert_equals(cdElement.__proto__.constructor.name, 'HTMLElement');
     document.body.appendChild(cdElement);
     assert_true(cdElement instanceof CDElement);
-}, 'createElement should create an upgrade candidate and the candidate should be upgraded when the element is defined');
+}, 'createElementNS should create an upgrade candidate and the candidate should be upgraded when the element is defined');
 
 test(() => {
     const doc = new Document();
-    const scopedElement = doc.createElement("time", {customElements: scopedRegistry});
+    const scopedElement = doc.createElementNS(null, "time", {customElements: scopedRegistry});
     assert_equals(scopedElement.namespaceURI, null);
     assert_equals(scopedElement.customElements, scopedRegistry);
 
-    const abElement = doc.createElement("a-b", {customElements: scopedRegistry});
+    const abElement = doc.createElementNS(null, "a-b", {customElements: scopedRegistry});
     assert_equals(abElement.namespaceURI, null);
     assert_equals(abElement.customElements, scopedRegistry);
     assert_false(abElement instanceof ScopedABElement);
-}, 'createElement on a non-HTML document should still handle registries correctly');
+}, 'createElementNS on a non-HTML document should still handle registries correctly');
 
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log
@@ -19,6 +19,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-initialize.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/CustomElementRegistry-upgrade.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-importNode.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements-exceptions.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Element-customElements.tentative.html

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -509,7 +509,7 @@ public:
     void whenVisible(Function<void()>&&);
 
     WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName);
-    ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName, const ElementCreationOptions&);
+    ExceptionOr<Ref<Element>> createElementForBindings(const AtomString& tagName, std::optional<std::variant<String, ElementCreationOptions>>&&);
     WEBCORE_EXPORT Ref<DocumentFragment> createDocumentFragment();
     WEBCORE_EXPORT Ref<Text> createTextNode(String&& data);
     WEBCORE_EXPORT Ref<Comment> createComment(String&& data);
@@ -519,6 +519,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> createAttributeNS(const AtomString& namespaceURI, const AtomString& qualifiedName, bool shouldIgnoreNamespaceChecks = false);
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> importNode(Node& nodeToImport, std::variant<bool, ImportNodeOptions>&&);
     WEBCORE_EXPORT ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName);
+    ExceptionOr<Ref<Element>> createElementNS(const AtomString& namespaceURI, const AtomString& qualifiedName, std::optional<std::variant<String, ElementCreationOptions>>&&);
 
     WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser, CustomElementRegistry* = nullptr);
 

--- a/Source/WebCore/dom/Document.idl
+++ b/Source/WebCore/dom/Document.idl
@@ -56,8 +56,8 @@ typedef (HTMLScriptElement or SVGScriptElement) HTMLOrSVGScriptElement;
     readonly attribute DocumentType? doctype;
     [DOMJIT=Getter] readonly attribute Element? documentElement;
 
-    [NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName, optional ElementCreationOptions options = { });
-    [NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName);
+    [NewObject, ImplementedAs=createElementForBindings] Element createElement([AtomString] DOMString localName, optional (DOMString or ElementCreationOptions) options = {});
+    [NewObject] Element createElementNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString qualifiedName, optional (DOMString or ElementCreationOptions) options = {});
     HTMLCollection getElementsByTagName([AtomString] DOMString qualifiedName);
     HTMLCollection getElementsByTagNameNS([AtomString] DOMString? namespaceURI, [AtomString] DOMString localName);
     HTMLCollection getElementsByClassName([AtomString] DOMString classNames);


### PR DESCRIPTION
#### 7ef6667167291a0e18a54bc2b6e48242e6a4963d
<pre>
Fix createElement[NS]&apos;s customElements handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=288473">https://bugs.webkit.org/show_bug.cgi?id=288473</a>
<a href="https://rdar.apple.com/145557562">rdar://145557562</a>

Reviewed by Ryosuke Niwa.

This makes a variety of changes to align ourselves with the latest
Scoped Custom Element Registries proposal:

1. Accept DOMString in addition to ElementCreationOptions. This was
   already part of the DOM standard and is needed for compatibility.
   (Although to be fair the need has not been proven recently, but now
   does not seem like the time to find out.)
2. Have createElementNS take the same argument as
   createElementForBindings.
3. createHTMLElementWithNameValidation no longer needs both TreeScope
   and Document as they are once again the same.
4. Given that createHTMLElementWithNameValidation defaults registry to
   document.customElementRegistry it does not seem unlikely that
   registry is non-null so remove UNLIKELY there.
5. addToScopedCustomElementRegistryMap needs to be called by
   createElementForBindings and createElementNS as it&apos;s relevant for
   all elements. Since we only need to call it for scoped registries,
   we don&apos;t have to move the registry defaulting to
   document.customElementRegistry logic to these methods.

Tests are upstreamed here:
<a href="https://github.com/web-platform-tests/wpt/pull/50925">https://github.com/web-platform-tests/wpt/pull/50925</a>

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElement.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/Document-createElementNS.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/revamped-scoped-registry/w3c-import.log:
* Source/WebCore/dom/Document.cpp:
(WebCore::createHTMLElementWithNameValidation):
(WebCore::Document::createElementForBindings):
(WebCore::Document::createElementNS):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Document.idl:

Canonical link: <a href="https://commits.webkit.org/291093@main">https://commits.webkit.org/291093@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8d66a748fb196dc5989713a84c26aeea98ce94a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91778 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96734 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93828 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70463 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27958 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83233 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50790 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/825 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41620 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/78983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98749 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13962 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79486 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78710 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19499 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23231 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/11993 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14604 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24141 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->