### PR TITLE
Implement request-close command for dialogs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3060,7 +3060,6 @@ http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-css-i
 imported/w3c/web-platform-tests/css/css-text/text-spacing-trim [ Skip ]
 
 # command/commandfor future: These tests cover additions to the command invokers API which aren't specced yet
-imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-behavior.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-invalid-behavior.tentative.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative-expected.txt
@@ -1,0 +1,33 @@
+
+
+PASS invoking to request-close (with command property as request-close) open dialog closes
+PASS invoking to request-close with value (with command property as request-close) open dialog closes and sets returnValue
+PASS invoking to request-close (with command property as request-close) open dialog with preventDefault is no-op
+PASS invoking to request-close (with command property as request-close) open modal dialog with preventDefault is no-op
+PASS invoking to request-close (with command property as request-close) open dialog while changing command still closes
+PASS invoking to request-close (with command property as request-close) open modal dialog while changing command still closes
+PASS invoking to request-close (with command attribute as request-close) open dialog closes
+PASS invoking to request-close with value (with command attribute as request-close) open dialog closes and sets returnValue
+PASS invoking to request-close (with command attribute as request-close) open dialog with preventDefault is no-op
+PASS invoking to request-close (with command attribute as request-close) open modal dialog with preventDefault is no-op
+PASS invoking to request-close (with command attribute as request-close) open dialog while changing command still closes
+PASS invoking to request-close (with command attribute as request-close) open modal dialog while changing command still closes
+PASS invoking to request-close (with command property as reQuEst-Close) open dialog closes
+PASS invoking to request-close with value (with command property as reQuEst-Close) open dialog closes and sets returnValue
+PASS invoking to request-close (with command property as reQuEst-Close) open dialog with preventDefault is no-op
+PASS invoking to request-close (with command property as reQuEst-Close) open modal dialog with preventDefault is no-op
+PASS invoking to request-close (with command property as reQuEst-Close) open dialog while changing command still closes
+PASS invoking to request-close (with command property as reQuEst-Close) open modal dialog while changing command still closes
+PASS invoking to request-close (with command attribute as reQuEst-Close) open dialog closes
+PASS invoking to request-close with value (with command attribute as reQuEst-Close) open dialog closes and sets returnValue
+PASS invoking to request-close (with command attribute as reQuEst-Close) open dialog with preventDefault is no-op
+PASS invoking to request-close (with command attribute as reQuEst-Close) open modal dialog with preventDefault is no-op
+PASS invoking to request-close (with command attribute as reQuEst-Close) open dialog while changing command still closes
+PASS invoking to request-close (with command attribute as reQuEst-Close) open modal dialog while changing command still closes
+PASS invoking (as request-close) already closed dialog is noop
+PASS invoking (as request-close) dialog as open popover=manual is noop
+PASS invoking (as request-close) dialog as open popover=auto is noop
+PASS invoking (as request-close) dialog that is removed is noop
+PASS invoking (as request-close) dialog from a detached invoker
+PASS invoking (as request-close) detached dialog from a detached invoker
+

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3272,6 +3272,7 @@ bool AccessibilityObject::supportsExpanded() const
             case CommandType::Custom:
             case CommandType::ShowModal:
             case CommandType::Close:
+            case CommandType::RequestClose:
                 break;
             default:
                 ASSERT_NOT_REACHED();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -127,6 +127,7 @@ enum class CommandType: uint8_t {
 
     ShowModal,
     Close,
+    RequestClose,
 };
 
 struct CheckVisibilityOptions;

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -164,6 +164,12 @@ static const AtomString& closeAtom()
     return identifier;
 }
 
+static const AtomString& requestCloseAtom()
+{
+    static MainThreadNeverDestroyed<const AtomString> identifier("request-close"_s);
+    return identifier;
+}
+
 static const AtomString& showModalAtom()
 {
     static MainThreadNeverDestroyed<const AtomString> identifier("show-modal"_s);
@@ -190,6 +196,9 @@ CommandType HTMLButtonElement::commandType() const
 
     if (equalIgnoringASCIICase(action, closeAtom()))
         return CommandType::Close;
+
+    if (equalIgnoringASCIICase(action, requestCloseAtom()))
+        return CommandType::RequestClose;
 
     if (action.startsWith("--"_s))
         return CommandType::Custom;
@@ -238,6 +247,8 @@ const AtomString& HTMLButtonElement::command() const
         return hidePopoverAtom();
     case CommandType::Close:
         return closeAtom();
+    case CommandType::RequestClose:
+        return requestCloseAtom();
     case CommandType::ShowModal:
         return showModalAtom();
     case CommandType::Custom:

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -198,7 +198,8 @@ void HTMLDialogElement::requestClose(const String& returnValue)
 
 bool HTMLDialogElement::isValidCommandType(const CommandType command)
 {
-    return HTMLElement::isValidCommandType(command) || command == CommandType::ShowModal || command == CommandType::Close;
+    return HTMLElement::isValidCommandType(command) || command == CommandType::ShowModal || command == CommandType::Close
+        || command == CommandType::RequestClose;
 }
 
 bool HTMLDialogElement::handleCommandInternal(HTMLButtonElement& invoker, const CommandType& command)
@@ -212,6 +213,10 @@ bool HTMLDialogElement::handleCommandInternal(HTMLButtonElement& invoker, const 
     if (isOpen()) {
         if (command == CommandType::Close) {
             close(invoker.value().string());
+            return true;
+        }
+        if (command == CommandType::RequestClose) {
+            requestClose(invoker.value().string());
             return true;
         }
     } else {


### PR DESCRIPTION
#### d4059e07954fc75bf970f73c26904e82df68fad1
<pre>
Implement request-close command for dialogs
<a href="https://bugs.webkit.org/show_bug.cgi?id=288476">https://bugs.webkit.org/show_bug.cgi?id=288476</a>

Reviewed by Anne van Kesteren.

Spec PR: <a href="https://github.com/whatwg/html/pull/11045">https://github.com/whatwg/html/pull/11045</a>

This patch implements the request-close command for dialog, this maps to the requestClose() method.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative-expected.txt: Added.
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::commandType const):
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::isValidCommandType):
(WebCore::HTMLDialogElement::handleCommandInternal):

Canonical link: <a href="https://commits.webkit.org/295330@main">https://commits.webkit.org/295330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca32f27f583096eb82bb5ec3acf64da5374d328d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/104637 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/24347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/14765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/109862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/55308 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/106677 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/24736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/32892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/79477 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/107643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/19252 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/94440 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/59784 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/19022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/12514 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/54681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/88726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/12573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/112240 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/31798 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/23409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/88555 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/32162 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/90673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/88167 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/22493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/33068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/10840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/27115 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/31725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/37067 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/31518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/34856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/33077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->