### PR TITLE
[visionOS] Crash in com.apple.WebKit.GPU at AVFCore:  -[AVSampleBufferVideoRenderer enqueueSampleBuffer:]

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1068,7 +1068,6 @@ platform/graphics/cg/PDFDocumentImage.cpp
 platform/graphics/cocoa/FontCacheCoreText.cpp
 platform/graphics/cocoa/ImageAdapterCocoa.mm
 platform/graphics/cocoa/SourceBufferParser.cpp
-platform/graphics/cocoa/VideoMediaSampleRenderer.mm
 platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
 platform/graphics/controls/ApplePayButtonPart.cpp
 platform/graphics/controls/ButtonPart.h

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -76,12 +76,6 @@
 @property (assign, nonatomic) BOOL preventsAutomaticBackgroundingDuringVideoPlayback;
 @end
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-@interface AVSampleBufferVideoRenderer (Staging_127455709)
-- (void)removeAllVideoTargets;
-@end
-#endif
-
 namespace WebCore {
 
 String convertEnumerationToString(MediaPlayerPrivateMediaSourceAVFObjC::SeekState enumerationValue)
@@ -964,8 +958,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoRenderer()
     CMTime currentTime = PAL::CMTimebaseGetTime([m_synchronizer timebase]);
     [m_synchronizer removeRenderer:renderer.get() atTime:currentTime completionHandler:nil];
 
-    if ([renderer respondsToSelector:@selector(removeAllVideoTargets)])
-        [renderer removeAllVideoTargets];
     m_sampleBufferVideoRenderer = nullptr;
 #endif // ENABLE(LINEAR_MEDIA_PLAYER)
 }

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -53,14 +53,14 @@ class EffectiveRateChangedListener;
 class MediaSample;
 class WebCoreDecompressionSession;
 
-class VideoMediaSampleRenderer : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoMediaSampleRenderer, WTF::DestructionThread::Main> {
+class VideoMediaSampleRenderer final : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<VideoMediaSampleRenderer, WTF::DestructionThread::Main> {
 public:
     static Ref<VideoMediaSampleRenderer> create(WebSampleBufferVideoRendering *renderer) { return adoptRef(*new VideoMediaSampleRenderer(renderer)); }
     ~VideoMediaSampleRenderer();
 
-    bool prefersDecompressionSession() const { return m_prefersDecompressionSession; }
+    bool prefersDecompressionSession() const;
     void setPrefersDecompressionSession(bool);
-    bool isUsingDecompressionSession() const;
+    bool isUsingDecompressionSession() const { return m_isUsingDecompressionSession; }
 
     void setTimebase(RetainPtr<CMTimebaseRef>&&);
     RetainPtr<CMTimebaseRef> timebase() const;
@@ -143,6 +143,7 @@ private:
     void ensureOnDispatcher(Function<void()>&&) const;
     void ensureOnDispatcherSync(Function<void()>&&) const;
     dispatch_queue_t dispatchQueue() const;
+    RefPtr<WebCoreDecompressionSession> decompressionSession() const;
 
     const RefPtr<WTF::WorkQueue> m_workQueue;
     RetainPtr<AVSampleBufferDisplayLayer> m_displayLayer;
@@ -156,7 +157,8 @@ private:
     std::atomic<FlushId> m_flushId { 0 };
     Deque<std::pair<RetainPtr<CMSampleBufferRef>, FlushId>> m_compressedSampleQueue WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
     RetainPtr<CMBufferQueueRef> m_decodedSampleQueue; // created on the main thread, immutable after creation.
-    RefPtr<WebCoreDecompressionSession> m_decompressionSession;
+    RefPtr<WebCoreDecompressionSession> m_decompressionSession WTF_GUARDED_BY_LOCK(m_lock);
+    std::atomic<bool> m_isUsingDecompressionSession { false };
     bool m_isDecodingSample WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
     bool m_isDisplayingSample WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
     bool m_forceLateSampleToBeDisplayed WTF_GUARDED_BY_CAPABILITY(dispatcher().get()) { false };
@@ -165,7 +167,7 @@ private:
     std::optional<CMTime> m_nextScheduledPurge WTF_GUARDED_BY_CAPABILITY(dispatcher().get());
 
     Function<void()> m_readyForMoreSampleFunction;
-    bool m_prefersDecompressionSession { false };
+    bool m_prefersDecompressionSession WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
     std::optional<uint32_t> m_currentCodec;
     std::atomic<bool> m_gotDecodingError { false };
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -54,6 +54,12 @@
 - (void)resetUpcomingSampleBufferPresentationTimeExpectations;
 @end
 
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+@interface AVSampleBufferVideoRenderer (Staging_127455709)
+- (void)removeAllVideoTargets;
+@end
+#endif
+
 // Equivalent to WTF_DECLARE_CF_TYPE_TRAIT(CMSampleBuffer);
 // Needed due to requirement of specifying the PAL namespace.
 template <>
@@ -157,19 +163,31 @@ VideoMediaSampleRenderer::~VideoMediaSampleRenderer()
 {
     assertIsMainThread();
 
+    clearTimebase();
+
     flushCompressedSampleQueue();
+
+    RefPtr<WebCoreDecompressionSession> decompressionSession = [&] {
+        Locker lock { m_lock };
+        return std::exchange(m_decompressionSession, nullptr);
+    }();
+    if (decompressionSession)
+        decompressionSession->invalidate();
 
     if (auto renderer = this->renderer()) {
         [renderer flush];
         [renderer stopRequestingMediaData];
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+        if ([m_renderer respondsToSelector:@selector(removeAllVideoTargets)])
+            [m_renderer removeAllVideoTargets];
+#endif
     }
+}
 
-    if (m_decompressionSession) {
-        m_decompressionSession->invalidate();
-        m_decompressionSession = nullptr;
-    }
-
-    clearTimebase();
+RefPtr<WebCoreDecompressionSession> VideoMediaSampleRenderer::decompressionSession() const
+{
+    Locker lock { m_lock };
+    return m_decompressionSession;
 }
 
 size_t VideoMediaSampleRenderer::decodedSamplesCount() const
@@ -257,7 +275,7 @@ void VideoMediaSampleRenderer::stopRequestingMediaData()
 
     m_readyForMoreSampleFunction = nil;
 
-    if (m_decompressionSession) {
+    if (isUsingDecompressionSession()) {
         // stopRequestingMediaData may deadlock if used on the main thread while enqueuing on the workqueue
         dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
@@ -268,17 +286,21 @@ void VideoMediaSampleRenderer::stopRequestingMediaData()
     [renderer() stopRequestingMediaData];
 }
 
+bool VideoMediaSampleRenderer::prefersDecompressionSession() const
+{
+    assertIsMainThread();
+
+    return m_prefersDecompressionSession;
+}
+
 void VideoMediaSampleRenderer::setPrefersDecompressionSession(bool prefers)
 {
-    if (m_prefersDecompressionSession == prefers || m_decompressionSession)
+    assertIsMainThread();
+
+    if (m_prefersDecompressionSession == prefers || isUsingDecompressionSession())
         return;
 
     m_prefersDecompressionSession = prefers;
-}
-
-bool VideoMediaSampleRenderer::isUsingDecompressionSession() const
-{
-    return !!m_decompressionSession;
 }
 
 void VideoMediaSampleRenderer::setTimebase(RetainPtr<CMTimebaseRef>&& timebase)
@@ -340,6 +362,8 @@ RetainPtr<CMTimebaseRef> VideoMediaSampleRenderer::timebase() const
 
 void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
 {
+    assertIsMainThread();
+
     ASSERT(sample.platformSampleType() == PlatformSample::Type::CMSampleBufferType);
     if (sample.platformSampleType() != PlatformSample::Type::CMSampleBufferType)
         return;
@@ -348,7 +372,7 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
 
     bool needsDecompressionSession = false;
 #if ENABLE(VP9)
-    if (!m_decompressionSession && !m_currentCodec) {
+    if (!isUsingDecompressionSession() && !m_currentCodec) {
         // Only use a decompression session for vp8 or vp9 when software decoded.
         CMVideoFormatDescriptionRef videoFormatDescription = PAL::CMSampleBufferGetFormatDescription(cmSampleBuffer);
         auto fourCC = PAL::CMFormatDescriptionGetMediaSubType(videoFormatDescription);
@@ -357,10 +381,10 @@ void VideoMediaSampleRenderer::enqueueSample(const MediaSample& sample)
     }
 #endif
 
-    if (!m_decompressionSession && (!renderer() || ((prefersDecompressionSession() || needsDecompressionSession) && !sample.isProtected())))
+    if (!decompressionSession() && (!renderer() || ((prefersDecompressionSession() || needsDecompressionSession) && !sample.isProtected())))
         initializeDecompressionSession();
 
-    if (!m_decompressionSession) {
+    if (!isUsingDecompressionSession()) {
         [renderer() enqueueSampleBuffer:cmSampleBuffer];
         return;
     }
@@ -386,7 +410,9 @@ void VideoMediaSampleRenderer::decodeNextSample()
 {
     assertIsCurrent(dispatcher().get());
 
-    if (m_isDecodingSample || m_gotDecodingError)
+    RefPtr decompressionSession = this->decompressionSession();
+
+    if (m_isDecodingSample || m_gotDecodingError || !decompressionSession)
         return;
 
     if (m_compressedSampleQueue.isEmpty())
@@ -410,7 +436,7 @@ void VideoMediaSampleRenderer::decodeNextSample()
         return;
     }
 
-    auto decodePromise = m_decompressionSession->decodeSample(sample.get(), displaying);
+    auto decodePromise = decompressionSession->decodeSample(sample.get(), displaying);
     m_isDecodingSample = true;
     decodePromise->whenSettled(dispatcher(), [weakThis = ThreadSafeWeakPtr { *this }, this, displaying, flushId = flushId](auto&& result) {
         RefPtr protectedThis = weakThis.get();
@@ -490,13 +516,20 @@ void VideoMediaSampleRenderer::initializeDecompressionSession()
 {
     assertIsMainThread();
 
-    ASSERT(!m_decompressionSession && !m_decodedSampleQueue);
-    if (m_decompressionSession)
+    if (isUsingDecompressionSession())
         return;
 
-    m_decodedSampleQueue = createBufferQueue();
-    m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
+    {
+        Locker locker { m_lock };
 
+        ASSERT(!m_decompressionSession && !m_decodedSampleQueue);
+        if (m_decompressionSession)
+            return;
+
+        m_decompressionSession = WebCoreDecompressionSession::createOpenGL();
+        m_isUsingDecompressionSession = true;
+    }
+    m_decodedSampleQueue = createBufferQueue();
     m_startupTime = MonotonicTime::now();
 
     resetReadyForMoreSample();
@@ -581,7 +614,7 @@ void VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay(FlushId flushId
 {
     assertIsCurrent(dispatcher().get());
 
-    if (!decodedSamplesCount())
+    if (!decodedSamplesCount() || !decompressionSession())
         return;
 
     bool samplesPurged = false;
@@ -688,13 +721,13 @@ void VideoMediaSampleRenderer::flush()
     assertIsMainThread();
     [renderer() flush];
 
-    if (!m_decompressionSession)
+    if (!isUsingDecompressionSession())
         return;
 
     cancelTimer();
     flushCompressedSampleQueue();
 
-    m_decompressionSession->flush();
+    decompressionSession()->flush();
     dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }]() mutable {
         if (RefPtr protectedThis = weakThis.get()) {
             protectedThis->flushDecodedSampleQueue();
@@ -714,7 +747,7 @@ void VideoMediaSampleRenderer::resetReadyForMoreSample()
 {
     assertIsMainThread();
 
-    if (!rendererOrDisplayLayer() || m_decompressionSession) {
+    if (!rendererOrDisplayLayer() || isUsingDecompressionSession()) {
         dispatcher()->dispatch([weakThis = ThreadSafeWeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->maybeBecomeReadyForMoreMediaData();
@@ -738,7 +771,7 @@ void VideoMediaSampleRenderer::resetReadyForMoreSample()
 void VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime(const MediaTime& time)
 {
     assertIsMainThread();
-    if (m_decompressionSession || ![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
+    if (isUsingDecompressionSession() || ![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(expectMinimumUpcomingSampleBufferPresentationTime:)])
         return;
 
     [renderer() expectMinimumUpcomingSampleBufferPresentationTime:PAL::toCMTime(time)];
@@ -747,7 +780,7 @@ void VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime
 void VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations()
 {
     assertIsMainThread();
-    if (m_decompressionSession || ![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(resetUpcomingSampleBufferPresentationTimeExpectations)])
+    if (isUsingDecompressionSession() || ![PAL::getAVSampleBufferDisplayLayerClass() instancesRespondToSelector:@selector(resetUpcomingSampleBufferPresentationTimeExpectations)])
         return;
 
     [renderer() resetUpcomingSampleBufferPresentationTimeExpectations];
@@ -793,7 +826,7 @@ auto VideoMediaSampleRenderer::copyDisplayedPixelBuffer() -> DisplayedPixelBuffe
 {
     assertIsMainThread();
 
-    if (!m_decompressionSession) {
+    if (!isUsingDecompressionSession()) {
         RetainPtr buffer = adoptCF([renderer() copyDisplayedPixelBuffer]);
         if (auto surface = CVPixelBufferGetIOSurface(buffer.get()); surface && m_resourceOwner)
             IOSurface::setOwnershipIdentity(surface, m_resourceOwner);
@@ -842,7 +875,7 @@ unsigned VideoMediaSampleRenderer::totalDisplayedFrames() const
 
 unsigned VideoMediaSampleRenderer::totalVideoFrames() const
 {
-    if (m_decompressionSession)
+    if (isUsingDecompressionSession())
         return m_totalVideoFrames;
 #if PLATFORM(WATCHOS)
     return 0;
@@ -853,7 +886,7 @@ unsigned VideoMediaSampleRenderer::totalVideoFrames() const
 
 unsigned VideoMediaSampleRenderer::droppedVideoFrames() const
 {
-    if (m_decompressionSession)
+    if (isUsingDecompressionSession())
         return m_droppedVideoFrames;
 #if PLATFORM(WATCHOS)
     return 0;
@@ -864,7 +897,7 @@ unsigned VideoMediaSampleRenderer::droppedVideoFrames() const
 
 unsigned VideoMediaSampleRenderer::corruptedVideoFrames() const
 {
-    if (m_decompressionSession)
+    if (isUsingDecompressionSession())
         return m_corruptedVideoFrames;
 #if PLATFORM(WATCHOS)
     return 0;
@@ -875,7 +908,7 @@ unsigned VideoMediaSampleRenderer::corruptedVideoFrames() const
 
 MediaTime VideoMediaSampleRenderer::totalFrameDelay() const
 {
-    if (m_decompressionSession)
+    if (isUsingDecompressionSession())
         return m_totalFrameDelay;
 #if PLATFORM(WATCHOS)
     return MediaTime::invalidTime();


### PR DESCRIPTION
#### e8ba0143ef25ddeca6162f0e76fa499f6f84fe09
<pre>
[visionOS] Crash in com.apple.WebKit.GPU at AVFCore:  -[AVSampleBufferVideoRenderer enqueueSampleBuffer:]
<a href="https://bugs.webkit.org/show_bug.cgi?id=288234">https://bugs.webkit.org/show_bug.cgi?id=288234</a>
<a href="https://rdar.apple.com/145047791">rdar://145047791</a>

Reviewed by Andy Estes.

It was possible that we would enqueue a frame to the AVSampleBufferRenderer
after all its video targets had been removed, causing it to throw.

We move the removal of the video targets to the `VideoMediaSampleRenderer`
destructor to reduce the potential number of concurrent access to the
AVSampleBufferRenderer.
Additionally, we endure that the TimerDispatchSource has been cancelled
first to further guarantee that no frames can be enqueued on a shutting down
AVSampleBufferRender.

Fly-By: It was possible for the VideoMediaSampleRenderer::m_decompressionSession
member to be cleared without thread synchronisation. We now ensure that the
read operation is guarded by a lock. It practice it doesn&apos;t make a difference
as the m_decompressionSession was only ever cleared in the destructor.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::destroyVideoRenderer):
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h: Make class final as destructor isn&apos;t virtual.
(WebCore::VideoMediaSampleRenderer::create): Deleted.
(WebCore::VideoMediaSampleRenderer::prefersDecompressionSession const): Deleted.
(WebCore::VideoMediaSampleRenderer::as const): Deleted.
(WebCore::VideoMediaSampleRenderer::WTF_GUARDED_BY_CAPABILITY): Deleted.
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::~VideoMediaSampleRenderer):
(WebCore::VideoMediaSampleRenderer::decompressionSession const):
(WebCore::VideoMediaSampleRenderer::stopRequestingMediaData):
(WebCore::VideoMediaSampleRenderer::prefersDecompressionSession const):
(WebCore::VideoMediaSampleRenderer::setPrefersDecompressionSession):
(WebCore::VideoMediaSampleRenderer::enqueueSample):
(WebCore::VideoMediaSampleRenderer::decodeNextSample):
(WebCore::VideoMediaSampleRenderer::initializeDecompressionSession):
(WebCore::VideoMediaSampleRenderer::purgeDecodedSampleQueueAndDisplay):
(WebCore::VideoMediaSampleRenderer::flush):
(WebCore::VideoMediaSampleRenderer::resetReadyForMoreSample):
(WebCore::VideoMediaSampleRenderer::expectMinimumUpcomingSampleBufferPresentationTime):
(WebCore::VideoMediaSampleRenderer::resetUpcomingSampleBufferPresentationTimeExpectations):
(WebCore::VideoMediaSampleRenderer::copyDisplayedPixelBuffer):
(WebCore::VideoMediaSampleRenderer::totalVideoFrames const):
(WebCore::VideoMediaSampleRenderer::droppedVideoFrames const):
(WebCore::VideoMediaSampleRenderer::corruptedVideoFrames const):
(WebCore::VideoMediaSampleRenderer::totalFrameDelay const):
(WebCore::VideoMediaSampleRenderer::isUsingDecompressionSession const): Deleted.

Canonical link: <a href="https://commits.webkit.org/291046@main">https://commits.webkit.org/291046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0a9e151531f1ab0730a9501b262297671fb2dad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91809 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11342 "Hash c0a9e151 for PR 41293 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96764 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93859 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70478 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/27981 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/8954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83182 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50806 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8694 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/774 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79013 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98781 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/18955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/13993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78726 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19488 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23259 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/18938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24163 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18639 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->