### PR TITLE
[UnifiedPDF] [iOS] Occasionally, loading a PDF with non-default Safari zoom scale applied shrinks the PDF content

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5236,13 +5236,6 @@ static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFind
 #if PLATFORM(MAC)
     _impl->setViewScale(viewScale);
 #else
-    if (_page->mainFramePluginOverridesViewScale()) {
-#if ENABLE(PDF_PLUGIN)
-        _page->resetViewportConfigurationForPDFPluginIfNeeded();
-#endif
-        return;
-    }
-
     if (_page->layoutSizeScaleFactorFromClient() == viewScale)
         return;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7675,13 +7675,6 @@ void WebPageProxy::mainFramePluginHandlesPageScaleGestureDidChange(bool mainFram
     m_pluginMaxZoomFactor = maxScale;
 }
 
-bool WebPageProxy::mainFramePluginOverridesViewScale() const
-{
-    if (m_mainFramePluginHandlesPageScaleGesture)
-        return false;
-    return m_pluginMaxZoomFactor.has_value() || m_pluginMinZoomFactor.has_value();
-}
-
 #if !PLATFORM(COCOA)
 void WebPageProxy::beginSafeBrowsingCheck(const URL&, bool, WebFramePolicyListenerProxy& listener)
 {
@@ -16227,23 +16220,6 @@ bool WebPageProxy::canStartNavigationSwipeAtLastInteractionLocation() const
     RefPtr client = pageClient();
     return !client || client->canStartNavigationSwipeAtLastInteractionLocation();
 }
-
-#if ENABLE(PDF_PLUGIN)
-void WebPageProxy::pluginDidInstallPDFDocument()
-{
-    resetViewportConfigurationForPDFPluginIfNeeded();
-}
-
-void WebPageProxy::resetViewportConfigurationForPDFPluginIfNeeded()
-{
-#if PLATFORM(IOS_FAMILY)
-    if (mainFramePluginOverridesViewScale()) {
-        if (layoutSizeScaleFactorFromClient() != 1)
-            setViewportConfigurationViewLayoutSize(viewLayoutSize(), 1, minimumEffectiveDeviceWidth());
-    }
-#endif
-}
-#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1790,10 +1790,7 @@ public:
     void saveDataToFileInDownloadsFolder(String&& suggestedFilename, String&& mimeType, URL&& originatingURL, API::Data&);
     void savePDFToFileInDownloadsFolder(String&& suggestedFilename, URL&& originatingURL, std::span<const uint8_t>);
 
-#if ENABLE(PDF_PLUGIN)
-    void pluginDidInstallPDFDocument();
-    void resetViewportConfigurationForPDFPluginIfNeeded();
-#if PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
     void savePDFToTemporaryFolderAndOpenWithNativeApplication(const String& suggestedFilename, FrameInfoData&&, std::span<const uint8_t>, const String& pdfUUID);
     void showPDFContextMenu(const PDFContextMenu&, PDFPluginIdentifier, CompletionHandler<void(std::optional<int32_t>&&)>&&);
 
@@ -1801,7 +1798,6 @@ public:
     void pdfZoomOut(PDFPluginIdentifier);
     void pdfSaveToPDF(PDFPluginIdentifier);
     void pdfOpenWithPreview(PDFPluginIdentifier);
-#endif
 #endif
 
     WebCore::IntRect visibleScrollerThumbRect() const;
@@ -2704,8 +2700,6 @@ public:
     void takeAccessibilityActivityWhenInWindow();
     bool hasAccessibilityActivityForTesting();
 #endif
-
-    bool mainFramePluginOverridesViewScale() const;
 
 private:
     void getWebCryptoMasterKey(CompletionHandler<void(std::optional<Vector<uint8_t>>&&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -553,12 +553,8 @@ messages -> WebPageProxy {
     [EnabledBy=SpeechSynthesisAPIEnabled] SpeechSynthesisResetState()
 #endif
 
-#if ENABLE(PDF_PLUGIN)
-    PluginDidInstallPDFDocument()
-#if PLATFORM(MAC)
+#if ENABLE(PDF_PLUGIN) && PLATFORM(MAC)
     ShowPDFContextMenu(struct WebKit::PDFContextMenu contextMenu, WebKit::PDFPluginIdentifier identifier) -> (std::optional<int32_t> selectedItem)
-#endif
-
 #endif
 
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -333,11 +333,6 @@ void UnifiedPDFPlugin::installPDFDocument()
     }
 
     sizeToFitContentsIfNeeded();
-
-    RefPtr frame = m_frame.get();
-    if (!frame || !frame->page())
-        return;
-    frame->protectedPage()->send(Messages::WebPageProxy::PluginDidInstallPDFDocument());
 }
 
 bool UnifiedPDFPlugin::shouldSizeToFitContent() const


### PR DESCRIPTION
#### 6dbe4bb4737eb531a30da5b99ef72abd87d356ea
<pre>
[UnifiedPDF] [iOS] Occasionally, loading a PDF with non-default Safari zoom scale applied shrinks the PDF content
<a href="https://bugs.webkit.org/show_bug.cgi?id=288495">https://bugs.webkit.org/show_bug.cgi?id=288495</a>
<a href="https://rdar.apple.com/145325400">rdar://145325400</a>

Reviewed by Abrar Rahman Protyasha.

Even though Safari per-site zoom (`_viewScale`) settings are disabled for PDF documents, it&apos;s still
possible to load a PDF document in Safari with a non-default page zoom by changing the zoom scale on
a non-PDF-document page hosted on the same domain. In this case, Safari calls into `-_setViewScale:`
on the web view containing the PDF.

From prior commits 290565@main and 290826@main, view scaling is meant to be completely disabled when
viewing unified PDFs. However, there&apos;s still one corner case in which it&apos;s possible for a PDF
document to be incorrectly sized, due to view scaling — if `setViewportConfigurationViewLayoutSize`
is called in the web process with a non-default view scale *before* the PDF document is installed
(i.e. `UnifiedPDFPlugin::installPDFDocument`), the PDF plugin will be set to the wrong height,
incorrectly taking the view scale into account.

To mitigate this, we effectively revert 290565@main and 290826@main and instead pull the logic to
avoid changing view scale (layout size scale factor) into the web process, in the case where a main-
frame plugin view exists and `pluginHandlesPageScaleFactor()` is `false`. This both ensures that the
effective layout size scale factor will always be 1 on iOS in the case where the mainframe is a
plugin `embed` element even if the client attempts to change the view scale as early as
`-webView:didCommitNavigation:`, since the web-process-side logic only depends on the existence of
the `mainFramePlugIn()`, which is initialized when the load commits in the web process.

Unfortunately, I wasn&apos;t able to consistently replicate this race condition in the form of an API or
layout test. I manually tested this by loading a PDF in Safari multiple times, and confirming (with
log statements) that the PDF is sized correctly in both cases where the PDF plugin is installed
before and after the view scale change is propagated to the web content process.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _setViewScale:]):

Revert prior logic added in 290565@main, to try and prevent the client from changing view scale
when a PDF is loaded.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::mainFramePluginOverridesViewScale const): Deleted.
(WebKit::WebPageProxy::pluginDidInstallPDFDocument): Deleted.
(WebKit::WebPageProxy::resetViewportConfigurationForPDFPluginIfNeeded): Deleted.

Revert prior logic added in 290826@main, that attempted to reset the view scale after a mainframe
PDF plugin was installed.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::installPDFDocument):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setViewportConfigurationViewLayoutSize):

Reimplement the fix here (see description above for more details).

Canonical link: <a href="https://commits.webkit.org/291079@main">https://commits.webkit.org/291079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/949166db209de206962ef650712e43f62c2e91c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91904 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96846 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42517 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70530 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28020 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94905 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50859 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41731 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98873 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19033 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79561 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19285 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19511 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23323 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19014 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->