### PR TITLE
[text-wrap-style:pretty] update params to avoid excessive hyphenation.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -42,25 +42,24 @@ namespace Layout {
 // used decreases. So, we ignore this ideal number of lines requirement beyond this threshold.
 static const size_t maximumLinesToBalanceWithLineRequirement { 12 };
 
-// TODO: Tweak these values to make pretty look nicer.
 // Define the penalty associated with show text wider/narrower than ideal bounds.
 // Separating stretchability and shrinkability allows us to weight under/over
 // filling the ideal bounds differently.
-static const InlineLayoutUnit textWrapPrettyStretchability = 10;
-static const InlineLayoutUnit textWrapPrettyShrinkability = 10;
+static const InlineLayoutUnit textWrapPrettyStretchability = 15;
+static const InlineLayoutUnit textWrapPrettyShrinkability = 15;
 
-// TODO: Tweak these values to make pretty look nicer.
 // Defines the maximum shrink/stretch factor allowed for text-wrap-pretty.
-static const float textWrapPrettyMaxStretch = 2;
-static const float textWrapPrettyMaxShrink = 2;
+static const float textWrapPrettyMaxStretch = 3;
+static const float textWrapPrettyMaxShrink = 3;
 
 // We would like 2 or more items on the last line for text-wrap-style:pretty to avoid orphans.
 static const size_t lastLinePreferredInlineItemCount = 2;
 
 // Use auto layout if ideal line width is too short relative to the largest inline item.
+// In these situations, text-wrap-pretty does very little of note other than take up time.
 static bool validIdealLineWidth(InlineLayoutUnit maxItemWidth, InlineLayoutUnit idealLineWidth)
 {
-    return idealLineWidth >= maxItemWidth * 2;
+    return idealLineWidth >= maxItemWidth * 3;
 }
 
 static bool validLineWidthPretty(InlineLayoutUnit candidateLineWidth, InlineLayoutUnit idealLineWidth)
@@ -89,8 +88,8 @@ static float computeCostPretty(InlineLayoutUnit candidateLineWidth, InlineLayout
 {
     // FIXME: add support for river minimization.
     if (breakIndex == numberOfBreakOpportunities - lastLinePreferredInlineItemCount) {
-        // Allow a slightly shorter next-to-last line if doing so would yield a final line with lastLinePreferredInlineItemCount inline items.
-        const auto minimumLastLineWidth = lastLineWidth - textWrapPrettyShrinkability * textWrapPrettyMaxShrink;
+        // Allow a shorter next-to-last line if doing so would yield a final line with lastLinePreferredInlineItemCount inline items.
+        const auto minimumLastLineWidth = lastLineWidth - 2 * textWrapPrettyShrinkability * textWrapPrettyMaxShrink;
         if (candidateLineWidth < minimumLastLineWidth)
             return std::numeric_limits<float>::infinity();
         return 0;
@@ -99,8 +98,7 @@ static float computeCostPretty(InlineLayoutUnit candidateLineWidth, InlineLayout
     // (lines that have more than one word but are still sufficiently short to appear like an orphan)
     if (breakIndex == numberOfBreakOpportunities - 1) {
         const auto minimumLastLineWidth = lastLineWidth * 0.2;
-        const auto maximumLastLineWidth = lastLineWidth + textWrapPrettyStretchability * textWrapPrettyMaxStretch;
-        if (candidateLineWidth < minimumLastLineWidth || candidateLineWidth > maximumLastLineWidth)
+        if (candidateLineWidth < minimumLastLineWidth)
             return std::numeric_limits<float>::infinity();
         return 0;
     }


### PR DESCRIPTION
#### e8b5a96a502af832d998c10ba8a4043acd970a73
<pre>
[text-wrap-style:pretty] update params to avoid excessive hyphenation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288433">https://bugs.webkit.org/show_bug.cgi?id=288433</a>
&lt;<a href="https://rdar.apple.com/145524087">rdar://145524087</a>&gt;

Reviewed by Alan Baradlay.

This PR allows for more flexibility in sizing to help pretty avoid excessive
hyphenation. Increasing the max stretch/shrink to increase acceptable range
while maintaining a strong preference for keeping line widths within:

        +textWrapPrettyStretchability / -textWrapPrettyShrinkability

Note that the current implementation has the same tolerances for shrinking
and stretching regardless of line width. Future work may adjust these
tolerances dynamically based on factors such as line width, inline item
widths, and font size.

This PR also tunes the orphan avoidance heuristic to be slightly
more aggressive.

Canonical link: <a href="https://commits.webkit.org/291082@main">https://commits.webkit.org/291082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c32ac2d9874e672e3ca5f6da0853ec586f9efa25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96891 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94006 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19973 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94957 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50886 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/884 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98920 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78815 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19512 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19059 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->