### PR TITLE
[WebCore] Use kCFAbsoluteTimeIntervalSince1970 instead of having a hardcoded value

### DIFF
--- a/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp
@@ -102,14 +102,11 @@ std::optional<CertificateSummary> CertificateInfo::summary() const
 
 #if PLATFORM(MAC)
     if (auto certificateDictionary = adoptCF(SecCertificateCopyValues(leafCertificate, nullptr, nullptr))) {
-        // CFAbsoluteTime is relative to 01/01/1970 00:00:00 GMT.
-        const Seconds absoluteReferenceDate(978307200);
-
         if (auto validNotBefore = checked_cf_cast<CFDictionaryRef>(CFDictionaryGetValue(certificateDictionary.get(), kSecOIDX509V1ValidityNotBefore))) {
             if (auto number = checked_cf_cast<CFNumberRef>(CFDictionaryGetValue(validNotBefore, CFSTR("value")))) {
                 double numberValue;
                 if (CFNumberGetValue(number, kCFNumberDoubleType, &numberValue))
-                    summaryInfo.validFrom = absoluteReferenceDate + Seconds(numberValue);
+                    summaryInfo.validFrom = Seconds(kCFAbsoluteTimeIntervalSince1970 + numberValue);
             }
         }
 
@@ -117,7 +114,7 @@ std::optional<CertificateSummary> CertificateInfo::summary() const
             if (auto number = checked_cf_cast<CFNumberRef>(CFDictionaryGetValue(validNotAfter, CFSTR("value")))) {
                 double numberValue;
                 if (CFNumberGetValue(number, kCFNumberDoubleType, &numberValue))
-                    summaryInfo.validUntil = absoluteReferenceDate + Seconds(numberValue);
+                    summaryInfo.validUntil = Seconds(kCFAbsoluteTimeIntervalSince1970 + numberValue);
             }
         }
 


### PR DESCRIPTION
#### 337000b1d429c4dd8a1eaddab4f7719d538e5bca
<pre>
[WebCore] Use kCFAbsoluteTimeIntervalSince1970 instead of having a hardcoded value
<a href="https://bugs.webkit.org/show_bug.cgi?id=288527">https://bugs.webkit.org/show_bug.cgi?id=288527</a>

Reviewed by Alex Christensen.

We already have a constant for number of seconds for this: kCFAbsoluteTimeIntervalSince1970.

* Source/WebCore/platform/network/cf/CertificateInfoCFNet.cpp:
  (WebCore::CertificateInfo::summary const): Use kCFAbsoluteTimeIntervalSince1970

Canonical link: <a href="https://commits.webkit.org/291583@main">https://commits.webkit.org/291583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2a85b35b0581acd5918236b5fd05ede1237c44e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70720 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28186 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51050 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1120 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79217 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99259 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79736 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78994 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19794 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23529 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/817 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12305 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24454 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->