### PR TITLE
Profile the quantities of small v.s. medium megapage allocations in libpas

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h
@@ -54,11 +54,11 @@ struct pas_basic_heap_page_caches {
     ((pas_basic_heap_page_caches){ \
         .megapage_large_heap_cache = PAS_MEGAPAGE_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER, \
         .large_heap_cache = PAS_LARGE_FREE_HEAP_PHYSICAL_PAGE_SHARING_CACHE_INITIALIZER, \
-        .small_exclusive_segregated_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER, \
+        .small_exclusive_segregated_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_small), \
         .small_shared_page_directories = PAS_SHARED_PAGE_DIRECTORY_BY_SIZE_INITIALIZER( \
             (small_log_shift), pas_share_pages), \
-        .small_other_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER, \
-        .medium_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER, \
+        .small_other_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_small), \
+        .medium_megapage_cache = PAS_MEGAPAGE_CACHE_INITIALIZER(pas_megapage_cache_size_medium), \
         .medium_shared_page_directories = PAS_SHARED_PAGE_DIRECTORY_BY_SIZE_INITIALIZER( \
             (medium_log_shift), pas_share_pages) \
     })

--- a/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c
@@ -46,16 +46,16 @@ static pas_allocation_result allocate_from_megapages(
     void* arg)
 {
     const pas_heap_config* heap_config;
+    pas_megapage_cache_size cache_size = (pas_megapage_cache_size)(uintptr_t)arg;
 
     PAS_UNUSED_PARAM(name);
     PAS_ASSERT(heap);
     PAS_ASSERT(transaction);
-    PAS_ASSERT(!arg);
     PAS_ASSERT(!alignment.alignment_begin);
 
     heap_config = pas_heap_config_kind_get_config(heap->config_kind);
 
-    PAS_PROFILE(MEGAPAGES_ALLOCATION, heap, size, alignment.alignment, heap_config);
+    PAS_PROFILE(MEGAPAGES_ALLOCATION, heap, size, alignment.alignment, heap_config, cache_size);
 
     return pas_large_heap_try_allocate_and_forget(
         &heap->large_heap, size, alignment.alignment, pas_non_compact_allocation_mode,
@@ -99,17 +99,17 @@ pas_basic_heap_page_caches* pas_create_basic_heap_page_caches_with_reserved_memo
     pas_megapage_cache_construct(
         &caches->small_exclusive_segregated_megapage_cache,
         allocate_from_megapages,
-        NULL);
+        pas_megapage_cache_size_small);
 
     pas_megapage_cache_construct(
         &caches->small_other_megapage_cache,
         allocate_from_megapages,
-        NULL);
+        pas_megapage_cache_size_small);
 
     pas_megapage_cache_construct(
         &caches->medium_megapage_cache,
         allocate_from_megapages,
-        NULL);
+        pas_megapage_cache_size_medium);
 
     for (PAS_EACH_SEGREGATED_PAGE_CONFIG_VARIANT_ASCENDING(segregated_variant)) {
         pas_shared_page_directory_by_size* directories;

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c
@@ -170,11 +170,11 @@ static pas_aligned_allocation_result megapage_cache_allocate_aligned(size_t size
 
 void pas_megapage_cache_construct(pas_megapage_cache* cache,
                                   pas_heap_page_provider provider,
-                                  void* provider_arg)
+                                  pas_megapage_cache_size cache_size)
 {
     pas_simple_large_free_heap_construct(&cache->free_heap);
     cache->provider = provider;
-    cache->provider_arg = provider_arg;
+    cache->provider_arg = (void*)(uintptr_t)cache_size;
 }
 
 void* pas_megapage_cache_try_allocate(pas_megapage_cache* cache,

--- a/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h
@@ -58,15 +58,20 @@ struct pas_megapage_cache_config {
     bool should_zero;
 };
 
-#define PAS_MEGAPAGE_CACHE_INITIALIZER { \
+typedef enum {
+    pas_megapage_cache_size_small,
+    pas_megapage_cache_size_medium
+} pas_megapage_cache_size;
+
+#define PAS_MEGAPAGE_CACHE_INITIALIZER(cache_size) { \
         .free_heap = PAS_SIMPLE_LARGE_FREE_HEAP_INITIALIZER, \
         .provider = pas_small_medium_bootstrap_heap_page_provider, \
-        .provider_arg = NULL \
+        .provider_arg = (void*)(uintptr_t)(cache_size) \
     }
 
 PAS_API void pas_megapage_cache_construct(pas_megapage_cache* cache,
                                           pas_heap_page_provider provider,
-                                          void* provider_arg);
+                                          pas_megapage_cache_size cache_size);
 
 PAS_API void* pas_megapage_cache_try_allocate(pas_megapage_cache* cache,
                                               pas_megapage_cache_config* cache_config,

--- a/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c
@@ -29,6 +29,7 @@
 
 #include "pas_small_medium_bootstrap_heap_page_provider.h"
 
+#include "pas_bootstrap_free_heap.h"
 #include "pas_small_medium_bootstrap_free_heap.h"
 
 pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
@@ -46,6 +47,8 @@ pas_allocation_result pas_small_medium_bootstrap_heap_page_provider(
 
     if (verbose)
         pas_log("small/medium bootstrap heap page-provider allocating %zu for %s\n", size, name);
+
+    PAS_PROFILE(SMALL_MEDIUM_BOOTSTRAP_ALLOCATION, heap, size, alignment, name, arg);
 
     pas_allocation_result retval = pas_small_medium_bootstrap_free_heap_try_allocate_with_alignment(
         size, alignment, name, pas_delegate_allocation);


### PR DESCRIPTION
#### e1fce65a6b058fb79777e0e2f3bb448b93ae7a2e
<pre>
Profile the quantities of small v.s. medium megapage allocations in libpas
<a href="https://bugs.webkit.org/show_bug.cgi?id=288532">https://bugs.webkit.org/show_bug.cgi?id=288532</a>
<a href="https://rdar.apple.com/144180799">rdar://144180799</a>

Reviewed by Yusuke Suzuki.

Adds PAS_PROFILE invocations to the paths where we allocate pages for small
and medium megapages, and uses the cache provider_arg to pass whether the
megapage is small or medium.

* Source/bmalloc/libpas/src/libpas/pas_basic_heap_page_caches.h:
* Source/bmalloc/libpas/src/libpas/pas_create_basic_heap_page_caches_with_reserved_memory.c:
(allocate_from_megapages):
(pas_create_basic_heap_page_caches_with_reserved_memory):
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.c:
(pas_megapage_cache_construct):
* Source/bmalloc/libpas/src/libpas/pas_megapage_cache.h:
* Source/bmalloc/libpas/src/libpas/pas_small_medium_bootstrap_heap_page_provider.c:
(pas_small_medium_bootstrap_heap_page_provider):

Canonical link: <a href="https://commits.webkit.org/291370@main">https://commits.webkit.org/291370@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c213ae3fb2e8a1e70f82eab67830a11ce7d19ab4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92497 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12042 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43004 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70871 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28314 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83767 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1404 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42335 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85207 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79369 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1346 "Found 60 new test failures: compositing/shared-backing/overflow-scroll/scrolled-contents-unconstrained-clip.html compositing/shared-backing/overflow-scroll/sharing-layer-becomes-non-scrollable.html fast/attachment/cocoa/wide-attachment-icon-from-file-extension.html fast/borders/border-image-pixelated.html fast/css-grid-layout/ascpect-ratio-with-percent-width.html fast/css/all-keyword-direction.html fast/css/style-preferred-stylesheet-01.html fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/forms/listbox-padding-clip-selected.html fast/lists/list-marker-with-display.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99508 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91163 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19548 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79157 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19663 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23684 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12560 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19532 "Built successfully") | | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113811 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19219 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32906 "Found 20 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20959 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->