### PR TITLE
[scroll-animations] remove the `TimelineMapAttachOperation` struct

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -160,9 +160,9 @@ void CSSAnimation::syncStyleOriginatedTimeline()
     WTF::switchOn(timeline,
         [&] (Animation::TimelineKeyword keyword) {
             setTimeline(keyword == Animation::TimelineKeyword::None ? nullptr : RefPtr { document->existingTimeline() });
-        }, [&] (const AtomString& name) {
+        }, [&] (const AtomString&) {
             CheckedRef styleOriginatedTimelinesController = document->ensureStyleOriginatedTimelinesController();
-            styleOriginatedTimelinesController->setTimelineForName(name, *owningElement(), *this);
+            styleOriginatedTimelinesController->attachAnimation(*this);
         }, [&] (const Animation::AnonymousScrollTimeline& anonymousScrollTimeline) {
             auto scrollTimeline = ScrollTimeline::create(anonymousScrollTimeline.scroller, anonymousScrollTimeline.axis);
             scrollTimeline->setSource(*owningElement());

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -233,19 +233,17 @@ void StyleOriginatedTimelinesController::updateCSSAnimationsAssociatedWithNamedT
 
 void StyleOriginatedTimelinesController::removePendingOperationsForCSSAnimation(const CSSAnimation& animation)
 {
-    m_pendingAttachOperations.removeAllMatching([&] (const TimelineMapAttachOperation& operation) {
-        return operation.animation.ptr() == &animation;
+    m_cssAnimationsPendingAttachment.removeAllMatching([&] (const auto& pendingAnimation) {
+        return pendingAnimation.ptr() == &animation;
     });
 }
 
 void StyleOriginatedTimelinesController::documentDidResolveStyle()
 {
-    auto operations = std::exchange(m_pendingAttachOperations, { });
-    for (auto& operation : operations) {
-        if (WeakPtr animation = operation.animation) {
-            if (auto styleable = operation.element.styleable())
-                setTimelineForName(operation.name, *styleable, *animation, AllowsDeferral::No);
-        }
+    auto cssAnimationsPendingAttachment = std::exchange(m_cssAnimationsPendingAttachment, { });
+    for (auto& cssAnimationPendingAttachment : cssAnimationsPendingAttachment) {
+        if (cssAnimationPendingAttachment->owningElement())
+            attachAnimation(cssAnimationPendingAttachment.get(), AllowsDeferral::No);
     }
 
     // Purge any inactive named timeline no longer attached to an animation.
@@ -327,16 +325,26 @@ void StyleOriginatedTimelinesController::unregisterNamedTimeline(const AtomStrin
         updateCSSAnimationsAssociatedWithNamedTimeline(name);
 }
 
-void StyleOriginatedTimelinesController::setTimelineForName(const AtomString& name, const Styleable& styleable, CSSAnimation& animation)
+void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation)
 {
-    setTimelineForName(name, styleable, animation, AllowsDeferral::Yes);
+    attachAnimation(animation, AllowsDeferral::Yes);
 }
 
-void StyleOriginatedTimelinesController::setTimelineForName(const AtomString& name, const Styleable& styleable, CSSAnimation& animation, AllowsDeferral allowsDeferral)
+void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation, AllowsDeferral allowsDeferral)
 {
-    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::setTimelineForName: " << name << " styleable: " << styleable);
+    Ref protectedAnimation { animation };
 
-    auto it = m_nameToTimelineMap.find(name);
+    auto target = protectedAnimation->owningElement();
+    if (!target)
+        return;
+
+    auto* timelineName = std::get_if<AtomString>(&protectedAnimation->backingAnimation().timeline());
+    if (!timelineName)
+        return;
+
+    LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << *timelineName << " target: " << *target);
+
+    auto it = m_nameToTimelineMap.find(*timelineName);
     auto hasNamedTimeline = it != m_nameToTimelineMap.end() && it->value.containsIf([](auto& timeline) {
         return !timeline->isInactiveStyleOriginatedTimeline();
     });
@@ -345,11 +353,11 @@ void StyleOriginatedTimelinesController::setTimelineForName(const AtomString& na
     // just register a pending timeline attachment operation so we can try again
     // when style has resolved.
     if (!hasNamedTimeline && allowsDeferral == AllowsDeferral::Yes) {
-        m_pendingAttachOperations.append({ styleable, name, animation });
+        m_cssAnimationsPendingAttachment.append(animation);
         return;
     }
 
-    auto timelineScopeElements = relatedTimelineScopeElements(name);
+    auto timelineScopeElements = relatedTimelineScopeElements(*timelineName);
 
     if (!hasNamedTimeline) {
         // First, determine whether the name is within scope, ie. whether a parent element
@@ -358,7 +366,7 @@ void StyleOriginatedTimelinesController::setTimelineForName(const AtomString& na
             for (auto timelineScopeElement : timelineScopeElements) {
                 ASSERT(timelineScopeElement.element());
                 Ref protectedTimelineScopeElement { *timelineScopeElement.element() };
-                if (styleable == timelineScopeElement.styleable() || Ref { styleable.element }->isDescendantOrShadowDescendantOf(protectedTimelineScopeElement.get()))
+                if (*target == timelineScopeElement.styleable() || Ref { target->element }->isDescendantOrShadowDescendantOf(protectedTimelineScopeElement.get()))
                     return true;
             }
             return false;
@@ -371,19 +379,19 @@ void StyleOriginatedTimelinesController::setTimelineForName(const AtomString& na
         //        scroll timeline, or,
         //     2. the name is not within scope and the timeline is null.
         if (nameIsWithinScope)
-            animation.setTimeline(&inactiveNamedTimeline(name));
+            protectedAnimation->setTimeline(&inactiveNamedTimeline(*timelineName));
         else {
-            animation.setTimeline(nullptr);
+            protectedAnimation->setTimeline(nullptr);
             // Since we have no timelines defined for this name yet, we need
             // to keep a pending operation such that we may attach the named
             // timeline should it appear.
-            m_pendingAttachOperations.append({ styleable, name, animation });
+            m_cssAnimationsPendingAttachment.append(animation);
         }
     } else {
         auto& timelines = it->value;
-        if (RefPtr timeline = determineTimelineForElement(timelines, styleable, timelineScopeElements)) {
-            LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::setTimelineForName: " << name << " styleable: " << styleable << " attaching to timeline of element: " << originatingElement(*timeline));
-            animation.setTimeline(WTFMove(timeline));
+        if (RefPtr timeline = determineTimelineForElement(timelines, *target, timelineScopeElements)) {
+            LOG_WITH_STREAM(Animations, stream << "StyleOriginatedTimelinesController::attachAnimation: " << *timelineName << " styleable: " << *target << " attaching to timeline of element: " << originatingElement(*timeline));
+            protectedAnimation->setTimeline(WTFMove(timeline));
         }
     }
 }
@@ -438,8 +446,8 @@ void StyleOriginatedTimelinesController::updateNamedTimelineMapForTimelineScope(
 bool StyleOriginatedTimelinesController::isPendingTimelineAttachment(const WebAnimation& animation) const
 {
     if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation)) {
-        return m_pendingAttachOperations.containsIf([&](auto& operation) {
-            return operation.animation.ptr() == cssAnimation.get();
+        return m_cssAnimationsPendingAttachment.containsIf([&](auto& pendingAnimation) {
+            return pendingAnimation.ptr() == cssAnimation.get();
         });
     }
     return false;
@@ -474,11 +482,10 @@ void StyleOriginatedTimelinesController::styleableWasRemoved(const Styleable& st
     for (auto& timeline : m_removedTimelines) {
         if (originatingElement(timeline) != styleable)
             continue;
-        auto& timelineName = timeline->name();
         for (auto& animation : timeline->relevantAnimations()) {
             if (RefPtr cssAnimation = dynamicDowncast<CSSAnimation>(animation.get())) {
                 if (auto owningElement = cssAnimation->owningElement()) {
-                    setTimelineForName(timelineName, *owningElement, *cssAnimation, AllowsDeferral::Yes);
+                    attachAnimation(*cssAnimation, AllowsDeferral::Yes);
                     Ref { owningElement->element }->invalidateStyleForAnimation();
                 }
             }

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -40,12 +40,6 @@ class WebAnimation;
 
 struct ViewTimelineInsets;
 
-struct TimelineMapAttachOperation {
-    WeakStyleable element;
-    AtomString name;
-    Ref<CSSAnimation> animation;
-};
-
 // A style-originated timeline is a timeline that is assigned to a CSS Animation
 // via the `animation-timeline` property. These timelines may be created directly
 // as a result of that property being set to a `scroll()` or `view()` value, but
@@ -71,7 +65,7 @@ public:
     void registerNamedScrollTimeline(const AtomString&, const Styleable&, ScrollAxis);
     void registerNamedViewTimeline(const AtomString&, const Styleable&, ScrollAxis, ViewTimelineInsets&&);
     void unregisterNamedTimeline(const AtomString&, const Styleable&);
-    void setTimelineForName(const AtomString&, const Styleable&, CSSAnimation&);
+    void attachAnimation(CSSAnimation&);
     void updateNamedTimelineMapForTimelineScope(const NameScope&, const Styleable&);
     void updateTimelineForTimelineScope(const Ref<ScrollTimeline>&, const AtomString&);
     void unregisterNamedTimelinesAssociatedWithElement(const Styleable&);
@@ -86,12 +80,12 @@ private:
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 
     enum class AllowsDeferral : bool { No, Yes };
-    void setTimelineForName(const AtomString&, const Styleable&, CSSAnimation&, AllowsDeferral);
+    void attachAnimation(CSSAnimation&, AllowsDeferral);
     ScrollTimeline* determineTimelineForElement(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
     ScrollTimeline* determineTreeOrder(const Vector<Ref<ScrollTimeline>>&, const Styleable&, const Vector<WeakStyleable>&);
     ScrollTimeline& inactiveNamedTimeline(const AtomString&);
 
-    Vector<TimelineMapAttachOperation> m_pendingAttachOperations;
+    Vector<Ref<CSSAnimation>> m_cssAnimationsPendingAttachment;
     Vector<std::pair<NameScope, WeakStyleable>> m_timelineScopeEntries;
     UncheckedKeyHashMap<AtomString, Vector<Ref<ScrollTimeline>>> m_nameToTimelineMap;
     HashSet<Ref<ScrollTimeline>> m_removedTimelines;


### PR DESCRIPTION
#### a638a633a78c7876ed9b8ecea2b84a9e42be707e
<pre>
[scroll-animations] remove the `TimelineMapAttachOperation` struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=288537">https://bugs.webkit.org/show_bug.cgi?id=288537</a>

Reviewed by Dean Jackson.

The `TimelineMapAttachOperation` struct is used to keep track of pending attachment operations for
CSS animations using the `animation-timeline` property. That structs contains the timeline name,
the target styleable and the CSS animation. But the names and targets can be obtained directly
from the CSS animation, so we can keep track of the CSS animations alone.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::removePendingOperationsForCSSAnimation):
(WebCore::StyleOriginatedTimelinesController::documentDidResolveStyle):
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
(WebCore::StyleOriginatedTimelinesController::isPendingTimelineAttachment const):
(WebCore::StyleOriginatedTimelinesController::styleableWasRemoved):
(WebCore::StyleOriginatedTimelinesController::setTimelineForName): Deleted.
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:

Canonical link: <a href="https://commits.webkit.org/291098@main">https://commits.webkit.org/291098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fe8215e0d1bb87d2c8072421ec92452b164bb2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11470 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1010 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11814 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70548 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28031 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50875 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/868 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41756 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98900 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19058 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79573 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19310 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79119 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78799 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23335 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12096 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14607 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22195 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->