### PR TITLE
Make denormal perspectiveMatrix determinant as non-invertible in matrix decomposition

### DIFF
--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -377,7 +377,7 @@ static bool decompose4(const TransformationMatrix::Matrix4& mat, TransformationM
         perspectiveMatrix[i][3] = 0;
     perspectiveMatrix[3][3] = 1;
 
-    if (determinant4x4(perspectiveMatrix) == 0)
+    if (!std::isnormal(determinant4x4(perspectiveMatrix)))
         return false;
 
     // First, isolate perspective. This is the messiest.


### PR DESCRIPTION
#### af57174065a389edc856032cbf0cb7482fb561a3
<pre>
Make denormal perspectiveMatrix determinant as non-invertible in matrix decomposition
<a href="https://bugs.webkit.org/show_bug.cgi?id=288539">https://bugs.webkit.org/show_bug.cgi?id=288539</a>
<a href="https://rdar.apple.com/145603306">rdar://145603306</a>

Reviewed by Matt Woodrow.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/src/+/d58ac75ef86aff544c42fe2a731b280ae83b1fc4">https://chromium.googlesource.com/chromium/src/+/d58ac75ef86aff544c42fe2a731b280ae83b1fc4</a>

This patch is to make denormal perspectiveMatrix determinant as non-invertible
in matrix decomposition.

* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
(WebCore::decompose4):

Canonical link: <a href="https://commits.webkit.org/292277@main">https://commits.webkit.org/292277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1680f338ed4d51521113d0f72e9e05478a1b3566

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42536 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/93977 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70539 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28025 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50869 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/976 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41750 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79056 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98893 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19052 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79568 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19304 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79227 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78794 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23336 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2886 "Found 11 new test failures: fast/attachment/cocoa/wide-attachment-rendering.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/empty-generated-content.html fast/css/text-wrap-pretty-disabled.html fast/layers/add-layer-with-nested-stacking.html fast/table/table-section-split-with-after-content.html fast/text/capitalize-empty-generated-string.html http/tests/misc/acid2-pixel.html http/tests/misc/acid2.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12091 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24243 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18730 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22189 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->