### PR TITLE
Selections that start or end in white space don't create text fragments.

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-trim-leading-and-trailing-whitespace-expected.txt
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-trim-leading-and-trailing-whitespace-expected.txt
@@ -1,0 +1,1 @@
+:~:text=a%20very%20simple-,document.,-There%20is%20no

--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-trim-leading-and-trailing-whitespace.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-can-trim-leading-and-trailing-whitespace.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8" />
+<title>Scroll to text fragment generation - ensure that we trim whitespace from the generated fragments.</title>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.addEventListener('load', () => {
+    const range = document.createRange();
+    range.selectNodeContents(document.getElementById("test"));
+    document.body.innerText = internals.textFragmentDirectiveForRange(range).split('#')[1];
+});
+</script>
+</head>
+<body>This is a very simple<span id="test"> document. </span>There is no text before 'this'.</body>
+</html>
+

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -274,6 +274,7 @@ public:
     bool atEnd() const { return m_underlyingIterator.atEnd(); }
     void advance(int numCharacters);
 
+    StringView text() const { return m_underlyingIterator.text().left(m_underlyingIterator.text().length() - m_runOffset); }
     SimpleRange range() const;
 
 private:


### PR DESCRIPTION
#### 7f3f1aa23390e2f4216445da5d4c8d8b8c6b21ef
<pre>
Selections that start or end in white space don&apos;t create text fragments.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288547">https://bugs.webkit.org/show_bug.cgi?id=288547</a>
<a href="https://rdar.apple.com/145614181">rdar://145614181</a>

Reviewed by Wenson Hsieh.

When trying to generate text fragments to attach to the URL,
we check to make sure that the fragment is the same range.
But when searching for fragments, we don&apos;t add white space at the
ends, we just find the end of the word. Therefore, if the
original selection starts or ends with whitespace, we will
never match that selection when looking for a fragment.
We can fix this by trimming whitespace off of the highlighted
range before making a fragment.

* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
(WebCore::startVisiblePositionForRangeRemovingLeadingWhitespace):
(WebCore::endVisiblePositionForRangeRemovingTrailingWhitespace):
(WebCore::FragmentDirectiveGenerator::generateFragmentDirective):
* Source/WebCore/editing/TextIterator.h:
(WebCore::BackwardsCharacterIterator::text const):

Canonical link: <a href="https://commits.webkit.org/291146@main">https://commits.webkit.org/291146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b9399b0e01b0a669f3837829314548c02704637

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96903 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70566 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28049 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83303 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50894 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8754 "Found 2 new test failures: imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/current-time-root-scroller.html imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/903 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41787 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79076 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/898 "Found 2 new test failures: fast/canvas/image-buffer-resource-limits.html imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_window_open_download_allow_downloads.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79599 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78827 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19070 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24279 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18767 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->