### PR TITLE
ListHashSet: Implement operator== and operator<< to TextStream

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -152,6 +152,7 @@ template<typename KeyArg, typename MappedArg, typename = DefaultHash<KeyArg>, ty
 template<typename KeyArg, typename MappedArg, typename KeyHash = DefaultHash<KeyArg>, typename KeyTraits = HashTraits<KeyArg>, typename MappedTraits = HashTraits<MappedArg>, typename HashTraits = HashTableTraits>
 using UncheckedKeyHashMap = HashMap<KeyArg, MappedArg, KeyHash, KeyTraits, MappedTraits, HashTraits, ShouldValidateKey::No>;
 template<typename ValueArg, typename = DefaultHash<ValueArg>, typename = HashTraits<ValueArg>, typename = HashTableTraits, ShouldValidateKey = ShouldValidateKey::Yes> class HashSet;
+template<typename ValueArg, typename = DefaultHash<ValueArg>> class ListHashSet;
 template<typename ValueArg, typename HashArg = DefaultHash<ValueArg>, typename TraitsArg = HashTraits<ValueArg>, typename TableTraitsArg = HashTableTraits>
 using UncheckedKeyHashSet = HashSet<ValueArg, HashArg, TraitsArg, TableTraitsArg, ShouldValidateKey::No>;
 template<typename ResolveValueT, typename RejectValueT, unsigned options = 0> class NativePromise;
@@ -190,6 +191,7 @@ using WTF::HashMap;
 using WTF::HashSet;
 using WTF::Hasher;
 using WTF::LazyNeverDestroyed;
+using WTF::ListHashSet;
 using WTF::Lock;
 using WTF::Logger;
 using WTF::MachSendRight;

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
 #include <wtf/HashSet.h>
 
 #if CHECK_HASHTABLE_ITERATORS
@@ -62,7 +63,7 @@ template<typename ValueArg> struct ListHashSetNode;
 template<typename HashArg> struct ListHashSetNodeHashFunctions;
 template<typename HashArg> struct ListHashSetTranslator;
 
-template<typename ValueArg, typename HashArg = DefaultHash<ValueArg>> class ListHashSet final
+template<typename ValueArg, typename HashArg> class ListHashSet final
 #if CHECK_HASHTABLE_ITERATORS
     : public CanMakeWeakPtr<ListHashSet<ValueArg, HashArg>, WeakPtrFactoryInitialization::Eager>
 #endif
@@ -177,6 +178,9 @@ public:
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, const ValueType&);
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, AddResult>::type insertBefore(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&, ValueType&&);
     template<typename V = ValueType> typename std::enable_if<IsSmartPtr<V>::value && !IsSmartPtr<V>::isNullable, bool>::type remove(std::add_const_t<typename GetPtrHelper<V>::UnderlyingType>&);
+
+    template<typename OtherCollection>
+    bool operator==(const OtherCollection&) const;
 
 private:
     void unlink(Node*);
@@ -882,6 +886,20 @@ inline auto ListHashSet<T, U>::makeConstIterator(Node* position) const -> const_
 { 
     return const_iterator(this, position);
 }
+
+template<typename T, typename U>
+template<typename OtherCollection>
+inline bool ListHashSet<T, U>::operator==(const OtherCollection& otherCollection) const
+{
+    if (size() != otherCollection.size())
+        return false;
+    for (const auto& other : otherCollection) {
+        if (!contains(other))
+            return false;
+    }
+    return true;
+}
+
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/text/TextStream.h
+++ b/Source/WTF/wtf/text/TextStream.h
@@ -282,6 +282,12 @@ TextStream& operator<<(TextStream& ts, const HashSet<ValueArg, HashArg, TraitsAr
     return streamSizedContainer(ts, set);
 }
 
+template<typename T, typename U>
+TextStream& operator<<(TextStream& ts, const ListHashSet<T, U>& set)
+{
+    return streamSizedContainer(ts, set);
+}
+
 template<typename T, size_t size>
 TextStream& operator<<(TextStream& ts, const std::array<T, size>& array)
 {

--- a/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp
@@ -521,6 +521,45 @@ TEST(WTF_ListHashSet, UniquePtrKey_RemoveUsingRawPointer)
     EXPECT_EQ(1u, ConstructorDestructorCounter::destructionCount);
 }
 
+TEST(WTF_ListHashSet, EqualityComparison)
+{
+    ListHashSet<int> emptyList;
+
+    ListHashSet<int> nonEmptyList1;
+    nonEmptyList1.add(1);
+    nonEmptyList1.add(2);
+
+    ListHashSet<int> nonEmptyList2;
+    nonEmptyList2.add(2);
+    nonEmptyList2.add(3);
+
+    ListHashSet<int> nonEmptyList3;
+    nonEmptyList3.add(1);
+    nonEmptyList3.add(2);
+
+    ListHashSet<int> nonEmptyList4;
+    nonEmptyList4.add(1);
+    nonEmptyList4.add(2);
+    nonEmptyList4.add(3);
+
+    // Lists should be equal to itself
+    ASSERT_TRUE(emptyList == emptyList);
+    ASSERT_TRUE(nonEmptyList1 == nonEmptyList1);
+    ASSERT_TRUE(nonEmptyList2 == nonEmptyList2);
+    ASSERT_TRUE(nonEmptyList3 == nonEmptyList3);
+    ASSERT_TRUE(nonEmptyList4 == nonEmptyList4);
+
+    // Lists of different size should not be equal
+    ASSERT_TRUE(emptyList != nonEmptyList1);
+    ASSERT_TRUE(nonEmptyList4 != nonEmptyList1);
+
+    // List of the same size but different content should not be equal
+    ASSERT_TRUE(nonEmptyList1 != nonEmptyList2);
+
+    // Lists of the same size and content should be equal
+    ASSERT_TRUE(nonEmptyList1 == nonEmptyList3);
+}
+
 class ListHashSetReferencedItem : public RefCounted<ListHashSetReferencedItem> {
 public:
     static Ref<ListHashSetReferencedItem> create()


### PR DESCRIPTION
#### 81ea22108648dca2a4f28b22dda67ec1bd1089b7
<pre>
ListHashSet: Implement operator== and operator&lt;&lt; to TextStream
<a href="https://rdar.apple.com/145603416">rdar://145603416</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288540">https://bugs.webkit.org/show_bug.cgi?id=288540</a>

Reviewed by NOBODY (OOPS!).

* Source/WTF/wtf/Forward.h: Forward declare ListHashSet
* Source/WTF/wtf/ListHashSet.h: Implement operator==
(WTF::= const):
* Source/WTF/wtf/text/TextStream.h:
(WTF::operator&lt;&lt;): Implement operator&lt;&lt; to output ListHashSet to TextStream
* Tools/TestWebKitAPI/Tests/WTF/ListHashSet.cpp:
(TestWebKitAPI::TEST(WTF_ListHashSet, EqualityComparison)): Add tests for operator==
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81ea22108648dca2a4f28b22dda67ec1bd1089b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96909 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94030 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11852 "Hash 81ea2210 for PR 41348 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70576 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94981 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/11852 "Hash 81ea2210 for PR 41348 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50904 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/11852 "Hash 81ea2210 for PR 41348 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/908 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41793 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84757 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/11852 "Hash 81ea2210 for PR 41348 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98941 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90707 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79615 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78846 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23367 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/681 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12133 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24285 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113302 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18773 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32792 "Found 324 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->