### PR TITLE
[JSC] Optimize Array.prototype.indexOf for Dense Atom String Arrays

### DIFF
--- a/JSTests/microbenchmarks/atom-string-array-index-of-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-index-of-found.js
@@ -1,0 +1,12 @@
+
+let words = ['break', 'yield', 'break', 'yield', 'break', 'yield', 'super'];
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('super') != 6)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-index-of-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-index-of-not-found.js
@@ -1,0 +1,12 @@
+
+let words = ['break', 'yield', 'break', 'yield', 'break', 'yield', 'super'];
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('superr') != -1)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-found.js
@@ -1,0 +1,12 @@
+
+let words = "greedisgood".split('');
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('s') != 6)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-not-found.js
@@ -1,0 +1,12 @@
+
+let words = "greedisgood".split('');
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('ss') != -1)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-found.js
@@ -1,0 +1,12 @@
+
+let words = "break break break break break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('yield') != 8)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-not-found.js
@@ -1,0 +1,12 @@
+
+let words = "break break break break break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('yieldd') != -1)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-found.js
@@ -1,0 +1,13 @@
+
+let words = "break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+let search = 'y' + 'i' + 'e' + 'l' + 'd';
+for (let i = 0; i < 1e5; i++) {
+    if (test(search) != 4)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-not-found.js
@@ -1,0 +1,13 @@
+
+let words = "break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+let search = 'y' + 'i' + 'e' + 'l' + 'd' + 'd';
+for (let i = 0; i < 1e5; i++) {
+    if (test(search) != -1)
+        throw new Error("bad");
+}

--- a/JSTests/stress/atom-string-array.js
+++ b/JSTests/stress/atom-string-array.js
@@ -1,0 +1,15 @@
+
+let words = "break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+let search = 'yield';
+for (let i = 0; i < testLoopCount; i++) {
+    if (test(search) != 1)
+        throw new Error("bad");
+    if (i == 1)
+        words.push('good');
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -374,6 +374,7 @@ JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32OrContiguous, UCPUStri
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -150,6 +150,10 @@ public:
 
     Butterfly* toButterfly() const { return std::bit_cast<Butterfly*>(std::bit_cast<char*>(this) + offsetOfData()); }
     static JSImmutableButterfly* fromButterfly(Butterfly* butterfly) { return std::bit_cast<JSImmutableButterfly*>(std::bit_cast<char*>(butterfly) - offsetOfData()); }
+    static bool isOnlyAtomStringsStructure(VM& vm, Butterfly* butterfly)
+    {
+        return fromButterfly(butterfly)->structure() == vm.immutableButterflyOnlyAtomStringsStructure.get();
+    }
 
     JSValue get(unsigned index) const
     {

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -784,7 +784,7 @@ inline const StringImpl* JSString::tryGetValueImpl() const
 
 inline JSString* asString(JSValue value)
 {
-    ASSERT(value.asCell()->isString());
+    ASSERT(value.isString());
     return jsCast<JSString*>(value.asCell());
 }
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -233,6 +233,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , emptyList(new ArgList)
     , machineCodeBytesPerBytecodeWordForBaselineJIT(makeUnique<SimpleStats>())
     , symbolImplToSymbolMap(*this)
+    , atomStringToJSStringMap(*this)
     , m_regExpCache(makeUnique<RegExpCache>())
     , m_compactVariableMap(adoptRef(*new CompactTDZEnvironmentMap))
     , m_codeCache(makeUnique<CodeCache>())
@@ -312,6 +313,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     rawImmutableButterflyStructure(CopyOnWriteArrayWithDouble).setWithoutWriteBarrier(Options::allowDoubleShape() ? JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
     rawImmutableButterflyStructure(CopyOnWriteArrayWithContiguous).setWithoutWriteBarrier(copyOnWriteArrayWithContiguousStructure);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    // This is only for JSImmutableButterfly filled with atom strings.
+    immutableButterflyOnlyAtomStringsStructure.setWithoutWriteBarrier(JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous));
 
     sourceCodeStructure.setWithoutWriteBarrier(JSSourceCode::createStructure(*this, nullptr, jsNull()));
     scriptFetcherStructure.setWithoutWriteBarrier(JSScriptFetcher::createStructure(*this, nullptr, jsNull()));
@@ -1658,6 +1662,7 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(symbolTableStructure);
     for (auto& structure : immutableButterflyStructures)
         visitor.append(structure);
+    visitor.append(immutableButterflyOnlyAtomStringsStructure);
     visitor.append(sourceCodeStructure);
     visitor.append(scriptFetcherStructure);
     visitor.append(scriptFetchParametersStructure);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -535,7 +535,8 @@ public:
     WriteBarrier<Structure> regExpStructure;
     WriteBarrier<Structure> symbolStructure;
     WriteBarrier<Structure> symbolTableStructure;
-    WriteBarrier<Structure> immutableButterflyStructures[NumberOfCopyOnWriteIndexingModes];
+    std::array<WriteBarrier<Structure>, NumberOfCopyOnWriteIndexingModes> immutableButterflyStructures;
+    WriteBarrier<Structure> immutableButterflyOnlyAtomStringsStructure;
     WriteBarrier<Structure> sourceCodeStructure;
     WriteBarrier<Structure> scriptFetcherStructure;
     WriteBarrier<Structure> scriptFetchParametersStructure;
@@ -623,6 +624,7 @@ public:
     }
 
     WeakGCMap<SymbolImpl*, Symbol, PtrHash<SymbolImpl*>> symbolImplToSymbolMap;
+    WeakGCMap<StringImpl*, JSString, PtrHash<StringImpl*>> atomStringToJSStringMap;
 
     enum class DeletePropertyMode {
         // Default behaviour of deleteProperty, matching the spec.


### PR DESCRIPTION
#### e1b94476e4f0eb65453c34e04b9ec7f4b94530f2
<pre>
[JSC] Optimize Array.prototype.indexOf for Dense Atom String Arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=288548">https://bugs.webkit.org/show_bug.cgi?id=288548</a>
<a href="https://rdar.apple.com/145614326">rdar://145614326</a>

Reviewed by Yusuke Suzuki.

Inspired by Yusuke&apos;s idea and draft patch, this patch optimizes
Array.prototype.indexOf for arrays of dense atom strings by enabling
direct pointer-based comparisons, eliminating the need for expensive
string content comparisons.

                                                                without                     with

atom-string-array-index-of-found                            1.8424+-0.0062     ^      1.4762+-0.0069        ^ definitely 1.2481x faster
atom-string-array-index-of-not-found                        1.5934+-0.0046     ^      1.1977+-0.0066        ^ definitely 1.3304x faster
atom-string-array-split-empty-index-of-found                1.8439+-0.1106     ^      1.4876+-0.0091        ^ definitely 1.2395x faster
atom-string-array-split-empty-index-of-not-found            1.9270+-0.0063     ^      1.1917+-0.0060        ^ definitely 1.6170x faster
atom-string-array-split-space-index-of-rope-found           1.5912+-0.0053     ^      1.3945+-0.0055        ^ definitely 1.1411x faster
atom-string-array-split-space-index-of-rope-not-found       1.7173+-0.0058     ^      1.2156+-0.0059        ^ definitely 1.4127x faster
atom-string-array-split-space-index-of-non-rope-found       2.2235+-0.0070     ^      1.5365+-0.0063        ^ definitely 1.4471x faster
atom-string-array-split-space-index-of-non-rope-not-found   1.7939+-0.0065     ^      1.1984+-0.0066        ^ definitely 1.4969x faster

* JSTests/microbenchmarks/atom-string-array-index-of-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-index-of-not-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-empty-index-of-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-empty-index-of-not-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-not-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-not-found.js: Added.
(test):
* JSTests/stress/atom-string-array.js: Added.
(test):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
(JSC::JSImmutableButterfly::isAtomStringsStructure):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::asString):
(JSC::asAtomString):
(JSC::JSString::ensureAtomString const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/291398@main">https://commits.webkit.org/291398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cebdfb5e8ef33781d6703a46210d8a6924a0e87f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43009 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28323 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51207 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1403 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42340 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85212 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99513 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91168 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79885 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23690 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12565 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24709 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113816 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19224 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32908 "Found 317 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22684 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->