### PR TITLE
[Tools][WPE] run-mvt-tests should print some status updates meanwhile is running the suites

### DIFF
--- a/Tools/Scripts/run-mvt-tests
+++ b/Tools/Scripts/run-mvt-tests
@@ -37,6 +37,7 @@ import urllib3
 from random import randint
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.common.exceptions import TimeoutException
+from time import sleep
 
 
 top_level_directory = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -91,6 +92,28 @@ def parse_args(argument_list):
     return args
 
 
+class ProgressLogInfo():
+
+    def __init__(self):
+        self.last_msg_printed = ""
+
+    def log(self, msg):
+        if msg == self.last_msg_printed:
+            return
+        if len(msg) < len(self.last_msg_printed):
+            self.maybe_clean()
+        sys.stdout.write(f"\r{msg}")
+        sys.stdout.flush()
+        self.last_msg_printed = msg
+
+    def maybe_clean(self):
+        len_last_msg_printed = len(self.last_msg_printed)
+        if len_last_msg_printed > 0:
+            clean_str = " " * len_last_msg_printed
+            sys.stdout.write(f"\r{clean_str}\r")
+            sys.stdout.flush()
+
+
 class MVTWebDriverRunner():
 
     def __init__(self, platform, configuration, extra_browser_args, mvt_instance_address, browser_name):
@@ -125,15 +148,38 @@ class MVTWebDriverRunner():
     def _suite_has_started(self, driver):
         return driver.execute_script('return !(typeof globalRunner === "undefined" || globalRunner === null);')
 
-    def _suite_has_finished(self, driver):
-        return driver.execute_script("return globalRunner.currentTestIdx == globalRunner.testList.length;")
+    def _wait_until_suite_has_finished(self, maxwait_secs, suite_name):
+        poll_interval_secs = 5
+        max_loops = maxwait_secs / poll_interval_secs
+        i=0
+        try:
+            progress_log_info = ProgressLogInfo()
+            while True:
+                sleep(poll_interval_secs)
+                i+=1
+                running_test_id = self.driver.execute_script("return globalRunner.currentTestIdx;")
+                total_tests_to_run = self.driver.execute_script("return globalRunner.testList.length;")
+                if total_tests_to_run > 0 and running_test_id==total_tests_to_run:
+                    break
+                if i >= max_loops:
+                    raise TimeoutException(f'Timed out waiting for the suite "{suite_name}" to finish after waiting {maxwait_secs} seconds')
+                if _log.getEffectiveLevel() in [logging.DEBUG, logging.INFO]:
+                    percent_completed = float(100) * float(running_test_id) / float(total_tests_to_run)
+                    progress_log_msg = f'Completed {percent_completed:.0f}% of suite "{suite_name}": running test {running_test_id} of {total_tests_to_run}.'
+                    if _log.getEffectiveLevel() == logging.INFO:
+                        progress_log_info.log(progress_log_msg)
+                    else:
+                        _log.debug(progress_log_msg)
+        finally:
+            progress_log_info.maybe_clean()
 
     def run_suite(self, suite):
         test_url = f"{self.mvt_instance_address}/?test_type={suite}&command=run"
         _log.info(f'Running MVT suite "{suite}" at {test_url}')
         self.driver.get(test_url)
         WebDriverWait(self.driver, 20).until(self._suite_has_started)
-        WebDriverWait(self.driver, 3600).until(self._suite_has_finished)
+        self._wait_until_suite_has_finished(3600, suite)
+        _log.info(f'MVT suite "{suite}" has finished. Results below:')
         return self.driver.execute_script("return getMvtTestResults()")
 
     def __del__(self):


### PR DESCRIPTION
#### 940df310a954df4bbcbdb20c86034bfa54086eef
<pre>
[Tools][WPE] run-mvt-tests should print some status updates meanwhile is running the suites
<a href="https://bugs.webkit.org/show_bug.cgi?id=288549">https://bugs.webkit.org/show_bug.cgi?id=288549</a>

Reviewed by Philippe Normand.

The run-mvt-tests script is not printing any status update meanwhile
the suites are run, and sometimes some of those suites can take more
than 20 minutes (1200 seconds), so that is causing random problems
on the buildbot because buildbot is configured to kill any test step
that spends more than 1200 seconds without printing anything.

To avoid this problem, and also to improve the feedback received when
running the test suites, this patch changes to code to print each 5
seconds an update of the progress on the run of the test suite.

This is printed on the same line, with \r (carriage return), so this
status updates won&apos;t appear on the final output, only when running
the test suite.

* Tools/Scripts/run-mvt-tests:

Canonical link: <a href="https://commits.webkit.org/291107@main">https://commits.webkit.org/291107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23f7ac878650e37ff2f5e21af5a7e666f6ff653a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91970 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11502 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11843 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19989 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70565 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28045 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50893 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8752 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41785 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98933 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14109 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79597 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19339 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23357 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12125 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19068 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18765 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->