### PR TITLE
Remove a tiny bit of unsafe buffer usage

### DIFF
--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -63,14 +63,12 @@ public:
         : ASCIILiteral()
     { }
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     template<size_t length>
     consteval ASCIILiteral(const char (&literal)[length])
         : m_charactersWithNullTerminator(unsafeMakeSpan(literal, length))
     {
-        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(literal[length - 1] == '\0');
+        RELEASE_ASSERT_UNDER_CONSTEXPR_CONTEXT(m_charactersWithNullTerminator[length - 1] == '\0');
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     unsigned hash() const;
     constexpr bool isNull() const { return m_charactersWithNullTerminator.empty(); }


### PR DESCRIPTION
#### 3c0c941a98e0a7c7951da9a568243f10a27fe606
<pre>
Remove a tiny bit of unsafe buffer usage
<a href="https://bugs.webkit.org/show_bug.cgi?id=288555">https://bugs.webkit.org/show_bug.cgi?id=288555</a>
<a href="https://rdar.apple.com/145618586">rdar://145618586</a>

Reviewed by Chris Dumez.

No need for unsafe buffer usage, since we have a span.

* Source/WTF/wtf/text/ASCIILiteral.h:

Canonical link: <a href="https://commits.webkit.org/291115@main">https://commits.webkit.org/291115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be117a8a7a6babdc0e573489bc6cf2af459307dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96900 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42569 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70568 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28047 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50896 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/900 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41784 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84748 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98932 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90698 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19086 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14107 "Found 1 new test failure: ipc/large-vector-allocate-failure-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79600 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79151 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78828 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23358 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/674 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12124 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14616 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19067 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24276 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113291 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18764 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32789 "Found 14 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.default, microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->