### PR TITLE
Add a build flag for writable file stream

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3035,6 +3035,7 @@ FileSystemWritableStreamEnabled:
   type: bool
   status: testable
   category: dom
+  condition: ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
   humanReadableName: "File System WritableStream"
   humanReadableDescription: "Enable File System WritableStream API"
   defaultValue:

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -585,6 +585,10 @@
 #define ENABLE_XSLT 1
 #endif
 
+#if !defined(FILE_SYSTEM_WRITABLE_STREAM)
+#define ENABLE_FILE_SYSTEM_WRITABLE_STREAM 0
+#endif
+
 /*
  * Enable this to put each IsoHeap and other allocation categories into their own malloc heaps, so that tools like vmmap can show how big each heap is.
  * Turn BENABLE_MALLOC_HEAP_BREAKDOWN on in bmalloc together when using this.

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp
@@ -129,6 +129,7 @@ void FileSystemFileHandle::unregisterSyncAccessHandle(FileSystemSyncAccessHandle
 }
 
 // https://fs.spec.whatwg.org/#api-filesystemfilehandle-createwritable
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 void FileSystemFileHandle::createWritable(const CreateWritableOptions& options, DOMPromiseDeferred<IDLInterface<FileSystemWritableFileStream>>&& promise)
 {
     if (isClosed())
@@ -187,6 +188,7 @@ void FileSystemFileHandle::executeCommandForWritable(FileSystemWritableFileStrea
         promise.settle(WTFMove(result));
     });
 }
+#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h
@@ -50,6 +50,7 @@ public:
     void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, FileSystemSyncAccessHandle&);
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier);
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     struct CreateWritableOptions {
         bool keepExistingData { false };
     };
@@ -57,6 +58,7 @@ public:
 
     void closeWritable(FileSystemWritableFileStreamIdentifier, FileSystemWriteCloseReason);
     void executeCommandForWritable(FileSystemWritableFileStreamIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, DOMPromiseDeferred<void>&&);
+#endif
 
 private:
     FileSystemFileHandle(ScriptExecutionContext&, String&&, FileSystemHandleIdentifier, Ref<FileSystemStorageConnection>&&);

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.idl
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.idl
@@ -26,6 +26,7 @@
 // https://fs.spec.whatwg.org/#api-filesystemhandle
 
 [
+    Conditional=FILE_SYSTEM_WRITABLE_STREAM,
     EnabledBySetting=AccessHandleEnabled&FileSystemWritableStreamEnabled
 ] dictionary FileSystemCreateWritableOptions {
     boolean keepExistingData = false;
@@ -38,5 +39,6 @@
 ] interface FileSystemFileHandle : FileSystemHandle {
     Promise<File> getFile();
     [EnabledBySetting=AccessHandleEnabled, Exposed=Worker] Promise<FileSystemSyncAccessHandle> createSyncAccessHandle();
-    [EnabledBySetting=AccessHandleEnabled&FileSystemWritableStreamEnabled] Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
+
+    [Conditional=FILE_SYSTEM_WRITABLE_STREAM, EnabledBySetting=AccessHandleEnabled&FileSystemWritableStreamEnabled] Promise<FileSystemWritableFileStream> createWritable(optional FileSystemCreateWritableOptions options = {});
 };

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "FileSystemStorageConnection.h"
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 #include "FileSystemWritableFileStream.h"
 
 namespace WebCore {
@@ -50,3 +52,5 @@ void FileSystemStorageConnection::unregisterFileSystemWritable(FileSystemWritabl
 }
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h
@@ -83,15 +83,19 @@ public:
     virtual void registerSyncAccessHandle(FileSystemSyncAccessHandleIdentifier, ScriptExecutionContextIdentifier) = 0;
     virtual void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) = 0;
     virtual void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) = 0;
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     virtual void createWritable(ScriptExecutionContextIdentifier, FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) = 0;
     virtual void closeWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCloseReason, VoidCallback&&) = 0;
     virtual void executeCommandForWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) = 0;
+#endif
     virtual void getHandleNames(FileSystemHandleIdentifier, GetHandleNamesCallback&&) = 0;
     virtual void getHandle(FileSystemHandleIdentifier, const String& name, GetHandleCallback&&) = 0;
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     WEBCORE_EXPORT bool errorFileSystemWritable(FileSystemWritableFileStreamIdentifier);
     void registerFileSystemWritable(FileSystemWritableFileStreamIdentifier, FileSystemWritableFileStream&);
     void unregisterFileSystemWritable(FileSystemWritableFileStreamIdentifier);
+#endif
 
 private:
     HashMap<FileSystemWritableFileStreamIdentifier, WeakPtr<FileSystemWritableFileStream>> m_writables;

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "FileSystemWritableFileStream.h"
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 #include "InternalWritableStream.h"
 #include "JSBlob.h"
 #include "JSDOMPromise.h"
@@ -116,3 +118,5 @@ void FileSystemWritableFileStream::truncate(JSC::JSGlobalObject& lexicalGlobalOb
 }
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 #include "FileSystemWriteCommandType.h"
 #include "WritableStream.h"
 
@@ -61,3 +63,5 @@ private:
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::FileSystemWritableFileStream)
     static bool isType(const WebCore::WritableStream& stream) { return stream.type() == WebCore::WritableStream::Type::FileSystem; }
 SPECIALIZE_TYPE_TRAITS_END()
+
+#endif

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.idl
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.idl
@@ -32,6 +32,7 @@ enum WriteCommandType {
 };
 
 [
+    Conditional=FILE_SYSTEM_WRITABLE_STREAM,
     EnabledBySetting=FileSystemWritableStreamEnabled,
     JSGenerateToJSObject,
     JSGenerateToNativeObject
@@ -45,6 +46,7 @@ enum WriteCommandType {
 typedef (BufferSource or Blob or USVString or WriteParams) FileSystemWriteChunkType;
 
 [
+    Conditional=FILE_SYSTEM_WRITABLE_STREAM,
     EnabledBySetting=FileSystemWritableStreamEnabled,
     Exposed=(Window,Worker),
     SecureContext

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "FileSystemWritableFileStreamSink.h"
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 #include "FileSystemFileHandle.h"
 #include "FileSystemWritableFileStream.h"
 #include "FileSystemWriteCloseReason.h"
@@ -184,3 +186,5 @@ void FileSystemWritableFileStreamSink::error(String&&)
 }
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 #include "FileSystemWritableFileStreamIdentifier.h"
 #include "WritableStreamSink.h"
 
@@ -51,3 +53,5 @@ private:
 };
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/filesystemaccess/FileSystemWriteCommandType.h
+++ b/Source/WebCore/Modules/filesystemaccess/FileSystemWriteCommandType.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 namespace WebCore {
 
 enum class FileSystemWriteCommandType : uint8_t {
@@ -34,3 +36,5 @@ enum class FileSystemWriteCommandType : uint8_t {
 };
 
 } // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp
@@ -317,6 +317,8 @@ void WorkerFileSystemStorageConnection::invalidateAccessHandle(WebCore::FileSyst
         handle->invalidate();
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 void WorkerFileSystemStorageConnection::createWritable(ScriptExecutionContextIdentifier contextIdentifier, FileSystemHandleIdentifier identifier, bool keepExistingData, StreamCallback&& callback)
 {
     if (!m_scope)
@@ -380,6 +382,8 @@ void WorkerFileSystemStorageConnection::executeCommandForWritable(FileSystemHand
         mainThreadConnection->executeCommandForWritable(identifier, streamIdentifier, type, position, size, bytes.span(), hasDataError, WTFMove(mainThreadCallback));
     });
 }
+
+#endif
 
 void WorkerFileSystemStorageConnection::getHandleNames(FileSystemHandleIdentifier identifier, GetHandleNamesCallback&& callback)
 {

--- a/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h
@@ -79,9 +79,11 @@ private:
     void unregisterSyncAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(FileSystemSyncAccessHandleIdentifier) final;
     void requestNewCapacityForSyncAccessHandle(FileSystemHandleIdentifier, FileSystemSyncAccessHandleIdentifier, uint64_t, RequestCapacityCallback&&) final;
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     void createWritable(ScriptExecutionContextIdentifier, FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) final;
     void closeWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCloseReason, VoidCallback&&) final;
     void executeCommandForWritable(FileSystemHandleIdentifier, FileSystemWritableFileStreamIdentifier, FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) final;
+#endif
 
     WeakPtr<WorkerGlobalScope, WeakPtrImplWithEventTargetData> m_scope;
     RefPtr<FileSystemStorageConnection> m_mainThreadConnection;

--- a/Source/WebCore/bindings/js/JSWritableStreamCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWritableStreamCustom.cpp
@@ -39,9 +39,10 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<WritableStream>&& stream)
 {
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     if (is<FileSystemWritableFileStream>(stream.get()))
         return createWrapper<FileSystemWritableFileStream>(globalObject, WTFMove(stream));
-
+#endif
     return createWrapper<WritableStream>(globalObject, WTFMove(stream));
 }
 

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -307,12 +307,16 @@ void Blob::arrayBuffer(DOMPromiseDeferred<IDLArrayBuffer>&& promise)
     });
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 void Blob::getArrayBuffer(CompletionHandler<void(ExceptionOr<Ref<JSC::ArrayBuffer>>)>&& completionHandler)
 {
     loadBlob(FileReaderLoader::ReadAsArrayBuffer, [completionHandler = WTFMove(completionHandler)](BlobLoader& blobLoader) mutable {
         completionHandler(arrayBufferFromBlobLoader(blobLoader));
     });
 }
+
+#endif
 
 void Blob::bytes(Ref<DeferredPromise>&& promise)
 {

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -125,7 +125,9 @@ public:
 
     void text(Ref<DeferredPromise>&&);
     void arrayBuffer(DOMPromiseDeferred<IDLArrayBuffer>&&);
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     void getArrayBuffer(CompletionHandler<void(ExceptionOr<Ref<JSC::ArrayBuffer>>)>&&);
+#endif
     void bytes(Ref<DeferredPromise>&&);
     ExceptionOr<Ref<ReadableStream>> stream();
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -1786,8 +1786,10 @@ bool NetworkConnectionToWebProcess::isAlwaysOnLoggingAllowed() const
 void NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess&& sharedPreferencesForWebProcess)
 {
     m_sharedPreferencesForWebProcess = WTFMove(sharedPreferencesForWebProcess);
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     if (CheckedPtr session = networkSession())
         session->protectedStorageManager()->updateSharedPreferencesForConnection(protectedConnection(), m_sharedPreferencesForWebProcess);
+#endif
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -88,10 +88,12 @@ void FileSystemStorageHandle::close()
     if (m_activeSyncAccessHandle)
         closeSyncAccessHandle(m_activeSyncAccessHandle->identifier);
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     auto activeWritableFileIdentifiers = copyToVector(m_activeWritableFiles.keys());
     for (auto identifier : activeWritableFileIdentifiers)
         closeWritable(identifier, WebCore::FileSystemWriteCloseReason::Aborted);
     ASSERT(m_activeWritableFiles.isEmpty());
+#endif
 
     manager->closeHandle(*this);
 }
@@ -238,6 +240,8 @@ std::optional<FileSystemStorageError> FileSystemStorageHandle::closeSyncAccessHa
     return std::nullopt;
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
+
 Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError> FileSystemStorageHandle::createWritable(bool keepExistingData)
 {
     RefPtr manager = m_manager.get();
@@ -359,6 +363,8 @@ Vector<WebCore::FileSystemWritableFileStreamIdentifier> FileSystemStorageHandle:
 {
     return copyToVector(m_activeWritableFiles.keys());
 }
+
+#endif
 
 Expected<Vector<String>, FileSystemStorageError> FileSystemStorageHandle::getHandleNames()
 {

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h
@@ -74,10 +74,12 @@ public:
     std::optional<FileSystemStorageError> closeSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier);
     std::optional<WebCore::FileSystemSyncAccessHandleIdentifier> activeSyncAccessHandle();
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError> createWritable(bool keepExistingData);
     std::optional<FileSystemStorageError> closeWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason);
     std::optional<FileSystemStorageError> executeCommandForWritable(WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError);
     Vector<WebCore::FileSystemWritableFileStreamIdentifier> writables() const;
+#endif
 
 private:
     FileSystemStorageHandle(FileSystemStorageManager&, Type, String&& path, String&& name);
@@ -94,7 +96,9 @@ private:
         uint64_t capacity { 0 };
     };
     std::optional<SyncAccessHandleInfo> m_activeSyncAccessHandle;
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     HashMap<WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileHandle> m_activeWritableFiles;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -220,8 +220,10 @@ void FileSystemStorageManager::close()
             if (auto accessHandleIdentifier = takenHandle->activeSyncAccessHandle())
                 IPC::Connection::send(connectionID, Messages::WebFileSystemStorageConnection::InvalidateAccessHandle(*accessHandleIdentifier), 0);
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
             for (auto writableIdentifier : takenHandle->writables())
                 IPC::Connection::send(connectionID, Messages::WebFileSystemStorageConnection::InvalidateWritable(writableIdentifier), 0);
+#endif
         }
     }
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -296,6 +296,7 @@ void NetworkStorageManager::startReceivingMessageFromConnection(IPC::Connection&
     m_connections.add(connection);
     addAllowedSitesForConnection(connection.uniqueID(), allowedSites);
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     protectedWorkQueue()->dispatch([this, protectedThis = Ref { *this }, connection = connection.uniqueID(), preferences]() mutable {
         assertIsCurrent(workQueue());
         ASSERT(!m_preferencesForConnections.contains(connection));
@@ -303,6 +304,9 @@ void NetworkStorageManager::startReceivingMessageFromConnection(IPC::Connection&
 
         RunLoop::protectedMain()->dispatch([protectedThis = WTFMove(protectedThis)] { });
     });
+#else
+    UNUSED_PARAM(preferences);
+#endif
 }
 
 void NetworkStorageManager::stopReceivingMessageFromConnection(IPC::Connection& connection)
@@ -329,14 +333,16 @@ void NetworkStorageManager::stopReceivingMessageFromConnection(IPC::Connection& 
         m_temporaryBlobPathsByConnection.remove(connection);
         if (m_allowedSitesForConnections)
             m_allowedSitesForConnections->remove(connection);
-
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
         ASSERT(m_preferencesForConnections.contains(connection));
         m_preferencesForConnections.remove(connection);
 
         RunLoop::protectedMain()->dispatch([protectedThis = WTFMove(protectedThis)] { });
+#endif
     });
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 void NetworkStorageManager::updateSharedPreferencesForConnection(IPC::Connection& connection, const SharedPreferencesForWebProcess& preferences)
 {
     ASSERT(RunLoop::isMain());
@@ -349,6 +355,7 @@ void NetworkStorageManager::updateSharedPreferencesForConnection(IPC::Connection
         RunLoop::protectedMain()->dispatch([protectedThis = WTFMove(protectedThis)] { });
     });
 }
+#endif
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -1023,6 +1030,7 @@ void NetworkStorageManager::requestNewCapacityForSyncAccessHandle(WebCore::FileS
     handle->requestNewCapacityForSyncAccessHandle(accessHandleIdentifier, newCapacity, WTFMove(completionHandler));
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 void NetworkStorageManager::createWritable(WebCore::FileSystemHandleIdentifier identifier, bool keepExistingData, CompletionHandler<void(Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError>)>&& completionHandler)
 {
     ASSERT(!RunLoop::isMain());
@@ -1055,6 +1063,7 @@ void NetworkStorageManager::executeCommandForWritable(WebCore::FileSystemHandleI
 
     completionHandler(handle->executeCommandForWritable(streamIdentifier, type, position, size, dataBytes, hasDataError));
 }
+#endif
 
 void NetworkStorageManager::getHandleNames(WebCore::FileSystemHandleIdentifier identifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&& completionHandler)
 {
@@ -2245,6 +2254,7 @@ RefPtr<FileSystemStorageHandleRegistry> NetworkStorageManager::protectedFileSyst
     return m_fileSystemStorageHandleRegistry;
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 std::optional<SharedPreferencesForWebProcess> NetworkStorageManager::sharedPreferencesForWebProcess(IPC::Connection& connection) const
 {
     assertIsCurrent(workQueue());
@@ -2255,6 +2265,7 @@ std::optional<SharedPreferencesForWebProcess> NetworkStorageManager::sharedPrefe
 
     return iter->value;
 }
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -107,7 +107,9 @@ public:
 
     void startReceivingMessageFromConnection(IPC::Connection&, const Vector<WebCore::RegistrableDomain>&, const SharedPreferencesForWebProcess&);
     void stopReceivingMessageFromConnection(IPC::Connection&);
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     void updateSharedPreferencesForConnection(IPC::Connection&, const SharedPreferencesForWebProcess&);
+#endif
 
     PAL::SessionID sessionID() const { return m_sessionID; }
     void close(CompletionHandler<void()>&&);
@@ -156,7 +158,11 @@ private:
     ~NetworkStorageManager();
 
     RefPtr<NetworkProcess> protectedProcess() const;
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
+#else
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const { return std::nullopt; }
+#endif
 
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
@@ -192,9 +198,11 @@ private:
     void createSyncAccessHandle(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<FileSystemSyncAccessHandleInfo, FileSystemStorageError>)>&&);
     void closeSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, CompletionHandler<void()>&&);
     void requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemSyncAccessHandleIdentifier, uint64_t newCapacity, CompletionHandler<void(std::optional<uint64_t>)>&&);
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     void createWritable(WebCore::FileSystemHandleIdentifier, bool keepExistingData, CompletionHandler<void(Expected<WebCore::FileSystemWritableFileStreamIdentifier, FileSystemStorageError>)>&&);
     void closeWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
     void executeCommandForWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, CompletionHandler<void(std::optional<FileSystemStorageError>)>&&);
+#endif
     void getHandleNames(WebCore::FileSystemHandleIdentifier, CompletionHandler<void(Expected<Vector<String>, FileSystemStorageError>)>&&);
     void getHandle(IPC::Connection&, WebCore::FileSystemHandleIdentifier, String&& name, CompletionHandler<void(Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, FileSystemStorageError>)>&&);
     
@@ -325,7 +333,9 @@ private:
     HashMap<WebCore::ClientOrigin, WallTime> m_lastModificationTimes WTF_GUARDED_BY_CAPABILITY(workQueue());
     using ConnectionSitesMap = HashMap<IPC::Connection::UniqueID, HashSet<WebCore::RegistrableDomain>>;
     std::optional<ConnectionSitesMap> m_allowedSitesForConnections WTF_GUARDED_BY_CAPABILITY(workQueue());
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     HashMap<IPC::Connection::UniqueID, SharedPreferencesForWebProcess> m_preferencesForConnections WTF_GUARDED_BY_CAPABILITY(workQueue());
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in
@@ -45,9 +45,13 @@
     CreateSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<WebKit::FileSystemSyncAccessHandleInfo, WebKit::FileSystemStorageError> result)
     CloseSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier) -> ()
     RequestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity) -> (std::optional<uint64_t> result)
+
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     [EnabledBy=FileSystemWritableStreamEnabled] CreateWritable(WebCore::FileSystemHandleIdentifier identifier, bool keepExistingData) -> (Expected<WebCore::FileSystemWritableFileStreamIdentifier, WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemWritableStreamEnabled] CloseWritable(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemWritableFileStreamIdentifier streamIdentifier, enum:bool WebCore::FileSystemWriteCloseReason reason) -> (std::optional<WebKit::FileSystemStorageError> result)
     [EnabledBy=FileSystemWritableStreamEnabled] ExecuteCommandForWritable(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemWritableFileStreamIdentifier streamIdentifier, enum:uint8_t WebCore::FileSystemWriteCommandType type, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError) ->  (std::optional<WebKit::FileSystemStorageError> result)
+#endif
+
     GetHandleNames(WebCore::FileSystemHandleIdentifier identifier) -> (Expected<Vector<String>, WebKit::FileSystemStorageError> result)
     GetHandle(WebCore::FileSystemHandleIdentifier identifier, String name) -> (Expected<std::optional<std::pair<WebCore::FileSystemHandleIdentifier, bool>>, WebKit::FileSystemStorageError> result)
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8879,12 +8879,14 @@ struct WebCore::ImageBufferResourceLimits {
     size_t imageBufferForCanvasLimit;
 };
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 header: <WebCore/FileSystemWriteCommandType.h>
 enum class WebCore::FileSystemWriteCommandType : uint8_t {
     Write,
     Seek,
     Truncate
 };
+#endif
 
 enum class WebCore::FileSystemWriteCloseReason : bool;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -47,6 +47,7 @@ WebFileSystemStorageConnection::WebFileSystemStorageConnection(Ref<IPC::Connecti
 {
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 void WebFileSystemStorageConnection::errorWritable(WebCore::ScriptExecutionContextIdentifier contextIdentifier, WebCore::FileSystemWritableFileStreamIdentifier writableIdentifier)
 {
     if (errorFileSystemWritable(writableIdentifier))
@@ -59,6 +60,7 @@ void WebFileSystemStorageConnection::errorWritable(WebCore::ScriptExecutionConte
             connection->errorFileSystemWritable(writableIdentifier);
     });
 }
+#endif
 
 void WebFileSystemStorageConnection::connectionClosed()
 {
@@ -67,9 +69,11 @@ void WebFileSystemStorageConnection::connectionClosed()
     for (auto identifier : m_syncAccessHandles.keys())
         invalidateAccessHandle(identifier);
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     auto writableIdentifiers = std::exchange(m_writableIdentifiers, { });
     for (auto keyValue : writableIdentifiers)
         errorWritable(keyValue.value, keyValue.key);
+#endif
 }
 
 void WebFileSystemStorageConnection::closeHandle(WebCore::FileSystemHandleIdentifier identifier)
@@ -231,6 +235,7 @@ void WebFileSystemStorageConnection::invalidateAccessHandle(WebCore::FileSystemS
     }
 }
 
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
 void WebFileSystemStorageConnection::createWritable(WebCore::ScriptExecutionContextIdentifier contextIdentifier, WebCore::FileSystemHandleIdentifier identifier, bool keepExistingData, StreamCallback&& completionHandler)
 {
     RefPtr connection = m_connection;
@@ -275,6 +280,7 @@ void WebFileSystemStorageConnection::executeCommandForWritable(WebCore::FileSyst
         completionHandler(convertToExceptionOr(error));
     });
 }
+#endif
 
 void WebFileSystemStorageConnection::requestNewCapacityForSyncAccessHandle(WebCore::FileSystemHandleIdentifier identifier, WebCore::FileSystemSyncAccessHandleIdentifier accessHandleIdentifier, uint64_t newCapacity, RequestCapacityCallback&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h
@@ -97,15 +97,19 @@ private:
     void registerSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier) final;
     void unregisterSyncAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
     void invalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier) final;
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     void createWritable(WebCore::ScriptExecutionContextIdentifier, WebCore::FileSystemHandleIdentifier, bool keepExistingData, StreamCallback&&) final;
     void closeWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCloseReason, VoidCallback&&) final;
     void executeCommandForWritable(WebCore::FileSystemHandleIdentifier, WebCore::FileSystemWritableFileStreamIdentifier, WebCore::FileSystemWriteCommandType, std::optional<uint64_t> position, std::optional<uint64_t> size, std::span<const uint8_t> dataBytes, bool hasDataError, VoidCallback&&) final;
 
     void invalidateWritable(WebCore::FileSystemWritableFileStreamIdentifier);
     void errorWritable(WebCore::ScriptExecutionContextIdentifier, WebCore::FileSystemWritableFileStreamIdentifier);
+#endif
 
     HashMap<WebCore::FileSystemSyncAccessHandleIdentifier, WebCore::ScriptExecutionContextIdentifier> m_syncAccessHandles;
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     HashMap<WebCore::FileSystemWritableFileStreamIdentifier, WebCore::ScriptExecutionContextIdentifier> m_writableIdentifiers;
+#endif
     RefPtr<IPC::Connection> m_connection;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in
@@ -26,5 +26,7 @@
 ]
 messages -> WebFileSystemStorageConnection {
     InvalidateAccessHandle(WebCore::FileSystemSyncAccessHandleIdentifier identifier)
+#if ENABLE(FILE_SYSTEM_WRITABLE_STREAM)
     InvalidateWritable(WebCore::FileSystemWritableFileStreamIdentifier identifier)
+#endif
 }


### PR DESCRIPTION
#### 9d5941e43401d1beec722e84ab79aee5790e41bf
<pre>
Add a build flag for writable file stream
<a href="https://bugs.webkit.org/show_bug.cgi?id=288557">https://bugs.webkit.org/show_bug.cgi?id=288557</a>

Reviewed by NOBODY (OOPS!).

Add a new compile time flag for writable file stream, which is off by default
to get rid of the memory regression 287390@main introduced.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/PlatformEnable.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.cpp:
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemFileHandle.idl:
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.cpp:
* Source/WebCore/Modules/filesystemaccess/FileSystemStorageConnection.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.cpp:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStream.idl:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.cpp:
* Source/WebCore/Modules/filesystemaccess/FileSystemWritableFileStreamSink.h:
* Source/WebCore/Modules/filesystemaccess/FileSystemWriteCommandType.h:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.cpp:
* Source/WebCore/Modules/filesystemaccess/WorkerFileSystemStorageConnection.h:
* Source/WebCore/bindings/js/JSWritableStreamCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/fileapi/Blob.cpp:
* Source/WebCore/fileapi/Blob.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::updateSharedPreferencesForWebProcess):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::close):
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp:
(WebKit::FileSystemStorageManager::close):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::startReceivingMessageFromConnection):
(WebKit::NetworkStorageManager::stopReceivingMessageFromConnection):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp:
(WebKit::WebFileSystemStorageConnection::connectionClosed):
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d5941e43401d1beec722e84ab79aee5790e41bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96906 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/19995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70575 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28050 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94977 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9031 "Found 4 new test failures: storage/filesystemaccess/writable-file-stream-abort.html storage/filesystemaccess/writable-file-stream-seek.html storage/filesystemaccess/writable-file-stream-truncate.html storage/filesystemaccess/writable-file-stream-write.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50903 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8760 "Found 33 new test failures: imported/w3c/web-platform-tests/file-system-access/sandboxed_FileSystemDirectoryHandle-move.https.any.html imported/w3c/web-platform-tests/file-system-access/sandboxed_FileSystemDirectoryHandle-move.https.any.worker.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.worker.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-BroadcastChannel.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-Error.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-frames.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-workers.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-frames.https.window.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/969 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41790 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84754 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79082 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/960 "Found 36 new test failures: imported/w3c/web-platform-tests/file-system-access/sandboxed_FileSystemDirectoryHandle-move.https.any.html imported/w3c/web-platform-tests/file-system-access/sandboxed_FileSystemDirectoryHandle-move.https.any.worker.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.worker.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-BroadcastChannel.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-frames.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-workers.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-frames.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-windows.https.window.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98938 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90704 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19092 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14115 "Found 60 new test failures: fast/text/glyph-display-lists/glyph-display-list-color.html fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html gamepad/gamepad-event-handlers.html http/tests/security/referrer-policy-header-multipart.html http/tests/site-isolation/history/add-iframes-and-go-back.html http/tests/xmlhttprequest/origin-exact-matching.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79611 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79220 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78841 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23362 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/725 "Found 36 new test failures: imported/w3c/web-platform-tests/file-system-access/sandboxed_FileSystemDirectoryHandle-move.https.any.html imported/w3c/web-platform-tests/file-system-access/sandboxed_FileSystemDirectoryHandle-move.https.any.worker.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.worker.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-BroadcastChannel.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-frames.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-windows.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-MessagePort-workers.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-frames.https.window.html imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-postMessage-windows.https.window.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12130 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24282 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113298 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18770 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32791 "Found 324 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->