### PR TITLE
[WebGPU] Structure size is incorrect for structs containing vec<T, 3> types

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-288558-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-288558-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash.

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-288558.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-288558.html
@@ -1,0 +1,182 @@
+<!-- webkit-test-runner [ enableMetalShaderValidation=true ] -->
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxStorageTexturesPerShaderStage: 4,
+    maxTextureDimension1D: 8192,
+    maxUniformBufferBindingSize: 2710603,
+    maxStorageBufferBindingSize: 156398292,
+  },
+});
+// START
+b = device0.createShaderModule({
+  code : ` 
+                    @group(0) @binding(231) var<storage, read_write> c: array<array<S0, 2> >;
+                    struct S0 {
+                   d: vec3u,   e: u32}
+                    @group(0) @binding(239) var<storage> f: array<array<array<vec2i, 1>, 12> >;
+                    fn g(v: u32) -> u32 {
+                 return v;
+                 }
+                    @compute @workgroup_size(1) fn h() 
+                   {
+                for (var i=c[6076][g(806475)].d[1];
+              i<u32(f[0][g(100753173)][0].r) ;
+              ) {}
+                }
+                   `
+})
+j = device0.createTexture({
+  size : [ 4, 4, 13 ],
+  format : 'bgra8unorm',
+  usage : GPUTextureUsage.TEXTURE_BINDING
+})
+k = j.createView({dimension : 'cube'})
+l = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.VERTEX,
+      texture : {viewDimension : 'cube'}
+    },
+    {
+      binding : 1,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 3,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage'}
+    },
+    {
+      binding : 220,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 231,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage'}
+    },
+    {
+      binding : 239,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'read-only-storage'}
+    }
+  ]
+})
+m = device0.createPipelineLayout({bindGroupLayouts : [ l ]})
+n = device0.createCommandEncoder()
+o = device0.createComputePipeline({layout : m, compute : {module : b}})
+p = n.beginComputePass()
+try {
+  p.setPipeline(o)
+} catch {
+}
+q = device0.createBuffer({size : 72, usage : GPUBufferUsage.STORAGE})
+s = device0.createBuffer({size : 40, usage : GPUBufferUsage.STORAGE})
+buffer44 = device0.createBuffer({size : 284, usage : GPUBufferUsage.STORAGE})
+buffer48 = device0.createBuffer({size : 60, usage : GPUBufferUsage.STORAGE})
+t = device0.createBuffer({size : 088, usage : GPUBufferUsage.STORAGE})
+bindGroup9 = device0.createBindGroup({
+  layout : l,
+  entries : [
+    {binding : 3, resource : {buffer : buffer48}},
+    {binding : 239, resource : {buffer : buffer44}},
+    {binding : 1, resource : {buffer : s}},
+    {binding : 231, resource : {buffer : t}}, {binding : 0, resource : k},
+    {binding : 220, resource : {buffer : q}}
+  ]
+})
+try {
+  p.setBindGroup(0, bindGroup9, [ 0, 0 ])
+} catch {
+}
+try {
+  p.dispatchWorkgroups(1)
+} catch {
+}
+try {
+  p.end()
+} catch {
+}
+u = n.finish()
+try {
+  device0.queue.submit([ u ])
+} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/AttributeValidator.cpp
+++ b/Source/WebGPU/WGSL/AttributeValidator.cpp
@@ -344,7 +344,7 @@ void AttributeValidator::visit(AST::Structure& structure)
             member.m_alignment = fieldAlignment;
         }
 
-        auto typeSize = type->size();
+        auto typeSize = WTF::roundUpToMultipleOf(*fieldAlignment, type->size());
         auto fieldSize = member.m_size;
         if (!fieldSize) {
             fieldSize = typeSize;


### PR DESCRIPTION
#### 829fd29e284e1c29bede7707dcd567001d650382
<pre>
[WebGPU] Structure size is incorrect for structs containing vec&lt;T, 3&gt; types
<a href="https://bugs.webkit.org/show_bug.cgi?id=288558">https://bugs.webkit.org/show_bug.cgi?id=288558</a>
<a href="https://rdar.apple.com/145584310">rdar://145584310</a>

Reviewed by NOBODY (OOPS!).

typeSize should be rounded to the field alignment, otherwise the following struct:

struct type0 {
    vec&lt;unsigned, 3&gt; field0;
    unsigned field1;
};

will have its size computed as 16 instead of 20. Note, vec&lt;T, 3&gt; has the same
alignment as vec&lt;T, 4&gt; because these are the same size in Metal shading language.

* LayoutTests/fast/webgpu/nocrash/fuzz-288558-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-288558.html: Added.
Add regression test.

* Source/WebGPU/WGSL/AttributeValidator.cpp:
(WGSL::AttributeValidator::visit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/829fd29e284e1c29bede7707dcd567001d650382

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96910 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70571 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28052 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/94982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50899 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1018 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41794 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79078 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1000 "Found 2 new test failures: http/tests/webgpu/webgpu/shader/execution/shader_io/compute_builtins.html http/tests/webgpu/webgpu/shader/execution/shader_io/shared_structs.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98942 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14120 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79604 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78832 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23363 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24286 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->