### PR TITLE
Create a driver to update StageMode Interactions based on Gesture Input

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -143,6 +143,7 @@ private:
 
     void computeTransform();
     void applyEnvironmentMapDataAndRelease();
+    void applyStageModeOperationToDriver();
 
     WebCore::ModelPlayerIdentifier m_id;
     Ref<IPC::Connection> m_webProcessConnection;
@@ -173,7 +174,7 @@ private:
     bool m_hasPortal { true };
 
     // For interactions
-    REPtr<REEntityRef> m_interactionContainerEntity;
+    RetainPtr<WKStageModeInteractionDriver> m_stageModeInteractionDriver;
     WebCore::StageModeOperation m_stageModeOperation { WebCore::StageModeOperation::None };
 };
 

--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm
@@ -35,6 +35,7 @@
 #import "ModelProcessModelPlayerMessages.h"
 #import "RealityKitBridging.h"
 #import "WKModelProcessModelLayer.h"
+#import "WKStageMode.h"
 #import <RealitySystemSupport/RealitySystemSupport.h>
 #import <SurfBoardServices/SurfBoardServices.h>
 #import <WebCore/Color.h>
@@ -216,6 +217,8 @@ ModelProcessModelPlayerProxy::~ModelProcessModelPlayerProxy()
 
     if (m_hostingEntity.get())
         REEntityRemoveFromSceneOrParent(m_hostingEntity.get());
+
+    [m_stageModeInteractionDriver removeInteractionContainerFromSceneOrParent];
 
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayerProxy deallocated id=%" PRIu64, this, m_id.toUInt64());
 }
@@ -450,20 +453,24 @@ void ModelProcessModelPlayerProxy::didFinishLoading(WebCore::REModelLoader& load
         REEntitySetName(m_model->rootEntity(), "WebKit:ModelRootEntity");
 
     if (canLoadWithRealityKit)
-        [m_model->rootRKEntity() setParentCoreEntity:clientComponentEntity];
+        [m_model->rootRKEntity() setParentCoreEntity:clientComponentEntity preservingWorldTransform:NO];
     else {
         REEntitySetParent(m_model->rootEntity(), clientComponentEntity);
-        REEntitySubtreeAddNetworkComponentRecursive(m_model->rootEntity());
     }
 
-    RENetworkMarkEntityMetadataDirty(clientComponentEntity);
+    m_stageModeInteractionDriver = adoptNS([allocWKStageModeInteractionDriverInstance() initWithModel:m_modelRKEntity.get() container:clientComponentEntity]);
+
+    REEntitySubtreeAddNetworkComponentRecursive([m_stageModeInteractionDriver interactionContainerRef]);
+    RENetworkMarkEntityMetadataDirty([m_stageModeInteractionDriver interactionContainerRef]);
+
+    applyStageModeOperationToDriver();
+
     if (!canLoadWithRealityKit)
         RENetworkMarkEntityMetadataDirty(m_model->rootEntity());
 
     computeTransform();
     updateTransform();
-
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287820
+    [m_stageModeInteractionDriver setContainerTransformInPortal];
 
     updateOpacity();
     startAnimating();
@@ -674,17 +681,19 @@ void ModelProcessModelPlayerProxy::setEnvironmentMap(Ref<WebCore::SharedBuffer>&
 
 void ModelProcessModelPlayerProxy::beginStageModeTransform(const WebCore::TransformationMatrix& transform)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287820
+    simd_float4x4 transformMatrix = simd_float4x4(transform);
+    [m_stageModeInteractionDriver interactionDidBegin:transformMatrix];
 }
 
 void ModelProcessModelPlayerProxy::updateStageModeTransform(const WebCore::TransformationMatrix& transform)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287820
+    simd_float4x4 transformMatrix = simd_float4x4(transform);
+    [m_stageModeInteractionDriver interactionDidUpdate:transformMatrix];
 }
 
 void ModelProcessModelPlayerProxy::endStageModeInteraction()
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287820
+    [m_stageModeInteractionDriver interactionDidEnd];
 }
 
 void ModelProcessModelPlayerProxy::applyEnvironmentMapDataAndRelease()
@@ -719,6 +728,22 @@ void ModelProcessModelPlayerProxy::setStageMode(WebCore::StageModeOperation stag
         return;
 
     m_stageModeOperation = stagemodeOp;
+    applyStageModeOperationToDriver();
+}
+
+void ModelProcessModelPlayerProxy::applyStageModeOperationToDriver()
+{
+    switch (m_stageModeOperation) {
+    case WebCore::StageModeOperation::Orbit: {
+        [m_stageModeInteractionDriver operationDidUpdate:WKStageModeOperationOrbit];
+        break;
+    }
+
+    case WebCore::StageModeOperation::None: {
+        [m_stageModeInteractionDriver operationDidUpdate:WKStageModeOperationNone];
+        break;
+    }
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -76,3 +76,4 @@ SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionTextIte
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionScrollableItem)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionImageItem)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSLinearMediaSpatialVideoMetadata)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKStageModeInteractionDriver)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2449,6 +2449,8 @@
 		EBA8D3B727A5E33F00CB7900 /* PushServiceConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = EBA8D3B127A5E33F00CB7900 /* PushServiceConnection.mm */; };
 		EBDF51D12C8FBC4700EA1376 /* WebsitePushAndNotificationsEnabledPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = EBDF51CF2C8FBC4700EA1376 /* WebsitePushAndNotificationsEnabledPolicy.h */; };
 		ED82A7F2128C6FAF004477B3 /* WKBundlePageOverlay.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22F0FF1289FCD90085E74F /* WKBundlePageOverlay.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EEA52F482D70545300D578B5 /* WKStageMode.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0D3CDD2D3709BE00072978 /* WKStageMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		EEA52F492D7055A700D578B5 /* WKStageMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0D3CDC2D3709BE00072978 /* WKStageMode.swift */; };
 		EEFE72792D64FE5600DC6214 /* StageModeInteractionState.h in Headers */ = {isa = PBXBuildFile; fileRef = EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */; };
 		F404455C2D5CFB56000E587E /* AppKitSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = F404455A2D5CFB56000E587E /* AppKitSoftLink.h */; };
 		F409BA181E6E64BC009DA28E /* WKDragDestinationAction.h in Headers */ = {isa = PBXBuildFile; fileRef = F409BA171E6E64B3009DA28E /* WKDragDestinationAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -8240,6 +8242,8 @@
 		EBF4E32F2C2E105A00FAC85C /* NotificationAllowLists.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = NotificationAllowLists.xcfilelist; sourceTree = "<group>"; };
 		ECA680D31E6904B500731D20 /* ExtraPrivateSymbolsForTAPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtraPrivateSymbolsForTAPI.h; sourceTree = "<group>"; };
 		ECBFC1DB1E6A4D66000300C7 /* ExtraPublicSymbolsForTAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExtraPublicSymbolsForTAPI.h; sourceTree = "<group>"; };
+		EE0D3CDC2D3709BE00072978 /* WKStageMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKStageMode.swift; sourceTree = "<group>"; };
+		EE0D3CDD2D3709BE00072978 /* WKStageMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKStageMode.h; sourceTree = "<group>"; };
 		EEFE72782D64FE5600DC6214 /* StageModeInteractionState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StageModeInteractionState.h; sourceTree = "<group>"; };
 		F036978715F4BF0500C3A80E /* WebColorPicker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebColorPicker.cpp; sourceTree = "<group>"; };
 		F404455A2D5CFB56000E587E /* AppKitSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppKitSoftLink.h; sourceTree = "<group>"; };
@@ -13892,6 +13896,7 @@
 				A14F9B332B68467F00AD9C56 /* MarketplaceKit */,
 				B66F88BE2B6D1D6000FB1734 /* Preview */,
 				5260053F2C707686005D813A /* RealityKit */,
+				EE0D3CDE2D3709BE00072978 /* StageMode */,
 				449A79EE2BAE299C0033BF53 /* TextAnimation */,
 				F48EC3512B75837200D1B886 /* TextExtraction */,
 				0785E7FE2CBCDFDD00F68126 /* WritingTools */,
@@ -16262,6 +16267,15 @@
 			path = NotificationAllowList;
 			sourceTree = "<group>";
 		};
+		EE0D3CDE2D3709BE00072978 /* StageMode */ = {
+			isa = PBXGroup;
+			children = (
+				EE0D3CDD2D3709BE00072978 /* WKStageMode.h */,
+				EE0D3CDC2D3709BE00072978 /* WKStageMode.swift */,
+			);
+			path = StageMode;
+			sourceTree = "<group>";
+		};
 		F48EC3512B75837200D1B886 /* TextExtraction */ = {
 			isa = PBXGroup;
 			children = (
@@ -18191,6 +18205,7 @@
 				A14F9B762B68CA6C00AD9C56 /* WKSLinearMediaPlayer.h in Headers */,
 				A14F9B632B686DD300AD9C56 /* WKSLinearMediaTypes.h in Headers */,
 				B66F88C22B6D202600FB1734 /* WKSPreviewWindowController.h in Headers */,
+				EEA52F482D70545300D578B5 /* WKStageMode.h in Headers */,
 				44DBDA4E2BAE451F004E3712 /* WKSTextAnimationSourceDelegate.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -20542,6 +20557,7 @@
 				440DB5B72C1914DC0021639B /* TextAnimationManager.swift in Sources */,
 				077FD1A02CC7569200C5D9E0 /* WKIntelligenceReplacementTextEffectCoordinator.swift in Sources */,
 				0735F3222D38B09E0003D029 /* WKIntelligenceSmartReplyTextEffectCoordinator.swift in Sources */,
+				EEA52F492D7055A700D578B5 /* WKStageMode.swift in Sources */,
 				F48EC3532B75837F00D1B886 /* WKTextExtractionItem.swift in Sources */,
 				F47AA6CA2B7A80BB00CD8AE9 /* WKWebView+TextExtraction.swift in Sources */,
 			);

--- a/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
+++ b/Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift
@@ -86,6 +86,10 @@ public final class WKSRKEntity: NSObject {
             entity.name = newValue
         }
     }
+    
+    @objc(interactionPivotPoint) public var interactionPivotPoint: simd_float3 {
+        entity.visualBounds(relativeTo: nil).center
+    }
 
     @objc(boundingBoxExtents) public var boundingBoxExtents: simd_float3 {
         guard let boundingBox = self.boundingBox else { return SIMD3<Float>(0, 0, 0) }
@@ -267,9 +271,9 @@ public final class WKSRKEntity: NSObject {
         delegate?.entityAnimationPlaybackStateDidUpdate?(self)
     }
 
-    @objc(setParentCoreEntity:) public func setParent(_ coreEntity: REEntityRef) {
+    @objc(setParentCoreEntity:preservingWorldTransform:) public func setParent(_ coreEntity: REEntityRef, preservingWorldTransform: Bool) {
         let parentEntity = Entity.__fromCore(__EntityRef.__fromCore(coreEntity))
-        entity.setParent(parentEntity)
+        entity.setParent(parentEntity, preservingWorldTransform: preservingWorldTransform)
     }
 }
 

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -50,6 +50,7 @@ typedef struct {
 
 @property (nonatomic, readonly) simd_float3 boundingBoxExtents;
 @property (nonatomic, readonly) simd_float3 boundingBoxCenter;
+@property (nonatomic, readonly) simd_float3 interactionPivotPoint;
 @property (nonatomic) WKEntityTransform transform;
 @property (nonatomic) float opacity;
 @property (nonatomic, readonly) NSTimeInterval duration;
@@ -61,7 +62,7 @@ typedef struct {
 + (bool)isLoadFromDataAvailable;
 + (void)loadFromData:(NSData *)data completionHandler:(void (^)(WKSRKEntity * _Nullable entity))completionHandler;
 - (instancetype)initWithCoreEntity:(REEntityRef)coreEntity;
-- (void)setParentCoreEntity:(REEntityRef)parentCoreEntity;
+- (void)setParentCoreEntity:(REEntityRef)parentCoreEntity preservingWorldTransform:(BOOL)preservingWorldTransform NS_SWIFT_NAME(setParent(_:preservingWorldTransform:));
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
 - (void)applyIBLData:(NSData *)data withCompletion:(void (^)(BOOL success))completion;
 - (void)removeIBL;

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,30 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#if defined(TARGET_OS_VISION) && TARGET_OS_VISION
+#import "RealityKitBridging.h"
+#import <Foundation/Foundation.h>
+#import <simd/simd.h>
 
-#import <wtf/SoftLinking.h>
+NS_ASSUME_NONNULL_BEGIN
 
-SOFT_LINK_LIBRARY_FOR_HEADER(WebKit, WebKitSwift)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKGroupSessionObserver)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaContentMetadata)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaPlayer)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaTimeRange)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaTrack)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSPreviewWindowController)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSRKEntity)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSTextAnimationManager)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKIntelligenceReplacementTextEffectCoordinator)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKIntelligenceSmartReplyTextEffectCoordinator)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionContainerItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionEditable)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionLink)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionTextItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionScrollableItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionImageItem)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaSpatialVideoMetadata)
-SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKStageModeInteractionDriver)
+typedef NS_ENUM(NSInteger, WKStageModeOperation) {
+    WKStageModeOperationNone = 0,
+    WKStageModeOperationOrbit,
+};
 
+@interface WKStageModeInteractionDriver : NSObject
+@property (nonatomic, readonly) REEntityRef interactionContainerRef;
+
+- (instancetype)initWithModel:(WKSRKEntity *)model container:(REEntityRef)container NS_SWIFT_NAME(init(with:container:));
+- (void)setContainerTransformInPortal NS_SWIFT_NAME(setContainerTransformInPortal());
+- (void)interactionDidBegin:(simd_float4x4)transform NS_SWIFT_NAME(interactionDidBegin(_:));
+- (void)interactionDidUpdate:(simd_float4x4)transform NS_SWIFT_NAME(interactionDidUpdate(_:));
+- (void)interactionDidEnd NS_SWIFT_NAME(interactionDidEnd());
+- (void)operationDidUpdate:(WKStageModeOperation)operation NS_SWIFT_NAME(operationDidUpdate(_:));
+- (void)removeInteractionContainerFromSceneOrParent;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -1,0 +1,104 @@
+// Copyright (C) 2025 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if os(visionOS)
+
+import Combine
+import RealityKit
+import Spatial
+import Foundation
+ @_spi(RealityKit) import RealityKit
+import WebKitSwift
+import os
+import simd
+
+/// A driver that maps all gesture updates to the specific transform we want for the specified StageMode behavior
+@MainActor
+@objc(WKStageModeInteractionDriver)
+final public class WKStageModeInteractionDriver: NSObject {
+    private var stageModeOperation: WKStageModeOperation = .none
+    
+    /// The parent container on which pitch changes will be applied
+    let interactionContainer: Entity
+    
+    /// The nested child container on which yaw changes will be applied
+    /// We need to separate rotation-related transforms into two entities so that we can later apply post-gesture animations along the yaw and pitch separately
+    let turntableInteractionContainer: Entity
+    
+    let modelEntity: WKSRKEntity
+    
+    // MARK: ObjC Exposed API
+    @objc(interactionContainerRef)
+    var interactionContainerRef: REEntityRef {
+        self.interactionContainer.__coreEntity.__as(REEntityRef.self)
+    }
+    
+    @objc(initWithModel:container:)
+    init(with model: WKSRKEntity, container: REEntityRef) {
+        self.modelEntity = model
+        self.interactionContainer = Entity()
+        self.turntableInteractionContainer = Entity()
+        self.interactionContainer.name = "WebKit:InteractionContainerEntity"
+        self.turntableInteractionContainer.name = "WebKit:TurntableContainerEntity"
+        
+        let containerEntity = Entity.__fromCore(__EntityRef.__fromCore(container))
+        self.interactionContainer.setParent(containerEntity, preservingWorldTransform: true)
+        self.turntableInteractionContainer.setPosition(self.interactionContainer.position(relativeTo: nil), relativeTo: nil)
+        self.turntableInteractionContainer.setParent(self.interactionContainer, preservingWorldTransform: true)
+    }
+    
+    @objc(setContainerTransformInPortal)
+    func setContainerTransformInPortal() {
+        // Configure entity hierarchy after we have correctly positioned the model
+        self.interactionContainer.setPosition(modelEntity.interactionPivotPoint, relativeTo: nil)
+        modelEntity.setParent(self.turntableInteractionContainer.__coreEntity.__as(REEntityRef.self), preservingWorldTransform: true)
+    }
+    
+    @objc(removeInteractionContainerFromSceneOrParent)
+    func removeInteractionContainerFromSceneOrParent() {
+        self.interactionContainer.removeFromParent()
+        self.turntableInteractionContainer.removeFromParent()
+    }
+    
+    @objc(interactionDidBegin:)
+    func interactionDidBegin(_ transform: simd_float4x4) {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287601
+    }
+    
+    @objc(interactionDidUpdate:)
+    func interactionDidUpdate(_ transform: simd_float4x4) {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287601
+    }
+    
+    @objc(interactionDidEnd)
+    func interactionDidEnd() {
+        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=287601
+    }
+    
+    @objc(operationDidUpdate:)
+    func operationDidUpdate(_ operation: WKStageModeOperation) {
+        self.stageModeOperation = operation
+    }
+}
+
+#endif

--- a/Source/WebKit/WebKitSwift/WebKitSwift.h
+++ b/Source/WebKit/WebKitSwift/WebKitSwift.h
@@ -32,3 +32,4 @@
 #import <WebKitSwift/WKSLinearMediaTypes.h>
 #import <WebKitSwift/WKSPreviewWindowController.h>
 #import <WebKitSwift/WKSTextAnimationSourceDelegate.h>
+#import <WebKitSwift/WKStageMode.h>


### PR DESCRIPTION
#### 0a89daa335939130198597b18646c556f00e2abb
<pre>
Create a driver to update StageMode Interactions based on Gesture Input
<a href="https://bugs.webkit.org/show_bug.cgi?id=287820">https://bugs.webkit.org/show_bug.cgi?id=287820</a>
<a href="https://rdar.apple.com/145006262">rdar://145006262</a>

Reviewed by Richard Robinson, Elliott Williams, and Wenson Hsieh.

This PR adds the StageModeInteractionDriver, which is a helper class object used in the ModelProcessModelPlayerProxy
to control how the model responds to the stagemode transform updates, based on the applied stagemode attribute. When
stagemode is set to &apos;none&apos; we ignore all transforms passed to the player proxy. When stagemode is set to &apos;orbit&apos; we
use the translation from the transform to rotate the model. To separate stagemode updates from Javascript updates,
we introduce an Interaction Container that wraps around the model entity, on which the stagemode updates will be applied.

The driver will be implemented in <a href="https://bugs.webkit.org/show_bug.cgi?id=287601.">https://bugs.webkit.org/show_bug.cgi?id=287601.</a>

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::didFinishLoading):
(WebKit::ModelProcessModelPlayerProxy::beginStageModeTransform):
(WebKit::ModelProcessModelPlayerProxy::updateStageModeTransform):
(WebKit::ModelProcessModelPlayerProxy::endStageModeInteraction):
(WebKit::ModelProcessModelPlayerProxy::setStageMode):
(WebKit::ModelProcessModelPlayerProxy::applyStageModeOperationToDriver):
- Updates the callbacks to use the interaction driver
- Also adds helper function to update the driver&apos;s internal state based on the stagemode attribute

* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift: Added.
(WKStageModeInteractionDriver.stageModeOperation):
(WKStageModeInteractionDriver.interactionDidBegin(_:)):
(WKStageModeInteractionDriver.interactionDidUpdate(_:)):
(WKStageModeInteractionDriver.interactionDidEnd):
(WKStageModeInteractionDriver.operationDidChange(_:)):
- Adds the necessary APIs to apply the transform to the interaction target.

* Source/WebKit/WebKitSwift/StageMode/WKStageModeBridging.h: Copied from Source/WebKit/WebKitSwift/WebKitSwift.h.
* Source/WebKit/WebKitSwift/WebKitSwift.h:

Canonical link: <a href="https://commits.webkit.org/291258@main">https://commits.webkit.org/291258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d531d57c168a64718af7a5db61e31b07dd24a8ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92433 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11974 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42940 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12252 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20435 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83706 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51158 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/persistent-storage (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9014 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42271 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99443 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19484 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19734 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79107 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23647 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19468 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19155 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->