### PR TITLE
Add Unit Test Support for StageMode Interaction

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -90,6 +90,10 @@
 - (BOOL)_hasResizeAssertion;
 - (void)_simulateSelectionStart;
 
+- (void)_simulateModelInteractionPanGestureBeginAtPoint:(CGPoint)hitPoint;
+- (void)_simulateModelInteractionPanGestureUpdateAtPoint:(CGPoint)hitPoint;
+- (NSDictionary *)_stageModeInfoForTesting;
+
 + (void)_resetPresentLockdownModeMessage;
 
 - (void)_doAfterNextVisibleContentRectAndStablePresentationUpdate:(void (^)(void))updateBlock;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -532,6 +532,29 @@ static void dumpUIView(TextStream& ts, UIView *view)
     }).get()];
 }
 
+- (void)_simulateModelInteractionPanGestureBeginAtPoint:(CGPoint)hitPoint
+{
+#if ENABLE(MODEL_PROCESS)
+    [_contentView _simulateModelInteractionPanGestureBeginAtPoint:hitPoint];
+#endif
+}
+
+- (void)_simulateModelInteractionPanGestureUpdateAtPoint:(CGPoint)hitPoint
+{
+#if ENABLE(MODEL_PROCESS)
+    [_contentView _simulateModelInteractionPanGestureUpdateAtPoint:hitPoint];
+#endif
+}
+
+- (NSDictionary *)_stageModeInfoForTesting
+{
+#if ENABLE(MODEL_PROCESS)
+    return [_contentView _stageModeInfoForTesting];
+#else
+    return @{ };
+#endif
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -1012,6 +1012,12 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 - (void)_dismissContactPickerWithContacts:(NSArray *)contacts;
 - (void)_simulateSelectionStart;
 
+#if ENABLE(MODEL_PROCESS)
+- (void)_simulateModelInteractionPanGestureBeginAtPoint:(CGPoint)hitPoint;
+- (void)_simulateModelInteractionPanGestureUpdateAtPoint:(CGPoint)hitPoint;
+- (NSDictionary *)_stageModeInfoForTesting;
+#endif
+
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
 - (BOOL)_allowAnimationControls;
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -14358,6 +14358,29 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
 #endif
 }
 
+#if ENABLE(MODEL_PROCESS)
+- (void)_simulateModelInteractionPanGestureBeginAtPoint:(CGPoint)hitPoint
+{
+    [self modelInteractionPanGestureDidBeginAtPoint:hitPoint];
+}
+
+- (void)_simulateModelInteractionPanGestureUpdateAtPoint:(CGPoint)hitPoint
+{
+    [self modelInteractionPanGestureDidUpdateWithPoint:hitPoint];
+}
+
+- (NSDictionary *)_stageModeInfoForTesting
+{
+    if (!_stageModeSession)
+        return @{ };
+
+    return @{
+        @"awaitingResult" : @(_stageModeSession->isPreparingForInteraction),
+        @"hitTestSuccessful" : @(_stageModeSession->elementID.has_value()),
+    };
+}
+#endif
+
 - (UITapGestureRecognizer *)singleTapGestureRecognizer
 {
     return _singleTapGestureRecognizer.get();

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1297,6 +1297,7 @@
 		EB9AD8C727646E7400D893A4 /* PushDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EB9AD8C627646E7300D893A4 /* PushDatabase.cpp */; };
 		EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EBA75C48275ED7BE00D6D31C /* PushMessageCrypto.cpp */; };
 		ECA680CE1E68CC0900731D20 /* StringUtilities.mm in Sources */ = {isa = PBXBuildFile; fileRef = ECA680CD1E68CC0900731D20 /* StringUtilities.mm */; };
+		EEA52EAB2D69203B00D578B5 /* stagemode-model-page.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = EEA52EA32D69202E00D578B5 /* stagemode-model-page.html */; };
 		F4010B8024DA24AC00A876E2 /* NavigationSwipeTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B7F24DA24AC00A876E2 /* NavigationSwipeTests.mm */; };
 		F4010B8324DA267F00A876E2 /* PoseAsClass.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B8124DA267F00A876E2 /* PoseAsClass.mm */; };
 		F402F56C23ECC2FB00865549 /* UIWKInteractionViewProtocol.mm in Sources */ = {isa = PBXBuildFile; fileRef = F402F56B23ECC2FB00865549 /* UIWKInteractionViewProtocol.mm */; };
@@ -2041,6 +2042,7 @@
 				A17C47FC2C98E5C20023F3C7 /* SpaceOnly.otf in Copy Resources */,
 				A17C47FD2C98E5C20023F3C7 /* speechrecognition-basic.html in Copy Resources */,
 				A17C47FE2C98E5C20023F3C7 /* speechrecognition-user-permission-persistence.html in Copy Resources */,
+				EEA52EAB2D69203B00D578B5 /* stagemode-model-page.html in Copy Resources */,
 				A17C47FF2C98E5C20023F3C7 /* start-offset.ts in Copy Resources */,
 				A17C46872C98E4D20023F3C7 /* StopLoadingFromDidReceiveResponse.html in Copy Resources */,
 				A17C48002C98E5C20023F3C7 /* StoreBlobToBeDeleted.html in Copy Resources */,
@@ -3767,6 +3769,7 @@
 		EBCD30F72B7C075F00268DA5 /* MemoryFootprintThreshold.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MemoryFootprintThreshold.mm; sourceTree = "<group>"; };
 		EC79F168BE454E579E417B05 /* Markable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Markable.cpp; sourceTree = "<group>"; };
 		ECA680CD1E68CC0900731D20 /* StringUtilities.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringUtilities.mm; sourceTree = "<group>"; };
+		EEA52EA32D69202E00D578B5 /* stagemode-model-page.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "stagemode-model-page.html"; sourceTree = "<group>"; };
 		F3CEF6B82808F2D3001E23A5 /* TimeZoneOverride.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TimeZoneOverride.mm; sourceTree = "<group>"; };
 		F3FC3EE213678B7300126A65 /* libgtest.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libgtest.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4010B7F24DA24AC00A876E2 /* NavigationSwipeTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = NavigationSwipeTests.mm; sourceTree = "<group>"; };
@@ -6013,6 +6016,7 @@
 				51E780361919AFF8001829A2 /* simple2.html */,
 				51E780371919AFF8001829A2 /* simple3.html */,
 				C02B7882126615410026BF0F /* spacebar-scrolling.html */,
+				EEA52EA32D69202E00D578B5 /* stagemode-model-page.html */,
 				51C234C72970E11400E35C4B /* test-mse-audio.webm */,
 				CD59F53319E910BC00CF1835 /* test-mse.mp4 */,
 				51BB6B7E296E8FFD0059B107 /* test-mse.webm */,

--- a/Tools/TestWebKitAPI/Tests/WebKit/stagemode-model-page.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/stagemode-model-page.html
@@ -1,0 +1,7 @@
+<model stagemode='orbit'>
+    <source src='cube.usdz'>
+</model>
+<script>
+    document.querySelector('model').addEventListener('load', event => window.webkit.messageHandlers.modelLoading.postMessage('LOADED'));
+    document.querySelector('model').ready.then((result) => window.webkit.messageHandlers.modelLoading.postMessage('READY'));
+</script>

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -2238,7 +2238,6 @@ TEST(DragAndDropTests, CanStartDragOnModel)
 }
 
 #if ENABLE(MODEL_PROCESS)
-
 TEST(DragAndDropTests, CheckModelDragPreview)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -2286,6 +2285,76 @@ TEST(DragAndDropTests, CheckModelDragPreview)
     done = false;
 }
 
+TEST(DragAndDropTests, IgnoreHitTestStageModeModel)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"ModelElementEnabled"] || [feature.key isEqualToString:@"ModelProcessEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"simple-model-page"];
+
+    while (![messageHandler didLoadModel])
+        Util::spinRunLoop();
+
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+
+    // Case 1: Hitting out of the model should fail
+    [simulator hitTestForStageModeAt:CGPointMake(320, 500)];
+
+    while ([simulator awaitingStageModeHitResult])
+        Util::spinRunLoop();
+
+    EXPECT_FALSE([simulator stageModeHitTestValidModel]);
+
+    // Case 2: Hitting a model with stagemode='none' should fail
+    [simulator hitTestForStageModeAt:CGPointMake(50, 50)];
+
+    while ([simulator awaitingStageModeHitResult])
+        Util::spinRunLoop();
+
+    EXPECT_FALSE([simulator stageModeHitTestValidModel]);
+}
+
+TEST(DragAndDropTests, CanHitTestStageModeModel)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"ModelElementEnabled"] || [feature.key isEqualToString:@"ModelProcessEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr messageHandler = adoptNS([[ModelLoadingMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"modelLoading"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"stagemode-model-page"];
+    while (![messageHandler didLoadModel])
+        Util::spinRunLoop();
+
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebView:webView.get()]);
+
+    // Case 1: Hitting out of the model should fail
+    [simulator hitTestForStageModeAt:CGPointMake(320, 500)];
+
+    while ([simulator awaitingStageModeHitResult])
+        Util::spinRunLoop();
+
+    EXPECT_FALSE([simulator stageModeHitTestValidModel]);
+
+    // Case 2: Hitting a model with stagemode='orbit' should succeed
+    [simulator hitTestForStageModeAt:CGPointMake(50, 50)];
+
+    while ([simulator awaitingStageModeHitResult])
+        Util::spinRunLoop();
+
+    EXPECT_TRUE([simulator stageModeHitTestValidModel]);
+}
 #endif
 
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
+++ b/Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h
@@ -165,4 +165,14 @@ typedef NSDictionary<NSNumber *, NSValue *> *ProgressToCGPointValueMap;
 
 #endif // !PLATFORM(MACCATALYST)
 
+#if ENABLE(MODEL_PROCESS)
+@interface DragAndDropSimulator (ModelElementStageMode)
+
+- (void)hitTestForStageModeAt:(CGPoint)hitPoint;
+- (BOOL)awaitingStageModeHitResult;
+- (BOOL)stageModeHitTestValidModel;
+
+@end
+#endif
+
 #endif // ENABLE(DRAG_SUPPORT)

--- a/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
+++ b/Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm
@@ -462,6 +462,21 @@ IGNORE_WARNINGS_END
         [[_webView dragInteractionDelegate] dragInteraction:[_webView dragInteraction] session:_dragSession.get() didEndWithOperation:UIDropOperationCancel];
 }
 
+- (void)hitTestForStageModeAt:(CGPoint)hitLocation
+{
+    [_webView _simulateModelInteractionPanGestureBeginAtPoint:hitLocation];
+}
+
+- (BOOL)awaitingStageModeHitResult
+{
+    return [[_webView _stageModeInfoForTesting][@"awaitingResult"] boolValue];
+}
+
+- (BOOL)stageModeHitTestValidModel
+{
+    return [[_webView _stageModeInfoForTesting][@"hitTestSuccessful"] boolValue];
+}
+
 - (void)runFrom:(CGPoint)startLocation to:(CGPoint)endLocation
 {
     [self runFrom:startLocation to:endLocation additionalItemRequestLocations:nil];


### PR DESCRIPTION
#### ac6ea44985584632f7154dfe7628cb2cb7ff406b
<pre>
Add Unit Test Support for StageMode Interaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=287943">https://bugs.webkit.org/show_bug.cgi?id=287943</a>
<a href="https://rdar.apple.com/145113469">rdar://145113469</a>

Reviewed by Wenson Hsieh.

This PR adds support for unit tests for stagemode interaction. It leverages existing APIs for Drag and Drop
but adds additional calls to simulate the pan gesture recognizer for model interaction. Subsequent PRs will
be made to add additional support for testing correct behavior when mapping XY translation to rotation.

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _simulatePanGestureBeginAtPoint:]):
(-[WKWebView _simulatePanGestureUpdateAtPoint:]):
(-[WKWebView _stageModeInfoForTesting]):
- Adds calls into the WKContentView to start and update the pan gesture
- Also adds a call to fetch information about the stageModeSession packaged as a dictionary

* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::TEST(DragAndDropTests, IgnoreHitTestStageModeModel)):
(TestWebKitAPI::TEST(DragAndDropTests, CanHitTestStageModeModel)):
- Adds unit tests to verify whether the returned information for stage mode is correct based on hit-testing

* Tools/TestWebKitAPI/cocoa/DragAndDropSimulator.h:
* Tools/TestWebKitAPI/ios/DragAndDropSimulatorIOS.mm:
(-[DragAndDropSimulator hitTestForStageModeAt:]):
(-[DragAndDropSimulator awaitingStageModeHitResult]):
(-[DragAndDropSimulator stageModeHitTestValidModel]):
- Adds additional APIs to the simulator to call into the WKWebView&apos;s testing API to simulate a pan

Canonical link: <a href="https://commits.webkit.org/291232@main">https://commits.webkit.org/291232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fda03bb28bd19d9a6a91cb96f5f28054efed3316

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42842 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20332 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70778 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28229 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51092 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8938 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1222 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42174 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1177 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99344 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19385 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19636 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79036 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19598 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23581 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12386 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24537 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19059 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->