### PR TITLE
Restore call to _dismissFullscreenViewController after 290536@main

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1747,6 +1747,7 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
     OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER);
     _inInteractiveDismiss = true;
     [self requestExitFullScreen];
+    [self _dismissFullscreenViewController:[] { }];
 }
 
 - (void)_dismissFullscreenViewController:(CompletionHandler<void()>&&)completionHandler


### PR DESCRIPTION
#### a69d661df341919c7e9b4b04b4d8bcbd304a3ae0
<pre>
Restore call to _dismissFullscreenViewController after 290536@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=288562">https://bugs.webkit.org/show_bug.cgi?id=288562</a>
<a href="https://rdar.apple.com/145513632">rdar://145513632</a>

Reviewed by Jer Noble.

In 290536@main I made it so that WebFullScreenManager::didExitFullScreen is called
as a response to Messages::WebFullScreenManagerProxy::BeganExitFullScreen, which means
there is no way to call it in the web process without the web process initiating it.
This is conceptually correct.  The consequence of this is that _dismissFullscreenViewController
needs to be called with a CompletionHandler which it gives to _completedExitFullScreen
which it calls instead of calling WebFullScreenManagerProxy::didExitFullScreen, which
no longer exists.  This is all good so far.

Before 290536@main, _startToDismissFullscreenChanged used to also call
_dismissFullscreenViewController, but I thought it shouldn&apos;t any more because it is no
longer doing so as a response to Messages::WebFullScreenManagerProxy::BeganExitFullScreen.
Instead, we should initiate the fullscreen exiting process by calling requestExitFullScreen
which seems like the logical replacement.  We are telling the web process to start exiting,
which will eventually send Messages::WebFullScreenManagerProxy::BeganExitFullScreen to
which we will respond.  However, this caused the gesture-based fullscreen exits to fail.
I verified manually that we need to both call requestExitFullScreen to start this process
AND call _dismissFullscreenViewController to immediately do the UI process cleanup with an
empty lambda &quot;reply&quot;.  The web process will eventually ask the UI process to exit, and
the UI process will tell it that it already has.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _startToDismissFullscreenChanged:]):

Canonical link: <a href="https://commits.webkit.org/291123@main">https://commits.webkit.org/291123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c377e80f359bd8c5b309bb0076507d7494f96a97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/91999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96924 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42591 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70583 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28064 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50911 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8766 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41806 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79087 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/920 "Found 1 new test failure: imported/w3c/web-platform-tests/css/selectors/invalidation/nth-child-in-shadow-root.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/98959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19111 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79613 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78843 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23381 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12146 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14627 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19092 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24298 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18789 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->