### PR TITLE
Address Safer CPP failures in PrivateClickMeasurement classes

### DIFF
--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h
@@ -50,7 +50,7 @@ private:
     bool runningInDaemon() const final { return false; }
 
     WeakPtr<NetworkSession> m_networkSession;
-    Ref<NetworkProcess> m_networkProcess;
+    const Ref<NetworkProcess> m_networkProcess;
 };
 
 } // namespace PCM

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -132,8 +132,8 @@ std::span<const ASCIILiteral> Database::sortedTables()
 void Database::interruptAllDatabases()
 {
     ASSERT(!RunLoop::isMain());
-    for (auto& database : allDatabases())
-        database.interrupt();
+    for (Ref database : allDatabases())
+        database->interrupt();
 }
 
 bool Database::createUniqueIndices()

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -74,6 +74,8 @@ private:
 
     PCM::Store& store();
     const PCM::Store& store() const;
+    Ref<PCM::Store> protectedStore();
+    Ref<const PCM::Store> protectedStore() const;
     void initializeStore() const;
     void startTimer(Seconds);
     void getTokenPublicKey(PrivateClickMeasurement&&, WebCore::PCM::AttributionReportEndpoint, PrivateClickMeasurement::PcmDataCarried, Function<void(PrivateClickMeasurement&& attribution, const String& publicKeyBase64URL)>&&);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
@@ -97,13 +97,14 @@ void PersistentStore::markAllUnattributedPrivateClickMeasurementAsExpiredForTest
 void PersistentStore::attributePrivateClickMeasurement(WebCore::PCM::SourceSite&& sourceSite, WebCore::PCM::AttributionDestinationSite&& destinationSite, const ApplicationBundleIdentifier& applicationBundleIdentifier, WebCore::PCM::AttributionTriggerData&& attributionTriggerData, WebCore::PrivateClickMeasurement::IsRunningLayoutTest isRunningTest, CompletionHandler<void(std::optional<WebCore::PCM::AttributionSecondsUntilSendData>&&, DebugInfo&&)>&& completionHandler)
 {
     postTask([this, protectedThis = Ref { *this }, sourceSite = WTFMove(sourceSite).isolatedCopy(), destinationSite = WTFMove(destinationSite).isolatedCopy(), applicationBundleIdentifier = applicationBundleIdentifier.isolatedCopy(), attributionTriggerData = WTFMove(attributionTriggerData), isRunningTest, completionHandler = WTFMove(completionHandler)] () mutable {
-        if (!m_database) {
+        RefPtr database = m_database;
+        if (!database) {
             return postTaskReply([completionHandler = WTFMove(completionHandler)] () mutable {
                 completionHandler(std::nullopt, { });
             });
         }
 
-        auto [seconds, debugInfo] = m_database->attributePrivateClickMeasurement(sourceSite, destinationSite, applicationBundleIdentifier, WTFMove(attributionTriggerData), isRunningTest);
+        auto [seconds, debugInfo] = database->attributePrivateClickMeasurement(sourceSite, destinationSite, applicationBundleIdentifier, WTFMove(attributionTriggerData), isRunningTest);
 
         postTaskReply([seconds = WTFMove(seconds), debugInfo = WTFMove(debugInfo).isolatedCopy(), completionHandler = WTFMove(completionHandler)]() mutable {
             completionHandler(WTFMove(seconds), WTFMove(debugInfo));

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h
@@ -72,7 +72,7 @@ private:
     void postTaskReply(Function<void()>&&) const;
 
     RefPtr<Database> m_database;
-    Ref<SuspendableWorkQueue> m_queue;
+    const Ref<SuspendableWorkQueue> m_queue;
 };
 
 } // namespace PCM

--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,5 +1,4 @@
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKBrowsingContextController.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -4,9 +4,6 @@ AutomationProtocolObjects.h
 NetworkProcess/Downloads/DownloadManager.cpp
 NetworkProcess/Downloads/cocoa/DownloadCocoa.mm
 NetworkProcess/Downloads/cocoa/WKDownloadProgress.mm
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
 NetworkProcess/SharedWorker/WebSharedWorkerServer.cpp
 NetworkProcess/cache/NetworkCacheSpeculativeLoad.cpp
 Platform/IPC/ArgumentCoders.h

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,4 +1,3 @@
-NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
 Platform/cocoa/WKPaymentAuthorizationDelegate.mm
 Shared/API/APIArray.cpp
 Shared/API/APIObject.h


### PR DESCRIPTION
#### e0531d3df12ae1e07acf5a8309b5dadddf1b5674
<pre>
Address Safer CPP failures in PrivateClickMeasurement classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=288567">https://bugs.webkit.org/show_bug.cgi?id=288567</a>

Reviewed by Geoffrey Garen.

* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementClientImpl.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::interruptAllDatabases):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::~PrivateClickMeasurementManager):
(WebKit::PrivateClickMeasurementManager::insertPrivateClickMeasurement):
(WebKit::PrivateClickMeasurementManager::migratePrivateClickMeasurementFromLegacyStorage):
(WebKit::PrivateClickMeasurementManager::attribute):
(WebKit::PrivateClickMeasurementManager::clearSentAttribution):
(WebKit::PrivateClickMeasurementManager::firePendingAttributionRequests):
(WebKit::PrivateClickMeasurementManager::clear):
(WebKit::PrivateClickMeasurementManager::clearForRegistrableDomain):
(WebKit::PrivateClickMeasurementManager::clearExpired):
(WebKit::PrivateClickMeasurementManager::toStringForTesting const):
(WebKit::PrivateClickMeasurementManager::markAllUnattributedAsExpiredForTesting):
(WebKit::PrivateClickMeasurementManager::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PrivateClickMeasurementManager::protectedStore):
(WebKit::PrivateClickMeasurementManager::protectedStore const):
(WebKit::PrivateClickMeasurementManager::destroyStoreForTesting):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp:
(WebKit::PCM::PersistentStore::attributePrivateClickMeasurement):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h:
* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/291133@main">https://commits.webkit.org/291133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba7d546f45381df6390f038f9fce028f9963b6af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42678 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20131 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95106 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83426 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/50993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/8837 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99064 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19214 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19466 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79286 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19537 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23465 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19194 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18888 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22345 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->