### PR TITLE
Unreviewed, reverting 291072@main (e8af1264b176)

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -313,12 +313,6 @@ void MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
     promise.resolve();
 }
 
-bool MediaSession::hasActionHandler(const MediaSessionAction action) const
-{
-    Locker lock { m_actionHandlersLock };
-    return m_actionHandlers.contains(action);
-}
-
 bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDetails, TriggerGestureIndicator triggerGestureIndicator)
 {
     RefPtr<MediaSessionActionHandler> handler;

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -133,7 +133,7 @@ public:
 #endif
 
     bool hasObserver(MediaSessionObserver&) const;
-    WEBCORE_EXPORT void addObserver(MediaSessionObserver&);
+    void addObserver(MediaSessionObserver&);
     void removeObserver(MediaSessionObserver&);
 
     RefPtr<HTMLMediaElement> activeMediaElement() const;
@@ -145,8 +145,6 @@ public:
     void setCameraActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Camera); }
     void setScreenshareActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Display); }
 #endif
-
-    WEBCORE_EXPORT bool hasActionHandler(const MediaSessionAction) const;
 
 private:
     explicit MediaSession(Navigator&);

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
@@ -44,7 +44,7 @@ public:
     ~NavigatorMediaSession();
 
     WEBCORE_EXPORT static MediaSession& mediaSession(Navigator&);
-    WEBCORE_EXPORT static RefPtr<MediaSession> mediaSessionIfExists(Navigator&);
+    static RefPtr<MediaSession> mediaSessionIfExists(Navigator&);
     MediaSession& mediaSession();
     RefPtr<MediaSession> mediaSessionIfExists();
 

--- a/Source/WebCore/PAL/pal/spi/mac/PIPSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/PIPSPI.h
@@ -27,10 +27,6 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <PIP/PIPViewControllerPrivate.h>
-#if HAVE(PIP_SKIP_PREROLL)
-#import <PIP/PIPPlaybackState.h>
-#import <PIP/PIPPrerollAttributes.h>
-#endif
 #else
 
 NS_ASSUME_NONNULL_BEGIN
@@ -45,14 +41,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) bool playing;
 @property (nonatomic) bool userCanResize;
 @property (nonatomic) NSSize aspectRatio;
-#if HAVE(PIP_SKIP_PREROLL)
-@property (nonatomic, readonly) PIPPlaybackState *playbackState;
-#endif
 
 - (void)presentViewControllerAsPictureInPicture:(NSViewController *)viewController;
-#if HAVE(PIP_SKIP_PREROLL)
-- (void)updatePlaybackStateUsingBlock:(void (NS_NOESCAPE ^)(PIPMutablePlaybackState *))updateBlock;
-#endif
+
 @end
 
 @protocol PIPViewControllerDelegate <NSObject>
@@ -65,13 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)pipActionStop:(PIPViewController *)pip;
 @end
 
-#if HAVE(PIP_SKIP_PREROLL)
-@interface PIPPrerollAttributes: NSObject <NSCopying, NSSecureCoding>
-
-+ (instancetype)prerollAttributesForAdContentWithRequiredLinearPlaybackEndTime:(NSTimeInterval)requiredLinearPlaybackEndTime preferredTintColor:(NSColor *)preferredTintColor;
-
-@end
-#endif
 NS_ASSUME_NONNULL_END
 
 #endif

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -137,7 +137,7 @@ public:
     BarProp& statusbar();
     BarProp& toolbar();
     WEBCORE_EXPORT Navigator& navigator();
-    WEBCORE_EXPORT Ref<Navigator> protectedNavigator();
+    Ref<Navigator> protectedNavigator();
     Navigator* optionalNavigator() const { return m_navigator.get(); }
 
     WEBCORE_EXPORT static void overrideTransientActivationDurationForTesting(std::optional<Seconds>&&);

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -78,9 +78,6 @@ public:
     virtual void togglePlayState() = 0;
     virtual void beginScrubbing() = 0;
     virtual void endScrubbing() = 0;
-#if HAVE(PIP_SKIP_PREROLL)
-    virtual void skipAd() { }
-#endif
     virtual void seekToTime(double time, double toleranceBefore = 0, double toleranceAfter = 0) = 0;
     virtual void fastSeek(double time) = 0;
     virtual void beginScanningForward() = 0;
@@ -178,9 +175,6 @@ public:
     virtual void externalPlaybackChanged(bool /* enabled */, PlaybackSessionModel::ExternalPlaybackTargetType, const String& /* localizedDeviceName */) { }
     virtual void wirelessVideoPlaybackDisabledChanged(bool) { }
     virtual void mutedChanged(bool) { }
-#if HAVE(PIP_SKIP_PREROLL)
-    virtual void canSkipAdChanged(bool) { }
-#endif
     virtual void volumeChanged(double) { }
     virtual void isPictureInPictureSupportedChanged(bool) { }
     virtual void pictureInPictureActiveChanged(bool) { }

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -79,9 +79,6 @@ public:
     void willBeginScrubbing();
     void beginScrubbing();
     void endScrubbing();
-#if HAVE(PIP_SKIP_PREROLL)
-    void skipAd();
-#endif
 
     void swapFullscreenModesWith(PlaybackSessionInterfaceMac&) { }
 

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -147,13 +147,7 @@ void PlaybackSessionInterfaceMac::endScrubbing()
     if (auto* model = playbackSessionModel())
         model->endScrubbing();
 }
-#if HAVE(PIP_SKIP_PREROLL)
-void PlaybackSessionInterfaceMac::skipAd()
-{
-    if (auto* model = playbackSessionModel())
-        model->skipAd();
-}
-#endif
+
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 static RetainPtr<NSMutableArray> timeRangesToArray(const TimeRanges& timeRanges)
 {

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -108,11 +108,9 @@ public:
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
 
     WEBCORE_EXPORT void documentVisibilityChanged(bool) final;
+
     void swapFullscreenModesWith(VideoPresentationInterfaceMac&) { }
-#if HAVE(PIP_SKIP_PREROLL)
-    WEBCORE_EXPORT void canSkipAdChanged(bool) override;
-    void skipAd();
-#endif
+
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -50,7 +50,6 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
 
 SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(PIP)
 SOFT_LINK_CLASS_OPTIONAL(PIP, PIPViewController)
-SOFT_LINK_CLASS_OPTIONAL(PIP, PIPPrerollAttributes)
 
 @class WebVideoViewContainer;
 
@@ -117,11 +116,8 @@ enum class PIPState {
 // Tracking video playback state
 @property (nonatomic) NSSize videoDimensions;
 @property (nonatomic, getter=isPlaying) BOOL playing;
-#if HAVE(PIP_SKIP_PREROLL)
-@property (nonatomic) BOOL canSkipAd;
-- (void)updateCanSkipAd:(BOOL)canSkipAd;
-#endif
 - (void)updateIsPlaying:(BOOL)isPlaying newPlaybackRate:(float)playbackRate;
+
 // Handling PIP transitions
 @property (nonatomic, getter=isExitingToStandardFullscreen) BOOL exitingToStandardFullscreen;
 
@@ -187,27 +183,7 @@ enum class PIPState {
     [_playerLayer setVideoDimensions:_videoDimensions];
     [_pipViewController setAspectRatio:_videoDimensions];
 }
-#if HAVE(PIP_SKIP_PREROLL)
-- (void)updateCanSkipAd:(BOOL)canSkipAd
-{
-    if (canSkipAd == _canSkipAd)
-        return;
-    _canSkipAd = canSkipAd;
-    [self updatePrerollAttributes];
-}
-- (void)updatePrerollAttributes
-{
-    if (!_pipViewController)
-        return;
 
-    [_pipViewController updatePlaybackStateUsingBlock:^(PIPMutablePlaybackState *playbackState) {
-        if (!_canSkipAd)
-            playbackState.prerollAttributes = nil;
-        else
-            playbackState.prerollAttributes = [getPIPPrerollAttributesClass() prerollAttributesForAdContentWithRequiredLinearPlaybackEndTime:0 preferredTintColor:nil];
-    }];
-}
-#endif
 - (void)setUpPIPForVideoView:(NSView *)videoView withFrame:(NSRect)frame inWindow:(NSWindow *)window
 {
     ASSERT(!_pipViewController);
@@ -256,9 +232,6 @@ enum class PIPState {
     [_videoViewContainerController view].layer.backgroundColor = CGColorGetConstantColor(kCGColorBlack);
     [_pipViewController presentViewControllerAsPictureInPicture:_videoViewContainerController.get()];
     _pipState = PIPState::EnteringPIP;
-#if HAVE(PIP_SKIP_PREROLL)
-    [self updatePrerollAttributes];
-#endif
 }
 
 - (void)exitPIP
@@ -341,17 +314,7 @@ enum class PIPState {
 
     return NO;
 }
-#if HAVE(PIP_SKIP_PREROLL)
-- (void)pipActionSkipPreroll:(PIPViewController *)pip
-{
-    ASSERT_UNUSED(pip, pip == _pipViewController);
 
-    if (!_videoPresentationInterfaceMac)
-        return;
-
-    _videoPresentationInterfaceMac->skipAd();
-}
-#endif
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)pipDidClose:(PIPViewController *)pip
 {
@@ -470,12 +433,7 @@ void VideoPresentationInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscre
     if (model)
         model->fullscreenModeChanged(m_mode);
 }
-#if HAVE(PIP_SKIP_PREROLL)
-void VideoPresentationInterfaceMac::skipAd()
-{
-    m_playbackSessionInterface->skipAd();
-}
-#endif
+
 void VideoPresentationInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     HTMLMediaElementEnums::VideoFullscreenMode newMode = m_mode & ~mode;
@@ -504,12 +462,7 @@ void VideoPresentationInterfaceMac::ensureControlsManager()
 {
     m_playbackSessionInterface->ensureControlsManager();
 }
-#if HAVE(PIP_SKIP_PREROLL)
-void VideoPresentationInterfaceMac::canSkipAdChanged(bool canSkipAd)
-{
-    [videoPresentationInterfaceObjC() updateCanSkipAd:canSkipAd];
-}
-#endif
+
 WebVideoPresentationInterfaceMacObjC *VideoPresentationInterfaceMac::videoPresentationInterfaceObjC()
 {
     if (!m_webVideoPresentationInterfaceObjC)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -95,9 +95,6 @@ public:
     void pictureInPictureSupportedChanged(bool);
     void pictureInPictureActiveChanged(bool);
     void isInWindowFullscreenActiveChanged(bool);
-#if HAVE(PIP_SKIP_PREROLL)
-    void canSkipAdChnged(bool);
-#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(bool);
     void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&);
@@ -121,10 +118,6 @@ private:
     void togglePlayState() final;
     void beginScrubbing() final;
     void endScrubbing() final;
-#if HAVE(PIP_SKIP_PREROLL)
-    void skipAd() final;
-    void canSkipAdChanged(bool);
-#endif
     void seekToTime(double, double, double) final;
     void fastSeek(double time) final;
     void beginScanningForward() final;
@@ -305,9 +298,6 @@ private:
     void volumeChanged(PlaybackSessionContextIdentifier, double volume);
     void pictureInPictureSupportedChanged(PlaybackSessionContextIdentifier, bool pictureInPictureSupported);
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool isInWindow);
-#if HAVE(PIP_SKIP_PREROLL)
-    void canSkipAdChanged(PlaybackSessionContextIdentifier, bool value);
-#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(PlaybackSessionContextIdentifier, bool);
     void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
@@ -315,9 +305,6 @@ private:
 #endif
 
     // Messages to PlaybackSessionManager
-#if HAVE(PIP_SKIP_PREROLL)
-    void skipAd(PlaybackSessionContextIdentifier);
-#endif
     void play(PlaybackSessionContextIdentifier);
     void pause(PlaybackSessionContextIdentifier);
     void togglePlayState(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -44,9 +44,6 @@ messages -> PlaybackSessionManagerProxy {
     VolumeChanged(WebKit::PlaybackSessionContextIdentifier contextId, double volume);
     PictureInPictureSupportedChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool pictureInPictureSupported)
     IsInWindowFullscreenActiveChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool isInWindow)
-#if HAVE(PIP_SKIP_PREROLL)
-    CanSkipAdChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool value)
-#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     SupportsLinearMediaPlayerChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool supportsLinearMediaPlayer)
     SpatialVideoMetadataChanged(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::SpatialVideoMetadata> metadata);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -43,9 +43,6 @@
 #import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
-#if HAVE(PIP_SKIP_PREROLL)
-#import <WebCore/VideoPresentationInterfaceMac.h>
-#endif
 #import <wtf/LoggerHelper.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -175,15 +172,6 @@ void PlaybackSessionModelContext::endScrubbing()
     m_isScrubbing = false;
     m_playbackStartedTimeNeedsUpdate = isPlaying();
 }
-
-#if HAVE(PIP_SKIP_PREROLL)
-void PlaybackSessionModelContext::skipAd()
-{
-    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    if (RefPtr manager = m_manager.get())
-        manager->skipAd(m_contextId);
-}
-#endif
 
 void PlaybackSessionModelContext::seekToTime(double time, double toleranceBefore, double toleranceAfter)
 {
@@ -476,14 +464,6 @@ void PlaybackSessionModelContext::isInWindowFullscreenActiveChanged(bool active)
     for (CheckedRef client : m_clients)
         client->isInWindowFullscreenActiveChanged(active);
 }
-
-#if HAVE(PIP_SKIP_PREROLL)
-void PlaybackSessionModelContext::canSkipAdChanged(bool value)
-{
-    for (CheckedRef client : m_clients)
-        client->canSkipAdChanged(value);
-}
-#endif
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 void PlaybackSessionModelContext::supportsLinearMediaPlayerChanged(bool supportsLinearMediaPlayer)
@@ -814,25 +794,6 @@ void PlaybackSessionManagerProxy::isInWindowFullscreenActiveChanged(PlaybackSess
     ensureModel(contextId)->isInWindowFullscreenActiveChanged(active);
 }
 
-#if HAVE(PIP_SKIP_PREROLL)
-void PlaybackSessionManagerProxy::canSkipAdChanged(PlaybackSessionContextIdentifier contextId, bool value)
-{
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    RefPtr videoPresentationManager = page->videoPresentationManager();
-    if (!videoPresentationManager)
-        return;
-
-    RefPtr interface = videoPresentationManager->controlsManagerInterface();
-    if (!interface)
-        return;
-
-    interface->canSkipAdChanged(value);
-}
-#endif
-
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 void PlaybackSessionManagerProxy::supportsLinearMediaPlayerChanged(PlaybackSessionContextIdentifier contextId, bool supportsLinearMediaPlayer)
 {
@@ -1008,14 +969,6 @@ void PlaybackSessionManagerProxy::setPlayingOnSecondScreen(PlaybackSessionContex
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetPlayingOnSecondScreen(contextId, value), page->webPageIDInMainFrameProcess());
 }
-
-#if HAVE(PIP_SKIP_PREROLL)
-void PlaybackSessionManagerProxy::skipAd(PlaybackSessionContextIdentifier contextId)
-{
-    if (RefPtr page = m_page.get())
-        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SkipAd(contextId), page->webPageIDInMainFrameProcess());
-}
-#endif
 
 void PlaybackSessionManagerProxy::sendRemoteCommand(PlaybackSessionContextIdentifier contextId, WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
 {

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -31,9 +31,6 @@
 #include "PlaybackSessionContextIdentifier.h"
 #include <WebCore/EventListener.h>
 #include <WebCore/HTMLMediaElementEnums.h>
-#if HAVE(PIP_SKIP_PREROLL)
-#include <WebCore/MediaSession.h>
-#endif
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/PlaybackSessionModelMediaElement.h>
@@ -114,14 +111,7 @@ private:
     PlaybackSessionContextIdentifier m_contextId;
 };
 
-class PlaybackSessionManager
-    : public RefCounted<PlaybackSessionManager>
-    , private IPC::MessageReceiver
-    , public CanMakeCheckedPtr<PlaybackSessionManager>
-#if HAVE(PIP_SKIP_PREROLL)
-    , public WebCore::MediaSessionObserver
-#endif
-    {
+class PlaybackSessionManager : public RefCounted<PlaybackSessionManager>, private IPC::MessageReceiver, public CanMakeCheckedPtr<PlaybackSessionManager> {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionManager);
 public:
@@ -143,10 +133,6 @@ public:
     WebCore::HTMLMediaElement* mediaElementWithContextId(PlaybackSessionContextIdentifier) const;
     WebCore::HTMLMediaElement* currentPlaybackControlsElement() const;
 
-#if HAVE(PIP_SKIP_PREROLL)
-    void actionHandlersChanged() final;
-#endif
-
 #if !RELEASE_LOG_DISABLED
     void sendLogIdentifierForMediaElement(WebCore::HTMLMediaElement&);
 #endif
@@ -165,9 +151,6 @@ private:
     void removeContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
-#if HAVE(PIP_SKIP_PREROLL)
-    void setMediaSessionAndRegisterAsObserver();
-#endif
 
     // Interface to PlaybackSessionInterfaceContext
     void durationChanged(PlaybackSessionContextIdentifier, double);
@@ -189,9 +172,6 @@ private:
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool);
     void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
     void isImmersiveVideoChanged(PlaybackSessionContextIdentifier, bool);
-#if HAVE(PIP_SKIP_PREROLL)
-    void canSkipAdChanged(PlaybackSessionContextIdentifier, bool);
-#endif
 
     // Messages from PlaybackSessionManagerProxy
     void play(PlaybackSessionContextIdentifier);
@@ -221,9 +201,6 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool value);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
     void setSoundStageSize(PlaybackSessionContextIdentifier, WebCore::AudioSessionSoundStageSize);
-#if HAVE(PIP_SKIP_PREROLL)
-    void skipAd(PlaybackSessionContextIdentifier);
-#endif
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setSpatialTrackingLabel(PlaybackSessionContextIdentifier, const String&);
@@ -243,10 +220,6 @@ private:
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     Markable<PlaybackSessionContextIdentifier> m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;
-#if HAVE(PIP_SKIP_PREROLL)
-    WeakPtr<WebCore::MediaSession> m_mediaSession;
-    bool m_canSkipAd { false };
-#endif
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
@@ -32,9 +32,6 @@ messages -> PlaybackSessionManager {
     TogglePlayState(WebKit::PlaybackSessionContextIdentifier contextId)
     BeginScrubbing(WebKit::PlaybackSessionContextIdentifier contextId)
     EndScrubbing(WebKit::PlaybackSessionContextIdentifier contextId)
-#if HAVE(PIP_SKIP_PREROLL)
-    SkipAd(WebKit::PlaybackSessionContextIdentifier contextId)
-#endif
     SeekToTime(WebKit::PlaybackSessionContextIdentifier contextId, double time, double toleranceBefore, double toleranceAfter)
     FastSeek(WebKit::PlaybackSessionContextIdentifier contextId, double time)
     BeginScanningForward(WebKit::PlaybackSessionContextIdentifier contextId)


### PR DESCRIPTION
#### 906d540d2f2b3444633365224a17dc7e9076a518
<pre>
Unreviewed, reverting 291072@main (e8af1264b176)
<a href="https://bugs.webkit.org/show_bug.cgi?id=288137">https://bugs.webkit.org/show_bug.cgi?id=288137</a>
<a href="https://rdar.apple.com/145305285">rdar://145305285</a>

Broke the build.

Reverted change:

    Add functionality to skip ads in PIP on macOS
    <a href="https://bugs.webkit.org/show_bug.cgi?id=288137">https://bugs.webkit.org/show_bug.cgi?id=288137</a>
    <a href="https://rdar.apple.com/145305285">rdar://145305285</a>
    291072@main (e8af1264b176)

Canonical link: <a href="https://commits.webkit.org/291089@main">https://commits.webkit.org/291089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f047ac9e8eeb95fbacded3504f0cbdb00ff1395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1093 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94063 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/11879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20036 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/96936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95014 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/11879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/96936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/11879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/41818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/11879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/98972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/98972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14601 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/18801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20549 "Build is in progress. Recent messages:") | | | 
<!--EWS-Status-Bubble-End-->