### PR TITLE
Make B3 Origin a tagged union

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1301,6 +1301,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     wasm/WasmName.h
     wasm/WasmNameSection.h
     wasm/WasmOSREntryData.h
+    wasm/WasmOpcodeOrigin.h
     wasm/WasmSIMDOpcodes.h
     wasm/WasmSections.h
     wasm/WasmTypeDefinition.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1205,7 +1205,7 @@
 		53B601EC2034B8C5006BE667 /* JSCast.h in Headers */ = {isa = PBXBuildFile; fileRef = 53B601EB2034B8C5006BE667 /* JSCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53C2CE9C22FCC3D6008B2853 /* AirHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C2CE9B22FCC3D6008B2853 /* AirHelpers.h */; };
 		53C4F66B21B1A409002FD009 /* JSAPIGlobalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C4F66A21B1A409002FD009 /* JSAPIGlobalObject.h */; };
-		53C6FEEF1E8ADFA900B18425 /* WasmOpcodeOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C6FEEE1E8ADFA900B18425 /* WasmOpcodeOrigin.h */; };
+		53C6FEEF1E8ADFA900B18425 /* WasmOpcodeOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 53C6FEEE1E8ADFA900B18425 /* WasmOpcodeOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53CA730A1EA533D80076049D /* WasmBBQPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CA73081EA533D80076049D /* WasmBBQPlan.h */; };
 		53CBE6532ACF18C0009C083D /* WasmIPIntTierUpCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = 53CBE6522ACF18C0009C083D /* WasmIPIntTierUpCounter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53D35499240D88BD008950DD /* BytecodeOperandsForCheckpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 53D35497240D88AD008950DD /* BytecodeOperandsForCheckpoint.h */; };

--- a/Source/JavaScriptCore/b3/B3Origin.cpp
+++ b/Source/JavaScriptCore/b3/B3Origin.cpp
@@ -32,7 +32,7 @@ namespace JSC { namespace B3 {
 
 void Origin::dump(PrintStream& out) const
 {
-    out.print("Origin(", RawPointer(m_data), ")");
+    out.print("Origin(", RawHex(m_data.bits()), ")");
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Origin.h
+++ b/Source/JavaScriptCore/b3/B3Origin.h
@@ -28,6 +28,17 @@
 #if ENABLE(B3_JIT)
 
 #include <wtf/PrintStream.h>
+#include <wtf/TaggedPtr.h>
+#include <wtf/ValidatedReinterpretCast.h>
+
+namespace JSC::Wasm {
+class OMGOrigin;
+class OpcodeOrigin;
+}
+
+namespace JSC::DFG {
+struct Node;
+}
 
 namespace JSC { namespace B3 {
 
@@ -37,22 +48,60 @@ namespace JSC { namespace B3 {
 // either drops Origins or lies about them.
 class Origin {
 public:
-    explicit Origin(const void* data = nullptr)
-        : m_data(data)
+    enum OriginType : uint8_t {
+        InvalidTag,
+        DFGOriginPtr,
+        OMGOriginPtr,
+        PackedWasmOrigin,
+    };
+
+    explicit Origin(const Wasm::OMGOrigin* data)
+        : m_data(data, OMGOriginPtr)
     {
     }
 
-    explicit operator bool() const { return !!m_data; }
+    explicit Origin(const DFG::Node* data)
+        : m_data(data, DFGOriginPtr)
+    {
+    }
 
-    const void* data() const { return m_data; }
+    explicit Origin()
+        : m_data(nullptr)
+    { }
 
-    friend bool operator==(const Origin&, const Origin&) = default;
+    explicit operator bool() const { return !!m_data.bits(); }
+
+    bool isDFGOrigin() const { return !m_data.bits() || m_data.tag() == DFGOriginPtr; }
+    bool isOMGOrigin() const { return !m_data.bits() || m_data.tag() == OMGOriginPtr; }
+    bool isPackedWasmOrigin() const { return !m_data.bits() || m_data.tag() == PackedWasmOrigin; }
+
+    Wasm::OMGOrigin* omgOrigin() const
+    {
+        ASSERT(isOMGOrigin());
+        return VALIDATED_REINTERPRET_CAST("OMGOrigin", Wasm::OMGOrigin, m_data.ptr());
+    }
+
+    DFG::Node* dfgOrigin() const
+    {
+        ASSERT(isDFGOrigin());
+        return std::bit_cast<DFG::Node*>(m_data.ptr());
+    }
+
+    const Wasm::OMGOrigin* maybeOMGOrigin() const { return isOMGOrigin() ? omgOrigin() : nullptr; }
 
     // You should avoid using this. Use OriginDump instead.
     void dump(PrintStream&) const;
-    
+
 private:
-    const void* m_data;
+
+    // See WasmOpcodeOrigin for packing details.
+    explicit Origin(uint64_t data)
+        : m_data(data, PackedWasmOrigin)
+    {
+    }
+
+    WTF::TaggedBits60 m_data;
+    friend class Wasm::OpcodeOrigin;
 };
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -74,7 +74,7 @@ State::State(Graph& graph)
 
     proc->setOriginPrinter(
         [] (PrintStream& out, B3::Origin origin) {
-            out.print(std::bit_cast<Node*>(origin.data()));
+            out.print(origin.dfgOrigin());
         });
 
     proc->setFrontendData(&graph);
@@ -130,7 +130,7 @@ void State::dumpDisassembly(PrintStream& out, LinkBuffer& linkBuffer, const Scop
             if (!currentB3Value)
                 return;
 
-            printDFGNode(std::bit_cast<Node*>(value->origin().data()));
+            printDFGNode(value->origin().dfgOrigin());
 
             UncheckedKeyHashSet<B3::Value*> localPrintedValues;
             auto printValueRecursive = recursableLambda([&] (auto self, B3::Value* value) -> void {

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.cpp
@@ -114,7 +114,7 @@ PCToCodeOriginMapBuilder::PCToCodeOriginMapBuilder(JSTag, VM& vm, const B3::PCTo
         return;
 
     for (const B3::PCToOriginMap::OriginRange& originRange : b3PCToOriginMap.ranges()) {
-        DFG::Node* node = std::bit_cast<DFG::Node*>(originRange.origin.data());
+        DFG::Node* node = originRange.origin.dfgOrigin();
         if (node)
             appendItem(originRange.label, node->origin.semantic);
         else

--- a/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
+++ b/Source/JavaScriptCore/jit/PCToCodeOriginMap.h
@@ -27,10 +27,17 @@
 
 #if ENABLE(JIT)
 
+#include "CallFrame.h"
 #include "CodeOrigin.h"
 #include "MacroAssembler.h"
 #include "VM.h"
+#include <wtf/StdLibExtras.h>
+#include <wtf/ValidatedReinterpretCast.h>
 #include <wtf/Vector.h>
+
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+#include "WasmOpcodeOrigin.h"
+#endif
 
 namespace JSC {
 
@@ -39,6 +46,27 @@ namespace B3 {
 class PCToOriginMap;
 }
 #endif
+
+#if ENABLE(WEBASSEMBLY_OMGJIT)
+namespace Wasm {
+class OMGOrigin {
+    MAKE_VALIDATED_REINTERPRET_CAST
+public:
+    friend bool operator==(const OMGOrigin&, const OMGOrigin&) = default;
+
+    OMGOrigin(CallSiteIndex callSiteIndex, OpcodeOrigin opcodeOrigin)
+        : m_callSiteIndex(callSiteIndex)
+        , m_opcodeOrigin(opcodeOrigin)
+    { }
+
+    CallSiteIndex m_callSiteIndex { };
+    OpcodeOrigin m_opcodeOrigin { };
+};
+
+MAKE_VALIDATED_REINTERPRET_CAST_IMPL("OMGOrigin", OMGOrigin)
+
+} // namespace Wasm
+#endif // ENABLE(WEBASSEMBLY_OMGJIT)
 
 class LinkBuffer;
 class PCToCodeOriginMapBuilder;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBASSEMBLY_BBQJIT)
 
+#include "PCToCodeOriginMap.h"
 #include "WasmCallingConvention.h"
 #include "WasmCompilationContext.h"
 #include "WasmFunctionParser.h"

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -35,6 +35,7 @@
 #include "LLIntExceptions.h"
 #include "LLIntThunks.h"
 #include "NativeCalleeRegistry.h"
+#include "PCToCodeOriginMap.h"
 #include "VMInspector.h"
 #include "WasmCallingConvention.h"
 #include "WasmModuleInformation.h"
@@ -489,8 +490,7 @@ Box<PCToCodeOriginMap> OptimizingJITCallee::materializePCToOriginMap(B3::PCToOri
     PCToCodeOriginMapBuilder builder(shouldBuildMapping);
     for (const B3::PCToOriginMap::OriginRange& originRange : originMap.ranges()) {
         B3::Origin b3Origin = originRange.origin;
-        auto* origin = std::bit_cast<const OMGOrigin*>(b3Origin.data());
-        if (origin) {
+        if (auto* origin = b3Origin.maybeOMGOrigin()) {
             // We stash the location into a BytecodeIndex.
             builder.appendItem(originRange.label, CodeOrigin(BytecodeIndex(origin->m_callSiteIndex.bits())));
         } else
@@ -504,8 +504,7 @@ Box<PCToCodeOriginMap> OptimizingJITCallee::materializePCToOriginMap(B3::PCToOri
         PCToCodeOriginMapBuilder samplingProfilerBuilder(shouldBuildMapping);
         for (const B3::PCToOriginMap::OriginRange& originRange : originMap.ranges()) {
             B3::Origin b3Origin = originRange.origin;
-            auto* origin = std::bit_cast<const OMGOrigin*>(b3Origin.data());
-            if (origin) {
+            if (auto* origin = b3Origin.maybeOMGOrigin()) {
                 // We stash the location into a BytecodeIndex.
                 samplingProfilerBuilder.appendItem(originRange.label, CodeOrigin(BytecodeIndex(origin->m_opcodeOrigin.location())));
             } else

--- a/Source/JavaScriptCore/wasm/WasmCompilationContext.h
+++ b/Source/JavaScriptCore/wasm/WasmCompilationContext.h
@@ -38,7 +38,6 @@
 #include "WasmJS.h"
 #include "WasmMemory.h"
 #include "WasmModuleInformation.h"
-#include "WasmOpcodeOrigin.h"
 #include "WasmTierUpCount.h"
 #include <wtf/Box.h>
 #include <wtf/Expected.h>
@@ -61,14 +60,6 @@ class CalleeGroup;
 class MemoryInformation;
 class OptimizingJITCallee;
 class TierUpCount;
-
-class OMGOrigin {
-public:
-    friend bool operator==(const OMGOrigin&, const OMGOrigin&) = default;
-
-    CallSiteIndex m_callSiteIndex { };
-    OpcodeOrigin m_opcodeOrigin { };
-};
 
 struct CompilationContext {
     std::unique_ptr<CCallHelpers> jsEntrypointJIT;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -6286,7 +6286,7 @@ auto OMGIRGenerator::origin() -> Origin
         break;
     }
     ASSERT(isValidOpType(static_cast<uint8_t>(origin.opcode())));
-    return std::bit_cast<Origin>(origin);
+    return origin.asB3Origin();
 }
 
 static bool shouldDumpIRFor(uint32_t functionIndex)
@@ -6317,8 +6317,9 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
 
     procedure.setNeedsPCToOriginMap();
     procedure.setOriginPrinter([] (PrintStream& out, Origin origin) {
-        if (origin.data())
-            out.print("Wasm: ", OpcodeOrigin(origin));
+        if (!origin)
+            return;
+        out.print("Wasm: ", origin);
     });
 
     // This means we cannot use either StackmapGenerationParams::usedRegisters() or

--- a/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeOrigin.cpp
@@ -26,11 +26,24 @@
 #include "config.h"
 #include "WasmOpcodeOrigin.h"
 
+#include "B3Origin.h"
+
 #include <wtf/text/MakeString.h>
 
 #if ENABLE(WEBASSEMBLY_OMGJIT)
 
 namespace JSC { namespace Wasm {
+
+OpcodeOrigin::OpcodeOrigin(B3::Origin origin)
+{
+    ASSERT(origin.isPackedWasmOrigin());
+    packedData = origin.m_data.bits();
+}
+
+B3::Origin OpcodeOrigin::asB3Origin()
+{
+    return B3::Origin(packedData);
+}
 
 void OpcodeOrigin::dump(PrintStream& out) const
 {
@@ -54,6 +67,9 @@ void OpcodeOrigin::dump(PrintStream& out) const
         break;
     }
 }
+
+static_assert(sizeof(OpcodeOrigin) == sizeof(uint64_t), "this packing doesn't work if this isn't the case");
+static_assert(sizeof(B3::Origin) == sizeof(uint64_t), "this packing doesn't work if this isn't the case");
 
 } } // namespace JSC::Wasm
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -540,6 +540,7 @@
 		DD3DC97F27A4BF8E007E5B61 /* StackBounds.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730F151A825B004123FF /* StackBounds.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98027A4BF8E007E5B61 /* Stopwatch.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F8A93619C65EB400B2B15D /* Stopwatch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98127A4BF8E007E5B61 /* StdLibExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47311151A825B004123FF /* StdLibExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DD3DC98127A4BF8E007E5B62 /* ValidatedReinterpretCast.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47311151A825B004123FG /* ValidatedReinterpretCast.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98227A4BF8E007E5B61 /* StringHashDumpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A748745117A0BDAE00FA04CB /* StringHashDumpContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98327A4BF8E007E5B61 /* OSRandomSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472DB151A825B004123FF /* OSRandomSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98527A4BF8E007E5B61 /* BlockPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A944F461C3D8814005BD28C /* BlockPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1559,6 +1560,7 @@
 		A8A4730E151A825B004123FF /* StackBounds.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackBounds.cpp; sourceTree = "<group>"; };
 		A8A4730F151A825B004123FF /* StackBounds.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackBounds.h; sourceTree = "<group>"; };
 		A8A47311151A825B004123FF /* StdLibExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdLibExtras.h; sourceTree = "<group>"; };
+		A8A47311151A825B004123FG /* ValidatedReinterpretCast.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ValidatedReinterpretCast.h; sourceTree = "<group>"; };
 		A8A47313151A825B004123FF /* StringExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringExtras.h; sourceTree = "<group>"; };
 		A8A47314151A825B004123FF /* Hasher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Hasher.h; sourceTree = "<group>"; };
 		A8A4731A151A825B004123FF /* SetForScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SetForScope.h; sourceTree = "<group>"; };
@@ -2660,6 +2662,7 @@
 				5CC0EE7221629F1900A1A842 /* URLParser.h */,
 				7AFEC6B01EB22B5900DADE36 /* UUID.cpp */,
 				7AFEC6AE1EB22AC600DADE36 /* UUID.h */,
+				A8A47311151A825B004123FG /* ValidatedReinterpretCast.h */,
 				A8A4736F151A825B004123FF /* ValueCheck.h */,
 				BCE0DFAA2D18670B003F0349 /* VariantExtras.h */,
 				BCEA08032CCFDB33000AC148 /* VariantList.h */,
@@ -3795,6 +3798,7 @@
 				FFE39CB12B1D7472004972B0 /* util.h in Headers */,
 				DDF306F527C086CC006A526F /* utils.h in Headers */,
 				DD3DC8C227A4BF8E007E5B61 /* UUID.h in Headers */,
+				DD3DC98127A4BF8E007E5B62 /* ValidatedReinterpretCast.h in Headers */,
 				DD3DC86D27A4BF8E007E5B61 /* ValueCheck.h in Headers */,
 				BCE0DFAB2D18670B003F0349 /* VariantExtras.h in Headers */,
 				BCEA08042CCFDB33000AC148 /* VariantList.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -363,6 +363,7 @@ set(WTF_PUBLIC_HEADERS
     UniqueRef.h
     UniqueRefVector.h
     VMTags.h
+    ValidatedReinterpretCast.h
     ValueCheck.h
     VariantExtras.h
     VariantList.h

--- a/Source/WTF/wtf/TaggedPtr.h
+++ b/Source/WTF/wtf/TaggedPtr.h
@@ -115,6 +115,37 @@ struct NoTaggingTraits {
     static TagType unwrapTag(StorageType) { return defaultTag; }
 };
 
+class TaggedBits60 {
+public:
+TaggedBits60(uint64_t bits, uint8_t tag)
+    {
+        uint64_t bigTag = static_cast<uint64_t>(tag);
+        ASSERT((bigTag << tagShift) >> tagShift == tag);
+        ASSERT(!(bits & ~ptrMask));
+        m_bits = bits | (bigTag << tagShift);
+    }
+
+    template <typename T>
+    TaggedBits60(T* bits, uint8_t tag)
+        : TaggedBits60(std::bit_cast<uintptr_t>(bits), tag)
+    {
+    }
+
+    TaggedBits60(std::nullptr_t)
+        : m_bits(0)
+    {
+    }
+
+    uint64_t bits() const { return m_bits & ptrMask; }
+    void* ptr() const { return std::bit_cast<void*>(static_cast<uintptr_t>(bits())); }
+    uint8_t tag() const { return (m_bits & ~ptrMask) >> tagShift; }
+
+private:
+    static constexpr size_t tagShift = 60;
+    static constexpr uint64_t ptrMask = (1ull << tagShift) - 1;
+    uint64_t m_bits;
+};
+
 } // namespace WTF
 
 using WTF::TaggedPtr;

--- a/Source/WTF/wtf/ValidatedReinterpretCast.h
+++ b/Source/WTF/wtf/ValidatedReinterpretCast.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2008-2024 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2013 Patrick Gansterer <paroga@paroga.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#pragma once
+
+#include "Compiler.h"
+#include "Platform.h"
+#include <bit>
+#include <cstdint>
+
+namespace WTF {
+
+// A small mixin to quickly check downcasts in debug builds.
+// MAKE_VALIDATED_REINTERPRET_CAST must be the first mixin included in the classs.
+// Use VALIDATED_REINTERPRET_CAST to perform the downcast.
+// A string (fqn) is provided to identify the class, that way downcasts
+// do not need to depend on the definiton of the subclass.
+template<typename T, typename U>
+constexpr inline T* validatedReinterpretCast(U* v, uint64_t magic)
+{
+    // We don't want to require the definition of T to do this cast.
+    ASSERT_UNUSED(magic, !v || std::bit_cast<uint64_t*>(v)[0] == magic);
+    return static_cast<T*>(v);
+}
+
+#if ASSERT_ENABLED
+#define MAKE_VALIDATED_REINTERPRET_CAST \
+    constexpr inline static uint64_t expectedMagicValue(); \
+    const uint64_t magicValue = expectedMagicValue();
+
+#define MAKE_VALIDATED_REINTERPRET_CAST_IMPL(fqn, T) \
+    constexpr inline uint64_t T::expectedMagicValue() \
+    { \
+        static_assert(!OBJECT_OFFSETOF(T, magicValue)); \
+        return ASCIILiteral(fqn).hash(); \
+    }
+
+#else
+#define MAKE_VALIDATED_REINTERPRET_CAST
+#define MAKE_VALIDATED_REINTERPRET_CAST_IMPL(fqn, T)
+#endif
+
+#define VALIDATED_REINTERPRET_CAST(fqn, T, v) \
+    WTF::validatedReinterpretCast<T>(v, ASCIILiteral(fqn).hash())
+
+template<typename T, typename U>
+ALWAYS_INLINE T* validatedReinterpretCast(U* u)
+{
+    T* casted = static_cast<T*>(u);
+    ASSERT(casted->magicValue == T::MAGIC_VALUE);
+    return casted;
+}
+
+} // namespace WTF


### PR DESCRIPTION
#### 1550e2947171f4c5a8bf47ad1536c38bdd101510
<pre>
Make B3 Origin a tagged union
<a href="https://bugs.webkit.org/show_bug.cgi?id=288575">https://bugs.webkit.org/show_bug.cgi?id=288575</a>

Reviewed by Keith Miller.

In <a href="https://commits.webkit.org/289952@main">https://commits.webkit.org/289952@main</a>, Yusuke introduced
a new way to handle OMG inline frame exceptions using code origins.

- We no longer allow origins to be imprecise on ARMv7
- We slightly reduce the number of extended wasm opcodes that can be
    packed to add a tag bit to OpcodeOrigin
- We use this tag bit in OMG to verify that we get the expected
    origin kind

At least on ARMv7, we can have both OMGOrigins and OpcodeOrigins,
so it remains to be investigated why this patch did not introduce
failures on 64-bit platforms.

* Source/JavaScriptCore/b3/B3Origin.cpp:
(JSC::B3::Origin::dump const):
* Source/JavaScriptCore/b3/B3Origin.h:
(JSC::B3::Origin::Origin):
(JSC::B3::Origin::isOMGOrigin const):
(JSC::B3::Origin::isPackedWasmOrigin const):
(JSC::B3::Origin::omgOrigin const):
(JSC::B3::Origin::maybeOMGOrigin const):
(JSC::B3::Origin::data const): Deleted.
* Source/JavaScriptCore/jit/PCToCodeOriginMap.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::OptimizingJITCallee::materializePCToOriginMap):
* Source/JavaScriptCore/wasm/WasmCompilationContext.h:
(): Deleted.
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitExceptionCheck):
(JSC::Wasm::OMGIRGenerator::addThrow):
(JSC::Wasm::OMGIRGenerator::addThrowRef):
(JSC::Wasm::OMGIRGenerator::addRethrow):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::origin):
(JSC::Wasm::parseAndCompileOMG):
* Source/JavaScriptCore/wasm/WasmOpcodeOrigin.h:
(JSC::Wasm::OpcodeOrigin::OpcodeOrigin):
(JSC::Wasm::OpcodeOrigin::opcode const):
(JSC::Wasm::OpcodeOrigin::ext1Opcode const):
(JSC::Wasm::OpcodeOrigin::simdOpcode const):
(JSC::Wasm::OpcodeOrigin::gcOpcode const):
(JSC::Wasm::OpcodeOrigin::atomicOpcode const):
(JSC::Wasm::OpcodeOrigin::location const):
(JSC::Wasm::OpcodeOrigin::asB3Origin):

Canonical link: <a href="https://commits.webkit.org/292486@main">https://commits.webkit.org/292486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7e6a39265ae3fd375851a2b76b63cafd8870765

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100788 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46242 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73007 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98740 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11706 "Found 1 new test failure: fast/forms/ios/focus-input-via-button.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86465 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4192 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45580 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81601 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102822 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94357 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22795 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16622 "Found 2 new test failures: html5lib/generated/run-entities01-write.html imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/shared-array-buffers/no-coop-coep.https.any.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82049 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81412 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20517 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22763 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27912 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/117836 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22422 "Built successfully") | | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33366 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Found 319 jsc stress test failures: microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate ...; Compiled JSC; Found 328 jsc stress test failures: microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate ...; Found 7 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25898 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24164 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->