### PR TITLE
Skip internals.setGridMaxTracksLimit from internals-object-property-access-on-window-without-frame-crash.html

### DIFF
--- a/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
+++ b/LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html
@@ -5,24 +5,25 @@ if (testRunner)
     testRunner.dumpAsText();
 
 const skippedInternalFunctions = [
-  // Calling the following internals function can cause crashes or assertions, but
-  // they don't actually involve a DOM tree and shouldn't be covered by this test.
-  "reportBacktrace",
-  "terminateWebContentProcess",
+  // Calling the following internals function can cause unexpected behavior
+  // (crashes, assertions, subsequent tests failing...) but they don't actually
+  // require a frame and so shouldn't be covered by this test.
   "beginAudioSessionInterruption",
   "beginMediaSessionInterruption",
   "createFile",
   "hasSandboxMachLookupAccessToGlobalName",
   "hasSandboxMachLookupAccessToXPCServiceName",
   "hasSandboxUnixSyscallAccess",
+  "hasServiceWorkerRegistration",
+  "reportBacktrace",
+  "setGridMaxTracksLimit",
   "setHardwareVP9DecoderDisabledForTesting",
   "setSystemHasACForTesting",
   "setSystemHasBatteryForTesting",
   "setVP9DecoderDisabledForTesting",
   "setVP9ScreenSizeAndScaleForTesting",
-  // These two crashes on mac-wk1, but don't require a frame.
-  "hasServiceWorkerRegistration",
   "storeRegistrationsOnDisk",
+  "terminateWebContentProcess",
 ];
 
 // The following exceptions can be thrown because the internals properties are

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -3022,8 +3022,6 @@ webkit.org/b/215773 http/tests/websocket/tests/hybi/client-close-2.html [ Pass F
 
 webkit.org/b/287976 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html [ Pass Failure ]
 
-webkit.org/b/288378 fast/harness/internals-object-property-access-on-window-without-frame-crash.html [ Skip ]
-
 webkit.org/b/288627 editing/spelling/spellcheck-async-mutation.html [ Timeout ]
 
 webkit.org/b/288725 http/tests/security/file-system-access-via-dataTransfer.html [ Pass Failure ]


### PR DESCRIPTION
#### c6c694c35157e5bfc08c0dfcb90415803af15d7b
<pre>
Skip internals.setGridMaxTracksLimit from internals-object-property-access-on-window-without-frame-crash.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=288378">https://bugs.webkit.org/show_bug.cgi?id=288378</a>

Reviewed by Anne van Kesteren.

This test was added in <a href="https://commits.webkit.org/289309@main.">https://commits.webkit.org/289309@main.</a> It calls
internals.setGridMaxTracksLimit which is causing subsequent grid tests
in the same runner to fail on WK1.

* LayoutTests/fast/harness/internals-object-property-access-on-window-without-frame-crash.html: Skip setGridMaxTracksLimit, tweak the comment and sort the list.
* LayoutTests/platform/mac-wk1/TestExpectations: Don&apos;t skip the test on mac-wk1.

Canonical link: <a href="https://commits.webkit.org/291242@main">https://commits.webkit.org/291242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1215d17d3a229e4cb8689c526b102fabad34829d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42830 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70757 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9226 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42162 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99331 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79782 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79029 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19604 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23574 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19355 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19047 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20786 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->