### PR TITLE
[TexMap] Wrong damage on layer resize

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4365,12 +4365,6 @@ imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inher
 imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https.html [ Failure Pass ]
 
-webkit.org/b/288462 platform/glib/damage/layer-downsize.html [ Failure ]
-webkit.org/b/288462 platform/glib/damage/layer-resize.html [ Failure ]
-webkit.org/b/288462 platform/glib/damage/non-accelerated-canvas-2d-downsizing.html [ Failure ]
-webkit.org/b/288462 platform/glib/damage/non-accelerated-canvas-2d-resizing.html [ Failure ]
-webkit.org/b/288462 platform/glib/damage/accelerated-canvas-2d-fillRect.html [ Failure ]
-
 webkit.org/b/288468 platform/glib/damage/scrolling-fullscreen-002.html [ Failure ]
 webkit.org/b/288468 platform/glib/damage/scrolling-fullscreen-003.html [ Failure ]
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -187,14 +187,13 @@ private:
     void collect3DRenderingContextLayers(Vector<TextureMapperLayer*>&);
 
 #if ENABLE(DAMAGE_TRACKING)
-    bool canInferDamage() const { return m_damagePropagation && !m_damage.isInvalid(); }
+    bool canInferDamage() const { return m_damagePropagation && !m_receivedDamage.isInvalid(); }
     void collectDamageRecursive(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfAndChildren(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelf(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void damageWholeLayerDueToTransformChange(const TransformationMatrix& beforeChange, const TransformationMatrix& afterChange);
-    FloatRect transformRectForDamage(const FloatRect&, const TransformationMatrix&, const TextureMapperPaintOptions&);
 #endif
 
     bool isVisible() const;
@@ -287,8 +286,9 @@ private:
 
 #if ENABLE(DAMAGE_TRACKING)
     bool m_damagePropagation { false };
-    Damage m_damage; // In layer coordinate space.
-    Damage m_inferredDamage; // In global coordinate space.
+    Damage m_receivedDamage; // In layer coordinate space.
+    Damage m_inferredLayerDamage; // In layer coordinate space.
+    Damage m_inferredGlobalDamage; // In global coordinate space.
     FloatRect m_accumulatedOverlapRegionDamage;
 #endif
 


### PR DESCRIPTION
#### 5d4f841d57c14aec0921ad1046ced8fde097d49a
<pre>
[TexMap] Wrong damage on layer resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=288462">https://bugs.webkit.org/show_bug.cgi?id=288462</a>

Reviewed by Carlos Garcia Campos.

This change fixes the damage produced by layer resizes. From
now on, the damage includes the area damaged before resize.
Moreover, the layer offset is now correctly taken into account.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::setDamage):
(WebCore::transformRectFromLayerToGlobalCoordinateSpace):
(WebCore::TextureMapperLayer::collectDamageSelf):
(WebCore::TextureMapperLayer::collectDamageSelfChildrenFilterAndMask):
(WebCore::TextureMapperLayer::damageWholeLayerDueToTransformChange):
(WebCore::TextureMapperLayer::setSize):
(WebCore::TextureMapperLayer::transformRectForDamage): Deleted.
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
(WebCore::TextureMapperLayer::canInferDamage const):

Canonical link: <a href="https://commits.webkit.org/291215@main">https://commits.webkit.org/291215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/917969c8e74c9440809257e95c1fa0fa1961ff40

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94103 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11919 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70640 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28094 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95054 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9077 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8807 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/984 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41849 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79125 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/971 "Found 60 new test failures: compositing/repaint/copy-forward-dirty-region-purged.html compositing/repaint/copy-forward-dirty-region.html fast/canvas/image-buffer-resource-limits.html fast/dynamic/float-moved-downwards-for-pagination.html fast/shadow-dom/shadow-style-text-mutation.html fast/shapes/shape-outside-floats/shape-outside-image-fit-004.html fast/shapes/shape-outside-floats/shape-outside-image-fit-005.html http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html imported/w3c/web-platform-tests/editing/other/delete-in-child-of-head.tentative.html?designMode=on&method=backspace imported/w3c/web-platform-tests/editing/other/delete-in-child-of-head.tentative.html?designMode=on&method=forwarddelete ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99012 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79653 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78894 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23421 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12187 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24338 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20581 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->