### PR TITLE
[GTK] REGRESSION(290937@main): /webkit/WebKitWebInspector/manual-attach-detach: is a failing API test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspector.cpp
@@ -60,9 +60,6 @@ public:
         return test->detach();
     }
 
-    static const unsigned gMinimumAttachedInspectorWidth = 750;
-    static const unsigned gMinimumAttachedInspectorHeight = 250;
-
     InspectorTest()
         : WebViewTest()
         , m_inspector(webkit_web_view_get_inspector(m_webView))
@@ -130,12 +127,20 @@ public:
         g_main_loop_quit(test->m_mainLoop);
     }
 
+    static constexpr unsigned gMinimumAttachedInspectorWidth = 750;
+    static constexpr unsigned gMinimumAttachedInspectorHeight = 250;
+
+    void resizeViewToMinimumSizeToAllowAttachingInspector()
+    {
+        resizeView(gMinimumAttachedInspectorWidth, (gMinimumAttachedInspectorHeight + 1) * 4 / 3);
+    }
+
     void resizeViewAndAttach()
     {
         // Resize the view to make room for the inspector.
         if (!webkit_web_inspector_get_can_attach(m_inspector)) {
             unsigned long handler = g_signal_connect_swapped(m_inspector, "notify::can-attach", G_CALLBACK(canAttachChanged), this);
-            resizeView(gMinimumAttachedInspectorWidth, (gMinimumAttachedInspectorHeight + 1) * 4 / 3);
+            resizeViewToMinimumSizeToAllowAttachingInspector();
             g_main_loop_run(m_mainLoop);
             g_signal_handler_disconnect(m_inspector, handler);
         }
@@ -319,6 +324,7 @@ public:
         g_assert_true(GTK_IS_PANED(pane));
         gtk_container_remove(GTK_CONTAINER(pane), GTK_WIDGET(inspectorView.get()));
 #endif
+        resizeViewToMinimumSizeToAllowAttachingInspector();
         return InspectorTest::detach();
     }
 

--- a/Tools/TestWebKitAPI/glib/TestExpectations.json
+++ b/Tools/TestWebKitAPI/glib/TestExpectations.json
@@ -507,12 +507,5 @@
                 "expected": {"gtk": {"status": ["TIMEOUT", "PASS"], "bug": "webkit.org/b/284812"}}
             }
         }
-    },
-    "TestInspector": {
-        "subtests": {
-            "/webkit/WebKitWebInspector/manual-attach-detach": {
-                "expected": {"gtk": { "status": ["FAIL"], "bug": "webkit.org/b/288385"}}
-            }
-        }
     }
 }


### PR DESCRIPTION
#### c173271bb2b628ab0aef6f70578ec6a44f3ba8f2
<pre>
[GTK] REGRESSION(290937@main): /webkit/WebKitWebInspector/manual-attach-detach: is a failing API test
<a href="https://bugs.webkit.org/show_bug.cgi?id=288385">https://bugs.webkit.org/show_bug.cgi?id=288385</a>

Reviewed by Michael Catanzaro.

When removing the view fom the GtkPane, resize the view again to make
sure it has the same size as before inspector was attached.

* Tools/TestWebKitAPI/Tests/WebKitGtk/TestInspector.cpp:
* Tools/TestWebKitAPI/glib/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/291616@main">https://commits.webkit.org/291616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02ab5b7b2294f8c7656a0da5986bee3f84b1c45f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95549 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28807 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96501 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84550 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51764 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9669 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2174 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43339 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79947 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/2222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100533 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20551 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80440 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20803 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79770 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24309 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13686 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14979 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20535 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20222 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->