### PR TITLE
WeakHashSet is unusable with WeakPtrFactory

### DIFF
--- a/Source/WTF/wtf/WeakHashSet.h
+++ b/Source/WTF/wtf/WeakHashSet.h
@@ -103,11 +103,23 @@ public:
         return end();
     }
 
+    const_iterator find(const WeakRef<T, WeakPtrImpl>& value) const
+    {
+        increaseOperationCountSinceLastCleanup();
+        return WeakHashSetConstIterator(*this, m_set.find(value.impl()));
+    }
+
     template <typename U>
     AddResult add(const U& value)
     {
         amortizedCleanupIfNeeded();
         return m_set.add(WeakRef<T, WeakPtrImpl>(static_cast<const T&>(value)).releaseImpl());
+    }
+
+    AddResult add(WeakRef<T, WeakPtrImpl> value)
+    {
+        amortizedCleanupIfNeeded();
+        return m_set.add(value.releaseImpl());
     }
 
     T* takeAny()
@@ -125,6 +137,12 @@ public:
         if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return m_set.remove(*impl);
         return false;
+    }
+
+    bool remove(const WeakRef<T, WeakPtrImpl>& value)
+    {
+        amortizedCleanupIfNeeded();
+        return m_set.remove(value.impl());
     }
 
     bool remove(const_iterator iterator)
@@ -147,6 +165,12 @@ public:
         if (auto* impl = value.weakImplIfExists(); impl && *impl)
             return m_set.contains(*impl);
         return false;
+    }
+
+    bool contains(const WeakRef<T, WeakPtrImpl>& value) const
+    {
+        increaseOperationCountSinceLastCleanup();
+        return m_set.contains(value.impl());
     }
 
     unsigned capacity() const { return m_set.capacity(); }

--- a/Source/WTF/wtf/WeakPtrFactory.h
+++ b/Source/WTF/wtf/WeakPtrFactory.h
@@ -85,12 +85,17 @@ public:
         m_impl = adoptRef(*new WeakPtrImpl(const_cast<T*>(&object)));
     }
 
-    template<typename U> WeakPtr<U, WeakPtrImpl> createWeakPtr(U& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) const
+    template<typename U> WeakRef<U, WeakPtrImpl> createWeakRef(U& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) const
     {
         initializeIfNeeded(object);
 
         ASSERT(&object == m_impl->template get<T>());
-        return WeakPtr<U, WeakPtrImpl>(*m_impl, enableWeakPtrThreadingAssertions);
+        return WeakRef<U, WeakPtrImpl>(*m_impl, enableWeakPtrThreadingAssertions);
+    }
+
+    template<typename U> WeakPtr<U, WeakPtrImpl> createWeakPtr(U& object, EnableWeakPtrThreadingAssertions enableWeakPtrThreadingAssertions = EnableWeakPtrThreadingAssertions::Yes) const
+    {
+        return createWeakRef(object, enableWeakPtrThreadingAssertions);
     }
 
     void revokeAll()

--- a/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp
@@ -116,10 +116,12 @@ template<typename T, typename = std::enable_if_t<!WTF::IsSmartPtr<T>::value>> in
     return makeWeakPtr(object.get(), enableWeakPtrThreadingAssertions);
 }
 
-struct Int : public CanMakeWeakPtr<Int> {
+struct Int {
+    using WeakValueType = Int;
     Int(int i) : m_i(i) { }
     operator int() const { return m_i; }
     bool operator==(const Int& other) const { return m_i == other.m_i; }
+    bool operator==(int other) const { return m_i == other; }
     int m_i;
 };
 
@@ -1008,6 +1010,61 @@ TEST(WTF_WeakPtr, WeakHashSetAmortizedCleanup)
         EXPECT_FALSE(weakHashSet.hasNullReferences());
     }
 }
+
+TEST(WTF_WeakPtr, WeakHashSetWithFactory)
+{
+    WeakHashSet<Int> set;
+    {
+        Int i { 77 };
+        WeakPtrFactory<Int> iFactory;
+        auto iRef = iFactory.createWeakRef(i);
+        set.add(iRef);
+        EXPECT_EQ(1u, set.computeSize());
+        EXPECT_TRUE(set.contains(iRef));
+        Int j { 88 };
+        WeakPtrFactory<Int> jFactory;
+        WeakRef jRef = jFactory.createWeakRef(j);
+        set.add(jRef);
+        EXPECT_EQ(2u, set.computeSize());
+        EXPECT_TRUE(set.contains(iRef));
+        EXPECT_TRUE(set.contains(jRef));
+        int saw77 = 0;
+        int saw88 = 0;
+        int sawOthers = 0;
+        for (Int& v : set) {
+            if (v == 77)
+                saw77++;
+            else if (v == 88)
+                saw88++;
+            else
+                sawOthers++;
+        }
+        EXPECT_EQ(1, saw77);
+        EXPECT_EQ(1, saw88);
+        EXPECT_EQ(0, sawOthers);
+        set.remove(iRef);
+        EXPECT_EQ(1u, set.computeSize());
+        EXPECT_FALSE(set.contains(iRef));
+        EXPECT_TRUE(set.contains(jRef));
+        saw77 = 0;
+        saw88 = 0;
+        sawOthers = 0;
+        for (Int& v : set) {
+            if (v == 77)
+                saw77++;
+            else if (v == 88)
+                saw88++;
+            else
+                sawOthers++;
+        }
+        EXPECT_EQ(0, saw77);
+        EXPECT_EQ(1, saw88);
+        EXPECT_EQ(0, sawOthers);
+        EXPECT_TRUE(set.find(jRef) != set.end());
+    }
+    EXPECT_EQ(0u, set.computeSize());
+}
+
 
 template <typename T, typename U>
 unsigned computeSizeOfWeakHashMap(const WeakHashMap<T, U>& map)


### PR DESCRIPTION
#### c40f711998fd0447502d194bbd8d5d9a0bc0519b
<pre>
WeakHashSet is unusable with WeakPtrFactory
<a href="https://bugs.webkit.org/show_bug.cgi?id=288590">https://bugs.webkit.org/show_bug.cgi?id=288590</a>
<a href="https://rdar.apple.com/145651253">rdar://145651253</a>

Reviewed by NOBODY (OOPS!).

WeakHashSet would create the weak reference from the instance, assuming
CanMakeWeakPtr. This does not support references made through
WeakPtrFactory.

Fix by:
Add WeakHashSet add/remove/find member function overloads for
WeakRefs.

Add WeakPtrFactory::createWeakRef() function. All weak pointers start
as WeakRefs, e.g. instances known to be valid. The WeakPtrFactory is
not renamed to WeakRefFactory with createWeakRef as the only create
method, because the typical use-case is to pass the weak reference
as a WeakPtr.

* Source/WTF/wtf/WeakHashSet.h:
* Source/WTF/wtf/WeakPtrFactory.h:
(WTF::WeakPtrFactory::createWeakRef const):
(WTF::WeakPtrFactory::createWeakPtr const):
* Tools/TestWebKitAPI/Tests/WTF/WeakPtr.cpp:
(TestWebKitAPI::Int::operator== const):
(TestWebKitAPI::TEST(WTF_WeakPtr, WeakHashSetWithFactory)):
In the test, Int is always used explicitly with WeakPtrFactory. Thus remove
the confusing CanMakeWeakPtr base class.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c40f711998fd0447502d194bbd8d5d9a0bc0519b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92068 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96987 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42645 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94118 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70645 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28111 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95069 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50974 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1003 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41863 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84840 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79136 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99027 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90791 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14188 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78912 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/746 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24350 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113391 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18853 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32815 "Found 10 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-eager-jettison, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-collect-continuously (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22310 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20596 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->