### PR TITLE
[TexMap] Damage rectangles are too big when scrolling

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4367,9 +4367,6 @@ imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inher
 imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/unset/img-tag.https.html [ Failure Pass ]
 imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/unset/img-tag.https.html [ Failure Pass ]
 
-webkit.org/b/288468 platform/glib/damage/scrolling-fullscreen-002.html [ Failure ]
-webkit.org/b/288468 platform/glib/damage/scrolling-fullscreen-003.html [ Failure ]
-
 webkit.org/b/288471 platform/glib/damage/transform-3d-dynamic-addition.html [ Failure ]
 
 # End: Common failures between GTK and WPE.

--- a/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
+++ b/LayoutTests/platform/glib/damage/accelerated-canvas-2d-fillRect.html
@@ -2,6 +2,11 @@
 <html lang="en">
   <head>
     <link rel="stylesheet" href="./common.css">
+    <style>
+      body {
+          overflow: hidden;
+      }
+    </style>
   </head>
   <body>
     <canvas width="2000" height="2000" />

--- a/LayoutTests/platform/glib/damage/scrolling-container-001.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-001.html
@@ -9,7 +9,7 @@
           left: 17px;
           width: 100px;
           height: 100px;
-          overflow: scroll;
+          overflow: hidden scroll;
           background: green;
       }
     </style>

--- a/LayoutTests/platform/glib/damage/scrolling-container-003.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-003.html
@@ -6,7 +6,7 @@
       .container {
           width: 100px;
           height: 100px;
-          overflow: scroll;
+          overflow: hidden scroll;
           background: green;
       }
     </style>

--- a/LayoutTests/platform/glib/damage/scrolling-container-004.html
+++ b/LayoutTests/platform/glib/damage/scrolling-container-004.html
@@ -6,7 +6,7 @@
       .container {
           width: 100px;
           height: 100px;
-          overflow: scroll;
+          overflow: hidden scroll;
           background: green;
       }
       .containee {

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1719,7 +1719,3 @@ webkit.org/b/287572 svg/compositing/outermost-svg-with-border-padding-margin.htm
 webkit.org/b/287572 svg/compositing/svg-poster-circle.html [ ImageOnlyFailure ]
 webkit.org/b/287572 svg/filters/filter-on-root-tile-boundary.html [ ImageOnlyFailure ]
 webkit.org/b/287572 svg/W3C-SVG-1.2-Tiny/struct-use-recursion-01-t.svg [ ImageOnlyFailure ]
-
-webkit.org/b/288468 platform/glib/damage/scrolling-container-001.html [ Failure ]
-webkit.org/b/288468 platform/glib/damage/scrolling-container-003.html [ Failure ]
-webkit.org/b/288468 platform/glib/damage/scrolling-container-004.html [ Failure ]

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -1434,10 +1434,21 @@ void TextureMapper::beginClip(const TransformationMatrix& modelViewMatrix, const
     clipStack().applyIfNeeded();
 }
 
+void TextureMapper::beginClipWithoutApplying(const TransformationMatrix& modelViewMatrix, const FloatRect& targetRect)
+{
+    clipStack().push();
+    clipStack().intersect(enclosingIntRect(modelViewMatrix.mapRect(targetRect)));
+}
+
 void TextureMapper::endClip()
 {
     clipStack().pop();
     clipStack().applyIfNeeded();
+}
+
+void TextureMapper::endClipWithoutApplying()
+{
+    clipStack().pop();
 }
 
 IntRect TextureMapper::clipBounds()

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -83,9 +83,11 @@ public:
     BitmapTexture* currentSurface();
     void beginClip(const TransformationMatrix&, const FloatRoundedRect&);
     void beginClip(const TransformationMatrix&, const ClipPath&);
+    void beginClipWithoutApplying(const TransformationMatrix&, const FloatRect&);
     WEBCORE_EXPORT void beginPainting(FlipY = FlipY::No, BitmapTexture* = nullptr);
     WEBCORE_EXPORT void endPainting();
     void endClip();
+    void endClipWithoutApplying();
     IntRect clipBounds();
     IntSize maxTextureSize() const;
     void setDepthRange(double zNear, double zFar);


### PR DESCRIPTION
#### cbe664e3befcd7e3db8ffb0350e60150a2deecd5
<pre>
[TexMap] Incorrect damage when 3d transform added dynamically
<a href="https://bugs.webkit.org/show_bug.cgi?id=288471">https://bugs.webkit.org/show_bug.cgi?id=288471</a>

Reviewed by NOBODY (OOPS!).

This change fixes the damage inference logic in a way that newly added
TextureMapperLayers are not taking the damage from before tranfrom
change into account.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.cpp:
(WebCore::TextureMapperLayer::collectDamageSelf):
(WebCore::TextureMapperLayer::damageWholeLayerDueToTransformChange):
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
</pre>