### PR TITLE
[JSC] Fix `Set.prototype.differenct` bug occurs when `this` is updated

### DIFF
--- a/JSTests/stress/set-prototype-difference-update-this.js
+++ b/JSTests/stress/set-prototype-difference-update-this.js
@@ -1,0 +1,82 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function compareArray(array1, array2) {
+    if (array1.length !== array2.length)
+        throw new Error(`Expected array length ${array2.length} but got array length ${array1.length}`);
+
+    for (let i = 0; i < array1.length; i++) {
+        if (array1[i] !== array2[i])
+            throw new Error(`Expected ${array2[i]} but got ${array1[i]} (${i})`);
+    }
+}
+
+
+function compareSet(set, array) {
+    let setArray = Array.from(set);
+    compareArray(setArray, array);
+}
+
+{
+  let originalKeys = null;
+
+  let setLike = {
+    size: 100,
+    has(v) {
+      if (!originalKeys) {
+        compareSet(set, [1, 2, 3, 4]);
+
+        originalKeys = [...set.keys()];
+
+        set.clear();
+
+        set.add(11);
+        set.add(22);
+      }
+
+      shouldBe(originalKeys.includes(v), true);
+
+      originalKeys.splice(originalKeys.indexOf(v), 1);
+
+      return true;
+    },
+    keys() {
+      throw new Error("Unexpected call to |keys| method");
+    },
+  };
+
+  let set = new Set([1, 2, 3, 4]);
+
+  compareSet(set.difference(setLike), []);
+  compareSet(set, [11, 22]);
+  compareArray(originalKeys, []);
+}
+
+{
+  let setLike = {
+    size: 0,
+    has() {
+      throw new Error("Unexpected call to |has| method");
+    },
+    *keys() {
+      compareSet(set, [1, 2, 3, 4]);
+
+      let originalKeys = [...set.keys()];
+
+      set.clear();
+
+      set.add(11);
+      set.add(22);
+
+      yield* originalKeys;
+    },
+  };
+
+  let set = new Set([1, 2, 3, 4]);
+
+  compareSet(set.difference(setLike), []);
+  compareSet(set, [11, 22]);
+}
+

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1368,8 +1368,6 @@ test/staging/sm/RegExp/unicode-class-negated.js:
   default: 'Test262Error: Actual [�] and expected [�] should have the same contents. '
 test/staging/sm/RegExp/unicode-raw.js:
   default: 'Test262Error: Expected SameValue(«🐸», «null») to be true'
-test/staging/sm/Set/difference.js:
-  default: 'Test262Error: Expected SameValue(«false», «true») to be true'
 test/staging/sm/Set/symmetric-difference.js:
   default: 'Test262Error: Expected SameValue(«3», «1») to be true'
 test/staging/sm/Set/union.js:

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -165,7 +165,7 @@ function difference(other)
 
     var result = @setClone(this);
     if (this.@size <= size) {
-        var storage = @setStorage(this);
+        var storage = @setStorage(result);
         var entry = 0;
 
         while (true) {
@@ -185,7 +185,7 @@ function difference(other)
         };
 
         for (var key of wrapper) {
-            if (this.@has(key))
+            if (result.@has(key))
                 result.@delete(key);
         }
     }


### PR DESCRIPTION
#### e055017c9e1fc1b46ce5d25c255e72e63fc4e17e
<pre>
[JSC] Fix `Set.prototype.differenct` bug occurs when `this` is updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=288595">https://bugs.webkit.org/show_bug.cgi?id=288595</a>

Reviewed by Yusuke Suzuki.

This patch fixes bugs that occurs when the contents of this
are updated while `Set.prototype.difference` is being executed.

* JSTests/stress/set-prototype-difference-update-this.js: Added.
(shouldBe):
(compareArray):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/SetPrototype.js:
(difference):

Canonical link: <a href="https://commits.webkit.org/291307@main">https://commits.webkit.org/291307@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/500d859679b727a51921ef41bab678a67107c296

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/96992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42650 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11943 "Hash 500d8596 for PR 41403 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20099 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70641 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28107 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95074 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/11943 "Hash 500d8596 for PR 41403 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/50970 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/11943 "Hash 500d8596 for PR 41403 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1007 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41868 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84845 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/11943 "Hash 500d8596 for PR 41403 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/990 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99032 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90796 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79665 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19434 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78909 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19633 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/749 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12202 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19163 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24353 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113396 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18858 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32817 "Found 13 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.no-llint, microbenchmarks/memcpy-wasm-small.js.dfg-eager, stress/string-value-of-error.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-slow-memory, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->