### PR TITLE
[Cocoa] Add support for per-media-element soundStageSize

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxCoreSPI.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, CAAudioTetherType) {
     CAAudioTetherTypeEntity,
 };
 
+NS_ASSUME_NONNULL_BEGIN
 @interface CAAudioTether : NSObject
 - (instancetype)initWithType:(CAAudioTetherType)type identifier:(NSUUID*)identifier pid:(pid_t)pid;
 @end
@@ -51,6 +52,7 @@ typedef NS_ENUM(NSInteger, CAAudioTetherType) {
 @interface CAAudioTetherAnchoringStrategy : CAAnchoringStrategy
 - (instancetype)initWithAudioTether:(CAAudioTether*)audioTether;
 @end
+NS_ASSUME_NONNULL_END
 #endif
 
 #endif

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9809,6 +9809,16 @@ void HTMLMediaElement::defaultSpatialTrackingLabelChanged(const String& defaultS
 }
 #endif
 
+void HTMLMediaElement::setSoundStageSize(SoundStageSize size)
+{
+    if (m_soundStageSize == size)
+        return;
+    m_soundStageSize = size;
+
+    if (m_player)
+        m_player->soundStageSizeDidChange();
+}
+
 bool HTMLMediaElement::shouldLogWatchtimeEvent() const
 {
     // Autoplaying content should not produce watchtime diagnostics:

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -765,6 +765,9 @@ protected:
 
     void ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen() { m_ignoreFullscreenPermissionsPolicy = true; }
 
+    SoundStageSize soundStageSize() const { return m_soundStageSize; }
+    void setSoundStageSize(SoundStageSize);
+
 protected:
     // ActiveDOMObject
     void stop() override;
@@ -883,6 +886,7 @@ private:
     void mediaPlayerVideoLayerSizeDidChange(const FloatSize& size) final { m_videoLayerSize = size; }
 
     MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const final { return identifier(); }
+    SoundStageSize mediaPlayerSoundStageSize() const final { return soundStageSize(); }
 
     void pendingActionTimerFired();
     void progressEventTimerFired();
@@ -1436,6 +1440,7 @@ private:
     RefPtr<WTF::Stopwatch> m_bufferingStopwatch;
 
     bool m_ignoreFullscreenPermissionsPolicy { false };
+    SoundStageSize m_soundStageSize { SoundStageSize::Auto };
 };
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include "MediaPlayerEnums.h"
+
 OBJC_CLASS CASpatialAudioExperience;
 
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
@@ -34,13 +36,14 @@ struct SpatialAudioExperienceOptions {
     bool hasLayer { false };
     bool hasTarget { false };
     bool isVisible { false };
+    MediaPlayerSoundStageSize soundStageSize { MediaPlayerSoundStageSize::Auto };
     String sceneIdentifier;
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String spatialTrackingLabel;
 #endif
 };
 
-RetainPtr<CASpatialAudioExperience> createExperienceWithOptions(const SpatialAudioExperienceOptions&);
+WEBCORE_EXPORT RetainPtr<CASpatialAudioExperience> createSpatialAudioExperienceWithOptions(const SpatialAudioExperienceOptions&);
 
 }
 #endif

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -2028,6 +2028,16 @@ void MediaPlayer::setPrefersSpatialAudioExperience(bool value)
 }
 #endif
 
+auto MediaPlayer::soundStageSize() const -> SoundStageSize
+{
+    return client().mediaPlayerSoundStageSize();
+}
+
+void MediaPlayer::soundStageSizeDidChange()
+{
+    m_private->soundStageSizeDidChange();
+}
+
 void MediaPlayer::setInFullscreenOrPictureInPicture(bool isInFullscreenOrPictureInPicture)
 {
     if (m_isInFullscreenOrPictureInPicture == isInFullscreenOrPictureInPicture)

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -347,6 +347,8 @@ public:
 
     virtual MediaPlayerClientIdentifier mediaPlayerClientIdentifier() const = 0;
 
+    virtual MediaPlayerSoundStageSize mediaPlayerSoundStageSize() const { return MediaPlayerSoundStageSize::Auto; }
+
 #if !RELEASE_LOG_DISABLED
     virtual uint64_t mediaPlayerLogIdentifier() { return 0; }
     virtual const Logger& mediaPlayerLogger() = 0;
@@ -785,6 +787,9 @@ public:
     void setPrefersSpatialAudioExperience(bool);
     bool prefersSpatialAudioExperience() const { return m_prefersSpatialAudioExperience; }
 #endif
+
+    SoundStageSize soundStageSize() const;
+    void soundStageSizeDidChange();
 
     void setInFullscreenOrPictureInPicture(bool);
     bool isInFullscreenOrPictureInPicture() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -110,6 +110,13 @@ enum class MediaPlayerNeedsRenderingModeChanged : bool {
     Yes,
 };
 
+enum class MediaPlayerSoundStageSize : uint8_t {
+    Auto,
+    Small,
+    Medium,
+    Large,
+};
+
 class MediaPlayerEnums {
 public:
     using NetworkState = MediaPlayerNetworkState;
@@ -123,6 +130,7 @@ public:
     using WirelessPlaybackTargetType = MediaPlayerWirelessPlaybackTargetType;
     using PitchCorrectionAlgorithm = MediaPlayerPitchCorrectionAlgorithm;
     using NeedsRenderingModeChanged = MediaPlayerNeedsRenderingModeChanged;
+    using SoundStageSize = MediaPlayerSoundStageSize;
 
     enum {
         VideoFullscreenModeNone = 0,

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivate.h
@@ -375,6 +375,8 @@ public:
     virtual void sceneIdentifierDidChange() { }
 #endif
 
+    virtual void soundStageSizeDidChange() { }
+
 protected:
     mutable PlatformTimeRanges m_seekable;
     bool m_shouldCheckHardwareSupport { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -4079,10 +4079,11 @@ void MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel()
 
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     if (player->prefersSpatialAudioExperience()) {
-        RetainPtr experience = createExperienceWithOptions({
+        RetainPtr experience = createSpatialAudioExperienceWithOptions({
             .hasLayer = !!m_videoLayer,
             .hasTarget = !!m_videoTarget,
             .isVisible = isVisible(),
+            .soundStageSize = player->soundStageSize(),
             .sceneIdentifier = player->sceneIdentifier(),
 #if HAVE(SPATIAL_TRACKING_LABEL)
             .spatialTrackingLabel = m_spatialTrackingLabel,

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1807,10 +1807,11 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel()
 
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     if (player->prefersSpatialAudioExperience()) {
-        RetainPtr experience = createExperienceWithOptions({
+        RetainPtr experience = createSpatialAudioExperienceWithOptions({
             .hasLayer = !!renderer,
             .hasTarget = !!m_videoTarget,
             .isVisible = m_visible,
+            .soundStageSize = player->soundStageSize(),
             .sceneIdentifier = player->sceneIdentifier(),
 #if HAVE(SPATIAL_TRACKING_LABEL)
             .spatialTrackingLabel = m_spatialTrackingLabel,

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1805,10 +1805,11 @@ void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
 
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     if (RefPtr player = m_player.get(); player && player->prefersSpatialAudioExperience()) {
-        RetainPtr experience = createExperienceWithOptions({
+        RetainPtr experience = createSpatialAudioExperienceWithOptions({
             .hasLayer = !!renderer,
             .hasTarget = !!m_videoTarget,
             .isVisible = m_visible,
+            .soundStageSize = player->soundStageSize(),
             .sceneIdentifier = player->sceneIdentifier(),
 #if HAVE(SPATIAL_TRACKING_LABEL)
             .spatialTrackingLabel = m_spatialTrackingLabel,

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -1352,6 +1352,15 @@ void RemoteMediaPlayerProxy::audioOutputDeviceChanged(String&& deviceId)
 #endif
 }
 
+void RemoteMediaPlayerProxy::setSoundStageSize(SoundStageSize size)
+{
+    if (m_soundStageSize == size)
+        return;
+    m_soundStageSize = size;
+
+    protectedPlayer()->soundStageSizeDidChange();
+}
+
 } // namespace WebKit
 
 #endif // ENABLE(GPU_PROCESS) && ENABLE(VIDEO)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -390,6 +390,9 @@ private:
     void isInFullscreenOrPictureInPictureChanged(bool);
 
     void audioOutputDeviceChanged(String&&);
+    using SoundStageSize = WebCore::MediaPlayer::SoundStageSize;
+    void setSoundStageSize(SoundStageSize);
+        SoundStageSize mediaPlayerSoundStageSize() const final { return m_soundStageSize; }
 
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final { return m_logger; }
@@ -460,6 +463,7 @@ private:
     Ref<RemoteVideoFrameObjectHeap> m_videoFrameObjectHeap;
     RefPtr<WebCore::VideoFrame> m_videoFrameForCurrentTime;
     bool m_shouldCheckHardwareSupport { false };
+    SoundStageSize m_soundStageSize { SoundStageSize::Auto };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in
@@ -160,6 +160,7 @@ messages -> RemoteMediaPlayerProxy {
 
     AudioOutputDeviceChanged(String deviceId)
     IsInFullscreenOrPictureInPictureChanged(bool value)
+    SetSoundStageSize(enum:uint8_t WebCore::MediaPlayerSoundStageSize value)
 }
 
 #endif

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -993,6 +993,7 @@ def headers_for_type(type):
         'WebCore::MediaEngineSupportParameters': ['<WebCore/MediaPlayer.h>'],
         'WebCore::MediaPlayerLoadOptions': ['<WebCore/MediaPlayer.h>'],
         'WebCore::MediaPlayerReadyState': ['<WebCore/MediaPlayerEnums.h>'],
+        'WebCore::MediaPlayerSoundStageSize': ['<WebCore/MediaPlayerEnums.h>'],
         'WebCore::MediaProducerMediaCaptureKind': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaProducerMediaState': ['<WebCore/MediaProducer.h>'],
         'WebCore::MediaProducerMutedState': ['<WebCore/MediaProducer.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4787,6 +4787,13 @@ enum class WebCore::MediaPlayerPitchCorrectionAlgorithm : uint8_t {
     BestForSpeech,
 };
 
+enum class WebCore::MediaPlayerSoundStageSize : uint8_t {
+    Auto,
+    Small,
+    Medium,
+    Large,
+};
+
 class WebCore::GeolocationPositionData {
     double timestamp;
     double latitude;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1818,6 +1818,12 @@ void MediaPlayerPrivateRemote::prefersSpatialAudioExperienceChanged()
 }
 #endif
 
+void MediaPlayerPrivateRemote::soundStageSizeDidChange()
+{
+    if (RefPtr player = m_player.get())
+        protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetSoundStageSize(player->soundStageSize()), m_id);
+}
+
 void MediaPlayerPrivateRemote::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
     protectedConnection()->send(Messages::RemoteMediaPlayerProxy::IsInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture), m_id);

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -483,6 +483,8 @@ private:
 
     void audioOutputDeviceChanged() final;
 
+    void soundStageSizeDidChange() final;
+
 #if PLATFORM(COCOA)
     void pushVideoFrameMetadata(WebCore::VideoFrameMetadata&&, RemoteVideoFrameProxy::Properties&&);
 #endif


### PR DESCRIPTION
#### d5fefcb58fd6bb56937ac2e0717526a491d6c12b
<pre>
[Cocoa] Add support for per-media-element soundStageSize
<a href="https://rdar.apple.com/145660143">rdar://145660143</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288601">https://bugs.webkit.org/show_bug.cgi?id=288601</a>

Reviewed by Andy Estes.

Previously, when web content entered fullscreen modes, the increased soundStageSize
would propagate down to the AVAudioSession, where that size was applied to all audio
generated by every web page. With CASpatialAudioExperience, the soundStageSize can
be applied granularly per audio-generating object.

Drive-by fix: address a review comment made against 291033@main and set NS_ASSUME_NONNULL
in AudioToolboxCoreSPI.h.

* Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxCoreSPI.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setSoundStageSize):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::soundStageSize const):
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.h:
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm:
(WebCore::toCASoundStageSize):
(WebCore::createSpatialAudioExperienceWithOptions):
(WebCore::createExperienceWithOptions): Deleted.
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::soundStageSize const):
(WebCore::MediaPlayer::soundStageSizeDidChange):
* Source/WebCore/platform/graphics/MediaPlayer.h:
(WebCore::MediaPlayerClient::mediaPlayerSoundStageSize const):
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivate.h:
(WebCore::MediaPlayerPrivateInterface::soundStageSizeDidChange):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateSpatialTrackingLabel):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerSoundStageSize const):
(WebKit::RemoteMediaPlayerProxy::setSoundStageSize):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.messages.in:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerOnNewVideoFrameMetadata):
(WebKit::RemoteMediaPlayerProxy::nativeImageForCurrentTime):
(WebKit::RemoteMediaPlayerProxy::colorSpace):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::soundStageSizeDidChange):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:

Canonical link: <a href="https://commits.webkit.org/291268@main">https://commits.webkit.org/291268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48b7c727f48e1c3fbc2c85ff6fc0a00b89b39674

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11704 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20190 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28163 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51031 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/91666 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1164 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41942 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1129 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99122 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79715 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78973 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19614 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12270 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19245 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24418 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18937 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22395 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20680 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->