### PR TITLE
[ANGLE][WPE] Failed to get system egl display

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp
@@ -43,6 +43,7 @@ bool IsValidPlatformTypeForPlatformDisplayConnection(EGLAttrib platformType)
     switch (platformType)
     {
         case EGL_PLATFORM_SURFACELESS_MESA:
+        case EGL_PLATFORM_GBM_KHR:
             return true;
         default:
             break;
@@ -419,6 +420,8 @@ EGLDisplay FunctionsEGL::getPlatformDisplay(EGLAttrib platformType,
         case EGL_PLATFORM_SURFACELESS_MESA:
             if (!hasExtension("EGL_MESA_platform_surfaceless"))
                 return EGL_NO_DISPLAY;
+            break;
+        case EGL_PLATFORM_GBM_KHR:
             break;
         default:
             UNREACHABLE();


### PR DESCRIPTION
#### 57275538bf3a6955f013756c34f58f43ff56d22c
<pre>
[ANGLE][WPE] Failed to get system egl display
<a href="https://bugs.webkit.org/show_bug.cgi?id=288600">https://bugs.webkit.org/show_bug.cgi?id=288600</a>

Reviewed by Kimmo Kinnunen.

When initializing WPE using gbm, which is the default path for
the WPE Platform, the egl display is initialized using `eglGetPlatformDisplay`.
This also sets the angle platform for webgl to EGL_PLATFORM_GBM_KHR and the
native display to the same drm device.

0d1736acdd5b498cb5b6b10d603943a4a998f227 added support for initializing the
ANGLE egl display from the passed platform and native display allowing to use
the same display.

68fbc85934efb878a9f70d88db0ba500e8b66209 limited the accepted platform types
to the surfaceless platform. The fallback to `eglGetDisplay` might fail on
some platforms and not all devices support `EGL_EXT_device_base`.
In a multi GPU setup the fallback to `getNativeDisplay` using `EGL_EXT_device_base`
might also result in a different egl display.

In addition to the surfaceless platform allow to initialize the egl display from
the matching gbm device as defined by the gbm platform display.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/gl/egl/FunctionsEGL.cpp:
(rx::FunctionsEGL::getPlatformDisplay):

Canonical link: <a href="https://commits.webkit.org/296309@main">https://commits.webkit.org/296309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ba526e453796f372e342b09a9e180cb1ce48926

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42926 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20421 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70821 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 20 flakes 118 failures; Uploaded test results; 24 flakes 75 failures; Compiled WebKit (warnings); 3 flakes 72 failures; Running analyze-layout-tests-results") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28280 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9299 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51145 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9000 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42256 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79326 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99429 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79833 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79095 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23641 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/937 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12471 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/17464 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19454 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19141 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->