### PR TITLE
Removing 'overflow: auto' for 'textarea' from StyleAdjuster.cpp

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt
@@ -321,7 +321,7 @@ PASS <textarea> - text-indent
 PASS <textarea> - text-shadow
 PASS <textarea> - text-align
 PASS <textarea> - display
-FAIL <textarea> - overflow assert_equals: expected "visible" but got "auto"
+PASS <textarea> - overflow
 PASS <textarea> - overflow-clip-margin
 PASS <textarea> - box-sizing
 PASS <table><tbody><tr><td> - letter-spacing

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -571,12 +571,6 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     }
 
     if (RefPtr element = m_element) {
-        // Textarea considers overflow visible as auto.
-        if (is<HTMLTextAreaElement>(*element)) {
-            style.setOverflowX(style.overflowX() == Overflow::Visible ? Overflow::Auto : style.overflowX());
-            style.setOverflowY(style.overflowY() == Overflow::Visible ? Overflow::Auto : style.overflowY());
-        }
-
         if (RefPtr input = dynamicDowncast<HTMLInputElement>(*element); input && input->isPasswordField())
             style.setTextSecurity(style.inputSecurity() == InputSecurity::Auto ? TextSecurity::Disc : TextSecurity::None);
 


### PR DESCRIPTION
#### 887bb64c0804dc11d1e122b02e9b8f4743ae3595
<pre>
Removing &apos;overflow: auto&apos; for &apos;textarea&apos; from StyleAdjuster.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288617">https://bugs.webkit.org/show_bug.cgi?id=288617</a>

Reviewed by NOBODY (OOPS!).

The removal of this adjustment resolves failures in the WPT resets.html test, which expected &lt;textarea&gt; to maintain overflow: visible instead of being forcefully set to overflow: auto. This brings WebKit&apos;s behavior in line with other browsers

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/form-controls/resets-expected.txt:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/887bb64c0804dc11d1e122b02e9b8f4743ae3595

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42699 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/11999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20158 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70679 "Found 28 new test failures: fast/block/float/overhanging-tall-block.html fast/css/resize-corner-tracking.html fast/css/resize-textarea-align-content.html fast/dom/HTMLTextAreaElement/reset-textarea.html fast/dynamic/008.html fast/parser/entity-comment-in-textarea.html fast/parser/open-comment-in-textarea.html fast/replaced/width100percent-textarea.html fast/scrolling/scrollable-area-frame-overflow-hidden.html fast/scrolling/scrollable-area-frame-overried-inherited-visibility-hidden.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28149 "Found 7 new test failures: editing/input/reveal-caret-of-transformed-input-scrollable-parent.html editing/input/reveal-caret-of-transformed-multiline-input.html fast/css/resize-textarea-align-content.html fast/events/autoscroll-in-textarea.html fast/events/mouse-events-on-textarea-resize.html fast/forms/textarea-no-scroll-on-blur.html fast/forms/textarea-scrolled-endline-caret.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95133 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9135 "Found 47 new test failures: compositing/overflow/textarea-scroll-touch.html editing/editable-region/textarea-basic.html editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html editing/input/reveal-caret-of-multiline-input.html editing/inserting/4960120-1.html editing/pasteboard/pasting-tabs.html fast/block/float/overhanging-tall-block.html fast/block/margin-collapse/103.html fast/dom/HTMLTextAreaElement/reset-textarea.html fast/dynamic/008.html ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51008 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8856 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1062 "Found 60 new test failures: accessibility/mac/range-for-line-textarea.html editing/input/reveal-caret-of-multiline-input.html editing/input/reveal-caret-of-transformed-input-scrollable-parent.html editing/input/reveal-caret-of-transformed-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html editing/mac/spelling/delete-autocorrected-word-2.html editing/pasteboard/pasting-tabs.html editing/selection/shrink-selection-after-shift-pagedown.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41917 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1035 "Found 60 new test failures: accessibility/mac/range-for-line-textarea.html compositing/overflow/textarea-scroll-touch.html editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html editing/input/reveal-caret-of-multiline-input.html editing/input/reveal-caret-of-transformed-input-scrollable-parent.html editing/input/reveal-caret-of-transformed-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-2.html editing/pasteboard/pasting-tabs.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99090 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19238 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14220 "Found 60 new test failures: accessibility/mac/basic-embed-pdf-accessibility.html accessibility/mac/range-for-line-textarea.html accessibility/mac/scrolling-in-pdf-crash.html compositing/overflow/textarea-scroll-touch.html editing/input/cocoa/writing-suggestions-textarea-multiple-lines.html editing/input/reveal-caret-of-multiline-input.html editing/input/reveal-caret-of-transformed-input-scrollable-parent.html editing/input/reveal-caret-of-transformed-multiline-input.html editing/inserting/4960120-1.html editing/mac/spelling/autocorrection-at-beginning-of-word-1.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79696 "Found 62 new test failures: editing/input/reveal-caret-of-multiline-input.html editing/input/reveal-caret-of-transformed-input-scrollable-parent.html editing/input/reveal-caret-of-transformed-multiline-input.html editing/inserting/4960120-1.html editing/pasteboard/pasting-tabs.html fast/block/float/overhanging-tall-block.html fast/css/resize-corner-tracking.html fast/css/resize-textarea-align-content.html fast/dom/HTMLTextAreaElement/reset-textarea.html fast/dynamic/008.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79312 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78950 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23485 "Found 3 new test failures: interaction-region/text-controls.html interaction-region/text-input-focused.html interaction-region/textarea-focused-edited-empty.html (failure)") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12246 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19218 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24394 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18911 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->