### PR TITLE
Fix a crash caused by a stale back/forward index in WebBackForwardList

### DIFF
--- a/Source/WebCore/history/BackForwardClient.h
+++ b/Source/WebCore/history/BackForwardClient.h
@@ -49,7 +49,6 @@ public:
     virtual void goToItem(HistoryItem&) = 0;
     virtual void goToProvisionalItem(const HistoryItem&) = 0;
     virtual void clearProvisionalItem(const HistoryItem&) = 0;
-    virtual void commitProvisionalItem(const HistoryItem&) = 0;
 
     virtual RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) = 0;
     virtual unsigned backListCount() const = 0;

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -162,11 +162,6 @@ void BackForwardController::clearProvisionalItem(const HistoryItem& item)
     protectedClient()->clearProvisionalItem(item);
 }
 
-void BackForwardController::commitProvisionalItem(const HistoryItem& item)
-{
-    protectedClient()->commitProvisionalItem(item);
-}
-
 bool BackForwardController::containsItem(const HistoryItem& item) const
 {
     return protectedClient()->containsItem(item);

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -62,7 +62,6 @@ public:
     void setCurrentItem(HistoryItem&);
     void setProvisionalItem(const HistoryItem&);
     void clearProvisionalItem(const HistoryItem&);
-    void commitProvisionalItem(const HistoryItem&);
 
     unsigned count() const;
     WEBCORE_EXPORT unsigned backCount() const;

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -124,7 +124,6 @@ class EmptyBackForwardClient final : public BackForwardClient {
     void goToItem(HistoryItem&) final { }
     void goToProvisionalItem(const HistoryItem&) final { }
     void clearProvisionalItem(const HistoryItem&) final { }
-    void commitProvisionalItem(const HistoryItem&) final { }
     RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) final { return nullptr; }
     unsigned backListCount() const final { return 0; }
     unsigned forwardListCount() const final { return 0; }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -644,7 +644,6 @@ void HistoryController::updateForCommit()
         ASSERT(m_provisionalItem);
         if (RefPtr provisionalItem = m_provisionalItem) {
             setCurrentItem(provisionalItem.releaseNonNull());
-            commitProvisionalItem();
             m_provisionalItem = nullptr;
         }
 
@@ -691,7 +690,6 @@ void HistoryController::recursiveUpdateForCommit()
         // Now commit the provisional item
         if (RefPtr provisionalItem = m_provisionalItem) {
             setCurrentItem(provisionalItem.releaseNonNull());
-            commitProvisionalItem();
             m_provisionalItem = nullptr;
         }
 
@@ -750,7 +748,6 @@ void HistoryController::recursiveUpdateForSameDocumentNavigation()
     // Commit the provisional item.
     if (RefPtr provisionalItem = m_provisionalItem) {
         setCurrentItem(provisionalItem.releaseNonNull());
-        commitProvisionalItem();
         m_provisionalItem = nullptr;
     }
 
@@ -814,16 +811,6 @@ void HistoryController::clearProvisionalItem()
 
     if (RefPtr page = m_frame->page())
         page->checkedBackForward()->clearProvisionalItem(*provisionalItem);
-}
-
-void HistoryController::commitProvisionalItem()
-{
-    RefPtr provisionalItem = m_provisionalItem;
-    if (!provisionalItem)
-        return;
-
-    if (RefPtr page = m_frame->page())
-        page->checkedBackForward()->commitProvisionalItem(*provisionalItem);
 }
 
 void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader> documentLoader)

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -125,7 +125,6 @@ private:
     void updateBackForwardListClippedAtTarget(bool doClip);
     void updateCurrentItem();
     bool isFrameLoadComplete() const { return m_frameLoadComplete; }
-    void commitProvisionalItem();
 
     struct FrameToNavigate;
     static void recursiveGatherFramesToNavigate(LocalFrame&, Vector<FrameToNavigate>&, HistoryItem& targetItem, HistoryItem* fromItem);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -205,9 +205,7 @@ void WebBackForwardList::addChildItem(FrameIdentifier parentFrameID, Ref<FrameSt
 
 void WebBackForwardList::goToItem(WebBackForwardListItem& item)
 {
-    if (m_provisionalIndex)
-        m_currentIndex = std::exchange(m_provisionalIndex, std::nullopt);
-
+    commitProvisionalItem();
     goToItemInternal(item, m_currentIndex);
 }
 
@@ -286,12 +284,9 @@ void WebBackForwardList::clearProvisionalItem(WebBackForwardListFrameItem& frame
     m_provisionalIndex = std::nullopt;
 }
 
-void WebBackForwardList::commitProvisionalItem(WebBackForwardListFrameItem& frameItem)
+void WebBackForwardList::commitProvisionalItem()
 {
     if (!m_provisionalIndex)
-        return;
-
-    if (m_entries[*m_provisionalIndex].ptr() != frameItem.backForwardListItem())
         return;
 
     if (*m_provisionalIndex >= m_entries.size()) {
@@ -312,6 +307,19 @@ WebBackForwardListItem* WebBackForwardList::currentItem() const
 RefPtr<WebBackForwardListItem> WebBackForwardList::protectedCurrentItem() const
 {
     return currentItem();
+}
+
+WebBackForwardListItem* WebBackForwardList::provisionalItem() const
+{
+    if (!m_provisionalIndex)
+        return nullptr;
+
+    if (*m_provisionalIndex >= m_entries.size()) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return m_entries[*m_provisionalIndex].ptr();
 }
 
 WebBackForwardListItem* WebBackForwardList::backItem() const

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -63,6 +63,7 @@ public:
 
     WebBackForwardListItem* currentItem() const;
     RefPtr<WebBackForwardListItem> protectedCurrentItem() const;
+    WebBackForwardListItem* provisionalItem() const;
     WebBackForwardListItem* backItem() const;
     WebBackForwardListItem* forwardItem() const;
     WebBackForwardListItem* itemAtIndex(int) const;
@@ -90,7 +91,7 @@ public:
 
     void goToProvisionalItem(WebBackForwardListItem&);
     void clearProvisionalItem(WebBackForwardListFrameItem&);
-    void commitProvisionalItem(WebBackForwardListFrameItem&);
+    void commitProvisionalItem();
 
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7179,6 +7179,11 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame() && preferences->textExtractionEnabled())
         prepareTextExtractionSupportIfNeeded();
 #endif
+
+    if (isBackForwardLoadType(frameLoadType)) {
+        if (RefPtr provisionalItem = m_backForwardList->provisionalItem(); provisionalItem && provisionalItem->navigatedFrameID() == frameID)
+            m_backForwardList->commitProvisionalItem();
+    }
 }
 
 void WebPageProxy::didFinishDocumentLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, const UserData& userData, WallTime timestamp)
@@ -9735,12 +9740,6 @@ void WebPageProxy::backForwardClearProvisionalItem(IPC::Connection& connection, 
     if (RefPtr frameItem = WebBackForwardListFrameItem::itemForID(itemID, frameItemID))
         m_backForwardList->clearProvisionalItem(*frameItem);
     completionHandler(m_backForwardList->counts());
-}
-
-void WebPageProxy::backForwardCommitProvisionalItem(IPC::Connection& connection, BackForwardItemIdentifier itemID, BackForwardFrameItemIdentifier frameItemID)
-{
-    if (RefPtr frameItem = WebBackForwardListFrameItem::itemForID(itemID, frameItemID))
-        m_backForwardList->commitProvisionalItem(*frameItem);
 }
 
 void WebPageProxy::backForwardItemAtIndex(int32_t index, FrameIdentifier frameID, CompletionHandler<void(RefPtr<FrameState>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2936,7 +2936,6 @@ private:
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
     void backForwardGoToProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardClearProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
-    void backForwardCommitProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
     void backForwardUpdateItem(IPC::Connection&, Ref<FrameState>&&);
 
     // Undo management

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -224,7 +224,6 @@ messages -> WebPageProxy {
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (bool shouldGoToItem) Synchronous
     BackForwardGoToProvisionalItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     BackForwardClearProvisionalItem(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
-    BackForwardCommitProvisionalItem(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID)
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(uint64_t commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -107,12 +107,6 @@ void WebBackForwardListProxy::clearProvisionalItem(const HistoryItem& item)
     m_cachedBackForwardListCounts = backForwardListCounts;
 }
 
-void WebBackForwardListProxy::commitProvisionalItem(const HistoryItem& item)
-{
-    if (RefPtr page = m_page.get())
-        page->send(Messages::WebPageProxy::BackForwardCommitProvisionalItem(item.itemID(), item.frameItemID()));
-}
-
 RefPtr<HistoryItem> WebBackForwardListProxy::itemAtIndex(int itemIndex, FrameIdentifier frameID)
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -52,7 +52,6 @@ private:
     void goToItem(WebCore::HistoryItem&) override;
     void goToProvisionalItem(const WebCore::HistoryItem&) final;
     void clearProvisionalItem(const WebCore::HistoryItem&) final;
-    void commitProvisionalItem(const WebCore::HistoryItem&) final;
 
     RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
     unsigned backListCount() const override;

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -53,7 +53,6 @@ public:
     void goToItem(WebCore::HistoryItem&) override;
     void goToProvisionalItem(const WebCore::HistoryItem&) final;
     void clearProvisionalItem(const WebCore::HistoryItem&) final;
-    void commitProvisionalItem(const WebCore::HistoryItem&) final { }
 
     RefPtr<WebCore::HistoryItem> backItem();
     RefPtr<WebCore::HistoryItem> currentItem();


### PR DESCRIPTION
#### 77bf2dc990684cfd080eda35cad136d5de72b282
<pre>
Fix a crash caused by a stale back/forward index in WebBackForwardList
<a href="https://bugs.webkit.org/show_bug.cgi?id=288619">https://bugs.webkit.org/show_bug.cgi?id=288619</a>
<a href="https://rdar.apple.com/145386151">rdar://145386151</a>

Reviewed by Alex Christensen and Pascoe.

The changes in 288518@main tried to fix a crash caused by the provisional back/forward index tracked by
the UI process not being committed, then cleared, resulting in it pointing to a stale index. So, I added
an IPC message to notify the UI process when the web process commits the provisional history item.
However, when navigating back to a cached page, the web process does not commit any history item, so the
provisional index could still remain uncommitted. Instead, this change moves the commit of the
provisional back/forward index to the DidCommitLoadForFrame message, which should be called when a
history item is committed or a cached page is restored.

* Source/WebCore/history/BackForwardClient.h:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::commitProvisionalItem): Deleted.
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForCommit):
(WebCore::HistoryController::recursiveUpdateForCommit):
(WebCore::HistoryController::recursiveUpdateForSameDocumentNavigation):
(WebCore::HistoryController::commitProvisionalItem): Deleted.
* Source/WebCore/loader/HistoryController.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::goToItem):
(WebKit::WebBackForwardList::commitProvisionalItem):
(WebKit::WebBackForwardList::provisionalItem const):
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::backForwardCommitProvisionalItem): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::commitProvisionalItem): Deleted.
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, DecidePolicyForNavigationActionCancelAfterDiscardingForwardItemsWithPSON)):

Canonical link: <a href="https://commits.webkit.org/291195@main">https://commits.webkit.org/291195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab8722ba148c507e641e5fb3ef1576853597056b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97045 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12001 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20161 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70685 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28147 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9137 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83456 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51014 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1068 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/41919 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79177 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99093 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14224 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79699 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19492 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79318 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78953 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23489 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12248 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14671 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19220 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24396 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18913 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->