### PR TITLE
Allocate Air types using SequesteredArenaAllocator

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp
@@ -39,6 +39,7 @@
 #include "DisallowMacroScratchRegisterUsage.h"
 #include "Reg.h"
 #include <wtf/ListDump.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -49,7 +50,7 @@ namespace GenerateAndAllocateRegistersInternal {
 static constexpr bool verbose = false;
 }
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(GenerateAndAllocateRegisters);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(GenerateAndAllocateRegisters);
 
 GenerateAndAllocateRegisters::GenerateAndAllocateRegisters(Code& code)
     : m_code(code)
@@ -398,7 +399,7 @@ void GenerateAndAllocateRegisters::prepareForGeneration()
     });
 #endif
 
-    m_liveness = makeUnique<UnifiedTmpLiveness>(m_code);
+    m_liveness = makeUniqueWithoutFastMallocCheck<UnifiedTmpLiveness>(m_code);
 
     {
         buildLiveRanges(*m_liveness);

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.h
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.h
@@ -30,6 +30,7 @@
 #include "AirLiveness.h"
 #include "AirTmpMap.h"
 #include <wtf/Nonmovable.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { 
@@ -41,7 +42,7 @@ namespace B3 { namespace Air {
 class Code;
 
 class GenerateAndAllocateRegisters {
-    WTF_MAKE_TZONE_ALLOCATED(GenerateAndAllocateRegisters);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(GenerateAndAllocateRegisters);
     WTF_MAKE_NONMOVABLE(GenerateAndAllocateRegisters);
 
     struct TmpData {

--- a/Source/JavaScriptCore/b3/air/AirBasicBlock.cpp
+++ b/Source/JavaScriptCore/b3/air/AirBasicBlock.cpp
@@ -36,7 +36,7 @@ namespace JSC { namespace B3 { namespace Air {
 
 const char* const BasicBlock::dumpPrefix = "#";
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(BasicBlock);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(BasicBlock);
 
 void BasicBlock::setSuccessors(FrequentedBlock target)
 {

--- a/Source/JavaScriptCore/b3/air/AirBasicBlock.h
+++ b/Source/JavaScriptCore/b3/air/AirBasicBlock.h
@@ -31,6 +31,7 @@
 #include "AirInst.h"
 #include "B3SuccessorCollection.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 {
@@ -46,7 +47,7 @@ class PhaseInsertionSet;
 
 class BasicBlock {
     WTF_MAKE_NONCOPYABLE(BasicBlock);
-    WTF_MAKE_TZONE_ALLOCATED(BasicBlock);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(BasicBlock);
 public:
     static const char* const dumpPrefix;
     static constexpr unsigned uninsertedIndex = UINT_MAX;

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp
@@ -33,7 +33,7 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(CCallSpecial);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(CCallSpecial);
 
 CCallSpecial::CCallSpecial(bool isSIMDContext)
     : m_isSIMDContext(isSIMDContext)

--- a/Source/JavaScriptCore/b3/air/AirCCallSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirCCallSpecial.h
@@ -29,6 +29,7 @@
 
 #include "AirSpecial.h"
 #include "RegisterSet.h"
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
@@ -44,7 +45,7 @@ namespace JSC { namespace B3 { namespace Air {
 // the prologue, whichever happened sooner.
 
 class CCallSpecial final : public Special {
-    WTF_MAKE_TZONE_ALLOCATED(CCallSpecial);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(CCallSpecial);
 public:
     CCallSpecial(bool isSIMDContext);
     ~CCallSpecial() final;

--- a/Source/JavaScriptCore/b3/air/AirCFG.h
+++ b/Source/JavaScriptCore/b3/air/AirCFG.h
@@ -31,13 +31,14 @@
 #include "AirCode.h"
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 class CFG {
     WTF_MAKE_NONCOPYABLE(CFG);
-    WTF_MAKE_TZONE_ALLOCATED(CFG);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(CFG);
 public:
     typedef BasicBlock* Node;
     typedef IndexSet<BasicBlock*> Set;

--- a/Source/JavaScriptCore/b3/air/AirCode.cpp
+++ b/Source/JavaScriptCore/b3/air/AirCode.cpp
@@ -43,8 +43,8 @@ namespace JSC { namespace B3 { namespace Air {
 
 const char* const tierName = "Air ";
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(CFG);
-WTF_MAKE_TZONE_ALLOCATED_IMPL(Code);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(CFG);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Code);
 
 static void defaultPrologueGenerator(CCallHelpers& jit, Code& code)
 {

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -40,6 +40,7 @@
 #include "StackAlignment.h"
 #include <wtf/HashSet.h>
 #include <wtf/IndexMap.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/SmallSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakRandom.h>
@@ -80,7 +81,7 @@ extern const char* const tierName;
 
 class Code {
     WTF_MAKE_NONCOPYABLE(Code);
-    WTF_MAKE_TZONE_ALLOCATED(Code);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(Code);
 public:
     ~Code();
 

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.cpp
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.cpp
@@ -40,7 +40,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC { namespace B3 { namespace Air {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(Disassembler);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(Disassembler);
 
 void Disassembler::startEntrypoint(CCallHelpers& jit)
 {

--- a/Source/JavaScriptCore/b3/air/AirDisassembler.h
+++ b/Source/JavaScriptCore/b3/air/AirDisassembler.h
@@ -28,6 +28,7 @@
 #if ENABLE(B3_JIT)
 
 #include "MacroAssembler.h"
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC {
@@ -42,7 +43,7 @@ class Code;
 struct Inst;
 
 class Disassembler {
-    WTF_MAKE_TZONE_ALLOCATED(Disassembler);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(Disassembler);
 public:
     Disassembler() = default;
 

--- a/Source/JavaScriptCore/b3/air/AirGenerate.cpp
+++ b/Source/JavaScriptCore/b3/air/AirGenerate.cpp
@@ -96,7 +96,7 @@ void prepareForGeneration(Code& code)
             dataLog(code);
         }
 
-        code.m_generateAndAllocateRegisters = makeUnique<GenerateAndAllocateRegisters>(code);
+        code.m_generateAndAllocateRegisters = makeUniqueWithoutFastMallocCheck<GenerateAndAllocateRegisters>(code);
         code.m_generateAndAllocateRegisters->prepareForGeneration();
 
         return;

--- a/Source/JavaScriptCore/b3/air/AirLiveness.h
+++ b/Source/JavaScriptCore/b3/air/AirLiveness.h
@@ -31,13 +31,14 @@
 #include "CompilerTimingScope.h"
 #include "SuperSampler.h"
 #include <wtf/Liveness.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
 
 template<typename Adapter>
 class Liveness : public WTF::Liveness<Adapter> {
-    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(Liveness);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE(Liveness);
 public:
     Liveness(Code& code)
         : WTF::Liveness<Adapter>(code.cfg(), code)
@@ -48,7 +49,7 @@ public:
     }
 };
 
-WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL(template<typename Adapter>, Liveness<Adapter>);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL(template<typename Adapter>, Liveness<Adapter>);
 
 template<Bank bank, Arg::Temperature minimumTemperature = Arg::Cold>
 using TmpLiveness = Liveness<TmpLivenessAdapter<bank, minimumTemperature>>;

--- a/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
+++ b/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
@@ -35,6 +35,7 @@
 #include "AirTmpInlines.h"
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/IndexMap.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC { namespace B3 { namespace Air {
@@ -149,7 +150,7 @@ public:
 
 template<Bank adapterBank, Arg::Temperature minimumTemperature = Arg::Cold>
 struct TmpLivenessAdapter : LivenessAdapter<TmpLivenessAdapter<adapterBank, minimumTemperature>> {
-    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(TmpLivenessAdapter);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE(TmpLivenessAdapter);
 public:
     typedef LivenessAdapter<TmpLivenessAdapter<adapterBank, minimumTemperature>> Base;
 
@@ -174,13 +175,13 @@ public:
 #define TZONE_TEMPLATE_PARAMS template<Bank adapterBank, Arg::Temperature minimumTemperature>
 #define TZONE_TYPE TmpLivenessAdapter<adapterBank, minimumTemperature>
 
-WTF_MAKE_TZONE_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS();
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_TEMPLATE_IMPL_WITH_MULTIPLE_OR_SPECIALIZED_PARAMETERS();
 
 #undef TZONE_TEMPLATE_PARAMS
 #undef TZONE_TYPE
 
 struct UnifiedTmpLivenessAdapter : LivenessAdapter<UnifiedTmpLivenessAdapter> {
-    WTF_MAKE_TZONE_ALLOCATED(UnifiedTmpLivenessAdapter);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(UnifiedTmpLivenessAdapter);
 public:
     typedef LivenessAdapter<UnifiedTmpLivenessAdapter> Base;
 
@@ -205,7 +206,7 @@ public:
 };
 
 struct StackSlotLivenessAdapter : LivenessAdapter<StackSlotLivenessAdapter> {
-    WTF_MAKE_TZONE_ALLOCATED(StackSlotLivenessAdapter);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(StackSlotLivenessAdapter);
 public:
     static constexpr const char* name = "StackSlotLiveness";
     typedef StackSlot* Thing;

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp
@@ -34,7 +34,7 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(PrintSpecial);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(PrintSpecial);
 
 PrintSpecial::PrintSpecial(Printer::PrintRecordList* list)
     : m_printRecordList(list)

--- a/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirPrintSpecial.h
@@ -30,6 +30,7 @@
 #include "AirInst.h"
 #include "AirSpecial.h"
 #include "MacroAssemblerPrinter.h"
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace JSC {
@@ -93,7 +94,7 @@ struct Printer<Reg> : public PrintRecord {
 namespace B3 { namespace Air {
 
 class PrintSpecial final : public Special {
-    WTF_MAKE_TZONE_ALLOCATED(PrintSpecial);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(PrintSpecial);
 public:
     PrintSpecial(Printer::PrintRecordList*);
     ~PrintSpecial() final;

--- a/Source/JavaScriptCore/b3/air/AirSpecial.h
+++ b/Source/JavaScriptCore/b3/air/AirSpecial.h
@@ -32,6 +32,7 @@
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/ScopedLambda.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
@@ -42,6 +43,7 @@ struct GenerationContext;
 
 class Special {
     WTF_MAKE_NONCOPYABLE(Special);
+    // TODO: move AirSpecial.h to use SequesteredMalloc
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(Special, JS_EXPORT_PRIVATE);
 public:
     static const char* const dumpPrefix;

--- a/Source/JavaScriptCore/b3/air/AirStackSlot.cpp
+++ b/Source/JavaScriptCore/b3/air/AirStackSlot.cpp
@@ -32,7 +32,7 @@
 
 namespace JSC { namespace B3 { namespace Air {
 
-WTF_MAKE_TZONE_ALLOCATED_IMPL(StackSlot);
+WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED_IMPL(StackSlot);
 
 void StackSlot::setOffsetFromFP(intptr_t value)
 {

--- a/Source/JavaScriptCore/b3/air/AirStackSlot.h
+++ b/Source/JavaScriptCore/b3/air/AirStackSlot.h
@@ -43,7 +43,7 @@ namespace Air {
 
 class StackSlot {
     WTF_MAKE_NONCOPYABLE(StackSlot);
-    WTF_MAKE_TZONE_ALLOCATED(StackSlot);
+    WTF_MAKE_SEQUESTERED_ARENA_ALLOCATED(StackSlot);
 public:
     unsigned byteSize() const { return m_byteSize; }
     StackSlotKind kind() const { return m_kind; }

--- a/Source/JavaScriptCore/b3/air/testair.cpp
+++ b/Source/JavaScriptCore/b3/air/testair.cpp
@@ -1951,7 +1951,7 @@ void testInvalidateCachedTempRegisters()
     root->append(Move, nullptr, Arg::bigImm(std::bit_cast<intptr_t>(&things)), base);
 
     B3::BasicBlock* patchPoint1Root = proc.addBlock();
-    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
     // In Patchpoint, Load things[0] -> tmp. This will materialize the address in x17 (dataMemoryRegister).
     B3::PatchpointValue* patchpoint1 = patchPoint1Root->appendNew<B3::PatchpointValue>(proc, B3::Void, B3::Origin());
@@ -2026,7 +2026,7 @@ void testArgumentRegPinned()
     GPRReg pinned = GPRInfo::argumentGPR0;
     proc.pinRegister(pinned);
 
-    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
     B3::BasicBlock* b3Root = proc.addBlock();
     B3::PatchpointValue* patchpoint = b3Root->appendNew<B3::PatchpointValue>(proc, B3::Void, B3::Origin());
@@ -2058,7 +2058,7 @@ void testArgumentRegPinned2()
     GPRReg pinned = GPRInfo::argumentGPR0;
     proc.pinRegister(pinned);
 
-    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
     B3::BasicBlock* b3Root = proc.addBlock();
     B3::PatchpointValue* patchpoint = b3Root->appendNew<B3::PatchpointValue>(proc, B3::Void, B3::Origin());
@@ -2096,7 +2096,7 @@ void testArgumentRegPinned3()
     GPRReg pinned = GPRInfo::argumentGPR0;
     proc.pinRegister(pinned);
 
-    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
     B3::BasicBlock* b3Root = proc.addBlock();
     B3::PatchpointValue* patchpoint = b3Root->appendNew<B3::PatchpointValue>(proc, B3::Void, B3::Origin());
@@ -2252,7 +2252,7 @@ void testElideHandlesEarlyClobber()
         });
     });
 
-    Inst inst(Patch, patch, Arg::special(code.addSpecial(WTF::makeUnique<JSC::B3::PatchpointSpecial>())));
+    Inst inst(Patch, patch, Arg::special(code.addSpecial(makeUniqueWithoutFastMallocCheck<JSC::B3::PatchpointSpecial>())));
     inst.args.append(Tmp(firstCalleeSave));
     root->appendInst(WTFMove(inst));
 
@@ -2346,7 +2346,7 @@ void testLinearScanSpillRangesLateUse()
 
     BasicBlock* root = code.addBlock();
 
-    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
     Vector<Tmp> tmps;
     for (unsigned i = 0; i < 100; ++i) {
@@ -2399,7 +2399,7 @@ void testLinearScanSpillRangesEarlyDef()
 
     BasicBlock* root = code.addBlock();
 
-    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+    B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
     Vector<Tmp> tmps;
     for (unsigned i = 0; i < 100; ++i) {
@@ -2510,7 +2510,7 @@ void testEarlyAndLateUseOfSameTmp()
         B3::Procedure proc;
         Code& code = proc.code();
 
-        B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+        B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
         BasicBlock* root = code.addBlock();
         Vector<Tmp> tmps;
@@ -2572,7 +2572,7 @@ void testEarlyClobberInterference()
         B3::Procedure proc;
         Code& code = proc.code();
 
-        B3::Air::Special* patchpointSpecial = code.addSpecial(makeUnique<B3::PatchpointSpecial>());
+        B3::Air::Special* patchpointSpecial = code.addSpecial(makeUniqueWithoutFastMallocCheck<B3::PatchpointSpecial>());
 
         BasicBlock* root = code.addBlock();
         Vector<Tmp> tmps;

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -60,7 +60,7 @@ void compile(State& state, Safepoint::Result& safepointResult)
     VM& vm = graph.m_vm;
 
     if (shouldDumpDisassembly() || vm.m_perBytecodeProfiler)
-        state.proc->code().setDisassembler(makeUnique<B3::Air::Disassembler>());
+        state.proc->code().setDisassembler(makeUniqueWithoutFastMallocCheck<B3::Air::Disassembler>());
 
     if (!shouldDumpDisassembly() && !verboseCompilationEnabled() && !Options::verboseValidationFailure() && !Options::asyncDisassembly() && !graph.compilation() && !state.proc->needsPCToOriginMap())
         graph.freeDFGIRAfterLowering();

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -5847,7 +5847,7 @@ Expected<std::unique_ptr<InternalFunction>, String> parseAndCompileOMG(Compilati
 
     {
         if (shouldDumpDisassemblyFor(compilationMode))
-            procedure.code().setDisassembler(makeUnique<B3::Air::Disassembler>());
+            procedure.code().setDisassembler(makeUniqueWithoutFastMallocCheck<B3::Air::Disassembler>());
         B3::prepareForGeneration(procedure);
         B3::generate(procedure, *compilationContext.wasmEntrypointJIT);
         compilationContext.wasmEntrypointByproducts = procedure.releaseByproducts();


### PR DESCRIPTION
#### a39a1f7cd01b83b16448394b0724b2789426434c
<pre>
Allocate Air types using SequesteredArenaAllocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=287994">https://bugs.webkit.org/show_bug.cgi?id=287994</a>
<a href="https://rdar.apple.com/145159432">rdar://145159432</a>

Reviewed by Yijia Huang.

This covers all of the air-internal types whose lifetimes do not extend
past that of a compilation job. Allocating these out of the arena is
intended to improve security and performance.
Note that this does not yet cover all bytes used by Air: components
which themselves allocate (e.g. Vector) need to be handled separately.
This patch just ensures that when the top-level types are allocated
directly, they&apos;re allocated using SequesteredArenaMalloc.

* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.cpp:
(JSC::B3::Air::GenerateAndAllocateRegisters::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirAllocateRegistersAndStackAndGenerateCode.h:
* Source/JavaScriptCore/b3/air/AirBasicBlock.cpp:
* Source/JavaScriptCore/b3/air/AirBasicBlock.h:
* Source/JavaScriptCore/b3/air/AirCCallSpecial.cpp:
* Source/JavaScriptCore/b3/air/AirCCallSpecial.h:
* Source/JavaScriptCore/b3/air/AirCFG.h:
* Source/JavaScriptCore/b3/air/AirCode.cpp:
(JSC::B3::Air::Code::cCallSpecial):
* Source/JavaScriptCore/b3/air/AirCode.h:
* Source/JavaScriptCore/b3/air/AirDisassembler.cpp:
* Source/JavaScriptCore/b3/air/AirDisassembler.h:
* Source/JavaScriptCore/b3/air/AirGenerate.cpp:
(JSC::B3::Air::prepareForGeneration):
* Source/JavaScriptCore/b3/air/AirLiveness.h:
* Source/JavaScriptCore/b3/air/AirLivenessAdapter.h:
* Source/JavaScriptCore/b3/air/AirPrintSpecial.cpp:
* Source/JavaScriptCore/b3/air/AirPrintSpecial.h:
* Source/JavaScriptCore/b3/air/AirSpecial.h:
* Source/JavaScriptCore/b3/air/AirStackSlot.cpp:
* Source/JavaScriptCore/b3/air/AirStackSlot.h:
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::parseAndCompileOMG):

Canonical link: <a href="https://commits.webkit.org/291924@main">https://commits.webkit.org/291924@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83522ab6f9f33b5c397b7a13aa24f012a40c6bf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22431 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72044 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29372 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97413 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10634 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52376 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2935 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44255 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87108 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101474 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93070 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21466 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80419 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20044 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24971 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14691 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21443 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115726 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21131 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22875 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->