### PR TITLE
[Screen Time Refactoring] Add release logging for Screen Time to help diagnose issues

### DIFF
--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -149,6 +149,7 @@ extern "C" {
     M(Resize) \
     M(ResourceLoadStatistics) \
     M(Sandbox) \
+    M(ScreenTime) \
     M(ScrollAnimations) \
     M(Scrolling) \
     M(SecureCoding) \

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -439,6 +439,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
             [screenTimeView setFrame:self.bounds];
             [self addSubview:screenTimeView.get()];
         }
+        RELEASE_LOG(ScreenTime, "Screen Time controller was installed.");
     }
 }
 
@@ -455,6 +456,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     [[_screenTimeWebpageController view] removeFromSuperview];
     [_screenTimeWebpageController removeObserver:self forKeyPath:@"URLIsBlocked" context:&screenTimeWebpageControllerBlockedKVOContext];
     _screenTimeWebpageController = nil;
+    RELEASE_LOG(ScreenTime, "Screen Time controller was uninstalled.");
 }
 
 - (void)_updateScreenTimeViewGeometry
@@ -471,15 +473,21 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
     BOOL showsSystemScreenTimeBlockingView = [_configuration _showsSystemScreenTimeBlockingView];
 
     if (viewIsInWindow) {
-        if (!showsSystemScreenTimeBlockingView && _screenTimeBlurredSnapshot)
+        if (!showsSystemScreenTimeBlockingView && _screenTimeBlurredSnapshot) {
             [_screenTimeBlurredSnapshot setHidden:NO];
-        else if (showsSystemScreenTimeBlockingView)
+            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to show blurred view.");
+        } else if (showsSystemScreenTimeBlockingView) {
             [[_screenTimeWebpageController view] setHidden:NO];
+            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to show system shield.");
+        }
     } else {
-        if (_screenTimeBlurredSnapshot)
+        if (_screenTimeBlurredSnapshot) {
             [_screenTimeBlurredSnapshot setHidden:YES];
-        else if (showsSystemScreenTimeBlockingView)
+            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to hide blurred view.");
+        } else if (showsSystemScreenTimeBlockingView) {
             [[_screenTimeWebpageController view] setHidden:YES];
+            RELEASE_LOG(ScreenTime, "Screen Time has updated visibility to hide system shield.");
+        }
     }
 
     BOOL viewIsVisible = viewIsInWindow;
@@ -504,6 +512,10 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
             [self willChangeValueForKey:@"_isBlockedByScreenTime"];
             _isBlockedByScreenTime = urlIsBlocked;
             [self didChangeValueForKey:@"_isBlockedByScreenTime"];
+            if (urlIsBlocked)
+                RELEASE_LOG(ScreenTime, "Screen Time is blocking the URL.");
+            else
+                RELEASE_LOG(ScreenTime, "Screen Time is not blocking the URL.");
         }
         if (wasBlockedByScreenTime != _isBlockedByScreenTime) {
             if (!_screenTimeBlurredSnapshot && ![_configuration _showsSystemScreenTimeBlockingView]) {


### PR DESCRIPTION
#### 95fcdf016aaa8c290c365f00c642267a93bbcf25
<pre>
[Screen Time Refactoring] Add release logging for Screen Time to help diagnose issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=288624">https://bugs.webkit.org/show_bug.cgi?id=288624</a>
<a href="https://rdar.apple.com/145674898">rdar://145674898</a>

Reviewed by Richard Robinson and Aditya Keerthi.

Add release logging for certain Screen Time updates to
help diagnose issues.

* Source/WebKit/Platform/Logging.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _installScreenTimeWebpageController]):
(-[WKWebView _uninstallScreenTimeWebpageController]):
(-[WKWebView _updateScreenTimeShieldVisibilityForWindow]):
(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):

Canonical link: <a href="https://commits.webkit.org/291175@main">https://commits.webkit.org/291175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5227c7ddcabcf2f029a4900c2acfdbcd87db6267

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1290 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/12042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20210 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95198 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/12042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83490 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/12042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/12042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99141 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19282 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79353 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78989 "Passed tests") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/23518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14656 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19263 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18955 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22413 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->