### PR TITLE
[macOS] Check in WebContent process with Launch Services from the Networking process

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
@@ -161,6 +161,8 @@ CFArrayRef _LSCopyMatchingApplicationsWithItems(LSSessionID, CFIndex count, CFTy
 typedef void (^ _LSOpenCompletionHandler)(LSASNRef, Boolean, CFErrorRef);
 void _LSOpenURLsUsingBundleIdentifierWithCompletionHandler(CFArrayRef, CFStringRef, CFDictionaryRef, _LSOpenCompletionHandler);
 
+Boolean _LSApplicationCheckInProxy(LSSessionID, const audit_token_t, CFDictionaryRef applicationInfoRef, void(^block)(CFDictionaryRef result, CFErrorRef));
+
 WTF_EXTERN_C_END
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -366,6 +366,9 @@ private:
 #if PLATFORM(MAC)
     void updateActivePages(const String& name, const Vector<String>& activePagesOrigins, CoreIPCAuditToken&&);
     void getProcessDisplayName(CoreIPCAuditToken&&, CompletionHandler<void(const String&)>&&);
+#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
+    void checkInWebProcess(const CoreIPCAuditToken&);
+#endif
 #endif
 
 #if USE(LIBWEBRTC)

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -120,6 +120,9 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 #if PLATFORM(MAC)
     GetProcessDisplayName(struct WebKit::CoreIPCAuditToken auditToken) -> (String displayName)
     UpdateActivePages(String name, Vector<String> activePagesOrigins, struct WebKit::CoreIPCAuditToken auditToken)
+#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
+    CheckInWebProcess(struct WebKit::CoreIPCAuditToken auditToken)
+#endif
 #endif
     SetResourceLoadSchedulingMode(WebCore::PageIdentifier webPageID, enum:uint8_t WebCore::LoadSchedulingMode mode)
     PrioritizeResourceLoads(Vector<WebCore::ResourceLoaderIdentifier> loadIdentifiers)

--- a/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
+++ b/Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
@@ -27,16 +27,24 @@
 #import "NetworkConnectionToWebProcess.h"
 
 #import "CoreIPCAuditToken.h"
+#import "Logging.h"
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
+#import <wtf/SoftLinking.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-namespace WebKit {
-
 #if PLATFORM(MAC)
+
+#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
+SOFT_LINK_FRAMEWORK(CoreServices)
+SOFT_LINK_OPTIONAL(CoreServices, _LSApplicationCheckInProxy, Boolean, __cdecl, (LSSessionID, const audit_token_t, CFDictionaryRef applicationInfoRef, void(^block)(CFDictionaryRef, CFErrorRef)))
+#endif
+
+namespace WebKit {
 
 void NetworkConnectionToWebProcess::updateActivePages(const String& overrideDisplayName, const Vector<String>& activePagesOrigins, CoreIPCAuditToken&& auditToken)
 {
     // Setting and getting the display name of another process requires a private entitlement.
+    RELEASE_LOG(Process, "NetworkConnectionToWebProcess::updateActivePages");
 #if USE(APPLE_INTERNAL_SDK)
     auto asn = adoptCF(_LSCopyLSASNForAuditToken(kLSDefaultSessionID, auditToken.auditToken()));
     if (!overrideDisplayName)
@@ -60,6 +68,53 @@ void NetworkConnectionToWebProcess::getProcessDisplayName(CoreIPCAuditToken&& au
 #endif
 }
 
-#endif // PLATFORM(MAC)
+#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
+void NetworkConnectionToWebProcess::checkInWebProcess(const CoreIPCAuditToken& auditToken)
+{
+    RELEASE_LOG(Process, "NetworkConnectionToWebProcess::checkInWebProcess");
+
+    int dyldPlatform = dyld_get_active_platform();
+    RetainPtr dyldPlatformValue = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &dyldPlatform));
+    RetainPtr sdkExecutableVersion = adoptCF(_LSVersionNumberCopyStringRepresentation(_LSVersionNumberGetCurrentSystemVersion()));
+    RetainPtr bundleURL = adoptCF(CFURLCreateWithString(kCFAllocatorDefault, CFSTR("file:///System/Library/Frameworks/WebKit.framework/XPCServices/com.apple.WebKit.WebContent.xpc"), nil));
+    RetainPtr bundle = adoptCF(CFBundleCreate(kCFAllocatorDefault, bundleURL.get()));
+    RetainPtr infoDictionary  = adoptCF(CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, CFBundleGetInfoDictionary(bundle.get())));
+    RetainPtr executableURL = adoptCF(CFBundleCopyExecutableURL(bundle.get()));
+    RetainPtr executablePath = adoptCF(CFURLCopyFileSystemPath(executableURL.get(), kCFURLPOSIXPathStyle));
+
+    if (!infoDictionary) {
+        RELEASE_LOG_ERROR(Process, "Failed to create dictionary for Launch Services checkin");
+        return;
+    }
+
+    CFDictionarySetValue(infoDictionary.get(), _kLSDisplayNameKey, CFSTR("Web Content Process"));
+#if CPU(ARM64E)
+    CFDictionarySetValue(infoDictionary.get(), _kLSArchitectureKey, _kLSArchitectureARM64Value);
+#else
+    CFDictionarySetValue(infoDictionary.get(), _kLSArchitectureKey, _kLSArchitecturex86_64Value);
+#endif
+    CFDictionarySetValue(infoDictionary.get(), _kLSExecutablePathKey, executablePath.get());
+    CFDictionarySetValue(infoDictionary.get(), _kLSDYLDPlatformKey, dyldPlatformValue.get());
+    CFDictionarySetValue(infoDictionary.get(), _kLSExecutableSDKVersionKey, sdkExecutableVersion.get());
+    CFDictionarySetValue(infoDictionary.get(), _kLSParentASNKey, _LSGetCurrentApplicationASN());
+
+    if (!_LSApplicationCheckInProxyPtr()) {
+        RELEASE_LOG_ERROR(Process, "Unable to soft link the function for Launch Services checkin");
+        return;
+    }
+
+    RELEASE_LOG(Process, "Launch Services checkin starting, infoDictionary = %{public}@", (__bridge NSDictionary *)infoDictionary.get());
+
+    Boolean ok = _LSApplicationCheckInProxyPtr()(kLSDefaultSessionID, auditToken.auditToken(), infoDictionary.get(), ^(CFDictionaryRef result, CFErrorRef error) {
+        NSDictionary *dictionary = (__bridge NSDictionary *)result;
+        RELEASE_LOG(Process, "Launch Services checkin completed, result = %{public}@, error = %{public}@", dictionary, (__bridge NSError *)error);
+    });
+
+    if (!ok)
+        RELEASE_LOG(Process, "Launch Services checkin did not succeed");
+}
+#endif
 
 } // namespace WebKit
+
+#endif // PLATFORM(MAC)

--- a/Source/WebKit/Scripts/process-entitlements.sh
+++ b/Source/WebKit/Scripts/process-entitlements.sh
@@ -174,6 +174,7 @@ function mac_process_network_entitlements()
         plistbuddy Add :com.apple.private.launchservices.allowedtochangethesekeysinotherapplications array
         plistbuddy Add :com.apple.private.launchservices.allowedtochangethesekeysinotherapplications:0 string LSActivePageUserVisibleOriginsKey
         plistbuddy Add :com.apple.private.launchservices.allowedtochangethesekeysinotherapplications:1 string LSDisplayName
+        plistbuddy Add :com.apple.private.launchservices.allowedtolaunchasproxy bool YES
         plistbuddy Add :com.apple.private.pac.exception bool YES
         plistbuddy Add :com.apple.private.webkit.use-xpc-endpoint bool YES
         plistbuddy Add :com.apple.rootless.storage.WebKitNetworkingSandbox bool YES

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1297,6 +1297,10 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
     }
 #endif
 
+#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
+    NetworkProcessProxy::ensureDefaultNetworkProcess();
+#endif
+
     return page;
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1268,7 +1268,10 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
         // The NSApplication initialization is being done in [NSApplication _accessibilityInitialize]
         LaunchServicesDatabaseManager::singleton().waitForDatabaseUpdate();
 #endif
-
+#if ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
+        if (auto auditToken = auditTokenForSelf())
+            m_networkProcessConnection->protectedConnection()->send(Messages::NetworkConnectionToWebProcess::CheckInWebProcess(*auditToken), 0);
+#endif
         // This can be called during a WebPage's constructor, so wait until after the constructor returns to touch the WebPage.
         RunLoop::protectedMain()->dispatch([this, protectedThis = Ref { *this }] {
             for (auto& webPage : m_pageMap.values())

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -1385,11 +1385,13 @@
             "com.apple.iconservices"
             "com.apple.iconservices.store")))
 
+#if !ENABLE(LAUNCHSERVICES_SANDBOX_EXTENSION_BLOCKING)
 (allow mach-lookup
     (require-all
         (extension "com.apple.webkit.extension.mach")
         (require-not (webcontent-process-launched))
         (global-name "com.apple.coreservices.launchservicesd")))
+#endif
 
 (deny mach-lookup (with no-report)
     (global-name "com.apple.audio.AudioComponentRegistrar"))


### PR DESCRIPTION
#### a5286f75826f7bee315d1c89aee8cf20669d582d
<pre>
[macOS] Check in WebContent process with Launch Services from the Networking process
<a href="https://rdar.apple.com/145370973">rdar://145370973</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288290">https://bugs.webkit.org/show_bug.cgi?id=288290</a>

Reviewed by Brady Eidson and Chris Dumez.

We currently allow a sandbox extension to Launch Services in the WebContent procces during launch. This extension is
revoked when the WebContent process has finished launching. To also remove this sandbox extension, we can check in
the WebContent process with Launch Services from the Networking process, instead of doing an in-process checkin.
This is currently guarded by a flag, which is not enabled, so there should be no behavior change from this patch.

* Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm:
(WebKit::NetworkConnectionToWebProcess::checkInWebProcess):
* Source/WebKit/Scripts/process-entitlements.sh:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
* Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::WebProcess::updateProcessName):
(WebKit::WebProcess::platformInitializeProcess):
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/291281@main">https://commits.webkit.org/291281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/33e9d846b1b439c6777b488de15df01e88e8a655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42877 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20372 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70799 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28257 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51116 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/91865 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1283 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42207 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79307 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99377 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19418 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14367 "Found 1 new test failure: imported/w3c/web-platform-tests/file-system-access/getDirectory.https.any.worker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79815 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79067 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/916 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12422 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14740 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24577 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19092 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->