### PR TITLE
Requesting the optional '<all_urls>' match pattern doesn't do anything

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1737,7 +1737,7 @@ WebExtensionContext::PermissionState WebExtensionContext::permissionState(const 
     if (!pattern.isValid())
         return PermissionState::Unknown;
 
-    if (pattern.matchesURL(baseURL()))
+    if (!pattern.matchesAllURLs() && pattern.matchesURL(baseURL()))
         return PermissionState::GrantedImplicitly;
 
     if (!pattern.matchesAllURLs() && !WebExtensionMatchPattern::validSchemes().contains(pattern.scheme()))


### PR DESCRIPTION
#### 4fd2be23e4b871b1b1360f059de4649e294d704a
<pre>
Requesting the optional &apos;&lt;all_urls&gt;&apos; match pattern doesn&apos;t do anything
<a href="https://bugs.webkit.org/show_bug.cgi?id=288641">https://bugs.webkit.org/show_bug.cgi?id=288641</a>
<a href="https://rdar.apple.com/140010739">rdar://140010739</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

This patch fixes a bug where requesting access to all URLs wouldn&apos;t do
anything. The reason that this was happening was because when we&apos;d
check whether or not we need to request permission, we were
incorrectly saying that it was implicitly granted.

The solution here is to fix the broken condition in the permissionState
method:

if (pattern.matchesURL(baseURL()))
    return PermissionState::GrantedImplicitly;

When we&apos;re requesting access to *all* URLs, obviously it would match
the base URL of the extension. Therefore, we should only perform this
check if the pattern doesn&apos;t match all URLs.

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::permissionState):
Fix the broken condition that was incorrectly reporting the permission
as implicitly granted.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestMatchPatternsOnly)):
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, RequestAllURLsMatchPattern)):
Write a new test to validate the fix.

Canonical link: <a href="https://commits.webkit.org/291225@main">https://commits.webkit.org/291225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d834ab6c8c9b5a5bf048d22d9f44041ad0bd9acc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92188 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97081 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28169 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51036 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1106 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42069 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99133 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79724 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79355 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/78982 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19594 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12280 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24428 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18948 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->