### PR TITLE
[SwiftUI] When using the `webViewOnScrollGeometryChange` view modifier, the affected WebView is redrawn with each scroll event

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/CocoaWebViewAdapter.swift
@@ -266,14 +266,7 @@ extension CocoaWebViewAdapter: WebPageWebView.Delegate {
             return
         }
 
-        let transformedNew = onScrollGeometryChange.transform(newScrollGeometry)
-        let transformedOld = onScrollGeometryChange.transform(oldScrollGeometry)
-
-        guard transformedOld != transformedNew else {
-            return
-        }
-
-        onScrollGeometryChange.action(transformedOld, transformedNew)
+        onScrollGeometryChange.apply(from: oldScrollGeometry, to: newScrollGeometry)
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift
@@ -34,18 +34,4 @@ func onNextMainRunLoop(do body: @escaping @MainActor () -> Void) {
     }
 }
 
-struct AnyEquatable: Equatable {
-    let value: Any
-    private let equals: (Any) -> Bool
-
-    init<E: Equatable>(_ value: E) {
-        self.value = value
-        self.equals = { ($0 as! E) == value }
-    }
-
-    static func == (lhs: AnyEquatable, rhs: AnyEquatable) -> Bool {
-        lhs.equals(rhs.value)
-    }
-}
-
 #endif

--- a/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
@@ -51,7 +51,7 @@ extension EnvironmentValues {
     var webViewContentBackground: Visibility = .automatic
 
     @Entry
-    var webViewOnScrollGeometryChange: OnScrollGeometryChangeContext? = nil
+    var webViewOnScrollGeometryChange = OnScrollGeometryChangeContext()
 }
 
 extension View {
@@ -125,13 +125,21 @@ extension View {
         for type: T.Type,
         of transform: @escaping (ScrollGeometry) -> T,
         action: @escaping (T, T) -> Void
-    ) -> some View where T : Equatable {
-        let change = OnScrollGeometryChangeContext {
-            AnyEquatable(transform($0))
-        } action: {
-            action($0.value as! T, $1.value as! T)
-        }
+    ) -> some View where T : Hashable {
+        modifier(OnScrollGeometryChangeModifier(transform: transform, action: action))
+    }
+}
 
-        return environment(\.webViewOnScrollGeometryChange, change)
+private struct OnScrollGeometryChangeModifier<T>: ViewModifier where T: Hashable {
+    @Namespace private var namespace
+    @Environment(\.webViewOnScrollGeometryChange) var onScrollGeometryChange
+
+    let transform: (ScrollGeometry) -> T
+    let action: (T, T) -> Void
+
+    func body(content: Content) -> some View {
+        onScrollGeometryChange.register(changeID: namespace, transform: transform, action: action)
+
+        return content.environment(\.webViewOnScrollGeometryChange, onScrollGeometryChange)
     }
 }


### PR DESCRIPTION
#### d36b858cb4e83f4a7be9bf86ef697e3ddbdf82f4
<pre>
[SwiftUI] When using the `webViewOnScrollGeometryChange` view modifier, the affected WebView is redrawn with each scroll event
<a href="https://bugs.webkit.org/show_bug.cgi?id=288645">https://bugs.webkit.org/show_bug.cgi?id=288645</a>
<a href="https://rdar.apple.com/145688135">rdar://145688135</a>

Reviewed by Aditya Keerthi.

SwiftUI layout results in the environment being re-evaluated to see if any values differ. In the case of
`webViewOnScrollGeometryChange`, this means that a new `OnScrollGeometryChangeContext` was created each time and the environment
updated.

When the environment is updated, SwiftUI calls the `update{UI/NS}View}` function of the view representable, and redraws the view.
As a result, each time a scroll event happens, all the logic in the update function was being unnecessarily invoked, and the view
was unnecessarily redrawn.

To fix this, ensure that only ever one `OnScrollGeometryChangeContext` is in the environment. The logic the client uses in the view
modifier is encapsulated inside an internal dictionary in the context. This is needed to ensure that if the view modifier is used
multiple times, that each transform/action is stored individually instead of replaced. This dictioanry is keyed by `Namespace` so that
if either of the closures change within the _same_ view modifier application, they are simply updated instead of a new change being added.

* Source/WebKit/_WebKit_SwiftUI/CocoaWebViewAdapter.swift:
(CocoaWebViewAdapter.geometryDidChange(_:)):
* Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift:
(OnScrollGeometryChangeModifier.body(_:)):
(EnvironmentValues.webViewOnScrollGeometryChange): Deleted.
* Source/WebKit/_WebKit_SwiftUI/ViewModifierContexts.swift:
(Change.transform):
(Change.action):
(changes):
(apply(from:to:)):

Canonical link: <a href="https://commits.webkit.org/291350@main">https://commits.webkit.org/291350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134066061cd9be225ce89f97e1506e6eaaac5dae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92748 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20751 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95750 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/20051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14787 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->