### PR TITLE
[JSC] Optimize Array.prototype.indexOf for Dense Atom String Arrays

### DIFF
--- a/JSTests/microbenchmarks/atom-string-array-index-of-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-index-of-found.js
@@ -1,0 +1,12 @@
+
+let words = ['break', 'yield', 'break', 'yield', 'break', 'yield', 'super'];
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('super') != 6)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-index-of-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-index-of-not-found.js
@@ -1,0 +1,12 @@
+
+let words = ['break', 'yield', 'break', 'yield', 'break', 'yield', 'super'];
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('superr') != -1)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-found.js
@@ -1,0 +1,12 @@
+
+let words = "greedisgood".split('');
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('s') != 6)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-empty-index-of-not-found.js
@@ -1,0 +1,12 @@
+
+let words = "greedisgood".split('');
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('ss') != -1)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-found.js
@@ -1,0 +1,12 @@
+
+let words = "break break break break break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('yield') != 8)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-not-found.js
@@ -1,0 +1,12 @@
+
+let words = "break break break break break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('yieldd') != -1)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-found.js
@@ -1,0 +1,13 @@
+
+let words = "break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+let search = 'y' + 'i' + 'e' + 'l' + 'd';
+for (let i = 0; i < 1e5; i++) {
+    if (test(search) != 4)
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-not-found.js
@@ -1,0 +1,13 @@
+
+let words = "break break break break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+let search = 'y' + 'i' + 'e' + 'l' + 'd' + 'd';
+for (let i = 0; i < 1e5; i++) {
+    if (test(search) != -1)
+        throw new Error("bad");
+}

--- a/JSTests/stress/atom-string-array.js
+++ b/JSTests/stress/atom-string-array.js
@@ -1,0 +1,15 @@
+
+let words = "break yield super".split(" ");
+
+function test(s) {
+    return words.indexOf(s);
+}
+noInline(test);
+
+let search = 'yield';
+for (let i = 0; i < testLoopCount; i++) {
+    if (test(search) != 1)
+        throw new Error("bad");
+    if (i == 1)
+        words.push('good');
+}

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -421,6 +421,7 @@ RegisterID* TaggedTemplateNode::emitBytecode(BytecodeGenerator& generator, Regis
 RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     bool hadVariableExpression = false;
+    bool allDenseStrings = true;
     unsigned length = 0;
 
     IndexingType recommendedIndexingType = ArrayWithUndecided;
@@ -434,24 +435,41 @@ RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
             JSValue constant = static_cast<ConstantNode*>(firstPutElement->value())->jsValue(generator);
             if (UNLIKELY(!constant))
                 hadVariableExpression = true;
-            else
+            else {
                 recommendedIndexingType = leastUpperBoundOfIndexingTypeAndValue(recommendedIndexingType, constant);
+                if (!constant.isString())
+                    allDenseStrings = false;
+                else if (auto* impl = asString(constant)->tryGetValueImpl(); !impl || !impl->isAtom())
+                    allDenseStrings = false;
+            }
         }
 
         ++length;
     }
+    if (hadVariableExpression)
+        allDenseStrings = false;
 
-    auto newArray = [&] (RegisterID* dst, ElementNode* elements, unsigned length, bool hadVariableExpression) {
+    auto newArray = [&](RegisterID* dst, ElementNode* elements, unsigned length) {
         if (length && !hadVariableExpression) {
+            VM& vm = generator.vm();
             recommendedIndexingType |= CopyOnWrite;
-            ASSERT(generator.vm().heap.isDeferred()); // We run bytecode generator under a DeferGC. If we stopped doing that, we'd need to put a DeferGC here as we filled in these slots.
-            auto* array = JSImmutableButterfly::create(generator.vm(), recommendedIndexingType, length);
+            ASSERT(vm.heap.isDeferred()); // We run bytecode generator under a DeferGC. If we stopped doing that, we'd need to put a DeferGC here as we filled in these slots.
+
+            Structure* immutableButterflyStructure = allDenseStrings ? vm.immutableButterflyAtomStringsStructure.get() : vm.immutableButterflyStructure(recommendedIndexingType);
+            auto* array = JSImmutableButterfly::tryCreate(generator.vm(), immutableButterflyStructure, length);
+            RELEASE_ASSERT(array);
+
             unsigned index = 0;
             for (ElementNode* element = elements; index < length; element = element->next()) {
                 ASSERT(element->value()->isConstant());
                 JSValue constant = static_cast<ConstantNode*>(element->value())->jsValue(generator);
                 ASSERT(constant);
                 array->setIndex(generator.vm(), index++, constant);
+                if (allDenseStrings) {
+                    ASSERT(constant.isString());
+                    JSString* string = asString(constant);
+                    vm.cacheAtomString(const_cast<StringImpl*>(string->getValueImpl()), string);
+                }
             }
             return generator.emitNewArrayBuffer(dst, array, recommendedIndexingType);
         }
@@ -459,7 +477,9 @@ RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
     };
 
     if (!firstPutElement && !m_elision)
-        return newArray(generator.finalDestination(dst), m_element, length, hadVariableExpression);
+        return newArray(generator.finalDestination(dst), m_element, length);
+
+    allDenseStrings = false;
 
     if (firstPutElement && firstPutElement->value()->isSpreadExpression()) {
         bool hasElision = m_elision;
@@ -476,7 +496,7 @@ RegisterID* ArrayNode::emitBytecode(BytecodeGenerator& generator, RegisterID* ds
             return generator.emitNewArrayWithSpread(generator.finalDestination(dst), m_element);
     }
 
-    RefPtr<RegisterID> array = newArray(generator.tempDestination(dst), m_element, length, hadVariableExpression);
+    RefPtr<RegisterID> array = newArray(generator.tempDestination(dst), m_element, length);
     ElementNode* n = firstPutElement;
     for (; n; n = n->next()) {
         if (n->value()->isSpreadExpression())

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3864,6 +3864,32 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIndexOfString, UCPUStrictInt32, (JSGlobal
     OPERATION_RETURN(scope, arrayIndexOfString(globalObject, butterfly, searchElement, index));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, JSString* searchElement, int32_t index))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (JSImmutableButterfly::isAtomStringsStructure(vm, butterfly)) {
+        StringImpl* searchImpl = searchElement->ensureAtomString(globalObject).impl();
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (vm.containsAtomString(searchImpl)) {
+            int32_t length = butterfly->publicLength();
+            auto data = butterfly->contiguous().data();
+            for (; index < length; ++index) {
+                JSValue value = data[index].get();
+                if (auto* valueImpl = asAtomString(value); valueImpl && valueImpl == searchImpl)
+                    OPERATION_RETURN(scope, toUCPUStrictInt32(index));
+            }
+        }
+        OPERATION_RETURN(scope, toUCPUStrictInt32(-1));
+    }
+
+    OPERATION_RETURN(scope, arrayIndexOfString(globalObject, butterfly, searchElement, index));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -374,6 +374,7 @@ JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32OrContiguous, UCPUStri
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationCopyOnWriteArrayIndexOfString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIndexOfValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIndexOfNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -9628,6 +9628,30 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
         GPRReg rightCharGPR = tempRightChar.gpr();
 
         JumpList slowCase;
+
+        auto operation = operationArrayIndexOfString;
+
+        auto isCopyOnWriteArrayWithContiguous = [&]() {
+            Edge& baseEdge = m_graph.varArgChild(node, 0);
+            auto& base = m_state.forNode(baseEdge);
+            if (!base.m_structure.isFinite())
+                return false;
+            if (auto structure = base.m_structure.onlyStructure()) {
+                JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                if (structure.get() == globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous))
+                    return true;
+            }
+            return false;
+        };
+
+        if (isCopyOnWriteArrayWithContiguous()) {
+            operation = operationCopyOnWriteArrayIndexOfString;
+            loadLinkableConstant(LinkableConstant(*this, vm().immutableButterflyAtomStringsStructure.get()), compareLengthGPR);
+            emitEncodeStructureID(compareLengthGPR, compareLengthGPR);
+            addPtr(TrustedImm32(-static_cast<ptrdiff_t>(JSImmutableButterfly::offsetOfData())), storageGPR, leftStringGPR);
+            slowCase.append(branch32(Equal, Address(leftStringGPR, JSCell::structureIDOffset()), compareLengthGPR));
+        }
+
         loadPtr(Address(searchElementGPR, JSString::offsetOfValue()), rightStringGPR);
         slowCase.append(branchIfRopeStringImpl(rightStringGPR));
         slowCase.append(branchTest32(
@@ -9724,7 +9748,7 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             unblessedBooleanResult(indexGPR, node);
         } else {
             addSlowPathGenerator(slowPathCall(
-                slowCase, this, operationArrayIndexOfString,
+                slowCase, this, operation,
                 indexGPR, LinkableConstant::globalObject(*this, node),
                 storageGPR, searchElementGPR, indexGPR
             ));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -7674,6 +7674,7 @@ IGNORE_CLANG_WARNINGS_END
             LValue searchElement = lowCell(searchElementEdge);
             speculateString(searchElementEdge, searchElement);
 
+            LBasicBlock checkSearchRopeString = m_out.newBlock();
             LBasicBlock checkSearchElement8Bit = m_out.newBlock();
             LBasicBlock loopHeader = m_out.newBlock();
             LBasicBlock fastCheckElementCell = m_out.newBlock();
@@ -7696,9 +7697,33 @@ IGNORE_CLANG_WARNINGS_END
 
             ValueFromBlock initialStartIndex = m_out.anchor(startIndex);
 
+            auto operation = operationArrayIndexOfString;
+
+            auto isCopyOnWriteArrayWithContiguous = [&]() {
+                Edge& baseEdge = m_graph.varArgChild(m_node, 0);
+                auto& base = m_state.forNode(baseEdge);
+                if (!base.m_structure.isFinite())
+                    return false;
+                if (auto structure = base.m_structure.onlyStructure()) {
+                    JSGlobalObject* globalObject = m_graph.globalObjectFor(m_node->origin.semantic);
+                    if (structure.get() == globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous))
+                        return true;
+                }
+                return false;
+            };
+
+            if (isCopyOnWriteArrayWithContiguous()) {
+                operation = operationCopyOnWriteArrayIndexOfString;
+                LValue targetStructureID = encodeStructureID(weakPointer(vm().immutableButterflyAtomStringsStructure.get()));
+                LValue butterflyStructureID = m_out.load32(m_out.add(storage, m_out.constIntPtr(-JSImmutableButterfly::offsetOfData())), m_heaps.JSCell_structureID);
+                m_out.branch(m_out.equal(butterflyStructureID, targetStructureID), unsure(slowCase), unsure(checkSearchRopeString));
+            } else
+                m_out.jump(checkSearchRopeString);
+
+            LBasicBlock lastNext = m_out.appendTo(checkSearchRopeString, checkSearchElement8Bit);
             m_out.branch(isRopeString(searchElement, searchElementEdge), rarely(slowCase), usually(checkSearchElement8Bit));
 
-            LBasicBlock lastNext = m_out.appendTo(checkSearchElement8Bit, loopHeader);
+            m_out.appendTo(checkSearchElement8Bit, loopHeader);
             LValue searchElementImpl = m_out.loadPtr(searchElement, m_heaps.JSString_value);
             m_out.branch(m_out.testIsZero32(m_out.load32(searchElementImpl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())), unsure(slowCase), unsure(loopHeader));
 
@@ -7767,7 +7792,7 @@ IGNORE_CLANG_WARNINGS_END
             m_out.jump(continuation);
 
             m_out.appendTo(slowCase, continuation);
-            ValueFromBlock slowCaseResult = isArrayIncludes ? m_out.anchor(vmCall(Int32, operationArrayIncludesString, weakPointer(globalObject), storage, searchElement, startIndex)) : m_out.anchor(vmCall(Int64, operationArrayIndexOfString, weakPointer(globalObject), storage, searchElement, startIndex));
+            ValueFromBlock slowCaseResult = isArrayIncludes ? m_out.anchor(vmCall(Int32, operationArrayIncludesString, weakPointer(globalObject), storage, searchElement, startIndex)) : m_out.anchor(vmCall(Int64, operation, weakPointer(globalObject), storage, searchElement, startIndex));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1513,7 +1513,24 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncIndexOf, (JSGlobalObject* globalObject, C
     JSValue searchElement = callFrame->argument(0);
 
     if (LIKELY(isJSArray(thisObject))) {
-        JSValue result = fastIndexOf<IndexOfDirection::Forward>(globalObject, vm, asArray(thisObject), length, searchElement, index);
+        JSArray* array = asArray(thisObject);
+        Butterfly* butterfly = array->butterfly();
+        if (isCopyOnWrite(array->indexingMode()) && JSImmutableButterfly::isAtomStringsStructure(vm, butterfly) && searchElement.isString()) {
+            StringImpl* searchImpl = asString(searchElement)->ensureAtomString(globalObject).impl();
+            RETURN_IF_EXCEPTION(scope, { });
+
+            if (vm.containsAtomString(searchImpl)) {
+                auto data = butterfly->contiguous().data();
+                for (unsigned i = index; i < length; ++i) {
+                    JSValue value = data[i].get();
+                    if (auto* valueImpl = asAtomString(value); valueImpl && valueImpl == searchImpl)
+                        return JSValue::encode(jsNumber(i));
+                }
+            }
+            return JSValue::encode(jsNumber(-1));
+        }
+
+        JSValue result = fastIndexOf<IndexOfDirection::Forward>(globalObject, vm, array, length, searchElement, index);
         RETURN_IF_EXCEPTION(scope, { });
         if (result)
             return JSValue::encode(result);

--- a/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
+++ b/Source/JavaScriptCore/runtime/JSImmutableButterfly.h
@@ -150,6 +150,10 @@ public:
 
     Butterfly* toButterfly() const { return std::bit_cast<Butterfly*>(std::bit_cast<char*>(this) + offsetOfData()); }
     static JSImmutableButterfly* fromButterfly(Butterfly* butterfly) { return std::bit_cast<JSImmutableButterfly*>(std::bit_cast<char*>(butterfly) - offsetOfData()); }
+    static bool isAtomStringsStructure(VM& vm, Butterfly* butterfly)
+    {
+        return fromButterfly(butterfly)->structure() == vm.immutableButterflyAtomStringsStructure.get();
+    }
 
     JSValue get(unsigned index) const
     {

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -220,6 +220,7 @@ protected:
 
 public:
     Identifier toIdentifier(JSGlobalObject*) const;
+    AtomString ensureAtomString(JSGlobalObject*) const;
     AtomString toAtomString(JSGlobalObject*) const;
     AtomString toExistingAtomString(JSGlobalObject*) const;
 
@@ -788,6 +789,14 @@ inline JSString* asString(JSValue value)
     return jsCast<JSString*>(value.asCell());
 }
 
+inline const StringImpl* asAtomString(JSValue value)
+{
+    ASSERT(value.isString());
+    if (auto* valueImpl = asString(value)->tryGetValueImpl(); valueImpl && valueImpl->isAtom())
+        return valueImpl;
+    return nullptr;
+}
+
 // This MUST NOT GC.
 inline JSString* jsEmptyString(VM& vm)
 {
@@ -888,6 +897,17 @@ ALWAYS_INLINE AtomString JSString::toExistingAtomString(JSGlobalObject* globalOb
     if (valueInternal().impl()->isAtom())
         return static_cast<AtomStringImpl*>(valueInternal().impl());
     return AtomStringImpl::lookUp(valueInternal().impl());
+}
+
+ALWAYS_INLINE AtomString JSString::ensureAtomString(JSGlobalObject* globalObject) const
+{
+    VM& vm = getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    AtomString result = toExistingAtomString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!result.isNull())
+        return result;
+    RELEASE_AND_RETURN(scope, toAtomString(globalObject));
 }
 
 inline GCOwnedDataScope<const String&> JSString::value(JSGlobalObject* globalObject) const

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1381,23 +1381,34 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
 
     auto& result = vm.stringSplitIndice;
     result.shrink(0);
+    constexpr unsigned atomStringsArrayLimit = 100;
 
     auto cacheAndCreateArray = [&]() -> JSArray* {
         if (result.isEmpty())
             return constructEmptyArray(globalObject, nullptr);
 
-        if (LIKELY(limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && result.size() < MIN_SPARSE_ARRAY_INDEX)) {
-            auto* newButterfly = JSImmutableButterfly::create(vm, CopyOnWriteArrayWithContiguous, result.size());
+        unsigned resultSize = result.size();
+        if (LIKELY(limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && resultSize < MIN_SPARSE_ARRAY_INDEX)) {
+            bool makeAtomStringsArray = resultSize < atomStringsArrayLimit;
+            Structure* immutableButterflyStructure = makeAtomStringsArray ? vm.immutableButterflyAtomStringsStructure.get() : vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous);
+
+            auto* newButterfly = JSImmutableButterfly::tryCreate(vm, immutableButterflyStructure, resultSize);
+            if (UNLIKELY(!newButterfly)) {
+                throwOutOfMemoryError(globalObject, scope);
+                return { };
+            }
+
             unsigned start = 0;
             auto view = thisString->view(globalObject);
             RETURN_IF_EXCEPTION(scope, { });
-            for (unsigned i = 0, size = result.size(); i < size; ++i) {
+            for (unsigned i = 0; i < resultSize; ++i) {
                 unsigned end = result[i];
                 JSString* string = nullptr;
-                if (size < 100) {
+                if (makeAtomStringsArray) {
                     auto subView = view->substring(start, end - start);
                     auto identifier = subView.is8Bit() ? Identifier::fromString(vm, subView.span8()) : Identifier::fromString(vm, subView.span16());
                     string = jsString(vm, identifier.string());
+                    vm.cacheAtomString(identifier.impl(), string);
                 } else {
                     string = jsSubstring(globalObject, thisString, start, end - start);
                     RETURN_IF_EXCEPTION(scope, { });
@@ -1410,10 +1421,10 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
             return JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly());
         }
 
-        auto* array = constructEmptyArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), result.size());
+        auto* array = constructEmptyArray(globalObject, static_cast<ArrayAllocationProfile*>(nullptr), resultSize);
         RETURN_IF_EXCEPTION(scope, { });
         unsigned start = 0;
-        for (unsigned i = 0, size = result.size(); i < size; ++i) {
+        for (unsigned i = 0; i < resultSize; ++i) {
             unsigned end = result[i];
             auto* string = jsSubstring(globalObject, thisString, start, end - start);
             RETURN_IF_EXCEPTION(scope, { });
@@ -1443,9 +1454,24 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSplitFast, (JSGlobalObject* globalObject
         ASSERT(resultSize);
 
         if (LIKELY(limit == 0xFFFFFFFFu && !globalObject->isHavingABadTime() && resultSize < MIN_SPARSE_ARRAY_INDEX)) {
-            auto* newButterfly = JSImmutableButterfly::create(vm, CopyOnWriteArrayWithContiguous, resultSize);
-            for (unsigned i = 0; i < resultSize; ++i)
-                newButterfly->setIndex(vm, i, jsSingleCharacterString(vm, input[i]));
+            bool makeAtomStringsArray = resultSize < atomStringsArrayLimit;
+            Structure* immutableButterflyStructure = makeAtomStringsArray ? vm.immutableButterflyAtomStringsStructure.get() : vm.immutableButterflyStructure(CopyOnWriteArrayWithContiguous);
+
+            auto* newButterfly = JSImmutableButterfly::tryCreate(vm, immutableButterflyStructure, resultSize);
+            if (UNLIKELY(!newButterfly)) {
+                throwOutOfMemoryError(globalObject, scope);
+                return { };
+            }
+
+            for (unsigned i = 0; i < resultSize; ++i) {
+                auto* string = jsSingleCharacterString(vm, input[i]);
+                if (makeAtomStringsArray) {
+                    Identifier identifier = string->toIdentifier(globalObject);
+                    RETURN_IF_EXCEPTION(scope, { });
+                    vm.cacheAtomString(identifier.impl(), string);
+                }
+                newButterfly->setIndex(vm, i, string);
+            }
             vm.stringSplitCache.set(input, separator, newButterfly);
             Structure* arrayStructure = globalObject->originalArrayStructureForIndexingType(CopyOnWriteArrayWithContiguous);
             return JSValue::encode(JSArray::createWithButterfly(vm, nullptr, arrayStructure, newButterfly->toButterfly()));

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -233,6 +233,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , emptyList(new ArgList)
     , machineCodeBytesPerBytecodeWordForBaselineJIT(makeUnique<SimpleStats>())
     , symbolImplToSymbolMap(*this)
+    , atomStringToJSStringMap(*this)
     , m_regExpCache(makeUnique<RegExpCache>())
     , m_compactVariableMap(adoptRef(*new CompactTDZEnvironmentMap))
     , m_codeCache(makeUnique<CodeCache>())
@@ -312,6 +313,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     rawImmutableButterflyStructure(CopyOnWriteArrayWithDouble).setWithoutWriteBarrier(Options::allowDoubleShape() ? JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
     rawImmutableButterflyStructure(CopyOnWriteArrayWithContiguous).setWithoutWriteBarrier(copyOnWriteArrayWithContiguousStructure);
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    // This is only for JSImmutableButterfly filled with atom strings.
+    immutableButterflyAtomStringsStructure.setWithoutWriteBarrier(JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous));
 
     sourceCodeStructure.setWithoutWriteBarrier(JSSourceCode::createStructure(*this, nullptr, jsNull()));
     scriptFetcherStructure.setWithoutWriteBarrier(JSScriptFetcher::createStructure(*this, nullptr, jsNull()));
@@ -1658,6 +1662,7 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(symbolTableStructure);
     for (auto& structure : immutableButterflyStructures)
         visitor.append(structure);
+    visitor.append(immutableButterflyAtomStringsStructure);
     visitor.append(sourceCodeStructure);
     visitor.append(scriptFetcherStructure);
     visitor.append(scriptFetchParametersStructure);
@@ -1841,6 +1846,18 @@ void VM::DrainMicrotaskDelayScope::decrement()
         JSLockHolder locker(*m_vm);
         m_vm->drainMicrotasks();
     }
+}
+
+bool VM::containsAtomString(StringImpl* stringImpl)
+{
+    ASSERT(stringImpl->isAtom());
+    return atomStringToJSStringMap.contains(stringImpl);
+}
+
+void VM::cacheAtomString(StringImpl* stringImpl, JSString* jsString)
+{
+    ASSERT(stringImpl->isAtom());
+    atomStringToJSStringMap.set(stringImpl, jsString);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -535,7 +535,8 @@ public:
     WriteBarrier<Structure> regExpStructure;
     WriteBarrier<Structure> symbolStructure;
     WriteBarrier<Structure> symbolTableStructure;
-    WriteBarrier<Structure> immutableButterflyStructures[NumberOfCopyOnWriteIndexingModes];
+    std::array<WriteBarrier<Structure>, NumberOfCopyOnWriteIndexingModes> immutableButterflyStructures;
+    WriteBarrier<Structure> immutableButterflyAtomStringsStructure;
     WriteBarrier<Structure> sourceCodeStructure;
     WriteBarrier<Structure> scriptFetcherStructure;
     WriteBarrier<Structure> scriptFetchParametersStructure;
@@ -622,7 +623,11 @@ public:
         return emptyPropertyNameEnumeratorSlow();
     }
 
+    bool containsAtomString(StringImpl*);
+    void cacheAtomString(StringImpl*, JSString*);
+
     WeakGCMap<SymbolImpl*, Symbol, PtrHash<SymbolImpl*>> symbolImplToSymbolMap;
+    WeakGCMap<StringImpl*, JSString, PtrHash<StringImpl*>> atomStringToJSStringMap;
 
     enum class DeletePropertyMode {
         // Default behaviour of deleteProperty, matching the spec.


### PR DESCRIPTION
#### a7e5055c0a8d8ecf5b17783d42a8a608fb756d7e
<pre>
[JSC] Optimize Array.prototype.indexOf for Dense Atom String Arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=288548">https://bugs.webkit.org/show_bug.cgi?id=288548</a>
<a href="https://rdar.apple.com/145614326">rdar://145614326</a>

Reviewed by NOBODY (OOPS!).

This patch significantly improves the performance of `Array.prototype.indexOf`
when searching in arrays of dense atom strings, enabling direct pointer-based
comparisons rather than expensive string content comparisons.

                                                                without                     with

atom-string-array-index-of-found                            1.8658+-0.0157     ^      1.8118+-0.0076        ^ definitely 1.0298x faster
atom-string-array-index-of-not-found                        1.6223+-0.0149     ^      1.2027+-0.0170        ^ definitely 1.3489x faster
atom-string-array-split-empty-index-of-found                1.8085+-0.0180     ?      1.8101+-0.0211        ?
atom-string-array-split-empty-index-of-not-found            1.9328+-0.0067     ^      1.1792+-0.0086        ^ definitely 1.6391x faster
atom-string-array-split-space-index-of-rope-found           1.6201+-0.0156     ?      1.6392+-0.0145        ? might be 1.0118x slower
atom-string-array-split-space-index-of-rope-not-found       1.7375+-0.0091     ^      1.2328+-0.0209        ^ definitely 1.4094x faster
atom-string-array-split-space-index-of-non-rope-found       2.2554+-0.0298     ^      1.8638+-0.0133        ^ definitely 1.2101x faster
atom-string-array-split-space-index-of-non-rope-not-found   1.7908+-0.0061     ^      1.1876+-0.0149        ^ definitely 1.5079x faster

* JSTests/microbenchmarks/atom-string-array-index-of-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-index-of-not-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-empty-index-of-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-empty-index-of-not-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-non-rope-not-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-found.js: Added.
(test):
* JSTests/microbenchmarks/atom-string-array-split-space-index-of-rope-not-found.js: Added.
(test):
* JSTests/stress/atom-string-array.js: Added.
(test):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ArrayNode::emitBytecode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSImmutableButterfly.h:
(JSC::JSImmutableButterfly::isAtomStringsStructure):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::asString):
(JSC::asAtomString):
(JSC::JSString::ensureAtomString const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4aad33a13ccc99b05b91b7dbc47dcfac60b27a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1300 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42750 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12051 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28180 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83501 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1116 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84952 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79209 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1085 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90903 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19291 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79365 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23523 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12295 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19272 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24444 "Found 2 new failures in runtime/ArrayPrototype.cpp, runtime/JSString.h") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113526 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/18964 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32844 "Found 13 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.mini-mode, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-eager-jettison ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22422 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->