### PR TITLE
Add SP3 subtest support to run-benchmark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.1.plan
@@ -518,7 +518,7 @@
             {"path": "worker/segmentation.js", "mode": "100644", "type": "blob"}
         ]
     },
-    "subtest_url_format": "test=${TEST}",
+    "subtest_url_format": "&test=${TEST}",
     "subtests": {
         "": [
             "Air",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.2.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.2.plan
@@ -518,7 +518,7 @@
         ],
         "truncated": false
     },
-    "subtest_url_format": "test=${TEST}",
+    "subtest_url_format": "&test=${TEST}",
     "subtests": {
         "": [
             "Air",

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.2.1.plan
@@ -7,7 +7,7 @@
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark.patch",
     "signpost_patch": "data/patches/signposts/MotionMark.patch",
     "entry_point": "index.html",
-    "subtest_entry_point": "developer.html",
+    "subtest_entry_point": "developer.html?",
     "config": {
         "orientation": "landscape"
     },

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.1.plan
@@ -6,7 +6,7 @@
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark1.3.1.patch",
     "signpost_patch": "data/patches/signposts/MotionMark1.3.1.patch",
     "entry_point": "index.html",
-    "subtest_entry_point": "developer.html",
+    "subtest_entry_point": "developer.html?",
     "config": {
         "orientation": "landscape"
     },

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/motionmark1.3.plan
@@ -6,7 +6,7 @@
     "webdriver_benchmark_patch": "data/patches/webdriver/MotionMark1.3.patch",
     "signpost_patch": "data/patches/signposts/MotionMark1.3.patch",
     "entry_point": "index.html",
-    "subtest_entry_point": "developer.html",
+    "subtest_entry_point": "developer.html?",
     "config": {
         "orientation": "landscape"
     },

--- a/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan
@@ -4,6 +4,29 @@
     "git_repository": {"url": "https://github.com/WebKit/Speedometer.git", "branch": "release/3.0"},
     "webserver_benchmark_patch": "data/patches/webserver/Speedometer3.patch",
     "signpost_patch": "data/patches/signposts/Speedometer3.patch",
-    "entry_point": "index.html",
-    "output_file": "speedometer3.result"
+    "entry_point": "index.html?developerMode=&suites=",
+    "output_file": "speedometer3.result",
+    "subtest_url_format": "${SUITE},",
+    "subtests": {
+        "TodoMVC-JavaScript-ES5": [""],
+        "TodoMVC-JavaScript-ES6-Webpack-Complex-DOM": [""],
+        "TodoMVC-WebComponents": [""],
+        "TodoMVC-React-Complex-DOM": [""],
+        "TodoMVC-React-Redux": [""],
+        "TodoMVC-Backbone": [""],
+        "TodoMVC-Angular-Complex-DOM": [""],
+        "TodoMVC-Vue": [""],
+        "TodoMVC-jQuery": [""],
+        "TodoMVC-Preact-Complex-DOM": [""],
+        "TodoMVC-Svelte-Complex-DOM": [""],
+        "TodoMVC-Lit-Complex-DOM": [""],
+        "NewsSite-Next": [""],
+        "NewsSite-Nuxt": [""],
+        "Editor-CodeMirror": [""],
+        "Editor-TipTap": [""],
+        "Charts-observable-plot": [""],
+        "Charts-chartjs": [""],
+        "React-Stockcharts-SVG": [""],
+        "Perf-Dashboard": [""]
+    }
 }

--- a/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webdriver_benchmark_runner.py
@@ -1,4 +1,3 @@
-import collections
 import json
 import logging
 
@@ -13,16 +12,6 @@ class WebDriverBenchmarkRunner(BenchmarkRunner):
     def _get_result(self, driver):
         result = driver.execute_script("return window.webdriver_results")
         return result
-
-    def _construct_subtest_url(self, subtests):
-        print(subtests)
-        if not subtests or not isinstance(subtests, collections.Mapping) or 'subtest_url_format' not in self._plan:
-            return ''
-        subtest_url = ''
-        for suite, tests in subtests.items():
-            for test in tests:
-                subtest_url = subtest_url + '&' + self._plan['subtest_url_format'].replace('${SUITE}', suite).replace('${TEST}', test)
-        return subtest_url
 
     def _run_one_test(self, web_root, test_file, iteration):
         from selenium.webdriver.support.ui import WebDriverWait

--- a/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py
@@ -1,4 +1,3 @@
-import collections
 import json
 import logging
 import os
@@ -26,15 +25,6 @@ class WebServerBenchmarkRunner(BenchmarkRunner):
         result = self._browser_driver.add_additional_results(test_url, self._http_server_driver.fetch_result())
         assert(not self._http_server_driver.get_return_code())
         return result
-
-    def _construct_subtest_url(self, subtests):
-        if not subtests or not isinstance(subtests, collections.abc.Mapping) or 'subtest_url_format' not in self._plan:
-            return ''
-        subtest_url = ''
-        for suite, tests in subtests.items():
-            for test in tests:
-                subtest_url = subtest_url + '&' + self._plan['subtest_url_format'].replace('${SUITE}', suite).replace('${TEST}', test)
-        return subtest_url
 
     def _run_one_test(self, web_root, test_file, iteration):
         enable_profiling = self._profile_output_dir and self._trace_type


### PR DESCRIPTION
#### 3675a599f9239273417cb66f1cf1a4f8596b0897
<pre>
Add SP3 subtest support to run-benchmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=288652">https://bugs.webkit.org/show_bug.cgi?id=288652</a>
<a href="https://rdar.apple.com/145692860">rdar://145692860</a>

Reviewed by Dewei Zhu.

Add SP3 subtests to the SP3 plan file.
Slightly adjust how plan files are used to construct a url.
(SP3 subtests aren&apos;t separated by &apos;&amp;&apos;.)
(In SP3, suites are runnable rather than tests within suites.)
Adjust other benchmark plan files to compensate for this.
Refactor _construct_subtest_url to parent class.

* Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.1.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/jetstream2.2.plan:
* Tools/Scripts/webkitpy/benchmark_runner/data/plans/speedometer3.plan:
* Tools/Scripts/webkitpy/benchmark_runner/webserver_benchmark_runner.py:
(WebServerBenchmarkRunner._construct_subtest_url):

Canonical link: <a href="https://commits.webkit.org/291516@main">https://commits.webkit.org/291516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f382d5a5851627f3f54e5440bd830e1f7981a5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92277 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/11809 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/1368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97284 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/42806 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/94327 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/12116 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/20281 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97284 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/42806 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/95278 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/12116 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/1368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97284 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/91772 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/12116 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/1368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42138 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/12116 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19348 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/20281 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19599 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/1368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19754 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1368 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19330 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22479 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/20762 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->