### PR TITLE
[text-wrap-style:pretty] Bias ideal line width to be closer to max bounds.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentConstrainer.cpp
@@ -45,11 +45,11 @@ static const size_t maximumLinesToBalanceWithLineRequirement { 12 };
 // Define the penalty associated with show text wider/narrower than ideal bounds.
 // Separating stretchability and shrinkability allows us to weight under/over
 // filling the ideal bounds differently.
-static const InlineLayoutUnit textWrapPrettyStretchability = 15;
+static const InlineLayoutUnit textWrapPrettyStretchability = 10;
 static const InlineLayoutUnit textWrapPrettyShrinkability = 15;
 
 // Defines the maximum shrink/stretch factor allowed for text-wrap-pretty.
-static const float textWrapPrettyMaxStretch = 3;
+static const float textWrapPrettyMaxStretch = 2;
 static const float textWrapPrettyMaxShrink = 3;
 
 // We would like 2 or more items on the last line for text-wrap-style:pretty to avoid orphans.


### PR DESCRIPTION
#### e8145c33bd3c235adaf9b594fa5a0315fdeafbe7
<pre>
[text-wrap-style:pretty] Bias ideal line width to be closer to max bounds.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288650">https://bugs.webkit.org/show_bug.cgi?id=288650</a>
&lt;<a href="https://rdar.apple.com/145692143">rdar://145692143</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR biases the ideal line width of text wrap pretty to better fill out target
bounds by reducing the stretchability and max stretch multiplier.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8145c33bd3c235adaf9b594fa5a0315fdeafbe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71604 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28975 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51939 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9859 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2413 "Found 1 new test failure: fast/text/whitespace/text-wrap-balance-shape.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43662 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80127 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2484 "Found 1 new test failure: fast/text/whitespace/text-wrap-balance-shape.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100863 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20873 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15226 "Found 1 new test failure: fast/text/whitespace/text-wrap-balance-shape.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80619 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80730 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79963 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24516 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1877 "Found 1 new test failure: fast/text/whitespace/text-wrap-balance-shape.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14030 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20544 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->