### PR TITLE
[WTF] Create SequesteredImmortalAllocator

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -42,6 +42,7 @@
 #include <wtf/ProcessID.h>
 #include <wtf/RedBlackTree.h>
 #include <wtf/Scope.h>
+#include <wtf/SequesteredMalloc.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/UUID.h>
@@ -472,7 +473,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 class FixedVMPoolExecutableAllocator final {
     // This does not need to be TZONE_ALLOCATED because it's only used as a singleton
     // and is only allocated once long before any scripts are executed.
-    WTF_MAKE_FAST_ALLOCATED(FixedVMPoolExecutableAllocator);
+    WTF_MAKE_SEQUESTERED_IMMORTAL_ALLOCATED(FixedVMPoolExecutableAllocator);
 
 #if ENABLE(JUMP_ISLANDS)
     class Islands;

--- a/Source/WTF/wtf/SequesteredMalloc.cpp
+++ b/Source/WTF/wtf/SequesteredMalloc.cpp
@@ -153,6 +153,16 @@ void sequesteredArenaMallocDumpMallocStats()
 {
 }
 
+void* sequesteredImmortalMalloc(size_t size)
+{
+    return SequesteredImmortalHeap::instance().immortalMalloc(size);
+}
+
+void* sequesteredImmortalAlignedMalloc(size_t alignment, size_t size)
+{
+    return SequesteredImmortalHeap::instance().immortalAlignedMalloc(alignment, size);
+}
+
 }
 
 #endif // USE(PROTECTED_JIT)


### PR DESCRIPTION
#### 603b096bc593c733ff459e2b2415237f6a82626f
<pre>
[WTF] Create SequesteredImmortalAllocator
<a href="https://bugs.webkit.org/show_bug.cgi?id=288659">https://bugs.webkit.org/show_bug.cgi?id=288659</a>
<a href="https://rdar.apple.com/145698858">rdar://145698858</a>

Reviewed by David Degazio.

This &quot;allocator&quot; essentially leaks memory, but ensures that
all memory allocated will come from the sequestered memory region.
This is necessary for singletons and other objects with near-static
lifetime.

This also changes JSC&apos;s FixedVMPoolExecutableAllocator to use
this new allocator, which sequesters (most, but not all) of the
data used by the ExecutibleAllocator.

* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
* Source/WTF/wtf/SequesteredImmortalHeap.cpp:
(WTF::SequesteredImmortalAllocator::addGranule):
* Source/WTF/wtf/SequesteredImmortalHeap.h:
(WTF::SequesteredImmortalAllocator::allocate):
(WTF::SequesteredImmortalAllocator::alignedAllocate):
(WTF::SequesteredImmortalAllocator::headIncrementedBy const):
(WTF::SequesteredImmortalAllocator::headAlignedUpTo const):
(WTF::SequesteredImmortalAllocator::allocateImpl):
(WTF::SequesteredImmortalAllocator::alignedAllocateImpl):
(WTF::SequesteredImmortalAllocator::allocateImplSlowPath):
(WTF::SequesteredImmortalAllocator::alignedAllocateImplSlowPath):
(WTF::SequesteredImmortalHeap::allocateAndInstall):
(WTF::SequesteredImmortalHeap::immortalMalloc):
(WTF::SequesteredImmortalHeap::immortalAlignedMalloc):
(WTF::SequesteredImmortalHeap::computeSlotIndex):
* Source/WTF/wtf/SequesteredMalloc.cpp:
(WTF::sequesteredImmortalMalloc):
(WTF::sequesteredImmortalAlignedMalloc):
* Source/WTF/wtf/SequesteredMalloc.h:

Canonical link: <a href="https://commits.webkit.org/291309@main">https://commits.webkit.org/291309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79bd64ca461fe0628257a78c2a4e0883fbef916e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92633 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1794 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/12457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/20636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95635 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/12457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/12457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/85343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/12457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/91299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/20636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14760 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/113947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/113947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->