### PR TITLE
Add a RefPtr constructor that takes a reference

### DIFF
--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -46,6 +46,7 @@ public:
     ALWAYS_INLINE constexpr RefPtr() : m_ptr(nullptr) { }
     ALWAYS_INLINE constexpr RefPtr(std::nullptr_t) : m_ptr(nullptr) { }
     ALWAYS_INLINE RefPtr(T* ptr) : m_ptr(RefDerefTraits::refIfNotNull(ptr)) { }
+    ALWAYS_INLINE RefPtr(T& object) : m_ptr(&RefDerefTraits::ref(object)) { }
     ALWAYS_INLINE RefPtr(const RefPtr& o) : m_ptr(RefDerefTraits::refIfNotNull(PtrTraits::unwrap(o.m_ptr))) { }
     template<typename X, typename Y, typename Z> RefPtr(const RefPtr<X, Y, Z>& o) : m_ptr(RefDerefTraits::refIfNotNull(PtrTraits::unwrap(o.get()))) { }
 

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -365,7 +365,7 @@ bool DocumentFullscreen::isSimpleFullscreenDocument() const
 static Vector<Ref<Document>> documentsToUnfullscreen(Frame& firstFrame)
 {
     Vector<Ref<Document>> documents;
-    for (RefPtr frame = &firstFrame; frame; frame = frame->tree().parent()) {
+    for (RefPtr frame = firstFrame; frame; frame = frame->tree().parent()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             continue;


### PR DESCRIPTION
#### 16260fa075b0c59dd1b848a809249a63cd23dcbf
<pre>
Add a RefPtr constructor that takes a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=288668">https://bugs.webkit.org/show_bug.cgi?id=288668</a>
<a href="https://rdar.apple.com/145703009">rdar://145703009</a>

Reviewed by NOBODY (OOPS!).

You can make a WeakPtr from a T&amp;, why not a RefPtr?
Usually you want a Ref when you&apos;re doing this, but sometimes,
like in DocumentFullscreen, the type has to be nullable but start
out non-null.  This avoids an unnecessary null check, and it
makes the code more elegant.

* Source/WTF/wtf/RefPtr.h:
(WTF::RefPtr::RefPtr):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::documentsToUnfullscreen):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16260fa075b0c59dd1b848a809249a63cd23dcbf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92251 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11786 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1345 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97266 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42788 "Hash 16260fa0 for PR 41467 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94301 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12094 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20261 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/97266 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/42788 "Hash 16260fa0 for PR 41467 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95252 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/12094 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/1345 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/97266 "Hash 16260fa0 for PR 41467 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/12094 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/1345 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42120 "Hash 16260fa0 for PR 41467 does not build (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/84991 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/12094 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/1345 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99288 "Hash 16260fa0 for PR 41467 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/90942 "Built successfully and passed tests") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19329 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/20261 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/99288 "Hash 16260fa0 for PR 41467 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19581 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/1345 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/99288 "Hash 16260fa0 for PR 41467 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/1345 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12332 "Hash 16260fa0 for PR 41467 does not build (failure)") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19311 "Hash 16260fa0 for PR 41467 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24482 "Failed to build and analyze WebKit") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113568 "Built successfully") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19003 "Hash 16260fa0 for PR 41467 does not build (failure)") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32857 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm.js.no-llint, wasm.yaml/wasm/spec-tests/float_exprs.wast.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.default-wasm ... (failure)") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22460 "Hash 16260fa0 for PR 41467 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20744 "Hash 16260fa0 for PR 41467 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->