### PR TITLE
[iOS] [UnifiedPDF] Maintain zoom scale and scroll position during rotation

### DIFF
--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -353,6 +353,9 @@ double ViewportConfiguration::minimumScale() const
     if (m_forceAlwaysUserScalable)
         minimumScale = std::min(minimumScale, forceAlwaysUserScalableMinimumScale());
 
+    if (m_configuration.minimumScaleDoesNotAdaptToContent)
+        return minimumScale;
+
     auto scaleForFittingContentIsApproximatelyEqualToMinimumScale = [] (double viewLength, double contentLength, double minimumScale) {
         if (contentLength <= 1 || viewLength <= 1)
             return false;
@@ -716,6 +719,7 @@ TextStream& operator<<(TextStream& ts, const ViewportConfiguration::Parameters& 
     ts.dumpProperty("avoidsUnsafeArea", parameters.avoidsUnsafeArea);
     ts.dumpProperty("ignoreInitialScaleForLayoutWidth", parameters.ignoreInitialScaleForLayoutWidth);
     ts.dumpProperty("shouldHonorMinimumEffectiveDeviceWidthFromClient", parameters.shouldHonorMinimumEffectiveDeviceWidthFromClient);
+    ts.dumpProperty("minimumScaleDoesNotAdaptToContent", parameters.minimumScaleDoesNotAdaptToContent);
 
     return ts;
 }

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -62,6 +62,7 @@ public:
         bool ignoreInitialScaleForLayoutWidth { false };
 
         bool shouldHonorMinimumEffectiveDeviceWidthFromClient { true };
+        bool minimumScaleDoesNotAdaptToContent { false };
 
         friend bool operator==(const Parameters&, const Parameters&) = default;
     };

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4289,7 +4289,7 @@ static bool isLockdownModeWarningNeeded()
     WebCore::FloatRect oldUnobscuredContentRect = _page->unobscuredContentRect();
 
     auto isOldBoundsValid = !CGRectIsEmpty(oldBounds) || !CGRectIsEmpty(_perProcessState.animatedResizeOldBounds);
-    if (![self usesStandardContentView] || !_perProcessState.hasCommittedLoadForMainFrame || !isOldBoundsValid || oldUnobscuredContentRect.isEmpty() || _perProcessState.liveResizeParameters) {
+    if (![self usesStandardContentView] || !_perProcessState.hasCommittedLoadForMainFrame || !isOldBoundsValid || oldUnobscuredContentRect.isEmpty() || _perProcessState.liveResizeParameters || [self _isDisplayingPDF]) {
         if ([_customContentView respondsToSelector:@selector(web_beginAnimatedResizeWithUpdates:)])
             [_customContentView web_beginAnimatedResizeWithUpdates:updateBlock];
         else

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -253,6 +253,7 @@ public:
     virtual void willAttachScrollingNode() { }
     virtual void didAttachScrollingNode() { }
     virtual void didChangeSettings() { }
+    virtual void finalizeRenderingUpdate() { }
 
     // HUD Actions.
 #if ENABLE(PDF_HUD)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -94,11 +94,6 @@ public:
     virtual std::optional<PDFLayoutRow> visibleRow() const { return { }; }
     virtual std::optional<PDFLayoutRow> rowForLayer(const WebCore::GraphicsLayer*) const { return { }; }
 
-    struct VisiblePDFPosition {
-        PDFDocumentLayout::PageIndex pageIndex { 0 };
-        WebCore::FloatPoint pagePoint;
-    };
-
     enum class AnchorPoint : uint8_t { TopLeft, Center };
     std::optional<VisiblePDFPosition> pdfPositionForCurrentView(AnchorPoint, bool preservePosition = true) const;
     WebCore::FloatPoint anchorPointInDocumentSpace(AnchorPoint) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -51,6 +51,7 @@ class TextStream;
 
 namespace WebCore {
 class FrameView;
+class LocalFrameView;
 class PageOverlay;
 class PlatformWheelEvent;
 class ShadowRoot;
@@ -103,6 +104,11 @@ private:
     bool m_isBeingHovered { false };
 };
 
+struct VisiblePDFPosition {
+    PDFDocumentLayout::PageIndex pageIndex { 0 };
+    WebCore::FloatPoint pagePoint;
+};
+
 enum class AnnotationSearchDirection : bool {
     Forward,
     Backward
@@ -133,6 +139,7 @@ public:
     };
     using PDFElementTypes = OptionSet<PDFElementType>;
 
+    WebCore::LocalFrameView* frameView() const;
     WebCore::FrameView* mainFrameView() const;
 
     CGRect pluginBoundsForAnnotation(RetainPtr<PDFAnnotation>&) const final;
@@ -222,6 +229,8 @@ public:
     bool shouldSizeToFitContent() const final;
 
     static WebCore::ViewportConfiguration::Parameters viewportParameters();
+
+    void finalizeRenderingUpdate() final;
 
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
@@ -697,6 +706,9 @@ private:
 #endif
 
     RefPtr<WebCore::ShadowRoot> m_shadowRoot;
+
+    std::optional<VisiblePDFPosition> m_pendingAnchoringInfo;
+    bool m_willSetPendingAnchoringInfo { false };
 
     // FIXME: We should rationalize these with the values in ViewGestureController.
     // For now, we'll leave them differing as they do in PDFPlugin.

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1225,6 +1225,14 @@ bool PluginView::pluginHandlesPageScaleFactor() const
     return protectedPlugin()->handlesPageScaleFactor();
 }
 
+void PluginView::finalizeRenderingUpdate()
+{
+    if (!m_isInitialized)
+        return;
+
+    return protectedPlugin()->finalizeRenderingUpdate();
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -164,6 +164,7 @@ public:
     WebCore::FloatRect absoluteBoundingRectForSmartMagnificationAtPoint(WebCore::FloatPoint) const;
 
     void frameViewLayoutOrVisualViewportChanged(const WebCore::IntRect& unobscuredContentRect);
+    void finalizeRenderingUpdate();
 
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5115,6 +5115,11 @@ void WebPage::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> fl
     WTFBeginSignpost(this, FinalizeRenderingUpdate);
 #endif
 
+#if ENABLE(PDF_PLUGIN)
+    if (RefPtr pluginView = mainFramePlugIn())
+        pluginView->finalizeRenderingUpdate();
+#endif
+
     protectedCorePage()->finalizeRenderingUpdate(flags);
 #if ENABLE(GPU_PROCESS)
     if (RefPtr proxy = m_remoteRenderingBackendProxy)


### PR DESCRIPTION
#### de23e754c4523e1b036bb1dda5529874ecf12d8f
<pre>
[iOS] [UnifiedPDF] Maintain zoom scale and scroll position during rotation
<a href="https://bugs.webkit.org/show_bug.cgi?id=288676">https://bugs.webkit.org/show_bug.cgi?id=288676</a>
<a href="https://rdar.apple.com/143047345">rdar://143047345</a>

Reviewed by Tim Horton and Abrar Rahman Protyasha.

Add support for keeping the zoom scale and scroll position stable, before and after device rotation
on iOS when viewing unified PDF. See below for more details. API test to come, once the dynamic
viewport size update codepath is reenabled below.

* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::ViewportConfiguration::minimumScale const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/ViewportConfiguration.h:

Add a new viewport configuration flag to ignore the content dimensions, for the purposes of
determining the minimum scale; in unified PDF, this should always be fixed at 1, since the plugin
element itself expands to exactly fit the width of the viewport.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _beginAnimatedResizeWithUpdates:]):

Disable dynamic viewport size updates in unified PDF for the time being; the web-process-side logic
doesn&apos;t work well with this mechanism yet, and results in both the scroll position being lost, and
extra space to the left/right of the plugin element.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::finalizeRenderingUpdate):

Add a hook to call into `UnifiedPDFPlugin` when finalizing a rendering update.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
(): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::pdfPositionForCurrentView const):

Teach this to handle the `shouldSizeToFitContent` case by using the unobscured content rect instead
of the bounds of the plugin element.

(WebKit::PDFPresentationController::anchorPointInDocumentSpace const):

Similarly, teach this to handle the `shouldSizeToFitContent` case, by returning an anchor point
based on the unobscured rect, rather than the plugin element rect (which expands to fill the entire
root view on iOS).

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::frameView const):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):

Force the viewport scale to auto-update on iOS.

(WebKit::UnifiedPDFPlugin::updateLayout):

Anchor to the center instead of the top left corner, which roughly matches the behavior of dynamic
viewport size updates for regular web content.

(WebKit::UnifiedPDFPlugin::finalizeRenderingUpdate):

Batch &quot;restore anchoring information&quot; requests until the next rendering update. See the `FIXME` in
`updateLayout` for more details.

* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::finalizeRenderingUpdate):
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::finalizeRenderingUpdate):

Canonical link: <a href="https://commits.webkit.org/291223@main">https://commits.webkit.org/291223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4029c2ee919cdf6c6729093e54174c66e47b96f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11871 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97324 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20336 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70781 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28231 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51096 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1228 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42178 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99348 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23583 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12390 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19374 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24550 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20802 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->