### PR TITLE
Add functionality to skip ads in PIP on macOS

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -313,6 +313,12 @@ void MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
     promise.resolve();
 }
 
+bool MediaSession::hasActionHandler(const MediaSessionAction action) const
+{
+    Locker lock { m_actionHandlersLock };
+    return m_actionHandlers.contains(action);
+}
+
 bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDetails, TriggerGestureIndicator triggerGestureIndicator)
 {
     RefPtr<MediaSessionActionHandler> handler;

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -133,7 +133,7 @@ public:
 #endif
 
     bool hasObserver(MediaSessionObserver&) const;
-    void addObserver(MediaSessionObserver&);
+    WEBCORE_EXPORT void addObserver(MediaSessionObserver&);
     void removeObserver(MediaSessionObserver&);
 
     RefPtr<HTMLMediaElement> activeMediaElement() const;
@@ -145,6 +145,8 @@ public:
     void setCameraActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Camera); }
     void setScreenshareActive(bool isActive, DOMPromiseDeferred<void>&& promise) { updateCaptureState(isActive, WTFMove(promise), MediaProducerMediaCaptureKind::Display); }
 #endif
+
+    WEBCORE_EXPORT bool hasActionHandler(const MediaSessionAction) const;
 
 private:
     explicit MediaSession(Navigator&);

--- a/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
+++ b/Source/WebCore/Modules/mediasession/NavigatorMediaSession.h
@@ -44,7 +44,7 @@ public:
     ~NavigatorMediaSession();
 
     WEBCORE_EXPORT static MediaSession& mediaSession(Navigator&);
-    static RefPtr<MediaSession> mediaSessionIfExists(Navigator&);
+    WEBCORE_EXPORT static RefPtr<MediaSession> mediaSessionIfExists(Navigator&);
     MediaSession& mediaSession();
     RefPtr<MediaSession> mediaSessionIfExists();
 

--- a/Source/WebCore/PAL/pal/spi/mac/PIPSPI.h
+++ b/Source/WebCore/PAL/pal/spi/mac/PIPSPI.h
@@ -27,6 +27,10 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <PIP/PIPViewControllerPrivate.h>
+#if HAVE(PIP_SKIP_PREROLL)
+#import <PIP/PIPPlaybackState.h>
+#import <PIP/PIPPrerollAttributes.h>
+#endif
 #else
 
 NS_ASSUME_NONNULL_BEGIN
@@ -41,9 +45,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic) bool playing;
 @property (nonatomic) bool userCanResize;
 @property (nonatomic) NSSize aspectRatio;
+#if HAVE(PIP_SKIP_PREROLL)
+@property (nonatomic, readonly) PIPPlaybackState *playbackState;
+#endif
 
 - (void)presentViewControllerAsPictureInPicture:(NSViewController *)viewController;
-
+#if HAVE(PIP_SKIP_PREROLL)
+- (void)updatePlaybackStateUsingBlock:(void (NS_NOESCAPE ^)(PIPMutablePlaybackState *))updateBlock;
+#endif
 @end
 
 @protocol PIPViewControllerDelegate <NSObject>
@@ -54,8 +63,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)pipActionPlay:(PIPViewController *)pip;
 - (void)pipActionPause:(PIPViewController *)pip;
 - (void)pipActionStop:(PIPViewController *)pip;
+- (void)pipActionSkipPreroll:(PIPViewController *)pip;
 @end
 
+#if HAVE(PIP_SKIP_PREROLL)
+@interface PIPPrerollAttributes: NSObject <NSCopying, NSSecureCoding>
+
++ (instancetype)prerollAttributesForAdContentWithRequiredLinearPlaybackEndTime:(NSTimeInterval)requiredLinearPlaybackEndTime preferredTintColor:(NSColor *)preferredTintColor;
+
+@end
+#endif
 NS_ASSUME_NONNULL_END
 
 #endif

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -137,7 +137,7 @@ public:
     BarProp& statusbar();
     BarProp& toolbar();
     WEBCORE_EXPORT Navigator& navigator();
-    Ref<Navigator> protectedNavigator();
+    WEBCORE_EXPORT Ref<Navigator> protectedNavigator();
     Navigator* optionalNavigator() const { return m_navigator.get(); }
 
     WEBCORE_EXPORT static void overrideTransientActivationDurationForTesting(std::optional<Seconds>&&);

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -78,6 +78,9 @@ public:
     virtual void togglePlayState() = 0;
     virtual void beginScrubbing() = 0;
     virtual void endScrubbing() = 0;
+#if HAVE(PIP_SKIP_PREROLL)
+    virtual void skipAd() { }
+#endif
     virtual void seekToTime(double time, double toleranceBefore = 0, double toleranceAfter = 0) = 0;
     virtual void fastSeek(double time) = 0;
     virtual void beginScanningForward() = 0;
@@ -175,6 +178,9 @@ public:
     virtual void externalPlaybackChanged(bool /* enabled */, PlaybackSessionModel::ExternalPlaybackTargetType, const String& /* localizedDeviceName */) { }
     virtual void wirelessVideoPlaybackDisabledChanged(bool) { }
     virtual void mutedChanged(bool) { }
+#if HAVE(PIP_SKIP_PREROLL)
+    virtual void canSkipAdChanged(bool) { }
+#endif
     virtual void volumeChanged(double) { }
     virtual void isPictureInPictureSupportedChanged(bool) { }
     virtual void pictureInPictureActiveChanged(bool) { }

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -79,6 +79,9 @@ public:
     void willBeginScrubbing();
     void beginScrubbing();
     void endScrubbing();
+#if HAVE(PIP_SKIP_PREROLL)
+    void skipAd();
+#endif
 
     void swapFullscreenModesWith(PlaybackSessionInterfaceMac&) { }
 

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -147,7 +147,13 @@ void PlaybackSessionInterfaceMac::endScrubbing()
     if (auto* model = playbackSessionModel())
         model->endScrubbing();
 }
-
+#if HAVE(PIP_SKIP_PREROLL)
+void PlaybackSessionInterfaceMac::skipAd()
+{
+    if (auto* model = playbackSessionModel())
+        model->skipAd();
+}
+#endif
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 static RetainPtr<NSMutableArray> timeRangesToArray(const TimeRanges& timeRanges)
 {

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -108,9 +108,11 @@ public:
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
 
     WEBCORE_EXPORT void documentVisibilityChanged(bool) final;
-
     void swapFullscreenModesWith(VideoPresentationInterfaceMac&) { }
-
+#if HAVE(PIP_SKIP_PREROLL)
+    WEBCORE_EXPORT void canSkipAdChanged(bool) override;
+    void skipAd();
+#endif
 #if !RELEASE_LOG_DISABLED
     uint64_t logIdentifier() const;
     const Logger* loggerPtr() const;

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -50,6 +50,7 @@ SOFT_LINK_CLASS_OPTIONAL(AVKit, AVValueTiming)
 
 SOFT_LINK_PRIVATE_FRAMEWORK_OPTIONAL(PIP)
 SOFT_LINK_CLASS_OPTIONAL(PIP, PIPViewController)
+SOFT_LINK_CLASS_OPTIONAL(PIP, PIPPrerollAttributes)
 
 @class WebVideoViewContainer;
 
@@ -116,8 +117,11 @@ enum class PIPState {
 // Tracking video playback state
 @property (nonatomic) NSSize videoDimensions;
 @property (nonatomic, getter=isPlaying) BOOL playing;
+#if HAVE(PIP_SKIP_PREROLL)
+@property (nonatomic) BOOL canSkipAd;
+- (void)updateCanSkipAd:(BOOL)canSkipAd;
+#endif
 - (void)updateIsPlaying:(BOOL)isPlaying newPlaybackRate:(float)playbackRate;
-
 // Handling PIP transitions
 @property (nonatomic, getter=isExitingToStandardFullscreen) BOOL exitingToStandardFullscreen;
 
@@ -183,7 +187,27 @@ enum class PIPState {
     [_playerLayer setVideoDimensions:_videoDimensions];
     [_pipViewController setAspectRatio:_videoDimensions];
 }
+#if HAVE(PIP_SKIP_PREROLL)
+- (void)updateCanSkipAd:(BOOL)canSkipAd
+{
+    if (canSkipAd == _canSkipAd)
+        return;
+    _canSkipAd = canSkipAd;
+    [self updatePrerollAttributes];
+}
+- (void)updatePrerollAttributes
+{
+    if (!_pipViewController)
+        return;
 
+    [_pipViewController updatePlaybackStateUsingBlock:^(PIPMutablePlaybackState *playbackState) {
+        if (!_canSkipAd)
+            playbackState.prerollAttributes = nil;
+        else
+            playbackState.prerollAttributes = [getPIPPrerollAttributesClass() prerollAttributesForAdContentWithRequiredLinearPlaybackEndTime:0 preferredTintColor:nil];
+    }];
+}
+#endif
 - (void)setUpPIPForVideoView:(NSView *)videoView withFrame:(NSRect)frame inWindow:(NSWindow *)window
 {
     ASSERT(!_pipViewController);
@@ -232,6 +256,9 @@ enum class PIPState {
     [_videoViewContainerController view].layer.backgroundColor = CGColorGetConstantColor(kCGColorBlack);
     [_pipViewController presentViewControllerAsPictureInPicture:_videoViewContainerController.get()];
     _pipState = PIPState::EnteringPIP;
+#if HAVE(PIP_SKIP_PREROLL)
+    [self updatePrerollAttributes];
+#endif
 }
 
 - (void)exitPIP
@@ -314,7 +341,18 @@ enum class PIPState {
 
     return NO;
 }
+#if HAVE(PIP_SKIP_PREROLL)
+- (void)pipActionSkipPreroll:(PIPViewController *)pip
+{
+    ASSERT_UNUSED(pip, pip == _pipViewController);
 
+    if (!_videoPresentationInterfaceMac)
+        return;
+
+    _videoPresentationInterfaceMac->skipAd();
+    [self updateCanSkipAd:NO];
+}
+#endif
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (void)pipDidClose:(PIPViewController *)pip
 {
@@ -433,7 +471,12 @@ void VideoPresentationInterfaceMac::setMode(HTMLMediaElementEnums::VideoFullscre
     if (model)
         model->fullscreenModeChanged(m_mode);
 }
-
+#if HAVE(PIP_SKIP_PREROLL)
+void VideoPresentationInterfaceMac::skipAd()
+{
+    m_playbackSessionInterface->skipAd();
+}
+#endif
 void VideoPresentationInterfaceMac::clearMode(HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     HTMLMediaElementEnums::VideoFullscreenMode newMode = m_mode & ~mode;
@@ -462,7 +505,12 @@ void VideoPresentationInterfaceMac::ensureControlsManager()
 {
     m_playbackSessionInterface->ensureControlsManager();
 }
-
+#if HAVE(PIP_SKIP_PREROLL)
+void VideoPresentationInterfaceMac::canSkipAdChanged(bool canSkipAd)
+{
+    [videoPresentationInterfaceObjC() updateCanSkipAd:canSkipAd];
+}
+#endif
 WebVideoPresentationInterfaceMacObjC *VideoPresentationInterfaceMac::videoPresentationInterfaceObjC()
 {
     if (!m_webVideoPresentationInterfaceObjC)

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -95,6 +95,9 @@ public:
     void pictureInPictureSupportedChanged(bool);
     void pictureInPictureActiveChanged(bool);
     void isInWindowFullscreenActiveChanged(bool);
+#if HAVE(PIP_SKIP_PREROLL)
+    void canSkipAdChnged(bool);
+#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(bool);
     void spatialVideoMetadataChanged(const std::optional<WebCore::SpatialVideoMetadata>&);
@@ -118,6 +121,10 @@ private:
     void togglePlayState() final;
     void beginScrubbing() final;
     void endScrubbing() final;
+#if HAVE(PIP_SKIP_PREROLL)
+    void skipAd() final;
+    void canSkipAdChanged(bool);
+#endif
     void seekToTime(double, double, double) final;
     void fastSeek(double time) final;
     void beginScanningForward() final;
@@ -298,6 +305,9 @@ private:
     void volumeChanged(PlaybackSessionContextIdentifier, double volume);
     void pictureInPictureSupportedChanged(PlaybackSessionContextIdentifier, bool pictureInPictureSupported);
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool isInWindow);
+#if HAVE(PIP_SKIP_PREROLL)
+    void canSkipAdChanged(PlaybackSessionContextIdentifier, bool value);
+#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     void supportsLinearMediaPlayerChanged(PlaybackSessionContextIdentifier, bool);
     void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
@@ -305,6 +315,9 @@ private:
 #endif
 
     // Messages to PlaybackSessionManager
+#if HAVE(PIP_SKIP_PREROLL)
+    void skipAd(PlaybackSessionContextIdentifier);
+#endif
     void play(PlaybackSessionContextIdentifier);
     void pause(PlaybackSessionContextIdentifier);
     void togglePlayState(PlaybackSessionContextIdentifier);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -44,6 +44,9 @@ messages -> PlaybackSessionManagerProxy {
     VolumeChanged(WebKit::PlaybackSessionContextIdentifier contextId, double volume);
     PictureInPictureSupportedChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool pictureInPictureSupported)
     IsInWindowFullscreenActiveChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool isInWindow)
+#if HAVE(PIP_SKIP_PREROLL)
+    CanSkipAdChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool value)
+#endif
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     SupportsLinearMediaPlayerChanged(WebKit::PlaybackSessionContextIdentifier contextId, bool supportsLinearMediaPlayer)
     SpatialVideoMetadataChanged(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::SpatialVideoMetadata> metadata);

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -43,6 +43,9 @@
 #import <WebCore/PlaybackSessionInterfaceAVKitLegacy.h>
 #import <WebCore/PlaybackSessionInterfaceMac.h>
 #import <WebCore/PlaybackSessionInterfaceTVOS.h>
+#if HAVE(PIP_SKIP_PREROLL)
+#import <WebCore/VideoPresentationInterfaceMac.h>
+#endif
 #import <wtf/LoggerHelper.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -172,6 +175,15 @@ void PlaybackSessionModelContext::endScrubbing()
     m_isScrubbing = false;
     m_playbackStartedTimeNeedsUpdate = isPlaying();
 }
+
+#if HAVE(PIP_SKIP_PREROLL)
+void PlaybackSessionModelContext::skipAd()
+{
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
+    if (RefPtr manager = m_manager.get())
+        manager->skipAd(m_contextId);
+}
+#endif
 
 void PlaybackSessionModelContext::seekToTime(double time, double toleranceBefore, double toleranceAfter)
 {
@@ -464,6 +476,14 @@ void PlaybackSessionModelContext::isInWindowFullscreenActiveChanged(bool active)
     for (CheckedRef client : m_clients)
         client->isInWindowFullscreenActiveChanged(active);
 }
+
+#if HAVE(PIP_SKIP_PREROLL)
+void PlaybackSessionModelContext::canSkipAdChanged(bool value)
+{
+    for (CheckedRef client : m_clients)
+        client->canSkipAdChanged(value);
+}
+#endif
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 void PlaybackSessionModelContext::supportsLinearMediaPlayerChanged(bool supportsLinearMediaPlayer)
@@ -794,6 +814,25 @@ void PlaybackSessionManagerProxy::isInWindowFullscreenActiveChanged(PlaybackSess
     ensureModel(contextId)->isInWindowFullscreenActiveChanged(active);
 }
 
+#if HAVE(PIP_SKIP_PREROLL)
+void PlaybackSessionManagerProxy::canSkipAdChanged(PlaybackSessionContextIdentifier contextId, bool value)
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    RefPtr videoPresentationManager = page->videoPresentationManager();
+    if (!videoPresentationManager)
+        return;
+
+    RefPtr interface = videoPresentationManager->controlsManagerInterface();
+    if (!interface)
+        return;
+
+    interface->canSkipAdChanged(value);
+}
+#endif
+
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 void PlaybackSessionManagerProxy::supportsLinearMediaPlayerChanged(PlaybackSessionContextIdentifier contextId, bool supportsLinearMediaPlayer)
 {
@@ -969,6 +1008,14 @@ void PlaybackSessionManagerProxy::setPlayingOnSecondScreen(PlaybackSessionContex
     if (RefPtr page = m_page.get())
         page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SetPlayingOnSecondScreen(contextId, value), page->webPageIDInMainFrameProcess());
 }
+
+#if HAVE(PIP_SKIP_PREROLL)
+void PlaybackSessionManagerProxy::skipAd(PlaybackSessionContextIdentifier contextId)
+{
+    if (RefPtr page = m_page.get())
+        page->protectedLegacyMainFrameProcess()->send(Messages::PlaybackSessionManager::SkipAd(contextId), page->webPageIDInMainFrameProcess());
+}
+#endif
 
 void PlaybackSessionManagerProxy::sendRemoteCommand(PlaybackSessionContextIdentifier contextId, WebCore::PlatformMediaSession::RemoteControlCommandType command, const WebCore::PlatformMediaSession::RemoteCommandArgument& argument)
 {

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -31,6 +31,9 @@
 #include "PlaybackSessionContextIdentifier.h"
 #include <WebCore/EventListener.h>
 #include <WebCore/HTMLMediaElementEnums.h>
+#if HAVE(PIP_SKIP_PREROLL)
+#include <WebCore/MediaSession.h>
+#endif
 #include <WebCore/PlatformCALayer.h>
 #include <WebCore/PlatformMediaSession.h>
 #include <WebCore/PlaybackSessionModelMediaElement.h>
@@ -111,7 +114,14 @@ private:
     PlaybackSessionContextIdentifier m_contextId;
 };
 
-class PlaybackSessionManager : public RefCounted<PlaybackSessionManager>, private IPC::MessageReceiver, public CanMakeCheckedPtr<PlaybackSessionManager> {
+class PlaybackSessionManager
+    : public RefCounted<PlaybackSessionManager>
+    , private IPC::MessageReceiver
+    , public CanMakeCheckedPtr<PlaybackSessionManager>
+#if HAVE(PIP_SKIP_PREROLL)
+    , public WebCore::MediaSessionObserver
+#endif
+    {
     WTF_MAKE_FAST_ALLOCATED;
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlaybackSessionManager);
 public:
@@ -133,6 +143,10 @@ public:
     WebCore::HTMLMediaElement* mediaElementWithContextId(PlaybackSessionContextIdentifier) const;
     WebCore::HTMLMediaElement* currentPlaybackControlsElement() const;
 
+#if HAVE(PIP_SKIP_PREROLL)
+    void actionHandlersChanged() final;
+#endif
+
 #if !RELEASE_LOG_DISABLED
     void sendLogIdentifierForMediaElement(WebCore::HTMLMediaElement&);
 #endif
@@ -151,6 +165,9 @@ private:
     void removeContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
+#if HAVE(PIP_SKIP_PREROLL)
+    void setMediaSessionAndRegisterAsObserver();
+#endif
 
     // Interface to PlaybackSessionInterfaceContext
     void durationChanged(PlaybackSessionContextIdentifier, double);
@@ -172,6 +189,9 @@ private:
     void isInWindowFullscreenActiveChanged(PlaybackSessionContextIdentifier, bool);
     void spatialVideoMetadataChanged(PlaybackSessionContextIdentifier, const std::optional<WebCore::SpatialVideoMetadata>&);
     void isImmersiveVideoChanged(PlaybackSessionContextIdentifier, bool);
+#if HAVE(PIP_SKIP_PREROLL)
+    void canSkipAdChanged(PlaybackSessionContextIdentifier, bool);
+#endif
 
     // Messages from PlaybackSessionManagerProxy
     void play(PlaybackSessionContextIdentifier);
@@ -201,6 +221,9 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool value);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
     void setSoundStageSize(PlaybackSessionContextIdentifier, WebCore::AudioSessionSoundStageSize);
+#if HAVE(PIP_SKIP_PREROLL)
+    void skipAd(PlaybackSessionContextIdentifier);
+#endif
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setSpatialTrackingLabel(PlaybackSessionContextIdentifier, const String&);
@@ -220,6 +243,10 @@ private:
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     Markable<PlaybackSessionContextIdentifier> m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;
+#if HAVE(PIP_SKIP_PREROLL)
+    WeakPtr<WebCore::MediaSession> m_mediaSession;
+    bool m_canSkipAd { false };
+#endif
 
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in
@@ -32,6 +32,9 @@ messages -> PlaybackSessionManager {
     TogglePlayState(WebKit::PlaybackSessionContextIdentifier contextId)
     BeginScrubbing(WebKit::PlaybackSessionContextIdentifier contextId)
     EndScrubbing(WebKit::PlaybackSessionContextIdentifier contextId)
+#if HAVE(PIP_SKIP_PREROLL)
+    SkipAd(WebKit::PlaybackSessionContextIdentifier contextId)
+#endif
     SeekToTime(WebKit::PlaybackSessionContextIdentifier contextId, double time, double toleranceBefore, double toleranceAfter)
     FastSeek(WebKit::PlaybackSessionContextIdentifier contextId, double time)
     BeginScanningForward(WebKit::PlaybackSessionContextIdentifier contextId)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm
@@ -41,6 +41,8 @@
 #import <WebCore/Event.h>
 #import <WebCore/EventNames.h>
 #import <WebCore/HTMLMediaElement.h>
+#import <WebCore/Navigator.h>
+#import <WebCore/NavigatorMediaSession.h>
 #import <WebCore/Quirks.h>
 #import <WebCore/Settings.h>
 #import <WebCore/TimeRanges.h>
@@ -318,6 +320,9 @@ void PlaybackSessionManager::setUpPlaybackControlsManager(WebCore::HTMLMediaElem
 
     m_page->videoControlsManagerDidChange();
     m_page->send(Messages::PlaybackSessionManagerProxy::SetUpPlaybackControlsManagerWithID(*m_controlsManagerContextId, mediaElement.isVideo()));
+#if HAVE(PIP_SKIP_PREROLL)
+    setMediaSessionAndRegisterAsObserver();
+#endif
 }
 
 void PlaybackSessionManager::clearPlaybackControlsManager()
@@ -576,6 +581,57 @@ void PlaybackSessionManager::selectLegibleMediaOption(PlaybackSessionContextIden
     // artificially trigger it here:
     legibleMediaSelectionIndexChanged(contextId, model->legibleMediaSelectedIndex());
 }
+
+#if HAVE(PIP_SKIP_PREROLL)
+void PlaybackSessionManager::setMediaSessionAndRegisterAsObserver()
+{
+    if (!m_controlsManagerContextId) {
+        m_mediaSession = nullptr;
+        return;
+    }
+
+    RefPtr mediaElement = ensureModel(*m_controlsManagerContextId)->mediaElement();
+    if (!mediaElement) {
+        m_mediaSession = nullptr;
+        return;
+    }
+
+    RefPtr window = mediaElement->document().domWindow();
+    if (!window) {
+        m_mediaSession = nullptr;
+        return;
+    }
+
+    auto mediaSession = NavigatorMediaSession::mediaSessionIfExists(window->protectedNavigator().get());
+    if (!mediaSession) {
+        m_mediaSession = nullptr;
+        return;
+    }
+
+    if (mediaSession.get() != m_mediaSession.get()) {
+        m_mediaSession = mediaSession;
+        m_mediaSession->addObserver(*this);
+        actionHandlersChanged();
+    }
+}
+
+void PlaybackSessionManager::actionHandlersChanged()
+{
+    if (!m_mediaSession)
+        return;
+
+    bool canSkipAd = m_mediaSession->hasActionHandler(MediaSessionAction::Skipad);
+    m_page->send(Messages::PlaybackSessionManagerProxy::CanSkipAdChanged(*m_controlsManagerContextId, canSkipAd));
+}
+
+void PlaybackSessionManager::skipAd(PlaybackSessionContextIdentifier contextId)
+{
+    if (!m_mediaSession)
+        return;
+
+    m_mediaSession->callActionHandler({ .action = MediaSessionAction::Skipad });
+}
+#endif
 
 void PlaybackSessionManager::handleControlledElementIDRequest(PlaybackSessionContextIdentifier contextId)
 {


### PR DESCRIPTION
#### 0be02770de86ec49feaeca8c6a0acff9e86a7eba
<pre>
Add functionality to skip ads in PIP on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=288137">https://bugs.webkit.org/show_bug.cgi?id=288137</a>
<a href="https://rdar.apple.com/145305285">rdar://145305285</a>

Reviewed by Jer Noble.

This patch hooks up the media session skipAd action handler to
PiP. If the skipAd action handler has been implemented by the
website, we tell the pip framework that the video is skippable,
and if the user presses pip&apos;s &apos;skip&apos; button, the action handler
is called.

* Source/WTF/wtf/PlatformHave.h:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::hasActionHandler const):
* Source/WebCore/Modules/mediasession/MediaSession.h:
* Source/WebCore/Modules/mediasession/NavigatorMediaSession.h:
* Source/WebCore/PAL/pal/spi/mac/PIPSPI.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/platform/cocoa/PlaybackSessionModel.h:
(WebCore::PlaybackSessionModel::skipAd):
(WebCore::PlaybackSessionModelClient::canSkipAdChanged):
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h:
* Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm:
(WebCore::PlaybackSessionInterfaceMac::skipAd):
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(-[WebVideoPresentationInterfaceMacObjC updateCanSkipAd:]):
(-[WebVideoPresentationInterfaceMacObjC pipActionSkipPreroll:]):
(WebCore::VideoPresentationInterfaceMac::skipAd):
(WebCore::VideoPresentationInterfaceMac::canSkipAdChanged):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::skipAd):
(WebKit::PlaybackSessionModelContext::canSkipAdChanged):
(WebKit::PlaybackSessionManagerProxy::canSkipAdChanged):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.messages.in:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::setUpPlaybackControlsManager):
(WebKit::PlaybackSessionManager::setMediaSessionAndRegisterAsObserver):
(WebKit::PlaybackSessionManager::actionHandlersChanged):
(WebKit::PlaybackSessionManager::skipAd):

Canonical link: <a href="https://commits.webkit.org/291236@main">https://commits.webkit.org/291236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6d1f99150b741a52a937d3fe73fc253f54c864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94331 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20285 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70741 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/constraints/infinite_backtracking.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28206 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51071 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8923 "Found 30 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-fixed-ancestor.html imported/w3c/web-platform-tests/fetch/metadata/generated/element-frame.sub.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/mediacapture-record/MediaRecorder-events-and-exceptions.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-dom.html imported/w3c/web-platform-tests/webaudio/the-audio-api/the-analysernode-interface/test-analyser-minimum.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1176 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99309 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79017 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23557 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12352 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14700 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19333 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24503 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->