### PR TITLE
Fix ARMv7 build warnings

### DIFF
--- a/Source/JavaScriptCore/b3/B3Common.cpp
+++ b/Source/JavaScriptCore/b3/B3Common.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(B3_JIT)
 
+#include "B3Procedure.h"
 #include "DFGCommon.h"
 #include "FTLState.h"
 #include "Options.h"
@@ -87,4 +88,3 @@ GPRReg extendedOffsetAddrRegister()
 } } // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)
-

--- a/Source/JavaScriptCore/b3/B3LowerInt64.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerInt64.cpp
@@ -29,18 +29,27 @@
 #if USE(JSVALUE32_64) && ENABLE(B3_JIT)
 #include "AirCCallingConvention.h"
 #include "B3BasicBlock.h"
+#include "B3BasicBlockInlines.h"
 #include "B3BlockInsertionSet.h"
 #include "B3Const32Value.h"
 #include "B3ConstPtrValue.h"
 #include "B3ExtractValue.h"
 #include "B3InsertionSet.h"
 #include "B3InsertionSetInlines.h"
+#include "B3AtomicValue.h"
+#include "B3CCallValue.h"
+#include "B3CheckValue.h"
 #include "B3MemoryValue.h"
+#include "B3MemoryValueInlines.h"
+#include "B3PatchpointValue.h"
 #include "B3PhaseScope.h"
 #include "B3Procedure.h"
 #include "B3StackmapGenerationParams.h"
+#include "B3UpsilonValue.h"
 #include "B3Value.h"
+#include "B3ValueInlines.h"
 #include "B3Variable.h"
+#include "B3VariableValue.h"
 #include <wtf/CheckedArithmetic.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
+++ b/Source/JavaScriptCore/disassembler/CapstoneDisassembler.cpp
@@ -29,6 +29,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 #if ENABLE(DISASSEMBLER) && USE(CAPSTONE)
 
+#include "AssemblyComments.h"
 #include "MacroAssemblerCodeRef.h"
 #include "Options.h"
 #include <capstone/capstone.h>

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -138,7 +138,7 @@ public:
         return m_size.load(order);
     }
 
-    std::span<uint8_t> mutableSpan(std::memory_order order = std::memory_order_seq_cst) { return { static_cast<uint8_t*>(memory()), size(order) }; }
+    std::span<uint8_t> mutableSpan(std::memory_order order = std::memory_order_seq_cst) { return unsafeMakeSpan(static_cast<uint8_t*>(memory()), size(order)); }
 
     size_t mappedCapacity() const { return m_mappedCapacity; }
     PageCount initial() const { return m_initial; }

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -628,7 +628,7 @@ inline JSString* jsSubstringOfResolved(VM& vm, GCDeferralContext* deferralContex
                 return JSString::create(vm, deferralContext, impl.releaseNonNull());
             };
             LChar buf[] = { static_cast<LChar>(first), static_cast<LChar>(second) };
-            WTF::HashTranslatorCharBuffer<LChar> buffer { std::span { buf, length } };
+            WTF::HashTranslatorCharBuffer<LChar> buffer { unsafeMakeSpan(buf, length) };
             return vm.keyAtomStringCache.make(vm, buffer, createFromSubstring);
         }
     }

--- a/Source/WTF/wtf/glib/WTFGType.h
+++ b/Source/WTF/wtf/glib/WTFGType.h
@@ -74,7 +74,9 @@ static GType type_name##_get_type_once(void); \
 static gpointer type_name##_parent_class = 0; \
 static void type_name##_finalize(GObject* object) \
 { \
+IGNORE_WARNINGS_BEGIN("cast-align") \
     TypeName* self = (TypeName*)object; \
+IGNORE_WARNINGS_END \
     self->priv->~TypeName##Private(); \
     G_OBJECT_CLASS(type_name##_parent_class)->finalize(object); \
 } \

--- a/Source/WebCore/css/CSSStyleDeclaration.cpp
+++ b/Source/WebCore/css/CSSStyleDeclaration.cpp
@@ -47,7 +47,7 @@ enum class PropertyNamePrefix { None, Epub, WebKit };
 
 static inline bool matchesCSSPropertyNamePrefix(const StringImpl& propertyName, ASCIILiteral prefix)
 {
-    ASSERT(toASCIILower(propertyName[0]) == prefix[0]);
+    ASSERT(toASCIILower(propertyName[0]) == prefix[0zu]);
     const size_t offset = 1;
 
 #ifndef NDEBUG

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -195,7 +195,7 @@ inline Ref<SpaceSplitStringData> SpaceSplitStringData::create(const AtomString& 
     ASSERT(tokenCount);
 
     RELEASE_ASSERT(tokenCount < (std::numeric_limits<unsigned>::max() - sizeof(SpaceSplitStringData)) / sizeof(AtomString));
-    unsigned sizeToAllocate = sizeof(SpaceSplitStringData) + tokenCount * sizeof(AtomString);
+    size_t sizeToAllocate = sizeof(SpaceSplitStringData) + tokenCount * sizeof(AtomString);
     SpaceSplitStringData* spaceSplitStringData = static_cast<SpaceSplitStringData*>(fastMalloc(sizeToAllocate));
 
     new (NotNull, spaceSplitStringData) SpaceSplitStringData(keyString, tokenCount);
@@ -203,7 +203,7 @@ inline Ref<SpaceSplitStringData> SpaceSplitStringData::create(const AtomString& 
     TokenAtomStringInitializer tokenInitializer(keyString, tokenArray);
     tokenizeSpaceSplitString(tokenInitializer, keyString);
     ASSERT(static_cast<unsigned>(tokenInitializer.nextMemoryBucket() - tokenArray.data()) == tokenCount);
-    ASSERT(reinterpret_cast<const char*>(tokenInitializer.nextMemoryBucket()) - reinterpret_cast<const char*>(spaceSplitStringData) == sizeToAllocate);
+    ASSERT(reinterpret_cast<const char*>(tokenInitializer.nextMemoryBucket()) - reinterpret_cast<const char*>(spaceSplitStringData) == static_cast<ptrdiff_t>(sizeToAllocate));
 
     return adoptRef(*spaceSplitStringData);
 }

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -365,7 +365,7 @@ void MemoryCache::pruneDeadResourcesToSize(unsigned targetSize)
         // destroyDecodedData() can alter the LRUList.
         auto lruList = copyToVector(*m_allResources[i]);
 
-        LOG(ResourceLoading, " lru list (size %lu) - flushing stage", lruList.size());
+        LOG(ResourceLoading, " lru list (size %zu) - flushing stage", lruList.size());
 
         // First flush all the decoded data in this queue.
         // Remove from the head, since this is the least frequently accessed of the objects.
@@ -392,7 +392,7 @@ void MemoryCache::pruneDeadResourcesToSize(unsigned targetSize)
             }
         }
 
-        LOG(ResourceLoading, " lru list (size %lu) - eviction stage", lruList.size());
+        LOG(ResourceLoading, " lru list (size %zu) - eviction stage", lruList.size());
 
         // Now evict objects from this list.
         // Remove from the head, since this is the least frequently accessed of the objects.

--- a/Source/WebCore/platform/audio/VectorMath.cpp
+++ b/Source/WebCore/platform/audio/VectorMath.cpp
@@ -187,10 +187,12 @@ float dotProduct(std::span<const float> inputVector1, std::span<const float> inp
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GLib/Win port
 
+#if CPU(X86_SSE2)
 static inline bool is16ByteAligned(const float* vector)
 {
     return !(reinterpret_cast<uintptr_t>(vector) & 0x0F);
 }
+#endif
 
 void multiplyByScalarThenAddToVector(std::span<const float> inputVector1, float scalar, std::span<const float> inputVector2, std::span<float> outputVector)
 {

--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -334,7 +334,7 @@ void FontCache::purgeInactiveFontData(unsigned purgeCount)
         return std::nullopt;
     });
 
-    LOG(Fonts, " removing %lu keys", keysToRemove.size());
+    LOG(Fonts, " removing %zu keys", keysToRemove.size());
 
     for (auto& key : keysToRemove)
         m_fontDataCaches->platformData.remove(key);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -995,7 +995,9 @@ GstElement* createAutoAudioSink(const String& role)
         if (role && g_object_class_find_property(objectClass, "stream-properties")) {
             GUniquePtr<GstStructure> properties(gst_structure_new("stream-properties", "media.role", G_TYPE_STRING, role->utf8().data(), nullptr));
             g_object_set(object, "stream-properties", properties.get(), nullptr);
+IGNORE_WARNINGS_BEGIN("cast-align")
             GST_DEBUG("Set media.role as %s on %" GST_PTR_FORMAT, role->utf8().data(), GST_ELEMENT_CAST(object));
+IGNORE_WARNINGS_END
         }
         if (g_object_class_find_property(objectClass, "client-name")) {
             auto& clientName = getApplicationName();

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoFrameConverter.cpp
@@ -200,7 +200,9 @@ GRefPtr<GstSample> GStreamerVideoFrameConverter::convert(const GRefPtr<GstSample
     gst_sample_set_caps(convertedSample.get(), destinationCaps.get());
 
     GRefPtr buffer = gst_sample_get_buffer(convertedSample.get());
+IGNORE_WARNINGS_BEGIN("cast-align")
     auto writableBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+IGNORE_WARNINGS_END
 
     if (auto meta = gst_buffer_get_video_meta(writableBuffer.get()))
         gst_buffer_remove_meta(writableBuffer.get(), GST_META_CAST(meta));

--- a/Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GstAllocatorFastMalloc.cpp
@@ -182,9 +182,11 @@ static gboolean gstAllocatorFastMallocMemIsSpan(GstMemory* _memory1, GstMemory* 
 static void gstAllocatorFastMallocConstructed(GObject* object)
 {
     G_OBJECT_CLASS(gst_allocator_fast_malloc_parent_class)->constructed(object);
+IGNORE_WARNINGS_BEGIN("cast-align")
     GST_OBJECT_FLAG_SET(GST_OBJECT_CAST(object), GST_OBJECT_FLAG_MAY_BE_LEAKED);
-
     auto allocator = GST_ALLOCATOR_CAST(object);
+IGNORE_WARNINGS_END
+
     allocator->mem_type = "FastMalloc";
     allocator->mem_map = gstAllocatorFastMallocMemMap;
     allocator->mem_unmap = gstAllocatorFastMallocMemUnmap;

--- a/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TextCombinerPadGStreamer.cpp
@@ -138,8 +138,10 @@ static void webkitTextCombinerPadConstructed(GObject* object)
 {
     G_OBJECT_CLASS(webkit_text_combiner_pad_parent_class)->constructed(object);
     gst_ghost_pad_construct(GST_GHOST_PAD(object));
+IGNORE_WARNINGS_BEGIN("cast-align")
     gst_pad_set_event_function(GST_PAD_CAST(object), webkitTextCombinerPadEvent);
     gst_pad_set_chain_function(GST_PAD_CAST(object), webkitTextCombinerPadChain);
+IGNORE_WARNINGS_END
 }
 
 static void webkit_text_combiner_pad_class_init(WebKitTextCombinerPadClass* klass)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameMetadataGStreamer.cpp
@@ -67,7 +67,9 @@ std::pair<GstBuffer*, VideoFrameMetadataGStreamer*> ensureVideoFrameMetadata(Gst
     if (meta)
         return { buffer, meta };
 
+IGNORE_WARNINGS_BEGIN("cast-align")
     buffer = gst_buffer_make_writable(buffer);
+IGNORE_WARNINGS_END
     return { buffer, VIDEO_FRAME_METADATA_CAST(gst_buffer_add_meta(buffer, videoFrameMetadataGetInfo(), nullptr)) };
 }
 
@@ -105,7 +107,9 @@ const GstMetaInfo* videoFrameMetadataGetInfo()
 
 GRefPtr<GstBuffer> webkitGstBufferSetVideoFrameTimeMetadata(GRefPtr<GstBuffer>&& buffer, std::optional<WebCore::VideoFrameTimeMetadata>&& metadata)
 {
+IGNORE_WARNINGS_BEGIN("cast-align")
     auto modifiedBuffer = adoptGRef(gst_buffer_make_writable(buffer.leakRef()));
+IGNORE_WARNINGS_END
     auto meta = getInternalVideoFrameMetadata(modifiedBuffer.get());
     if (meta) {
         meta->priv->videoSampleMetadata = WTFMove(metadata);

--- a/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/WebKitAudioSinkGStreamer.cpp
@@ -135,8 +135,10 @@ static GstStateChangeReturn webKitAudioSinkChangeState(GstElement* element, GstS
 static void webKitAudioSinkConstructed(GObject* object)
 {
     G_OBJECT_CLASS(webkit_audio_sink_parent_class)->constructed(object);
+IGNORE_WARNINGS_BEGIN("cast-align")
     GST_OBJECT_FLAG_SET(GST_OBJECT_CAST(object), GST_ELEMENT_FLAG_SINK);
     gst_bin_set_suppressed_flags(GST_BIN_CAST(object), static_cast<GstElementFlags>(GST_ELEMENT_FLAG_SOURCE | GST_ELEMENT_FLAG_SINK));
+IGNORE_WARNINGS_END
 }
 
 static void webkit_audio_sink_class_init(WebKitAudioSinkClass* klass)

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -843,7 +843,7 @@ std::pair<AppendPipeline::CreateTrackResult, AppendPipeline::Track*> AppendPipel
     auto preferredTrackId = getStreamIdFromPad(demuxerSrcPad).value_or((static_cast<TrackID>(newTrackIndex)));
     auto trackInfo = m_sourceBufferPrivate.registerTrack(preferredTrackId, streamType);
 
-    GST_DEBUG_OBJECT(pipeline(), "Creating new AppendPipeline::Track with type %s, index %" PRIu64" and id '%" PRIu64 "'", streamTypeToString(streamType), trackInfo.index, trackInfo.id);
+    GST_DEBUG_OBJECT(pipeline(), "Creating new AppendPipeline::Track with type %s, index %" PRIu64" and id '%" PRIu64"'", streamTypeToString(streamType), static_cast<uint64_t>(trackInfo.index), static_cast<uint64_t>(trackInfo.id));
     m_tracks.append(makeUnique<Track>(trackInfo.id, streamType, parsedCaps, presentationSize));
     Track& track = *m_tracks.at(newTrackIndex);
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -240,7 +240,7 @@ MediaSourcePrivateGStreamer::RegisteredTrack MediaSourcePrivateGStreamer::regist
     ASSERT(result.isNewEntry);
 
     if (player)
-        GST_DEBUG_OBJECT(player->pipeline(), "Registered new Track with index %" PRIu64 " and ID %" PRIu64 " (preferred ID was %" PRIu64 ")", assignedIndex, assignedId, preferredId);
+        GST_DEBUG_OBJECT(player->pipeline(), "Registered new Track with index %" PRIu64 " and ID %" PRIu64 " (preferred ID was %" PRIu64 ")", static_cast<uint64_t>(assignedIndex), static_cast<uint64_t>(assignedId), static_cast<uint64_t>(preferredId));
 
     return info;
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -309,7 +309,9 @@ static void webKitMediaSrcConstructed(GObject* object)
     G_OBJECT_CLASS(webkit_media_src_parent_class)->constructed(object);
 
     ASSERT(isMainThread());
+IGNORE_WARNINGS_BEGIN("cast-align")
     GST_OBJECT_FLAG_SET(object, GST_ELEMENT_FLAG_SOURCE);
+IGNORE_WARNINGS_END
 }
 
 void webKitMediaSrcEmitStreams(WebKitMediaSrc* source, const Vector<RefPtr<MediaSourceTrackGStreamer>>& tracks)
@@ -615,9 +617,11 @@ static void webKitMediaSrcLoop(void* userData)
             GST_DEBUG_OBJECT(pad, "First buffer on this pad was pushed (ret = %s).", gst_flow_get_name(result));
             dumpPipeline("first-frame-after"_s, stream);
         }
+IGNORE_WARNINGS_BEGIN("cast-align")
     } else if (GST_IS_EVENT(object.get())) {
         // EOS events and other enqueued events are also sent unlocked so they can react to flushes if necessary.
         GRefPtr<GstEvent> event = GRefPtr<GstEvent>(GST_EVENT(object.leakRef()));
+IGNORE_WARNINGS_END
 
         streamingMembers.unlockEarly();
         GST_DEBUG_OBJECT(pad, "Pushing event downstream: %" GST_PTR_FORMAT, event.get());

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp
@@ -275,8 +275,8 @@ OpenTypeMathData::OpenTypeMathData(const FontPlatformData&) = default;
 
 OpenTypeMathData::~OpenTypeMathData() = default;
 
-#if ENABLE(OPENTYPE_MATH)
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+#if ENABLE(OPENTYPE_MATH)
 float OpenTypeMathData::getMathConstant(const Font& font, MathConstant constant) const
 {
     int32_t value = 0;

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -614,7 +614,7 @@ static CString getShaderLog(GLuint shader)
     glGetShaderInfoLog(shader, logLength, &infoLength, info.data());
 
     size_t stringLength = std::max(infoLength, 0);
-    return std::span<const char> { info.data(), stringLength };
+    return unsafeMakeSpan<const char>(info.data(), stringLength);
 }
 
 static CString getProgramLog(GLuint program)
@@ -629,7 +629,7 @@ static CString getProgramLog(GLuint program)
     glGetProgramInfoLog(program, logLength, &infoLength, info.data());
 
     size_t stringLength = std::max(infoLength, 0);
-    return std::span<const char> { info.data(), stringLength };
+    return unsafeMakeSpan<const char>(info.data(), stringLength);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -48,11 +48,11 @@ void CoordinatedBackingStoreTile::processPendingUpdates(TextureMapper& textureMa
     if (!updatesCount)
         return;
 
-    WTFBeginSignpost(this, CoordinatedSwapBuffers, "%lu updates", updatesCount);
+    WTFBeginSignpost(this, CoordinatedSwapBuffers, "%zu updates", updatesCount);
     for (unsigned updateIndex = 0; updateIndex < updatesCount; ++updateIndex) {
         auto& update = updates[updateIndex];
 
-        WTFBeginSignpost(this, CoordinatedSwapBuffer, "%u/%lu, rect %ix%i+%i+%i", updateIndex + 1, updatesCount, update.tileRect.x(), update.tileRect.y(), update.tileRect.width(), update.tileRect.height());
+        WTFBeginSignpost(this, CoordinatedSwapBuffer, "%u/%zu, rect %ix%i+%i+%i", updateIndex + 1, updatesCount, update.tileRect.x(), update.tileRect.y(), update.tileRect.width(), update.tileRect.height());
 
         ASSERT(textureMapper.maxTextureSize().width() >= update.tileRect.size().width());
         ASSERT(textureMapper.maxTextureSize().height() >= update.tileRect.size().height());

--- a/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
+++ b/Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp
@@ -58,7 +58,7 @@ void PlatformPasteboard::getTypes(Vector<String>& types) const
     wpe_pasteboard_get_types(m_pasteboard, &pasteboardTypes);
     for (auto& typeString : unsafeMakeSpan(pasteboardTypes.strings, pasteboardTypes.length)) {
         const auto length = std::min(static_cast<size_t>(typeString.length), std::numeric_limits<size_t>::max());
-        types.append(String({ typeString.data, length }));
+        types.append(String(unsafeMakeSpan(typeString.data, length)));
     }
 
     wpe_pasteboard_string_vector_free(&pasteboardTypes);
@@ -72,7 +72,7 @@ String PlatformPasteboard::readString(size_t, const String& type) const
         return String();
 
     const auto length = std::min(static_cast<size_t>(string.length), std::numeric_limits<size_t>::max());
-    String returnValue({ string.data, length });
+    String returnValue(unsafeMakeSpan(string.data, length));
 
     wpe_pasteboard_string_free(&string);
     return returnValue;

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -1103,7 +1103,9 @@ static GstPadProbeReturn webkitMediaStreamSrcPadProbeCb(GstPad* pad, GstPadProbe
             GST_DEBUG_OBJECT(self, "Replacing stream-start event");
             auto sequenceNumber = gst_event_get_seqnum(event);
             gst_event_unref(event);
+            IGNORE_WARNINGS_BEGIN("cast-align")
             data->streamStartEvent = adoptGRef(gst_event_make_writable(data->streamStartEvent.leakRef()));
+            IGNORE_WARNINGS_END
             gst_event_set_seqnum(data->streamStartEvent.get(), sequenceNumber);
             info->data = gst_event_ref(data->streamStartEvent.get());
         }

--- a/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebCore/platform/xr/openxr/PlatformXROpenXR.cpp
@@ -65,7 +65,7 @@ void OpenXRDevice::initialize(CompletionHandler<void()>&& callback)
 #if !LOG_DISABLED
         else
             LOG(XR, "xrGetSystemProperties(): error %s\n", resultToString(result, m_instance).utf8().data());
-        LOG(XR, "Found XRSystem %lu: \"%s\", vendor ID %d\n", systemProperties.systemId, systemProperties.systemName, systemProperties.vendorId);
+        LOG(XR, "Found XRSystem %" PRIu64 ": \"%s\", vendor ID %d\n", systemProperties.systemId, systemProperties.systemName, systemProperties.vendorId);
 #endif
 
         collectSupportedSessionModes();

--- a/Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
+++ b/Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.cpp
@@ -56,7 +56,7 @@ void WKPageHandleKeyboardEvent(WKPageRef pageRef, WKKeyboardEvent event)
     NativeWebKeyboardEvent::HandledByInputMethod handledByInputMethod = NativeWebKeyboardEvent::HandledByInputMethod::No;
     std::optional<Vector<WebCore::CompositionUnderline>> preeditUnderlines;
     std::optional<WebKit::EditingRange> preeditSelectionRange;
-    WebKit::toImpl(pageRef)->handleKeyboardEvent(NativeWebKeyboardEvent(&wpeEvent, std::span { event.text, event.length }, false, handledByInputMethod, WTFMove(preeditUnderlines), WTFMove(preeditSelectionRange)));
+    WebKit::toImpl(pageRef)->handleKeyboardEvent(NativeWebKeyboardEvent(&wpeEvent, unsafeMakeSpan(event.text, event.length), false, handledByInputMethod, WTFMove(preeditUnderlines), WTFMove(preeditSelectionRange)));
 }
 
 void WKPageHandleMouseEvent(WKPageRef pageRef, WKMouseEvent event)

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -230,7 +230,7 @@ void WebResourceLoader::didReceiveResponse(ResourceResponse&& response, PrivateR
 void WebResourceLoader::didReceiveData(IPC::SharedBufferReference&& data, uint64_t encodedDataLength, uint64_t bytesTransferredOverNetwork)
 {
     RefPtr coreLoader = m_coreLoader;
-    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %lu for '%s'", data.size(), coreLoader->url().string().latin1().data());
+    LOG(Network, "(WebProcess) WebResourceLoader::didReceiveData of size %zu for '%s'", data.size(), coreLoader->url().string().latin1().data());
     ASSERT_WITH_MESSAGE(!m_isProcessingNetworkResponse, "Network process should not send data until we've validated the response");
 
     if (UNLIKELY(m_interceptController.isIntercepting(*coreLoader->identifier()))) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebPopupMenu.cpp
@@ -99,7 +99,7 @@ void WebPopupMenu::show(const IntRect& rect, LocalFrameView& view, int selectedI
         return;
     }
 
-    RELEASE_ASSERT_WITH_MESSAGE(selectedIndex == -1 || static_cast<unsigned>(selectedIndex) < items.size(), "Invalid selectedIndex (%d) for popup menu with %lu items", selectedIndex, items.size());
+    RELEASE_ASSERT_WITH_MESSAGE(selectedIndex == -1 || static_cast<unsigned>(selectedIndex) < items.size(), "Invalid selectedIndex (%d) for popup menu with %zu items", selectedIndex, items.size());
 
     m_page->setActivePopupMenu(this);
 

--- a/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
+++ b/Source/WebKit/WebProcess/wpe/WebProcessMainWPE.cpp
@@ -46,7 +46,9 @@
 #if USE(SYSPROF_CAPTURE)
 #include <wtf/SystemTracing.h>
 #if USE(SKIA_OPENTYPE_SVG)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <skia/modules/svg/SkSVGOpenTypeSVGDecoder.h>
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 #endif
 

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -30,6 +30,7 @@
 #include <WPEToolingBackends/WindowViewBackend.h>
 #include <memory>
 #include <wpe/webkit.h>
+#include <wtf/Compiler.h>
 
 #if ENABLE_WPE_PLATFORM_HEADLESS
 #include <wpe/headless/wpe-headless.h>
@@ -40,7 +41,9 @@
 #endif
 
 #if !USE_GSTREAMER_FULL && (ENABLE_WEB_AUDIO || ENABLE_VIDEO)
+IGNORE_WARNINGS_BEGIN("cast-align")
 #include <gst/gst.h>
+IGNORE_WARNINGS_END
 #endif
 
 static const char** uriArguments;


### PR DESCRIPTION
#### 356b22df6a2afa45dc9f47eaafa5c21d57ee51db
<pre>
Fix ARMv7 build warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=288678">https://bugs.webkit.org/show_bug.cgi?id=288678</a>

Reviewed by Darin Adler.

There are many cast alignment warnings that we skip on 32-bit, mostly related
to GObject* downcasts. Since these warnings aren&apos;t very helpful, we just disable
them on 32-bit.

We also fix a few uint64_t &lt;&gt; size_t confusions with format strings.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
* Source/WebCore/platform/graphics/opentype/OpenTypeMathData.cpp:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/libwpe/PlatformPasteboardLibWPE.cpp:
(WebCore::PlatformPasteboard::getTypes const):
(WebCore::PlatformPasteboard::readString const):
* Source/WebKit/UIProcess/API/C/wpe/WKPagePrivateWPE.cpp:
(WKPageHandleKeyboardEvent):
* Source/cmake/WebKitCommon.cmake:
* Tools/MiniBrowser/wpe/main.cpp:
* Tools/Scripts/webkitdirs.pm:
(generateBuildSystemFromCMakeProject):

Canonical link: <a href="https://commits.webkit.org/292361@main">https://commits.webkit.org/292361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/891b7a43e9cb7eb647907332b50c7e466acc8bee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/5262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/46244 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73014 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30261 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86469 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/4197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45583 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/88407 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/4307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102824 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/94359 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22797 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/23049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81420 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20417 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/16134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27914 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/117838 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22424 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/24166 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->