### PR TITLE
AX: With ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), getting the unignored children of a node-only object with aria-owns loops infinitely

### DIFF
--- a/LayoutTests/accessibility/node-only-object-aria-owns-hang-expected.txt
+++ b/LayoutTests/accessibility/node-only-object-aria-owns-hang-expected.txt
@@ -1,0 +1,8 @@
+This test ensures we don't hang when getting the unignored children for a node-only object.
+
+PASS: accessibilityController.accessibleElementById('div1').childrenCount === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Book One Two

--- a/LayoutTests/accessibility/node-only-object-aria-owns-hang.html
+++ b/LayoutTests/accessibility/node-only-object-aria-owns-hang.html
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<a aria-controls="div1">Book</a>
+<div id="div1" role="group" style="display: contents">
+    <span id="owner-span" role="group" aria-owns="zzz">One</span>
+    <span id="zzz">Two</span>
+</div>
+
+<script>
+var output = "This test ensures we don't hang when getting the unignored children for a node-only object.\n\n";
+
+if (window.accessibilityController) {
+    output += expect("accessibilityController.accessibleElementById('div1').childrenCount", "1");
+    debug(output);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -633,6 +633,18 @@ static bool isTableComponent(AXCoreObject& axObject)
 
 void AccessibilityObject::insertChild(AccessibilityObject& child, unsigned index, DescendIfIgnored descendIfIgnored)
 {
+    auto owners = child.owners();
+    if (owners.size()) {
+        size_t indexOfThis = owners.findIf([this] (const Ref<AXCoreObject>& object) {
+            return object.ptr() == this;
+        });
+
+        if (indexOfThis == notFound) {
+            // The child is aria-owned, and not by us, so we shouldn't insert it.
+            return;
+        }
+    }
+
     // If the parent is asking for this child's children, then either it's the first time (and clearing is a no-op),
     // or its visibility has changed. In the latter case, this child may have a stale child cached.
     // This can prevent aria-hidden changes from working correctly. Hence, whenever a parent is getting children, ensure data is not stale.

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2565,10 +2565,6 @@ void AccessibilityRenderObject::addChildren()
         if (object.renderer()->isRenderListMarker())
             return;
 #endif
-        auto owners = object.owners();
-        if (owners.size() && !owners.contains(Ref { *this }))
-            return;
-
         addChild(object);
     };
 


### PR DESCRIPTION
#### d2c534bec1644b989026b4b41da29263cc7a5381
<pre>
AX: With ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), getting the unignored children of a node-only object with aria-owns loops infinitely
<a href="https://bugs.webkit.org/show_bug.cgi?id=288684">https://bugs.webkit.org/show_bug.cgi?id=288684</a>
<a href="https://rdar.apple.com/145715339">rdar://145715339</a>

Reviewed by Chris Fleizach.

Prior to this commit, only AccessibilityRenderObject::addChildren() verified that it didn&apos;t insert a child aria-owned
by another object. Node-only objects, such as those with display:contents or display:none, would not check aria-ownership,
and thus would insert the owned child. This results in the double-exposure of this subtree, and causes an infinite
loop in anything that uses AXCoreObject::nextInPreOrder over affected subtrees (e.g. AXCoreObject::unignoredChildren).

With this commit, we move the aria-owns check from AccessibilityRenderObject::addChildren to AccessibilityObject::insertChild,
so we always behave correctly, since all m_children inserts go through this path.

* LayoutTests/accessibility/node-only-object-aria-owns-hang-expected.txt: Added.
* LayoutTests/accessibility/node-only-object-aria-owns-hang.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::insertChild):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addChildren):

Canonical link: <a href="https://commits.webkit.org/291241@main">https://commits.webkit.org/291241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04bd0cd906c105049727b2ba2f3da38eab959471

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1397 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12134 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70750 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28212 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95301 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9218 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51078 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8934 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42155 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79280 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1159 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-element/iframe_sandbox_window_open_download_allow_downloads.tentative.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99324 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79766 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19617 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79444 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79023 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19603 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23569 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12367 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24518 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19040 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22497 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20779 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->