### PR TITLE
Web Inspector: REGRESSION(290430@main, 291074@main): Timeline view has no grid node for record selected in timeline overview.

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js
@@ -79,10 +79,19 @@ WI.ScriptClusterTimelineView = class ScriptClusterTimelineView extends WI.Cluste
     set endTime(x) { this._contentViewContainer.currentContentView.endTime = x; }
     get currentTime() { return this._contentViewContainer.currentContentView.currentTime; }
     set currentTime(x) { this._contentViewContainer.currentContentView.currentTime = x; }
-    selectRecord(record) { this._contentViewContainer.currentContentView.selectRecord(record); }
     updateFilter(filters) { return this._contentViewContainer.currentContentView.updateFilter(filters); }
     filterDidChange() { return this._contentViewContainer.currentContentView.filterDidChange(); }
     matchDataGridNodeAgainstCustomFilters(node) { return this._contentViewContainer.currentContentView.matchDataGridNodeAgainstCustomFilters(node); }
+
+    selectRecord(record)
+    {
+        if (record) {
+            this._selectedTarget = this._displayedTarget = record.target;
+            this._currentContentViewSetting.value = WI.ScriptClusterTimelineView.EventsIdentifier;
+            this._updateCurrentContentView();
+        }
+        this._contentViewContainer.currentContentView.selectRecord(record);
+    }
 
     reset()
     {


### PR DESCRIPTION
#### fa0b2e54ab2dd8373a205dcbb273e7f26c5d957d
<pre>
Web Inspector: REGRESSION(290430@main, 291074@main): Timeline view has no grid node for record selected in timeline overview.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288686">https://bugs.webkit.org/show_bug.cgi?id=288686</a>

Reviewed by BJ Burg.

Now that there is a separate `WI.ScriptDetailsTimelineView` (and `WI.ScriptProfileTimelineView`) for each `WI.Target`, we can&apos;t just use the `currentContentView` when selecting a `WI.ScriptTimelineRecord`.

* Source/WebInspectorUI/UserInterface/Views/ScriptClusterTimelineView.js:
(WI.ScriptClusterTimelineView.prototype.selectRecord):
Switch to the Events view for the `WI.Target` of the `WI.ScriptTimelineRecord` being selected.

Canonical link: <a href="https://commits.webkit.org/291287@main">https://commits.webkit.org/291287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60a5558a274683dd351015df39c112c613b6e96c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20308 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70751 "Found 1 new test failure: fast/events/domactivate-sets-underlying-click-event-as-handled.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95305 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9213 "Found 2 new test failures: fast/forms/ios/focus-input-in-fixed.html fast/mediacapturefromelement/CanvasCaptureMediaStream-exceptions.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1199 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42159 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1161 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99328 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79778 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19621 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79025 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19624 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12371 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24522 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20783 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->