### PR TITLE
Web Inspector: Timelines: show a separate overview record bar row for each `WI.Target`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.css
@@ -23,11 +23,46 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.timeline-overview-graph.script > .timeline-record-bar {
-    margin-top: 8px;
-    height: 20px;
+.timeline-overview-graph.script > .graph-row {
+    /* (--graph-row-height * rows) + (--graph-row-margin * (rows + 1)) = --timeline-overview-graph-height - --timeline-overview-graph-border-top-height */
+    height: var(--graph-row-height);
+    margin-bottom: var(--graph-row-margin);
+    padding-top: var(--graph-row-margin);
 }
 
-.timeline-overview-graph.script > .timeline-record-bar > .segment {
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(1) {
+    --graph-row-height: 21px;
+    --graph-row-margin: 7px;
+}
+
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(2),
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(2) ~ .graph-row {
+    --graph-row-height: 12px;
+    --graph-row-margin: 4px;
+}
+
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(3),
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(3) ~ .graph-row {
+    --graph-row-height: 8px;
+    --graph-row-margin: 3px;
+}
+
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(4),
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(4) ~ .graph-row {
+    --graph-row-height: 6.5px;
+    --graph-row-margin: 2px;
+}
+
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(5),
+.timeline-overview-graph.script > .graph-row:first-child:nth-last-child(5) ~ .graph-row {
+    --graph-row-height: 6px;
+    --graph-row-margin: 1px;
+}
+
+.timeline-overview-graph.script > .graph-row > .timeline-record-bar {
+    height: var(--graph-row-height);
+}
+
+.timeline-overview-graph.script > .graph-row > .timeline-record-bar > .segment {
     border-radius: 2px;
 }

--- a/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
+++ b/Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css
@@ -194,7 +194,9 @@ body[dir=rtl] .timeline-overview.frames > .timeline-ruler:not(.both-handles-clam
 }
 
 .timeline-overview > .graphs-container > .timeline-overview-graph {
-    height: 36px;
+    height: var(--timeline-overview-graph-height);
+
+    --timeline-overview-graph-height: 36px;
 }
 
 .timeline-overview:not(.frames) > .graphs-container > .timeline-overview-graph:nth-child(even) {
@@ -203,7 +205,9 @@ body[dir=rtl] .timeline-overview.frames > .timeline-ruler:not(.both-handles-clam
 }
 
 .timeline-overview:not(.frames) > .graphs-container > .timeline-overview-graph:not(:first-child) {
-    border-top: 1px solid hsla(0, 0%, var(--foreground-lightness), 0.09);
+    border-top: var(--timeline-overview-graph-border-top-height) solid hsla(0, 0%, var(--foreground-lightness), 0.09);
+
+    --timeline-overview-graph-border-top-height: 1px;
 }
 
 .timeline-overview:not(.has-scrollbar) > .scroll-container {


### PR DESCRIPTION
#### e4b6167f9482ba564157c37005f095027deb3a3c
<pre>
Web Inspector: Timelines: show a separate overview record bar row for each `WI.Target`
<a href="https://bugs.webkit.org/show_bug.cgi?id=288687">https://bugs.webkit.org/show_bug.cgi?id=288687</a>

Reviewed by BJ Burg.

This will allow developers to more visually distinguish activity based on the `WI.Target` (e.g. is this page activity or in a `Worker`?).

* Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.js:
(WI.ScriptTimelineOverviewGraph):
(WI.ScriptTimelineOverviewGraph.prototype.reset):
(WI.ScriptTimelineOverviewGraph.prototype.layout):
(WI.ScriptTimelineOverviewGraph.prototype.layout.createBar):
(WI.ScriptTimelineOverviewGraph.prototype.updateSelectedRecord):
(WI.ScriptTimelineOverviewGraph.prototype._scriptTimelineRecordAdded):

* Source/WebInspectorUI/UserInterface/Views/ScriptTimelineOverviewGraph.css:
(.timeline-overview-graph.script &gt; .graph-row): Added.
(.timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(1)): Added.
(.timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(2), .timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(2) ~ .graph-row): Added.
(.timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(3), .timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(3) ~ .graph-row): Added.
(.timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(4), .timeline-overview-graph.script &gt; .graph-row:first-child:nth-last-child(4) ~ .graph-row): Added.
(.timeline-overview-graph.script &gt; .graph-row &gt; .timeline-record-bar): Renamed from `.timeline-overview-graph.script &gt; .timeline-record-bar`.
(.timeline-overview-graph.script &gt; .graph-row &gt; .timeline-record-bar &gt; .segment): Renamed from `.timeline-overview-graph.script &gt; .timeline-record-bar &gt; .segment`.
Adjust the height of the record bar row based on how many of them there are.

* Source/WebInspectorUI/UserInterface/Views/TimelineOverview.css:
(.timeline-overview &gt; .graphs-container &gt; .timeline-overview-graph):
(.timeline-overview:not(.frames) &gt; .graphs-container &gt; .timeline-overview-graph:not(:first-child)):
Use CSS variables to allow future developers to search for uses of it to know what to also modify when changing the value.

Canonical link: <a href="https://commits.webkit.org/292169@main">https://commits.webkit.org/292169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab08d7ad904cdaf3b0619bfe85d0932699c2f2bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12110 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97550 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43072 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70899 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28346 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95567 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9393 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51231 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1447 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42403 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1387 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99576 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79903 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20247 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1018 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12628 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24772 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21027 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->