### PR TITLE
Restructure Positioned Layout

### DIFF
--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -720,10 +720,8 @@ private:
 
     struct PositionedLayoutConstraints;
     void computePositionedLogicalHeight(LogicalExtentComputedValues&) const;
-    void computePositionedLogicalWidthUsing(SizeType, Length logicalWidth, const PositionedLayoutConstraints&,
-                                            LogicalExtentComputedValues&) const;
-    void computePositionedLogicalHeightUsing(SizeType, Length logicalHeightLength, LayoutUnit computedHeight, const PositionedLayoutConstraints&,
-                                             LogicalExtentComputedValues&) const;
+    LayoutUnit computePositionedLogicalWidthUsing(SizeType, Length logicalWidth, const PositionedLayoutConstraints&) const;
+    LayoutUnit computePositionedLogicalHeightUsing(SizeType, Length logicalHeightLength, LayoutUnit computedHeight, const PositionedLayoutConstraints&) const;
 
     void computePositionedLogicalHeightReplaced(LogicalExtentComputedValues&) const;
     void computePositionedLogicalWidthReplaced(LogicalExtentComputedValues&) const;


### PR DESCRIPTION
#### 94ca2b0f38366468f9b71005ed9aa7781ea2cce7
<pre>
Restructure Positioned Layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=288648">https://bugs.webkit.org/show_bug.cgi?id=288648</a>
<a href="https://rdar.apple.com/145690034">rdar://145690034</a>

Reviewed by Antti Koivisto.

1. Factors out style extraction into a helper method called from the
PositionedLayoutConstraints() constructor. See captureInsets().

2. Cleans up calls to the RTL adjustment function by removing
unnecessary parameters, making the code easier to follow or adjust.
(Also renamed function to match.) See ~RTLInlineBoxContainingBlock().

3. Factors out margin+position resolution from size resolution,
consolidating constraint resolution into a single shared method and
simplifying logic in the core layout methods. Also cleans up the code
flow so we&apos;re not making so many redundant or useless layout function
calls. See resolvePosition() and resulting simplifications to
computePositionedLogical~().

4. Simplifies writing mode arithmetic for heights by performing more
conversions up front. See captureInsets() and convertLogicalTopValue().

This makes positioned layout easier to understand, easier to build
on top of, and less wasteful.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::PositionedLayoutConstraints::containingCoordsAreFlipped const):
(WebCore::RenderBox::PositionedLayoutConstraints::availableContentSpace const):
(WebCore::RenderBox::PositionedLayoutConstraints::PositionedLayoutConstraints):
(WebCore::RenderBox::PositionedLayoutConstraints::captureInsets):
(WebCore::RenderBox::PositionedLayoutConstraints::adjustForPositionArea):
(WebCore::RenderBox::PositionedLayoutConstraints::resolvePosition const):
(WebCore::RenderBox::containingBlockLogicalHeightForPositioned const):
(WebCore::RenderBox::PositionedLayoutConstraints::computeInlineStaticDistance):
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::adjustmentForRTLInlineBoxContainingBlock):
(WebCore::RenderBox::computePositionedLogicalWidthUsing const):
(WebCore::RenderBox::PositionedLayoutConstraints::computeBlockStaticDistance):
(WebCore::RenderBox::computePositionedLogicalHeight const):
(WebCore::RenderBox::PositionedLayoutConstraints::convertLogicalTopValue const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computePositionedLogicalHeightReplaced const):
(WebCore::positionWithRTLInlineBoxContainingBlock): Deleted.
* Source/WebCore/rendering/RenderBox.h:

Canonical link: <a href="https://commits.webkit.org/291298@main">https://commits.webkit.org/291298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7f2aa03461a8c0833971cadcd6d4d964f2a5a4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94524 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20477 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70857 "Found 5 new test failures: imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-allowed-for-self.https.sub.html imported/w3c/web-platform-tests/feature-policy/feature-policy-frame-policy-timing.https.sub.html imported/w3c/web-platform-tests/fullscreen/api/element-ready-check-fullscreen-iframe-child.html imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-remove-quickly.html imported/w3c/web-platform-tests/webaudio/the-audio-api/the-mediaelementaudiosourcenode-interface/no-cors.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28306 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1390 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42312 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99484 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19525 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79863 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79136 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19628 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23673 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24681 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19196 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->