### PR TITLE
[Content Filtering] Adopt WebContentRestrictions SPI for content filtering

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8157,6 +8157,22 @@ UsesSingleWebProcess:
       default: false
   sharedPreferenceForWebProcess: true
 
+UsesWebContentRestrictionsForFilter:
+  type: bool
+  status: internal
+  condition: HAVE(WEBCONTENTRESTRICTIONS)
+  defaultsOverridable: true
+  humanReadableName: "Uses WebContentRestriction framework for content filter"
+  webcoreBinding: DeprecatedGlobalSettings
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 VP9DecoderEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
+++ b/Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj
@@ -49,6 +49,9 @@
 		2E1342CD215AA10A007199D2 /* UIKitSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2E1342CB215AA10A007199D2 /* UIKitSoftLink.mm */; };
 		31647FB0251759DD0010F8FB /* OpenGLSoftLinkCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 31647FAE251759DB0010F8FB /* OpenGLSoftLinkCocoa.mm */; };
 		3A02FE2B2B214A38001724B1 /* ARKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A02FE2A2B214A38001724B1 /* ARKitSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3AA35C462D6E7F430078EA17 /* WebContentRestrictionsSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AA35C452D6E7F430078EA17 /* WebContentRestrictionsSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3AA35C4C2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AA35C4A2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3AA35C4D2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3AA35C4B2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm */; };
 		3CBEEDE928A1861D00221FAE /* BarcodeSupportSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		416E995323DAE6BE00E871CB /* AudioToolboxSoftLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */; };
 		4177B3DA296CB8C3009711F0 /* CoreCryptoSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 4177B3D9296CB8C3009711F0 /* CoreCryptoSPI.h */; };
@@ -609,6 +612,9 @@
 		31647FAE251759DB0010F8FB /* OpenGLSoftLinkCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OpenGLSoftLinkCocoa.mm; sourceTree = "<group>"; };
 		31647FAF251759DC0010F8FB /* OpenGLSoftLinkCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenGLSoftLinkCocoa.h; sourceTree = "<group>"; };
 		3A02FE2A2B214A38001724B1 /* ARKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ARKitSPI.h; sourceTree = "<group>"; };
+		3AA35C452D6E7F430078EA17 /* WebContentRestrictionsSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebContentRestrictionsSPI.h; sourceTree = "<group>"; };
+		3AA35C4A2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebContentRestrictionsSoftLink.h; sourceTree = "<group>"; };
+		3AA35C4B2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WebContentRestrictionsSoftLink.mm; sourceTree = "<group>"; };
 		3C963637289DC1C600570DD6 /* BarcodeSupportSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BarcodeSupportSPI.h; sourceTree = "<group>"; };
 		411A9AC02525D4CA00807D7E /* AVAssetWriterSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AVAssetWriterSPI.h; sourceTree = "<group>"; };
 		416E995123DAE6BD00E871CB /* AudioToolboxSoftLink.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AudioToolboxSoftLink.cpp; sourceTree = "<group>"; };
@@ -920,6 +926,7 @@
 				E5C5B20A2C379AA000838733 /* UIFoundationSPI.h */,
 				0C2DA12B1F3BEB4900DBC317 /* URLFormattingSPI.h */,
 				F46B8C4E26740AD8007A6554 /* VisionKitCoreSPI.h */,
+				3AA35C452D6E7F430078EA17 /* WebContentRestrictionsSPI.h */,
 				0C2DA13D1F3BEB4900DBC317 /* WebFilterEvaluatorSPI.h */,
 				F499BAAE2947FDDB001241D6 /* WebPrivacySPI.h */,
 				077121B52C1E8B4400FACBF9 /* WritingToolsSPI.h */,
@@ -1168,6 +1175,8 @@
 				F46B8C4C26740918007A6554 /* VisionKitCoreSoftLink.mm */,
 				E57B44B329AB45F4006069DE /* VisionSoftLink.h */,
 				E57B44B429AB45F4006069DE /* VisionSoftLink.mm */,
+				3AA35C4A2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h */,
+				3AA35C4B2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm */,
 				F499BAAA2947FDBA001241D6 /* WebPrivacySoftLink.h */,
 				F499BAAB2947FDBA001241D6 /* WebPrivacySoftLink.mm */,
 				44047A0A2C220D22004EF28D /* WritingToolsUISoftLink.h */,
@@ -1619,6 +1628,8 @@
 				E57B44B529AB45F4006069DE /* VisionSoftLink.h in Headers */,
 				A1038D332AB12BF100F57BA4 /* WebAVContentKeyGrouping.h in Headers */,
 				A1038D4F2AB21FBB00F57BA4 /* WebAVContentKeyReportGroupExtras.h in Headers */,
+				3AA35C4C2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.h in Headers */,
+				3AA35C462D6E7F430078EA17 /* WebContentRestrictionsSPI.h in Headers */,
 				DD20DE0E27BC90D80093D175 /* WebFilterEvaluatorSPI.h in Headers */,
 				DD20DE4727BC90D80093D175 /* WebPanel.h in Headers */,
 				F499BAAC2947FDBA001241D6 /* WebPrivacySoftLink.h in Headers */,
@@ -1820,6 +1831,7 @@
 				41E1F344248A6A000022D5DE /* VideoToolboxSoftLink.cpp in Sources */,
 				F46B8C4D26740918007A6554 /* VisionKitCoreSoftLink.mm in Sources */,
 				E57B44B729AB462E006069DE /* VisionSoftLink.mm in Sources */,
+				3AA35C4D2D6E802D0078EA17 /* WebContentRestrictionsSoftLink.mm in Sources */,
 				A10826FA1F576292004772AC /* WebPanel.mm in Sources */,
 				F499BAAD2947FDBA001241D6 /* WebPrivacySoftLink.mm in Sources */,
 				44047A0F2C220D45004EF28D /* WritingToolsUISoftLink.mm in Sources */,

--- a/Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#import <pal/spi/cocoa/WebContentRestrictionsSPI.h>
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_FRAMEWORK_FOR_HEADER(PAL, WebContentRestrictions);
+SOFT_LINK_CLASS_FOR_HEADER(PAL, WCRBrowserEngineClient);
+
+#endif

--- a/Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.mm
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#import <Foundation/Foundation.h>
+#import <wtf/SoftLinking.h>
+
+SOFT_LINK_PRIVATE_FRAMEWORK_FOR_SOURCE_WITH_EXPORT(PAL, WebContentRestrictions, PAL_EXPORT)
+SOFT_LINK_CLASS_FOR_SOURCE_WITH_EXPORT(PAL, WebContentRestrictions, WCRBrowserEngineClient, PAL_EXPORT);
+
+#endif

--- a/Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#if USE(APPLE_INTERNAL_SDK)
+
+#import <WebContentRestrictions/WebContentRestrictions.h>
+
+#else
+
+@interface WCRBrowserEngineClient : NSObject
++ (BOOL)shouldEvaluateURLs;
+- (void)evaluateURL:(NSURL *)url withCompletion:(void (^)(BOOL shouldBlock, NSData * _Nullable blockPageRepresentation))completion onCompletionQueue:(dispatch_queue_t)queue;
+- (void)allowURL:(NSURL *)url withCompletion:(void (^)(BOOL didAllow, NSError *error))completion;
+@end
+
+#endif // USE(APPLE_INTERNAL_SDK)
+
+#endif

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -371,6 +371,27 @@ void ContentFilter::setHostProcessAuditToken(const std::optional<audit_token_t>&
 }
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+bool ContentFilter::isWebContentRestrictionsUnblockURL(const URL& url)
+{
+#if PLATFORM(MAC)
+    // FIXME: Remove this when rdar://145714903 is fixed.
+    if (url.host() == "127.0.0.1"_s && url.path() == "/webcontentfilter.override.local"_s)
+        return true;
+#endif
+
+    return url.protocolIs(ContentFilter::urlScheme()) && equalIgnoringASCIICase(url.host(), "unblock"_s);
+}
+
+void ContentFilter::setUsesWebContentRestrictions(bool usesWebContentRestrictions)
+{
+    for (auto& contentFilter : m_contentFilters)
+        contentFilter->setUsesWebContentRestrictions(usesWebContentRestrictions);
+}
+
+#endif
+
 } // namespace WebCore
 
 #endif // ENABLE(CONTENT_FILTERING)

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -44,10 +44,10 @@ class ResourceRequest;
 class ResourceResponse;
 class SubstituteData;
 
-class ContentFilter {
+class ContentFilter : public CanMakeWeakPtr<ContentFilter>, public CanMakeCheckedPtr<ContentFilter> {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(Loader);
     WTF_MAKE_NONCOPYABLE(ContentFilter);
-
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ContentFilter);
 public:
     template <typename T> static void addType() { types().append(type<T>()); }
 
@@ -80,6 +80,11 @@ public:
 
 #if HAVE(AUDIT_TOKEN)
     WEBCORE_EXPORT void setHostProcessAuditToken(const std::optional<audit_token_t>&);
+#endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    WEBCORE_EXPORT void setUsesWebContentRestrictions(bool);
+    static bool isWebContentRestrictionsUnblockURL(const URL&);
 #endif
 
 private:

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -42,6 +42,7 @@
 #include "CrossOriginOpenerPolicy.h"
 #include "CustomHeaderFields.h"
 #include "DNS.h"
+#include "DeprecatedGlobalSettings.h"
 #include "DocumentInlines.h"
 #include "DocumentParser.h"
 #include "DocumentWriter.h"
@@ -2179,6 +2180,10 @@ void DocumentLoader::startLoadingMainResource()
     contentFilterInDocumentLoader() = frame && frame->view() && frame->protectedView()->platformWidget();
     if (contentFilterInDocumentLoader())
         m_contentFilter = !m_substituteData.isValid() ? ContentFilter::create(*this) : nullptr;
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    if (m_contentFilter)
+        m_contentFilter->setUsesWebContentRestrictions(DeprecatedGlobalSettings::usesWebContentRestrictionsForFilter());
+#endif
 #endif
 
     auto url = m_request.url();

--- a/Source/WebCore/page/DeprecatedGlobalSettings.h
+++ b/Source/WebCore/page/DeprecatedGlobalSettings.h
@@ -120,6 +120,10 @@ public:
     static bool modelDocumentEnabled() { return shared().m_modelDocumentEnabled; }
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    static void setUsesWebContentRestrictionsForFilter(bool uses) { shared().m_usesWebContentRestrictionsForFilter = uses; }
+    static bool usesWebContentRestrictionsForFilter() { return shared().m_usesWebContentRestrictionsForFilter; };
+#endif
 
 private:
     WEBCORE_EXPORT static DeprecatedGlobalSettings& shared();
@@ -177,6 +181,9 @@ private:
     bool m_modelDocumentEnabled { false };
 #endif
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    bool m_usesWebContentRestrictionsForFilter { false };
+#endif
     friend class NeverDestroyed<DeprecatedGlobalSettings>;
 };
 

--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -35,7 +35,11 @@
 OBJC_CLASS NSCoder;
 OBJC_CLASS NSNumber;
 
-#if PLATFORM(IOS_FAMILY)
+#if HAVE(WEBCONTENTRESTRICTIONS)
+OBJC_CLASS WCRBrowserEngineClient;
+#endif
+
+#if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
 OBJC_CLASS WebFilterEvaluator;
 #endif
 
@@ -50,6 +54,9 @@ public:
 
     ContentFilterUnblockHandler() = default;
     WEBCORE_EXPORT ContentFilterUnblockHandler(String unblockURLHost, UnblockRequesterFunction);
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    ContentFilterUnblockHandler(const URL& evaluatedURL);
+#endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     ContentFilterUnblockHandler(String unblockURLHost, RetainPtr<WebFilterEvaluator>);
 #endif
@@ -57,6 +64,9 @@ public:
     WEBCORE_EXPORT ContentFilterUnblockHandler(
         String&& unblockURLHost,
         URL&& unreachableURL,
+#if HAVE(WEBCONTENTRESTRICTIONS)
+        std::optional<URL>&& evaluatedURL,
+#endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
         Vector<uint8_t>&& webFilterEvaluatorData,
 #endif
@@ -72,6 +82,9 @@ public:
     const URL& unreachableURL() const { return m_unreachableURL; }
     void setUnreachableURL(const URL& url) { m_unreachableURL = url; }
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    std::optional<URL> evaluatedURL() const { return m_evaluatedURL; }
+#endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     WEBCORE_EXPORT Vector<uint8_t> webFilterEvaluatorData() const;
 #endif
@@ -87,6 +100,10 @@ private:
     String m_unblockURLHost;
     URL m_unreachableURL;
     UnblockRequesterFunction m_unblockRequester;
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    std::optional<URL> m_evaluatedURL;
+    mutable RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
+#endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
 #endif

--- a/Source/WebCore/platform/PlatformContentFilter.h
+++ b/Source/WebCore/platform/PlatformContentFilter.h
@@ -27,6 +27,7 @@
 #define PlatformContentFilter_h
 
 #include "SharedBuffer.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/Ref.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
@@ -49,8 +50,9 @@ class ResourceRequest;
 class ResourceResponse;
 class SharedBuffer;
 
-class PlatformContentFilter : public CanMakeWeakPtr<PlatformContentFilter> {
+class PlatformContentFilter : public CanMakeWeakPtr<PlatformContentFilter>, public CanMakeCheckedPtr<PlatformContentFilter> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PlatformContentFilter);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(PlatformContentFilter);
     WTF_MAKE_NONCOPYABLE(PlatformContentFilter);
 
 public:
@@ -78,6 +80,10 @@ public:
 #if HAVE(AUDIT_TOKEN)
     const std::optional<audit_token_t> hostProcessAuditToken() const { return m_hostProcessAuditToken; }
     void setHostProcessAuditToken(const std::optional<audit_token_t>& token) { m_hostProcessAuditToken = token; }
+#endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    virtual void setUsesWebContentRestrictions(bool) { };
 #endif
 
 protected:

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -34,6 +34,10 @@
 OBJC_CLASS NSData;
 OBJC_CLASS WebFilterEvaluator;
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+OBJC_CLASS WCRBrowserEngineClient;
+#endif
+
 namespace WebCore {
 
 class ParentalControlsContentFilter final : public PlatformContentFilter {
@@ -53,13 +57,27 @@ public:
 #endif
     
 private:
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    static bool enabled(bool usesWebContentRestrictions);
+#else
     static bool enabled();
+#endif
 
     ParentalControlsContentFilter() = default;
     void updateFilterState();
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    void updateFilterState(bool shouldBlock, NSData *replacmentData);
+    void setUsesWebContentRestrictions(bool) final;
+#endif
 
     RetainPtr<WebFilterEvaluator> m_webFilterEvaluator;
     RetainPtr<NSData> m_replacementData;
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    bool m_usesWebContentRestrictions { false };
+    RetainPtr<WCRBrowserEngineClient> m_wcrBrowserEngineClient;
+    std::optional<URL> m_evaluatedURL;
+#endif
 };
     
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -268,6 +268,10 @@ public:
 
     bool isAlwaysOnLoggingAllowed() const;
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    bool usesWebContentRestrictionsForFilter() const { return m_sharedPreferencesForWebProcess.usesWebContentRestrictionsForFilter; };
+#endif
+
 private:
     NetworkConnectionToWebProcess(NetworkProcess&, WebCore::ProcessIdentifier, PAL::SessionID, NetworkProcessConnectionParameters&&, IPC::Connection::Identifier&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -294,6 +294,9 @@ bool NetworkResourceLoader::startContentFiltering(ResourceRequest& request)
 #if HAVE(AUDIT_TOKEN)
     m_contentFilter->setHostProcessAuditToken(protectedConnectionToWebProcess()->protectedNetworkProcess()->sourceApplicationAuditToken());
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    m_contentFilter->setUsesWebContentRestrictions(protectedConnectionToWebProcess()->usesWebContentRestrictionsForFilter());
+#endif
     m_contentFilter->startFilteringMainResource(request.url());
     if (!m_contentFilter->continueAfterWillSendRequest(request, ResourceResponse())) {
         m_contentFilter->stopFilteringMainResource();

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -88,6 +88,9 @@ header: <WebCore/FontPlatformData.h>
 class WebCore::ContentFilterUnblockHandler {
     String unblockURLHost()
     URL unreachableURL()
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    std::optional<URL> evaluatedURL();
+#endif
 #if HAVE(PARENTAL_CONTROLS_WITH_UNBLOCK_HANDLER)
     Vector<uint8_t> webFilterEvaluatorData()
 #endif


### PR DESCRIPTION
#### f2242a8c4fe28924b69c6e026e8f4119a12506e7
<pre>
[Content Filtering] Adopt WebContentRestrictions SPI for content filtering
<a href="https://bugs.webkit.org/show_bug.cgi?id=288696">https://bugs.webkit.org/show_bug.cgi?id=288696</a>
<a href="https://rdar.apple.com/145720557">rdar://145720557</a>

Reviewed by Per Arne Vollan.

Use simpler WCRBrowserEngineClient interface to replace WebFilterEvaluator. This is not enabled yet.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/PAL/PAL.xcodeproj/project.pbxproj:
* Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.h:
* Source/WebCore/PAL/pal/cocoa/WebContentRestrictionsSoftLink.mm:
* Source/WebCore/PAL/pal/spi/cocoa/WebContentRestrictionsSPI.h:
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::isWebContentRestrictionsUnblockURL):
(WebCore::ContentFilter::setUsesWebContentRestrictions):
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::startLoadingMainResource):
* Source/WebCore/page/DeprecatedGlobalSettings.h:
(WebCore::DeprecatedGlobalSettings::setUsesWebContentRestrictionsForFilter):
(WebCore::DeprecatedGlobalSettings::usesWebContentRestrictionsForFilter):
* Source/WebCore/platform/ContentFilterUnblockHandler.h:
(WebCore::ContentFilterUnblockHandler::evaluatedURL const):
* Source/WebCore/platform/PlatformContentFilter.h:
(WebCore::PlatformContentFilter::setUsesWebContentRestrictions):
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::ContentFilterUnblockHandler):
(WebCore::ContentFilterUnblockHandler::wrapWithDecisionHandler):
(WebCore::ContentFilterUnblockHandler::needsUIProcess const):
(WebCore::ContentFilterUnblockHandler::canHandleRequest const):
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync const):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::ParentalControlsContentFilter::enabled):
(WebCore::ParentalControlsContentFilter::responseReceived):
(WebCore::ParentalControlsContentFilter::addData):
(WebCore::ParentalControlsContentFilter::finishedAddingData):
(WebCore::ParentalControlsContentFilter::unblockHandler const):
(WebCore::ParentalControlsContentFilter::updateFilterState):
(WebCore::ParentalControlsContentFilter::setUsesWebContentRestrictions):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startContentFiltering):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:

Canonical link: <a href="https://commits.webkit.org/291264@main">https://commits.webkit.org/291264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aba264708a2ae5dc0ca790cba4af97ea968e5c66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92443 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20445 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95445 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9322 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51165 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1359 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42281 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85153 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99453 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91109 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19494 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79117 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23658 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/950 "Build is in progress. Recent messages:") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19478 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113757 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19165 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32896 "Found 10 new JSC stress test failures: stress/sampling-profiler-display-name.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-slow-memory, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.default-wasm, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20905 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->