### PR TITLE
REGRESSION(290563@main): [UnifiedPDF] [iOS] Web content process jetsams while zooming when find-in-page results are presented

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -4993,7 +4993,7 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
             RefPtr pluginView = mainFramePlugIn();
             if (!pluginView)
                 return true;
-            return pluginView->pluginHandlesPageScaleFactor() ? false : m_isInStableState;
+            return !pluginView->pluginHandlesPageScaleFactor();
 #else
             UNUSED_PARAM(this);
             return true;


### PR DESCRIPTION
#### 9b7724366badac916ce7a47ed0b0952d166977b7
<pre>
REGRESSION(290563@main): [UnifiedPDF] [iOS] Web content process jetsams while zooming when find-in-page results are presented
<a href="https://bugs.webkit.org/show_bug.cgi?id=288702">https://bugs.webkit.org/show_bug.cgi?id=288702</a>
<a href="https://rdar.apple.com/145686833">rdar://145686833</a>

Reviewed by Aditya Keerthi.

In 290563@main, we introduced a behavior change where, for main frame
plugins on iOS, we would only apply the new page scale factor from a
visible content rects update if we were in steady state, i.e. at the end
of pinch gestures.

This change meant that when we would pinch out, since the new page scale
factor was not applied, there was an unnecessarily large number of tiles
for the find overlay layer - all of which were full resolution too. This
caused unnecessary memory spikes in the web content process and lead to
crossing the memory watermark on said process when pinch zooming around
while the find overlay was up.

This patch addresses the bug by partially reverting the behavior change
introduced in 290563@main. We do not require being in steady state to
apply page scale factor anymore. This also means that we align better
with pinch zooming behavior on general web content in iOS, in that the
content remains sharp throughout the gesture.

* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/291230@main">https://commits.webkit.org/291230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b50885ad7acd70658ebf70265b7c995b47befda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97322 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42844 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70779 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51093 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8939 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42176 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79285 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99346 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19387 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79038 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19597 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23584 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12388 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19372 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24539 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->