### PR TITLE
Fix "Never put an Inlines.h header in a non-Inlines.h header" style errors under `WebCore/dom` directory

### DIFF
--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -6725,6 +6725,7 @@ sub GenerateCallbackHeaderContent
     my $name = $interfaceOrCallback->type->name;
     my $className = GetCallbackClassName($name);
 
+    $includesRef->{"ContextDestructionObserverInlines.h"} = 1;
     $includesRef->{"IDLTypes.h"} = 1;
     $includesRef->{"JSCallbackData.h"} = 1;
     $includesRef->{"<wtf/Forward.h>"} = 1;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSTestCallbackFunction.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "TestCallbackFunction.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSTestCallbackFunctionGenerateIsReachable.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "TestCallbackFunctionGenerateIsReachable.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSTestCallbackFunctionWithThisObject.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertSequences.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "TestCallbackFunctionWithThisObject.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSTestCallbackFunctionWithTypedefs.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertNullable.h"
 #include "JSDOMConvertNumbers.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "TestCallbackFunctionWithTypedefs.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSTestCallbackFunctionWithVariadic.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "JSDOMConvertAny.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -24,7 +24,6 @@
 
 #include "JSTestCallbackInterface.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "JSDOMConstructorNotConstructable.h"
 #include "JSDOMConvertBase.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -22,6 +22,7 @@
 
 #if ENABLE(TEST_CONDITIONAL)
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "JSDOMConvertDictionary.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "JSTestCallbackWithFunctionOrDict.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertCallbacks.h"
 #include "JSDOMConvertDictionary.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "TestCallbackWithFunctionOrDict.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -24,7 +24,6 @@
 
 #include "JSTestVoidCallbackFunction.h"
 
-#include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertBase.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMConvertBufferSource.h"

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -22,6 +22,7 @@
 
 #if ENABLE(TEST_CONDITIONAL)
 
+#include "ContextDestructionObserverInlines.h"
 #include "IDLTypes.h"
 #include "JSCallbackData.h"
 #include "TestVoidCallbackFunction.h"

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -293,4 +293,9 @@ bool BroadcastChannel::isEligibleForMessaging() const
     return !downcast<WorkerGlobalScope>(*context).isClosing();
 }
 
+ScriptExecutionContext* BroadcastChannel::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -74,7 +74,7 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::BroadcastChannel; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void derefEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -24,6 +24,7 @@
 
 #include "Attr.h"
 #include "ChildChangeInvalidation.h"
+#include "DocumentInlines.h"
 #include "ElementTraversal.h"
 #include "EventNames.h"
 #include "FrameSelection.h"

--- a/Source/WebCore/dom/ChildListMutationScope.cpp
+++ b/Source/WebCore/dom/ChildListMutationScope.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "ChildListMutationScope.h"
 
+#include "DocumentInlines.h"
 #include "MutationObserverInterestGroup.h"
 #include "MutationRecord.h"
 #include "StaticNodeList.h"
@@ -145,6 +146,12 @@ bool ChildListMutationAccumulator::isEmpty()
     }
 #endif
     return result;
+}
+
+ChildListMutationScope::ChildListMutationScope(ContainerNode& target)
+{
+    if (target.document().hasMutationObserversOfType(MutationObserverOptionType::ChildList))
+        m_accumulator = ChildListMutationAccumulator::getOrCreate(target);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ChildListMutationScope.h
+++ b/Source/WebCore/dom/ChildListMutationScope.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "ContainerNode.h"
-#include "DocumentInlines.h"
+#include "Document.h"
 #include "MutationObserver.h"
 #include <memory>
 #include <wtf/Noncopyable.h>
@@ -77,11 +77,7 @@ private:
 class ChildListMutationScope {
     WTF_MAKE_NONCOPYABLE(ChildListMutationScope);
 public:
-    explicit ChildListMutationScope(ContainerNode& target)
-    {
-        if (target.document().hasMutationObserversOfType(MutationObserverOptionType::ChildList))
-            m_accumulator = ChildListMutationAccumulator::getOrCreate(target);
-    }
+    explicit ChildListMutationScope(ContainerNode& target);
 
     bool canObserve() const { return m_accumulator; }
 

--- a/Source/WebCore/dom/ContextDestructionObserver.h
+++ b/Source/WebCore/dom/ContextDestructionObserver.h
@@ -37,7 +37,7 @@ class ContextDestructionObserver {
 public:
     WEBCORE_EXPORT virtual void contextDestroyed();
 
-    ScriptExecutionContext* scriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
+    inline ScriptExecutionContext* scriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
     RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
 protected:

--- a/Source/WebCore/dom/MutationObserverInterestGroup.cpp
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.cpp
@@ -29,9 +29,9 @@
  */
 
 #include "config.h"
-
 #include "MutationObserverInterestGroup.h"
 
+#include "DocumentInlines.h"
 #include "MutationObserverRegistration.h"
 #include "MutationRecord.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -45,6 +45,31 @@ inline MutationObserverInterestGroup::MutationObserverInterestGroup(UncheckedKey
     , m_oldValueFlag(oldValueFlag)
 {
     ASSERT(!m_observers.isEmpty());
+}
+
+std::unique_ptr<MutationObserverInterestGroup> MutationObserverInterestGroup::createForChildListMutation(Node& target)
+{
+    if (!target.document().hasMutationObserversOfType(MutationObserverOptionType::ChildList))
+        return nullptr;
+
+    MutationRecordDeliveryOptions oldValueFlag;
+    return createIfNeeded(target, MutationObserverOptionType::ChildList, oldValueFlag);
+}
+
+std::unique_ptr<MutationObserverInterestGroup> MutationObserverInterestGroup::createForCharacterDataMutation(Node& target)
+{
+    if (!target.document().hasMutationObserversOfType(MutationObserverOptionType::CharacterData))
+        return nullptr;
+
+    return createIfNeeded(target, MutationObserverOptionType::CharacterData, MutationObserverOptionType::CharacterDataOldValue);
+}
+
+std::unique_ptr<MutationObserverInterestGroup> MutationObserverInterestGroup::createForAttributesMutation(Node& target, const QualifiedName& attributeName)
+{
+    if (!target.document().hasMutationObserversOfType(MutationObserverOptionType::Attributes))
+        return nullptr;
+
+    return createIfNeeded(target, MutationObserverOptionType::Attributes, MutationObserverOptionType::AttributeOldValue, &attributeName);
 }
 
 std::unique_ptr<MutationObserverInterestGroup> MutationObserverInterestGroup::createIfNeeded(Node& target, MutationObserverOptionType type, MutationRecordDeliveryOptions oldValueFlag, const QualifiedName* attributeName)

--- a/Source/WebCore/dom/MutationObserverInterestGroup.h
+++ b/Source/WebCore/dom/MutationObserverInterestGroup.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "DocumentInlines.h"
+#include "Document.h"
 #include "MutationObserver.h"
 #include <memory>
 #include <wtf/HashMap.h>
@@ -45,30 +45,9 @@ class MutationObserverInterestGroup {
 public:
     MutationObserverInterestGroup(UncheckedKeyHashMap<Ref<MutationObserver>, MutationRecordDeliveryOptions>&&, MutationRecordDeliveryOptions);
 
-    static std::unique_ptr<MutationObserverInterestGroup> createForChildListMutation(Node& target)
-    {
-        if (!target.document().hasMutationObserversOfType(MutationObserverOptionType::ChildList))
-            return nullptr;
-
-        MutationRecordDeliveryOptions oldValueFlag;
-        return createIfNeeded(target, MutationObserverOptionType::ChildList, oldValueFlag);
-    }
-
-    static std::unique_ptr<MutationObserverInterestGroup> createForCharacterDataMutation(Node& target)
-    {
-        if (!target.document().hasMutationObserversOfType(MutationObserverOptionType::CharacterData))
-            return nullptr;
-
-        return createIfNeeded(target, MutationObserverOptionType::CharacterData, MutationObserverOptionType::CharacterDataOldValue);
-    }
-
-    static std::unique_ptr<MutationObserverInterestGroup> createForAttributesMutation(Node& target, const QualifiedName& attributeName)
-    {
-        if (!target.document().hasMutationObserversOfType(MutationObserverOptionType::Attributes))
-            return nullptr;
-
-        return createIfNeeded(target, MutationObserverOptionType::Attributes, MutationObserverOptionType::AttributeOldValue, &attributeName);
-    }
+    static std::unique_ptr<MutationObserverInterestGroup> createForChildListMutation(Node& target);
+    static std::unique_ptr<MutationObserverInterestGroup> createForCharacterDataMutation(Node& target);
+    static std::unique_ptr<MutationObserverInterestGroup> createForAttributesMutation(Node& target, const QualifiedName& attributeName);
 
     bool isOldValueRequested() const;
     void enqueueMutationRecord(Ref<MutationRecord>&&);

--- a/Source/WebCore/dom/ViewTransitionTypeSet.h
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.h
@@ -29,7 +29,7 @@
 #include "JSDOMSetLike.h"
 #include <wtf/ListHashSet.h>
 #include <wtf/RefCounted.h>
-#include <wtf/TZoneMallocInlines.h>
+#include <wtf/TZoneMalloc.h>
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp
@@ -29,6 +29,7 @@
 
 #include "EXTDisjointTimerQuery.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventLoop.h"
 #include "ScriptExecutionContext.h"
 #include "WebGLRenderingContext.h"

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -28,6 +28,7 @@
 #if ENABLE(WEBGL)
 #include "EXTDisjointTimerQueryWebGL2.h"
 
+#include "ContextDestructionObserverInlines.h"
 #include "EventLoop.h"
 #include "ScriptExecutionContext.h"
 

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -189,6 +189,11 @@ bool TrackListBase::isAnyTrackEnabled() const
     return false;
 }
 
+ScriptExecutionContext* TrackListBase::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 } // namespace WebCore
 
 #endif

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -70,7 +70,7 @@ public:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const override = 0;
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     void didMoveToNewDocument(Document&);
 

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -455,4 +455,9 @@ void Performance::scheduleTaskIfNeeded()
     });
 }
 
+ScriptExecutionContext* Performance::scriptExecutionContext() const
+{
+    return ContextDestructionObserver::scriptExecutionContext();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -113,7 +113,7 @@ public:
     DOMHighResTimeStamp relativeTimeFromTimeOriginInReducedResolution(MonotonicTime) const;
     MonotonicTime monotonicTimeFromRelativeTime(DOMHighResTimeStamp) const;
 
-    ScriptExecutionContext* scriptExecutionContext() const final { return ContextDestructionObserver::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
 
     using RefCounted::ref;
     using RefCounted::deref;

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -144,7 +144,7 @@ public:
     bool paintsContinuationOutline(RenderInline*);
 
     static RenderPtr<RenderBlock> createAnonymousWithParentRendererAndDisplay(const RenderBox& parent, DisplayType = DisplayType::Block);
-    RenderPtr<RenderBlock> createAnonymousBlock(DisplayType = DisplayType::Block) const;
+    inline RenderPtr<RenderBlock> createAnonymousBlock(DisplayType = DisplayType::Block) const;
 
     RenderPtr<RenderBox> createAnonymousBoxWithSameTypeAs(const RenderBox&) const override;
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "RenderBlockInlines.h"
 #include "RenderTreeBuilder.h"
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp
@@ -251,4 +251,9 @@ bool BackgroundFetchRegistration::virtualHasPendingActivity() const
     return m_information.recordsAvailable;
 }
 
+ScriptExecutionContext* BackgroundFetchRegistration::scriptExecutionContext() const
+{
+    return ActiveDOMObject::scriptExecutionContext();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -77,7 +77,7 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::BackgroundFetchRegistration; }
-    ScriptExecutionContext* scriptExecutionContext() const final { return ActiveDOMObject::scriptExecutionContext(); }
+    ScriptExecutionContext* scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 


### PR DESCRIPTION
#### 6b05bf7f3a1e54745301737e6645ff579fafbce7
<pre>
Fix &quot;Never put an Inlines.h header in a non-Inlines.h header&quot; style errors under `WebCore/dom` directory
<a href="https://bugs.webkit.org/show_bug.cgi?id=288701">https://bugs.webkit.org/show_bug.cgi?id=288701</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateCallbackHeaderContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::scriptExecutionContext const):
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/CharacterData.cpp:
* Source/WebCore/dom/ChildListMutationScope.cpp:
(WebCore::ChildListMutationScope::ChildListMutationScope):
* Source/WebCore/dom/ChildListMutationScope.h:
(WebCore::ChildListMutationScope::ChildListMutationScope): Deleted.
* Source/WebCore/dom/ContextDestructionObserver.h:
* Source/WebCore/dom/MutationObserverInterestGroup.cpp:
(WebCore::MutationObserverInterestGroup::createForChildListMutation):
(WebCore::MutationObserverInterestGroup::createForCharacterDataMutation):
(WebCore::MutationObserverInterestGroup::createForAttributesMutation):
* Source/WebCore/dom/MutationObserverInterestGroup.h:
(WebCore::MutationObserverInterestGroup::createForChildListMutation): Deleted.
(WebCore::MutationObserverInterestGroup::createForCharacterDataMutation): Deleted.
(WebCore::MutationObserverInterestGroup::createForAttributesMutation): Deleted.
* Source/WebCore/dom/ViewTransitionTypeSet.h:
* Source/WebCore/html/canvas/EXTDisjointTimerQuery.cpp:
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::scriptExecutionContext const):
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::scriptExecutionContext const):
* Source/WebCore/page/Performance.h:
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.h:
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.cpp:
(WebCore::BackgroundFetchRegistration::scriptExecutionContext const):
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b05bf7f3a1e54745301737e6645ff579fafbce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92642 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12189 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1807 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97628 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43149 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94692 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12466 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20645 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/97628 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28380 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95644 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/12466 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/138/builds/1807 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/97628 "Hash 6b05bf7f for PR 41500 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/12466 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/138/builds/1807 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42480 "Hash 6b05bf7f for PR 41500 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/12466 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/138/builds/1807 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99654 "Hash 6b05bf7f for PR 41500 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19693 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/123/builds/20645 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/99654 "Hash 6b05bf7f for PR 41500 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19943 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/138/builds/1807 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/99654 "Hash 6b05bf7f for PR 41500 does not build (failure)") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/138/builds/1807 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12708 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19677 "Hash 6b05bf7f for PR 41500 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24849 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19364 "Hash 6b05bf7f for PR 41500 does not build (failure)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22824 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21105 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->