### PR TITLE
[Cocoa] Unable to use system appearance features in stylesheets inside UA shadow roots

### DIFF
--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -49,21 +49,28 @@ const CSSParserContext& strictCSSParserContext()
     return strictContext;
 }
 
+static void applyUASheetBehaviorsToContext(CSSParserContext& context)
+{
+    // FIXME: We should turn all of the features on from their WebCore Settings defaults.
+    context.cssAppearanceBaseEnabled = true;
+    context.cssTextUnderlinePositionLeftRightEnabled = true;
+    context.lightDarkColorEnabled = true;
+    context.popoverAttributeEnabled = true;
+    context.propertySettings.cssInputSecurityEnabled = true;
+    context.propertySettings.cssCounterStyleAtRulesEnabled = true;
+    context.propertySettings.viewTransitionsEnabled = true;
+#if HAVE(CORE_MATERIAL)
+    context.propertySettings.useSystemAppearance = true;
+#endif
+    context.thumbAndTrackPseudoElementsEnabled = true;
+}
+
 CSSParserContext::CSSParserContext(CSSParserMode mode, const URL& baseURL)
     : baseURL(baseURL)
     , mode(mode)
 {
-    // FIXME: We should turn all of the features on from their WebCore Settings defaults.
-    if (isUASheetBehavior(mode)) {
-        cssAppearanceBaseEnabled = true;
-        cssTextUnderlinePositionLeftRightEnabled = true;
-        lightDarkColorEnabled = true;
-        popoverAttributeEnabled = true;
-        propertySettings.cssInputSecurityEnabled = true;
-        propertySettings.cssCounterStyleAtRulesEnabled = true;
-        propertySettings.viewTransitionsEnabled = true;
-        thumbAndTrackPseudoElementsEnabled = true;
-    }
+    if (isUASheetBehavior(mode))
+        applyUASheetBehaviorsToContext(*this);
 
     StaticCSSValuePool::init();
 }
@@ -170,6 +177,12 @@ ResolvedURL CSSParserContext::completeURL(const String& string) const
         return { };
 
     return result;
+}
+
+void CSSParserContext::setUASheetMode()
+{
+    mode = UASheetMode;
+    applyUASheetBehaviorsToContext(*this);
 }
 
 bool mayDependOnBaseURL(const ResolvedURL& resolved)

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -112,7 +112,10 @@ struct CSSParserContext {
     CSSParserContext(CSSParserMode, const URL& baseURL = URL());
     WEBCORE_EXPORT CSSParserContext(const Document&);
     CSSParserContext(const Document&, const URL& baseURL, ASCIILiteral charset = ""_s);
+
     ResolvedURL completeURL(const String&) const;
+
+    void setUASheetMode();
 
     bool operator==(const CSSParserContext&) const = default;
 };

--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -48,7 +48,7 @@ static CSSParserContext parserContextForElement(const Element& element)
 
     CSSParserContext result = CSSParserContext { element.document(), baseURL, element.document().characterSetWithUTF8Fallback() };
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::UserAgent)
-        result.mode = UASheetMode;
+        result.setUASheetMode();
     return result;
 }
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1699,8 +1699,8 @@ bool InspectorStyleSheet::ensureSourceData()
     // FIXME: <webkit.org/b/161747> Media control CSS uses out-of-spec selectors in inline user agent shadow root style
     // element. See corresponding workaround in `CSSSelectorParser::extractCompoundFlags`.
     if (auto* ownerNode = m_pageStyleSheet->ownerNode(); ownerNode && ownerNode->isInUserAgentShadowTree())
-        context.mode = UASheetMode;
-    
+        context.setUASheetMode();
+
     StyleSheetHandler handler(m_parsedStyleSheet->text(), m_pageStyleSheet->ownerDocument(), ruleSourceDataResult.get());
     CSSParser::parseSheetForInspector(context, newStyleSheet, m_parsedStyleSheet->text(), handler);
     m_parsedStyleSheet->setSourceData(WTFMove(ruleSourceDataResult));


### PR DESCRIPTION
#### 901adf26e0db6b8b2cef3c2c81336eb0c0ef43c8
<pre>
[Cocoa] Unable to use system appearance features in stylesheets inside UA shadow roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=288707">https://bugs.webkit.org/show_bug.cgi?id=288707</a>
<a href="https://rdar.apple.com/145703473">rdar://145703473</a>

Reviewed by Tim Horton.

When constructing a `CSSParserContext` with `UASheetMode`, settings are manually
turned on to allow User-Agent style stylesheets to use features that are
experimental and/or non-web exposed. However, for `CSSParserContext`s where the
`mode` is set after construction, the same settings are not enabled.

This is problematic for things like media controls, which use a `&lt;style&gt;` inside a
UA shadow root, and should be able to use system appearance features.

Fix by adding a method to `CSSParserContext` which sets UA mode and applies the
necessary settings.

* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::applyUASheetBehaviorsToContext):

Share logic to enable features.

(WebCore::CSSParserContext::CSSParserContext):
(WebCore::CSSParserContext::setUASheetMode):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::parserContextForElement):

This is the main fix. Contexts for styles in UA shadow roots should turn on
more settings.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::ensureSourceData):

Canonical link: <a href="https://commits.webkit.org/291260@main">https://commits.webkit.org/291260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/240d115e5775d2ce173b4dae7f538fc40fd84078

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42910 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28277 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95405 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9287 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51142 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8993 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42240 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79320 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1263 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99413 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19704 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79092 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23631 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12455 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14720 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19438 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24610 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19125 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20865 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->