### PR TITLE
[JSC] byteLength CheckInBounds should be eliminated

### DIFF
--- a/JSTests/stress/uint8array-check-in-bounds.js
+++ b/JSTests/stress/uint8array-check-in-bounds.js
@@ -1,0 +1,12 @@
+function test(array)
+{
+    let result = 0;
+    for (let i = 0; i < array.length; ++i)
+        result += array[i];
+    return array;
+}
+noInline(test);
+
+let array = new Uint8Array(1024);
+for (let i = 0; i < testLoopCount; ++i)
+    test(array);

--- a/Source/JavaScriptCore/dfg/DFGArrayMode.h
+++ b/Source/JavaScriptCore/dfg/DFGArrayMode.h
@@ -205,6 +205,11 @@ public:
         return ArrayMode(type, arrayClass(), speculation(), conversion(), action(), mayBeLargeTypedArray(), mayBeResizableOrGrowableSharedTypedArray());
     }
 
+    ArrayMode withAction(Array::Action action) const
+    {
+        return ArrayMode(type(), arrayClass(), speculation(), conversion(), action, mayBeLargeTypedArray(), mayBeResizableOrGrowableSharedTypedArray());
+    }
+
     ArrayMode withSpeculation(Array::Speculation speculation) const
     {
         return ArrayMode(type(), arrayClass(), speculation, conversion(), action(), mayBeLargeTypedArray(), mayBeResizableOrGrowableSharedTypedArray());
@@ -223,6 +228,11 @@ public:
     ArrayMode withArrayClassAndSpeculation(Array::Class arrayClass, Array::Speculation speculation, bool mayBeLargeTypedArray, bool mayBeResizableOrGrowableSharedTypedArray) const
     {
         return ArrayMode(type(), arrayClass, speculation, conversion(), action(), mayBeLargeTypedArray, mayBeResizableOrGrowableSharedTypedArray);
+    }
+
+    ArrayMode withArrayClass(Array::Class arrayClass) const
+    {
+        return ArrayMode(type(), arrayClass, speculation(), conversion(), action(), mayBeLargeTypedArray(), mayBeResizableOrGrowableSharedTypedArray());
     }
 
     static Array::Speculation speculationFromProfile(const ConcurrentJSLocker& locker, ArrayProfile* profile, bool makeSafe)

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1617,6 +1617,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         ArrayMode mode = node->arrayMode();
         DFG_ASSERT(graph, node, mode.isSomeTypedArrayView());
         DFG_ASSERT(graph, node, !mode.mayBeResizableOrGrowableSharedTypedArray());
+        mode = mode.withAction(Array::Action::Read); // Force action to Read to prevent incorrect optimizations in equality checks.
         def(PureValue(node, mode.asWord()));
         return;
     }

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -436,6 +436,7 @@ private:
                         if (canFold) {
                             if (m_graph.isWatchingArrayBufferDetachWatchpoint(node)) {
                                 node->setOp(GetUndetachedTypeArrayLength);
+                                node->setArrayMode(arrayMode.withArrayClass(Array::NonArray));
                                 changed = true;
                                 break;
                             }

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -403,6 +403,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         if (changed) {
             // State-at-tail and state-at-head will be invalid if we did strength reduction since
             // it might increase live ranges.
+            RUN_PHASE(performGlobalCSE);
             RUN_PHASE(performGraphPackingAndLivenessAnalysis);
             RUN_PHASE(performCFA);
             RUN_PHASE(performConstantFolding);

--- a/Source/JavaScriptCore/dfg/DFGSSALoweringPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSSALoweringPhase.cpp
@@ -158,32 +158,29 @@ private:
             break;
         }
 
-        Node* checkInBounds;
+        Node* checkInBounds = nullptr;
+        if (op == GetArrayLength && m_node->arrayMode().isSomeTypedArrayView()) {
 #if USE(LARGE_TYPED_ARRAYS)
-        if ((op == GetArrayLength) && m_node->arrayMode().isSomeTypedArrayView() && (m_node->arrayMode().mayBeLargeTypedArray() || m_graph.hasExitSite(m_node->origin.semantic, Overflow))) {
-            Node* length = m_insertionSet.insertNode(
-                m_nodeIndex, SpecInt52Any, GetTypedArrayLengthAsInt52, m_node->origin,
-                OpInfo(m_node->arrayMode().asWord()), Edge(base.node(), KnownCellUse), storage);
-            if (m_node->arrayMode().mayBeResizableOrGrowableSharedTypedArray())
-                m_insertionSet.insertNode(m_nodeIndex, SpecNone, ExitOK, m_node->origin.withExitOK(true));
-            // The return type is a dummy since this node does not actually return anything.
-            checkInBounds = m_insertionSet.insertNode(
-                m_nodeIndex, SpecInt32Only, CheckInBoundsInt52, m_node->origin,
-                index, Edge(length, Int52RepUse));
-        } else {
+            if (m_node->arrayMode().mayBeLargeTypedArray() || m_graph.hasExitSite(m_node->origin.semantic, Overflow)) {
+                Node* length = m_insertionSet.insertNode(
+                    m_nodeIndex, SpecInt52Any, GetTypedArrayLengthAsInt52, m_node->origin,
+                    OpInfo(m_node->arrayMode().asWord()), Edge(base.node(), KnownCellUse), storage);
+                if (m_node->arrayMode().mayBeResizableOrGrowableSharedTypedArray())
+                    m_insertionSet.insertNode(m_nodeIndex, SpecNone, ExitOK, m_node->origin.withExitOK(true));
+                // The return type is a dummy since this node does not actually return anything.
+                checkInBounds = m_insertionSet.insertNode(m_nodeIndex, SpecInt32Only, CheckInBoundsInt52, m_node->origin, index, Edge(length, Int52RepUse));
+            }
 #endif
+        }
+
+        if (!checkInBounds) {
             Node* length = m_insertionSet.insertNode(
                 m_nodeIndex, SpecInt32Only, op, m_node->origin,
                 OpInfo(m_node->arrayMode().asWord()), Edge(base.node(), KnownCellUse), storage);
             if (m_node->arrayMode().mayBeResizableOrGrowableSharedTypedArray())
                 m_insertionSet.insertNode(m_nodeIndex, SpecNone, ExitOK, m_node->origin.withExitOK(true));
-            checkInBounds = m_insertionSet.insertNode(
-                m_nodeIndex, SpecInt32Only, CheckInBounds, m_node->origin,
-                index, Edge(length, KnownInt32Use));
-#if USE(LARGE_TYPED_ARRAYS)
+            checkInBounds = m_insertionSet.insertNode(m_nodeIndex, SpecInt32Only, CheckInBounds, m_node->origin, index, Edge(length, KnownInt32Use));
         }
-#endif
-
 
         AdjacencyList adjacencyList = m_graph.copyVarargChildren(m_node);
         m_graph.m_varArgChildren.append(Edge(checkInBounds, UntypedUse));


### PR DESCRIPTION
#### 90052846372d777d22fad055ed11885f4a84aff7
<pre>
[JSC] byteLength CheckInBounds should be eliminated
<a href="https://bugs.webkit.org/show_bug.cgi?id=288709">https://bugs.webkit.org/show_bug.cgi?id=288709</a>
<a href="https://rdar.apple.com/145730507">rdar://145730507</a>

Reviewed by Yijia Huang.

We found an issue that CheckInBounds is not eliminated when we run the
script like this.

    let array = new Uint8Array(1024);
    for (let i = 0; i &lt; array.byteLength; ++i) {
        array[i] = 42;
    }

The reason is that we convert array.byteLength to
GetUndetachedTypeArrayLength, but SSA lowering converts PutByVal with
GetArrayLength. While GetArrayLength gets converted to GetUndetachedTypeArrayLength later,
it is too late and we failed to identify bound loop.

In this patch, we fix two things.

1. Fix GetUndetachedTypeArrayLength conversion&apos;s ArrayMode to align it
   to `byteLength` etc.&apos;s ArrayMode use. This allows CSE for that.
2. Run performGlobalCSE before integer range optimization to merge
   PutByVal&apos;s GetUndetachedTypeArrayLength to loop condition&apos;s one.

* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::withAction const):
(JSC::DFG::ArrayMode::withArrayClass const):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGSSALoweringPhase.cpp:
(JSC::DFG::SSALoweringPhase::lowerBoundsCheck):

Canonical link: <a href="https://commits.webkit.org/291395@main">https://commits.webkit.org/291395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3ecc03e0d7c15ab85168d04cd6eadcc139370b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92827 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2020 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20830 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95829 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9239 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85537 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1591 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91493 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19879 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20130 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79881 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/23870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14823 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19863 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114141 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/23010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->