### PR TITLE
MediaStream from canvas.captureStream and then read VideoFrame using MediaStreamTrackProcessor, copyTo does not produce any content.

### DIFF
--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-expected.txt
@@ -1,5 +1,6 @@
 
 PASS Transfer MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor
+PASS Transfer canvas MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor
 PASS Transferred audio track get muted/unmuted according page state
 PASS Transferred video track get muted/unmuted according page state
 PASS Page state gets updated when transferred tracks get stopped

--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
@@ -6,6 +6,7 @@
 <script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
+<canvas id=canvas width=640 height=480></canvas>
 <script>
 
 async function createWorker(script)
@@ -43,6 +44,44 @@ promise_test(async test => {
     assert_equals(result.value.codedWidth, 640);
     assert_equals(result.value.codedHeight, 480);
 }, "Transfer MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor");
+
+promise_test(async test => {
+    const stream = canvas.captureStream();
+
+    const context = canvas.getContext('2d');
+    const timer = setInterval(() => {
+        context.fillStyle = "#ff0000";
+        context.fillRect(0, 0, 640, 480);
+    }, 50);
+    test.add_cleanup(() => clearInterval(timer));
+
+    const worker = await createWorker(`
+        self.onmessage = async (event) => {
+            const processor = new MediaStreamTrackProcessor({ track: event.data.track });
+            const data = await processor.readable.getReader().read();
+            self.postMessage(data);
+            data.value.close();
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+    const track = stream.getVideoTracks()[0];
+    worker.postMessage({ track }, [track]);
+
+    const result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
+    assert_false(result.done);
+
+    test.add_cleanup(() => result.value.close());
+    assert_equals(result.value.codedWidth, 640);
+    assert_equals(result.value.codedHeight, 480);
+    assert_equals(result.value.format, "BGRA");
+
+   const buffer = new Uint8Array(canvas.width * canvas.height * 4);
+   await result.value.copyTo(buffer);
+   assert_equals(buffer[0], 0, "b");
+   assert_equals(buffer[1], 0, "g");
+   assert_equals(buffer[2], 255, "r");
+   assert_equals(buffer[3], 255, "a");
+}, "Transfer canvas MediaStreamTrack to dedicated worker and use MediaStreamTrackProcessor");
 
 promise_test(async test => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -174,11 +174,13 @@ RefPtr<WebCodecsVideoFrame> MediaStreamTrackProcessor::VideoFrameObserver::takeV
         videoFrame = m_videoFrames.takeFirst();
     }
 
-    WebCodecsVideoFrame::BufferInit init;
-    init.codedWidth = videoFrame->presentationSize().width();
-    init.codedHeight = videoFrame->presentationSize().height();
-    init.colorSpace = videoFrame->colorSpace();
-    init.timestamp = Seconds(videoFrame->presentationTime().toDouble()).microseconds();
+    WebCodecsVideoFrame::BufferInit init {
+        .format = convertVideoFramePixelFormat(videoFrame->pixelFormat()),
+        .codedWidth = static_cast<size_t>(videoFrame->presentationSize().width()),
+        .codedHeight = static_cast<size_t>(videoFrame->presentationSize().height()),
+        .timestamp = Seconds(videoFrame->presentationTime().toDouble()).microsecondsAs<int64_t>(),
+        .colorSpace = videoFrame->colorSpace()
+    };
 
     return WebCodecsVideoFrame::create(context, videoFrame.releaseNonNull(), WTFMove(init));
 }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -81,20 +81,20 @@ public:
         std::optional<size_t> displayHeight;
     };
     struct BufferInit {
-        VideoPixelFormat format { VideoPixelFormat::I420 };
+        VideoPixelFormat format;
         size_t codedWidth { 0 };
         size_t codedHeight { 0 };
         int64_t timestamp { 0 };
-        std::optional<uint64_t> duration;
+        std::optional<uint64_t> duration { };
 
-        std::optional<Vector<PlaneLayout>> layout;
+        std::optional<Vector<PlaneLayout>> layout { };
 
-        std::optional<DOMRectInit> visibleRect;
+        std::optional<DOMRectInit> visibleRect { };
 
-        std::optional<size_t> displayWidth;
-        std::optional<size_t> displayHeight;
+        std::optional<size_t> displayWidth { };
+        std::optional<size_t> displayHeight { };
 
-        std::optional<VideoColorSpaceInit> colorSpace;
+        std::optional<VideoColorSpaceInit> colorSpace { };
     };
 
     static ExceptionOr<Ref<WebCodecsVideoFrame>> create(ScriptExecutionContext&, CanvasImageSource&&, Init&&);

--- a/Source/WebCore/platform/VideoPixelFormat.h
+++ b/Source/WebCore/platform/VideoPixelFormat.h
@@ -39,7 +39,7 @@ enum class VideoPixelFormat {
     BGRX
 };
 
-VideoPixelFormat convertVideoFramePixelFormat(uint32_t, bool shouldDiscardAlpha);
+VideoPixelFormat convertVideoFramePixelFormat(uint32_t, bool shouldDiscardAlpha = false);
 
 inline bool isRGBVideoPixelFormat(VideoPixelFormat format)
 {


### PR DESCRIPTION
#### 400e12cfc98db7f29783a15dce831e21e85968c7
<pre>
MediaStream from canvas.captureStream and then read VideoFrame using MediaStreamTrackProcessor, copyTo does not produce any content.
<a href="https://rdar.apple.com/145454281">rdar://145454281</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=287787">https://bugs.webkit.org/show_bug.cgi?id=287787</a>

Reviewed by Eric Carlson.

We were setting the pixel format to I420, which is not true for canvas video frame.
Instead, we now use the underlying pixel format for WebCodecsVideoFrame format.

Covered by added test.

* LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker-expected.txt:
* LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
(WebCore::MediaStreamTrackProcessor::VideoFrameObserver::takeVideoFrame):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/platform/VideoPixelFormat.h:

Canonical link: <a href="https://commits.webkit.org/291312@main">https://commits.webkit.org/291312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c796a8940df0c44fb5d981465db375f5cdceadb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92378 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11921 "Hash 0c796a89 for PR 41505 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97362 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42885 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70806 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83667 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8988 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1295 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42215 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99387 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19429 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14370 "Found 1 new test failure: ipc/media-player-invalid-test.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79818 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79540 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79072 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19634 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23614 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/920 "Found 1 new test failure: http/wpt/webcodecs/copyTo-same-decoder.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12430 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24585 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19100 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->