### PR TITLE
Spatial Video does not show Immersive or View Spatial button when muted or lacks audio track

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8262,6 +8262,21 @@ VerticalFormControlsEnabled:
       "PLATFORM(COCOA)": true
       default: false
 
+VideoFullsceenPrefersMostVisibleHeuristic:
+  type: bool
+  status: testable
+  category: media
+  humanReadableName: "Prefers most visible video in element fullscreen."
+  humanReadableDescription: "Prefers most visible video in element fullscreen."
+  condition: ENABLE(FULLSCREEN_API)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 VideoFullscreenRequiresElementFullscreen:
   type: bool
   status: embedder
@@ -8274,7 +8289,7 @@ VideoFullscreenRequiresElementFullscreen:
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true
-      
+
 VideoPresentationManagerEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -640,6 +640,16 @@ void DocumentFullscreen::fullyExitFullscreen()
     });
 }
 
+static bool hasJSEventListener(Node& node, const AtomString& eventType)
+{
+    for (const auto& listener : node.eventListeners(eventType)) {
+        if (listener->callback().type() == EventListener::JSEventListenerType)
+            return true;
+    }
+
+    return false;
+}
+
 // MARK: - Fullscreen rendering update steps / event dispatching.
 // https://fullscreen.spec.whatwg.org/#run-the-fullscreen-steps
 
@@ -679,7 +689,7 @@ void DocumentFullscreen::dispatchPendingEvents()
         case EventType::Change: {
             Ref targetDocument = target->document();
             target->dispatchEvent(Event::create(eventNames().fullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
-            bool shouldEmitUnprefixed = !(target->hasEventListeners(eventNames().webkitfullscreenchangeEvent) && target->hasEventListeners(eventNames().fullscreenchangeEvent)) && !(targetDocument->hasEventListeners(eventNames().webkitfullscreenchangeEvent) && targetDocument->hasEventListeners(eventNames().fullscreenchangeEvent));
+            bool shouldEmitUnprefixed = !(hasJSEventListener(target, eventNames().webkitfullscreenchangeEvent) && hasJSEventListener(target, eventNames().fullscreenchangeEvent)) && !(hasJSEventListener(targetDocument, eventNames().webkitfullscreenchangeEvent) && hasJSEventListener(targetDocument, eventNames().fullscreenchangeEvent));
             if (shouldEmitUnprefixed)
                 target->dispatchEvent(Event::create(eventNames().webkitfullscreenchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes));
             break;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModel.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModel.h
@@ -75,6 +75,7 @@ public:
 
     virtual FloatSize videoDimensions() const = 0;
     virtual bool hasVideo() const = 0;
+    virtual bool isChildOfElementFullscreen() const = 0;
 
     virtual void willEnterPictureInPicture() = 0;
     virtual void didEnterPictureInPicture() = 0;
@@ -129,6 +130,7 @@ public:
     virtual void didExitPictureInPicture() { }
     virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) { }
     virtual void documentVisibilityChanged(bool) { }
+    virtual void isChildOfElementFullscreenChanged(bool) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h
@@ -71,6 +71,7 @@ public:
     WEBCORE_EXPORT void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) final;
     FloatSize videoDimensions() const final { return m_videoDimensions; }
     bool hasVideo() const final { return m_hasVideo; }
+    bool isChildOfElementFullscreen() const final { return m_isChildOfElementFullscreen; }
 
     WEBCORE_EXPORT void setVideoSizeFenced(const FloatSize&, WTF::MachSendRight&&);
 
@@ -120,6 +121,9 @@ private:
     void updateForEventName(const AtomString&);
     void cleanVideoListeners();
     void documentVisibilityChanged();
+#if ENABLE(FULLSCREEN_API)
+    void documentFullscreenChanged();
+#endif
 
     Ref<VideoListener> m_videoListener;
     RefPtr<HTMLVideoElement> m_videoElement;
@@ -128,12 +132,13 @@ private:
     UncheckedKeyHashSet<CheckedPtr<VideoPresentationModelClient>> m_clients;
     bool m_hasVideo { false };
     bool m_documentIsVisible { true };
+    bool m_isChildOfElementFullscreen { false };
     FloatSize m_videoDimensions;
     FloatRect m_videoFrame;
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
-
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 #if !RELEASE_LOG_DISABLED
     mutable uint64_t m_childIdentifierSeed { 0 };
 #endif

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -81,15 +81,19 @@ public:
     void incrementCheckedPtrCount() const final { CanMakeCheckedPtr::incrementCheckedPtrCount(); }
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
 
+    // VideoPresentationModelClient
+    void hasVideoChanged(bool) override { }
+    WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&) override;
+    WEBCORE_EXPORT void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) override;
+
+    // PlaybackSessionModelClient
+    WEBCORE_EXPORT void externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName) override;
+
     WEBCORE_EXPORT void setVideoPresentationModel(VideoPresentationModel*);
     PlaybackSessionInterfaceIOS& playbackSessionInterface() const { return m_playbackSessionInterface.get(); }
     PlaybackSessionModel* playbackSessionModel() const { return m_playbackSessionInterface->playbackSessionModel(); }
-    WEBCORE_EXPORT virtual void hasVideoChanged(bool) = 0;
-    WEBCORE_EXPORT void videoDimensionsChanged(const FloatSize&);
     virtual void setSpatialImmersive(bool) { }
-    WEBCORE_EXPORT virtual void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>);
     WEBCORE_EXPORT virtual void setupFullscreen(const FloatRect& initialRect, const FloatSize& videoDimensions, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture);
-    WEBCORE_EXPORT virtual void externalPlaybackChanged(bool enabled, PlaybackSessionModel::ExternalPlaybackTargetType, const String& localizedDeviceName);
     WEBCORE_EXPORT virtual AVPlayerViewController *avPlayerViewController() const = 0;
     WebAVPlayerController *playerController() const;
     WEBCORE_EXPORT void enterFullscreen();

--- a/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
+++ b/Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm
@@ -207,6 +207,7 @@ private:
     void setVideoFullscreenFrame(FloatRect) override { }
     void fullscreenModeChanged(HTMLMediaElementEnums::VideoFullscreenMode) override;
     bool hasVideo() const override;
+    bool isChildOfElementFullscreen() const override;
     FloatSize videoDimensions() const override;
     bool isMuted() const override;
     double volume() const override;
@@ -638,6 +639,12 @@ bool VideoFullscreenControllerContext::hasVideo() const
 {
     ASSERT(isUIThread());
     return m_presentationModel ? m_presentationModel->hasVideo() : false;
+}
+
+bool VideoFullscreenControllerContext::isChildOfElementFullscreen() const
+{
+    ASSERT(isUIThread());
+    return m_presentationModel ? m_presentationModel->isChildOfElementFullscreen() : false;
 }
 
 bool VideoFullscreenControllerContext::isMuted() const

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -118,6 +118,7 @@ enum class TapHandlingResult : uint8_t;
 - (void)_updateScrollViewIndicatorStyle;
 
 - (void)_videoControlsManagerDidChange;
+- (void)_videosInElementFullscreenChanged;
 
 - (void)_navigationGestureDidBegin;
 - (void)_navigationGestureDidEnd;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -713,6 +713,14 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
 #endif
 }
 
+- (void)_videosInElementFullscreenChanged
+{
+#if ENABLE(FULLSCREEN_API)
+    if (_fullScreenWindowController)
+        [_fullScreenWindowController videosInElementFullscreenChanged];
+#endif
+}
+
 - (CGPoint)_initialContentOffsetForScrollView
 {
     // FIXME: Should this use -[_scrollView adjustedContentInset]?

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
@@ -29,6 +29,7 @@
 messages -> VideoPresentationManagerProxy {
     SetHasVideo(WebKit::PlaybackSessionContextIdentifier contextId, bool hasVideo)
     SetDocumentVisibility(WebKit::PlaybackSessionContextIdentifier contextId, bool isDocumentVisible)
+    SetIsChildOfElementFullscreen(WebKit::PlaybackSessionContextIdentifier contextId, bool isChildOfElementFullscreen)
     SetVideoDimensions(WebKit::PlaybackSessionContextIdentifier contextId, WebCore::FloatSize videoDimensions)
     SetupFullscreenWithID(WebKit::PlaybackSessionContextIdentifier contextId, WebKit::LayerHostingContextID videoLayerID, WebCore::FloatRect screenRect, WebCore::FloatSize initialSize, WebCore::FloatSize videoDimensions, float hostingScaleFactor, WebCore::MediaPlayerEnums::VideoFullscreenMode videoFullscreenMode, bool allowsPictureInPicture, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
     SetPlayerIdentifier(WebKit::PlaybackSessionContextIdentifier contextId, std::optional<WebCore::MediaPlayerIdentifier> playerIdentifier)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -692,6 +692,7 @@ public:
     virtual void systemAudioCaptureChanged() { }
 
     virtual void videoControlsManagerDidChange() { }
+    virtual void videosInElementFullscreenChanged() { }
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
     virtual WebCore::WebMediaSessionManager& mediaSessionManager() = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -13700,6 +13700,12 @@ void WebPageProxy::videoControlsManagerDidChange()
         pageClient->videoControlsManagerDidChange();
 }
 
+void WebPageProxy::videosInElementFullscreenChanged()
+{
+    if (RefPtr pageClient = this->pageClient())
+        pageClient->videosInElementFullscreenChanged();
+}
+
 bool WebPageProxy::hasActiveVideoForControlsManager() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1946,6 +1946,7 @@ public:
     void handleAutoplayEvent(WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>);
 
     void videoControlsManagerDidChange();
+    void videosInElementFullscreenChanged();
     bool hasActiveVideoForControlsManager() const;
     void requestControlledElementID() const;
     void handleControlledElementIDResponse(const String&) const;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -283,6 +283,7 @@ private:
 
     void didChangeBackgroundColor() override;
     void videoControlsManagerDidChange() override;
+    void videosInElementFullscreenChanged() override;
 
     void refView() override;
     void derefView() override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -991,6 +991,11 @@ void PageClientImpl::videoControlsManagerDidChange()
     [webView() _videoControlsManagerDidChange];
 }
 
+void PageClientImpl::videosInElementFullscreenChanged()
+{
+    [webView() _videosInElementFullscreenChanged];
+}
+
 void PageClientImpl::refView()
 {
     [m_contentView retain];

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h
@@ -54,6 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)showBanner;
 - (void)hideBanner;
 - (void)videoControlsManagerDidChange;
+- (void)videosInElementFullscreenChanged;
 - (void)setAnimatingViewAlpha:(CGFloat)alpha;
 - (void)setSupportedOrientations:(UIInterfaceOrientationMask)supportedOrientations;
 - (void)resetSupportedOrientations;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h
@@ -58,6 +58,7 @@
 - (void)close;
 - (void)webViewDidRemoveFromSuperviewWhileInFullscreen;
 - (void)videoControlsManagerDidChange;
+- (void)videosInElementFullscreenChanged;
 - (void)didCleanupFullscreen;
 
 #if PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1477,6 +1477,12 @@ static constexpr NSString *kPrefersFullScreenDimmingKey = @"WebKitPrefersFullScr
         [_fullscreenViewController videoControlsManagerDidChange];
 }
 
+- (void)videosInElementFullscreenChanged
+{
+    if (_fullscreenViewController)
+        [_fullscreenViewController videosInElementFullscreenChanged];
+}
+
 - (void)placeholderWillMoveToSuperview:(UIView *)superview
 {
 #if !PLATFORM(APPLETV)

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h
@@ -105,6 +105,7 @@ private:
     // VideoPresentationModelClient
     void hasVideoChanged(bool) override;
     void documentVisibilityChanged(bool) override;
+    void isChildOfElementFullscreenChanged(bool) final;
 
     // CheckedPtr interface
     uint32_t checkedPtrCount() const final { return CanMakeCheckedPtr::checkedPtrCount(); }
@@ -185,6 +186,7 @@ protected:
     // Interface to VideoPresentationInterfaceContext
     void hasVideoChanged(PlaybackSessionContextIdentifier, bool hasVideo);
     void documentVisibilityChanged(PlaybackSessionContextIdentifier, bool isDocumentVisible);
+    void isChildOfElementFullscreenChanged(PlaybackSessionContextIdentifier, bool);
     void videoDimensionsChanged(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
     void setPlayerIdentifier(PlaybackSessionContextIdentifier, std::optional<WebCore::MediaPlayerIdentifier>);
 

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -122,6 +122,12 @@ void VideoPresentationInterfaceContext::documentVisibilityChanged(bool isDocumen
         manager->documentVisibilityChanged(m_contextId, isDocumentVisible);
 }
 
+void VideoPresentationInterfaceContext::isChildOfElementFullscreenChanged(bool isChildOfElementFullscreen)
+{
+    if (RefPtr manager = m_manager.get())
+        manager->isChildOfElementFullscreenChanged(m_contextId, isChildOfElementFullscreen);
+}
+
 void VideoPresentationInterfaceContext::videoDimensionsChanged(const FloatSize& videoDimensions)
 {
     if (m_manager)
@@ -567,6 +573,12 @@ void VideoPresentationManager::documentVisibilityChanged(PlaybackSessionContextI
 {
     if (RefPtr page = m_page.get())
         page->send(Messages::VideoPresentationManagerProxy::SetDocumentVisibility(contextId, isDocumentVisibile));
+}
+
+void VideoPresentationManager::isChildOfElementFullscreenChanged(PlaybackSessionContextIdentifier contextId, bool isChildOfElementFullscreen)
+{
+    if (RefPtr page = m_page.get())
+        page->send(Messages::VideoPresentationManagerProxy::SetIsChildOfElementFullscreen(contextId, isChildOfElementFullscreen));
 }
 
 void VideoPresentationManager::videoDimensionsChanged(PlaybackSessionContextIdentifier contextId, const FloatSize& videoDimensions)


### PR DESCRIPTION
#### b062855c649fe25410061d45e175ede7554f760b
<pre>
Spatial Video does not show Immersive or View Spatial button when muted or lacks audio track
<a href="https://bugs.webkit.org/show_bug.cgi?id=288706">https://bugs.webkit.org/show_bug.cgi?id=288706</a>
<a href="https://rdar.apple.com/137636134">rdar://137636134</a>

Reviewed by Jer Noble.

When and how to display Docking, Immersive and View Spatial used the same
heuristic as PiP when in element fullscreen. That is, it always used
the NowPlaying eligible media element which requires that:
- the element has an audible audio track
- is not muted
- is currently playing or has been played previously.

This NowPlaying eligible media would be used when docking even if it wasn&apos;t
in the hierarchy of the element in fullscreen.
As such, we couldn&apos;t dock or play in immersive or spatial mode silent videos.

We now decouple the handling of element fullscreen from this heuristic.
Instead we will only consider all video elements that are a child of the element
in fullscreen.
To avoid having the UI process regularly query the web process, we now maintain
in each of the VideoPresentationModels the fullscreen inheritance state and keep
those in sync between the webcontent and UI processes.

Should more than one video element be visible while in element fullscreen
for now we will select the one that is the most visible in the current viewport
and fill over 25% of the web view area (similar to the heuristic adopted in 280710@main).
Whenever the fullscreen visibility change, we will update the status
of the top icons and display them accordingly.

This heuristic will be further tuned in a future change (such as preferring
a video that was the most recently played).
For now, this new heuristic is placed behind a pref which is off by default.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::hasJSEventListener): Added.
(WebCore::DocumentFullscreen::dispatchPendingEvents): Only check for JS listeners to determine which even to fire.
* Source/WebCore/platform/cocoa/VideoPresentationModel.h:
(WebCore::VideoPresentationModelClient::isChildOfElementFullscreenChanged):
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::cleanVideoListeners): Fly-by: Keep separate weakRef to Document
so that we properly unregister listeners if HTMLMediaElement was GCed.
(WebCore::VideoPresentationModelVideoElement::setVideoElement):
(WebCore::VideoPresentationModelVideoElement::updateForEventName):
(WebCore::VideoPresentationModelVideoElement::documentFullscreenChanged):
(WebCore::VideoPresentationModelVideoElement::documentObservedEventNames):
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
(WebCore::VideoPresentationInterfaceIOS::playbackSessionModel const):
(WebCore::VideoPresentationInterfaceIOS::setSpatialImmersive):
* Source/WebCore/platform/ios/WebVideoFullscreenControllerAVKit.mm:
(VideoFullscreenControllerContext::isChildOfElementFullscreen const):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _videosInElementFullscreenChanged]):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setDocumentVisibility):
(WebKit::VideoPresentationManagerProxy::setIsChildOfElementFullscreen):
(WebKit::VideoPresentationManagerProxy::videosInElementFullscreenChanged):
(WebKit::VideoPresentationManagerProxy::createModelAndInterface):
(WebKit::VideoPresentationManagerProxy::ensureModelAndInterface):
(WebKit::VideoPresentationManagerProxy::ensureModel):
(WebKit::VideoPresentationManagerProxy::ensureInterface):
(WebKit::VideoPresentationManagerProxy::findModelAndInterface const):
(WebKit::VideoPresentationManagerProxy::findInterface const):
(WebKit::VideoPresentationManagerProxy::returningToStandbyInterface const):
(WebKit::VideoPresentationManagerProxy::setHasVideo):
(WebKit::VideoPresentationManagerProxy::setVideoDimensions):
(WebKit::VideoPresentationManagerProxy::enterFullscreen):
(WebKit::VideoPresentationManagerProxy::bestVideoForElementFullscreen):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::videosInElementFullscreenChanged):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::videosInElementFullscreenChanged):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::videosInElementFullscreenChanged):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController videoControlsManagerDidChange]):
(-[WKFullScreenViewController videosInElementFullscreenChanged]):
(-[WKFullScreenViewController _bestVideoPresentationInterface]):
(-[WKFullScreenViewController configureEnvironmentPickerOrFullscreenVideoButtonView]):
(-[WKFullScreenViewController viewDidAppear:]):
(-[WKFullScreenViewController viewWillTransitionToSize:withTransitionCoordinator:]):
(-[WKFullScreenViewController _enterVideoFullscreenAction:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.h:
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController videosInElementFullscreenChanged]):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationInterfaceContext::isChildOfElementFullscreenChanged):
(WebKit::VideoPresentationManager::isChildOfElementFullscreenChanged):

Canonical link: <a href="https://commits.webkit.org/291482@main">https://commits.webkit.org/291482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b91d65858a3adaab59a59cfe5155b3ba98df719f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95091 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21046 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71138 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28558 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51467 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9398 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1821 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42880 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85751 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79689 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1798 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100065 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91707 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20093 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80161 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79463 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19728 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13168 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25253 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114356 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19764 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33004 "Found 12 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23224 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21505 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->