### PR TITLE
[JSC] `%WrapForValidIteratorPrototype%.return` should not throw `TypeError` when underlying iterator's `return` method is null

### DIFF
--- a/JSTests/stress/iterator-from-null-checks.js
+++ b/JSTests/stress/iterator-from-null-checks.js
@@ -1,0 +1,15 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const iter = {
+    next() { return { done: false, value: 1 } },
+    return(value) { return { done: true, value } },
+};
+const wrap = Iterator.from(iter);
+
+iter.return = null;
+const returnResult = wrap.return("ignored");
+shouldBe(returnResult.done, true);
+shouldBe(returnResult.value, undefined);

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1332,8 +1332,6 @@ test/staging/sm/Function/function-name-assignment.js:
   default: 'Test262Error: Expected SameValue(«"inParen"», «""») to be true'
 test/staging/sm/Function/function-toString-builtin-name.js:
   default: 'Test262Error: Incorrect match for undefined Expected SameValue(«"fn"», «undefined») to be true'
-test/staging/sm/Iterator/from/modify-return.js:
-  default: 'TypeError: null is not a function'
 test/staging/sm/Iterator/prototype/every/check-fn-after-getting-iterator.js:
   default: 'Test262Error: Actual [get: every, get: return] and expected [get: every] should have the same contents. '
 test/staging/sm/Iterator/prototype/find/check-fn-after-getting-iterator.js:

--- a/Source/JavaScriptCore/builtins/WrapForValidIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/WrapForValidIteratorPrototype.js
@@ -57,7 +57,7 @@ function return()
     var returnMethod = iterator.return;
     // 6. If returnMethod is undefined, then
     //   a. Return CreateIterResultObject(undefined, true).
-    if (returnMethod === @undefined)
+    if (@isUndefinedOrNull(returnMethod))
         return { value: @undefined, done: true };
     // 7. Return ? Call(returnMethod, iterator).
     return returnMethod.@call(iterator);


### PR DESCRIPTION
#### a9b3c904d0bb7d3cb52b1b2758128726156be870
<pre>
[JSC] `%WrapForValidIteratorPrototype%.return` should not throw `TypeError` when underlying iterator&apos;s `return` method is null
<a href="https://bugs.webkit.org/show_bug.cgi?id=288714">https://bugs.webkit.org/show_bug.cgi?id=288714</a>

Reviewed by Yusuke Suzuki.

According to the spec[1], `%WrapForValidIteratorPrototype%.return`
returns `{ done: true, value: undefined }` if the underlying
iterator&apos;s `return` method is `null` or `undefined`.

However, our JSC throws `TypeError` if the underlying iterator&apos;s
`return` method is `null`.

This patch fixes it to comply with the spec.

[1]: <a href="https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return">https://tc39.es/ecma262/#sec-%wrapforvaliditeratorprototype%.return</a>

* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/WrapForValidIteratorPrototype.js:
(return):

Canonical link: <a href="https://commits.webkit.org/291302@main">https://commits.webkit.org/291302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adf6151c101eb8e8d8127996a74219406a298459

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/11904 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/42873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70797 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28253 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95367 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83639 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/8977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1275 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42203 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85076 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1236 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99372 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91031 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79524 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79058 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19631 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23601 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12418 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24573 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113679 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19088 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32884 "Found 9 new JSC stress test failures: microbenchmarks/memcpy-wasm-small.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-tag-arg.js.wasm-collect-continuously, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->