### PR TITLE
Handle suppress-HDR notifications for videos

### DIFF
--- a/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-expected.txt
+++ b/LayoutTests/media/video-suppress-hdr-dynamic-range-limit-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/video-suppress-hdr-dynamic-range-limit.html
+++ b/LayoutTests/media/video-suppress-hdr-dynamic-range-limit.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true ] -->
+<html id="html">
+<body>
+<script src='../resources/js-test-pre.js'></script>
+<video id="videon"></video>
+<video id="videoc" style="dynamic-range-limit: constrained-high"></video>
+<video id="videos" style="dynamic-range-limit: standard"></video>
+<script>
+var videon;
+var videoc;
+var videos;
+var video2;
+var video3;
+
+function verifyVideo(expectations)
+{
+    const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+    shouldBe(expectations.video + '.style["dynamic-range-limit"]', expectations.limit, quiet);
+    shouldBe('getComputedStyle(' + expectations.video + ')["dynamic-range-limit"]', expectations.computed, quiet);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(' + expectations.video + ')', expectations.value, quiet);
+}
+
+window.addEventListener('load', async event => {
+    if (!window.internals) {
+        failTest('This test requires window.internals.');
+        return;
+    }
+
+    if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "constrained-high") && CSS.supports("dynamic-range-limit", "no-limit")) {
+        const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+
+        videon = document.getElementById("videon");
+        videoc = document.getElementById("videoc");
+        videos = document.getElementById("videos");
+
+        internals.setPageShouldSuppressHDR(false);
+        verifyVideos({video: 'videon', limit: '""', computed: '"no-limit"', value: '1.0'});
+        verifyVideos({video: 'videoc', limit: '""', computed: '"constrained-high"', value: '0.5'});
+        verifyVideos({video: 'videos', limit: '""', computed: '"standard"', value: '0.0'});
+
+        internals.setPageShouldSuppressHDR(true);
+        verifyVideos({video: 'videon', limit: '""', computed: '"no-limit"', value: '0.5'});
+        verifyVideos({video: 'videoc', limit: '""', computed: '"constrained-high"', value: '0.5'});
+        verifyVideos({video: 'videos', limit: '""', computed: '"standard"', value: '0.0'});
+
+        video2 = document.createElement("video");
+        video1.append(video2);
+        verifyVideos({video: 'video2', limit: '""', computed: '"no-limit"', value: '0.5'});
+
+        internals.setPageShouldSuppressHDR(false);
+        verifyVideos({video: 'videon', limit: '""', computed: '"no-limit"', value: '1.0'});
+        verifyVideos({video: 'videoc', limit: '""', computed: '"constrained-high"', value: '0.5'});
+        verifyVideos({video: 'videos', limit: '""', computed: '"standard"', value: '0.0'});
+        verifyVideos({video: 'video2', limit: '""', computed: '"no-limit"', value: '1.0'});
+
+        video3 = document.createElement("video");
+        video2.append(video3);
+        verifyVideos({video: 'video3', limit: '""', computed: '"no-limit"', value: '1.0'});
+    }
+});
+</script>
+<script src='../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/media/video-suppress-hdr-expected.txt
+++ b/LayoutTests/media/video-suppress-hdr-expected.txt
@@ -1,0 +1,4 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/video-suppress-hdr.html
+++ b/LayoutTests/media/video-suppress-hdr.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=false ] -->
+<html id="html">
+<style>video { dynamic-range-limit: standard }</style> <!-- should be ignored -->
+<body>
+<script src='../resources/js-test-pre.js'></script>
+<video id="video1"></video>
+<script>
+var video1;
+var video2;
+var video3;
+
+window.addEventListener('load', async event => {
+    if (!window.internals) {
+        failTest('This test requires window.internals.');
+        return;
+    }
+    video1 = document.getElementById("video1");
+
+    internals.setPageShouldSuppressHDR(false);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(video1)', '1.0', quiet);
+
+    internals.setPageShouldSuppressHDR(true);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(video1)', '0.5', quiet);
+
+    video2 = document.createElement("video");
+    video1.append(video2);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(video2)', '0.5', quiet);
+
+    internals.setPageShouldSuppressHDR(false);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(video1)', '1.0', quiet);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(video2)', '1.0', quiet);
+
+    video3 = document.createElement("video");
+    video2.append(video3);
+    shouldBe('internals.effectiveDynamicRangeLimitValue(video3)', '1.0', quiet);
+});
+</script>
+<script src='../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7415,7 +7415,14 @@ void Document::updateTextTrackRepresentationImageIfNeeded()
         mediaElement->updateTextTrackRepresentationImageIfNeeded();
 }
 
-#endif
+void Document::shouldSuppressHDRDidChange()
+{
+    forEachMediaElement([](HTMLMediaElement& element) {
+        element.shouldSuppressHDRDidChange();
+    });
+}
+
+#endif // ENABLE(VIDEO)
 
 void Document::setShouldCreateRenderers(bool f)
 {

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1337,6 +1337,7 @@ public:
     void setMediaElementShowingTextTrack(const HTMLMediaElement&);
     void clearMediaElementShowingTextTrack();
     void updateTextTrackRepresentationImageIfNeeded();
+    WEBCORE_EXPORT void shouldSuppressHDRDidChange();
 #endif
 
     void registerForVisibilityStateChangedCallbacks(VisibilityChangeClient&);

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -652,6 +652,7 @@ public:
     WEBCORE_EXPORT void setOverridePreferredDynamicRangeMode(DynamicRangeMode);
     void setPreferredDynamicRangeMode(DynamicRangeMode);
     void dynamicRangeLimitDidChange(PlatformDynamicRangeLimit);
+    void shouldSuppressHDRDidChange();
 
     void didReceiveRemoteControlCommand(PlatformMediaSession::RemoteControlCommandType, const PlatformMediaSession::RemoteCommandArgument&) override;
 
@@ -1119,6 +1120,7 @@ private:
 #endif
 
     bool shouldDisableHDR() const;
+    WEBCORE_EXPORT PlatformDynamicRangeLimit computePlayerDynamicRangeLimit() const;
 
     bool shouldLogWatchtimeEvent() const;
     bool isWatchtimeTimerActive() const;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2975,6 +2975,17 @@ void Page::setMuted(MediaProducerMutedStateFlags mutedState)
     });
 }
 
+void Page::setShouldSuppressHDR(bool shouldSuppressHDR)
+{
+    if (m_shouldSuppressHDR == shouldSuppressHDR)
+        return;
+
+    m_shouldSuppressHDR = shouldSuppressHDR;
+    forEachDocument([](auto& document) {
+        document.shouldSuppressHDRDidChange();
+    });
+}
+
 #if ENABLE(MEDIA_STREAM)
 static inline MediaProducerMutedStateFlags toMediaProducerMutedStateFlags(MediaProducerMediaCaptureKind kind)
 {

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -990,6 +990,8 @@ public:
     void mediaEngineChanged(HTMLMediaElement&);
 #endif
     WEBCORE_EXPORT void setMuted(MediaProducerMutedStateFlags);
+    bool shouldSuppressHDR() const { return m_shouldSuppressHDR; }
+    WEBCORE_EXPORT void setShouldSuppressHDR(bool);
 
     WEBCORE_EXPORT void stopMediaCapture(MediaProducerMediaCaptureKind);
 #if ENABLE(MEDIA_STREAM)
@@ -1441,6 +1443,7 @@ private:
     bool m_hasPendingMemoryCacheLoadNotifications { false };
     float m_mediaVolume { 1 };
     MediaProducerMutedStateFlags m_mutedState;
+    bool m_shouldSuppressHDR { false };
 
     float m_pageScaleFactor { 1 };
     float m_zoomedOutPageScaleFactor { 0 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4602,7 +4602,22 @@ void Internals::enableGStreamerHolePunching(HTMLVideoElement& element)
 #endif
 }
 
+double Internals::effectiveDynamicRangeLimitValue(const HTMLMediaElement& media)
+{
+    return media.computePlayerDynamicRangeLimit().value();
+}
+
 #endif
+
+ExceptionOr<void> Internals::setPageShouldSuppressHDR(bool shouldSuppressHDR)
+{
+    Document* document = contextDocument();
+    if (!document || !document->page())
+        return Exception { ExceptionCode::InvalidAccessError };
+
+    document->page()->setShouldSuppressHDR(shouldSuppressHDR);
+    return { };
+}
 
 bool Internals::isSelectPopupVisible(HTMLSelectElement& element)
 {

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -814,7 +814,11 @@ public:
     ExceptionOr<void> setOverridePreferredDynamicRangeMode(HTMLMediaElement&, const String&);
 
     void enableGStreamerHolePunching(HTMLVideoElement&);
+
+    double effectiveDynamicRangeLimitValue(const HTMLMediaElement&);
 #endif
+
+    ExceptionOr<void> setPageShouldSuppressHDR(bool);
 
     ExceptionOr<void> setIsPlayingToBluetoothOverride(std::optional<bool>);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -991,6 +991,9 @@ enum ContentsFormat {
 
     [Conditional=VIDEO] undefined enableGStreamerHolePunching(HTMLVideoElement element);
 
+    [Conditional=VIDEO] double effectiveDynamicRangeLimitValue(HTMLMediaElement media);
+    undefined setPageShouldSuppressHDR(boolean shouldSuppressHDR);
+
     undefined setIsPlayingToBluetoothOverride(optional boolean? isPlaying = null);
 
     [Conditional=LEGACY_ENCRYPTED_MEDIA] undefined initializeMockCDM();

--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -31,6 +31,7 @@
 
 #define CGCOLORTAGGEDPOINTER_H_
 
+#import <AppKit/NSApplication_Private.h>
 #import <AppKit/NSInspectorBar.h>
 #import <AppKit/NSMenu_Private.h>
 #import <AppKit/NSPreviewRepresentingActivityItem_Private.h>

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -104,6 +104,10 @@
 #import <WebKitAdditions/WKWebViewIOSAdditionsBefore.mm>
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+#import <UIKit/_UITraitHDRHeadroomUsage.h>
+#endif
+
 #import <pal/ios/ManagedConfigurationSoftLink.h>
 
 #define FORWARD_ACTION_TO_WKCONTENTVIEW(_action) \
@@ -238,6 +242,11 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
     [center addObserver:self selector:@selector(_enhancedWindowingToggled:) name:_UIWindowSceneEnhancedWindowingModeChanged object:nil];
 #endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+    [self registerForTraitChanges:@[[_UITraitHDRHeadroomUsage class]] withAction:@selector(_UITraitHDRHeadroomUsageDidChange)];
+    [self _UITraitHDRHeadroomUsageDidChange];
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 }
 
 - (BOOL)_isShowingVideoPictureInPicture
@@ -3662,6 +3671,14 @@ static WebCore::UserInterfaceLayoutDirection toUserInterfaceLayoutDirection(UISe
 }
 
 #endif // HAVE(UIKIT_RESIZABLE_WINDOWS)
+
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+- (void)_UITraitHDRHeadroomUsageDidChange
+{
+    const _UIHDRHeadroomUsage _headroomUsage = [[self traitCollection] _headroomUsage];
+    _page->setShouldSuppressHDR(_headroomUsage != _UIHDRHeadroomUsageEnabled);
+}
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 
 #if ENABLE(LOCKDOWN_MODE_API)
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -918,6 +918,20 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+#if PLATFORM(MAC)
+    NSNotificationName const NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification = @"NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification";
+    NSNotificationName const NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification = @"NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification";
+    m_beginSuppressingHDRObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+        sendToAllProcesses(Messages::WebProcess::SetShouldSuppressHDR(true));
+    }];
+
+    m_endSuppressingHDRObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
+        sendToAllProcesses(Messages::WebProcess::SetShouldSuppressHDR(false));
+    }];
+#endif // PLATFORM(MAC)
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+
     m_finishedMobileAssetFontDownloadObserver = [[NSNotificationCenter defaultCenter] addObserverForName:@"FontActivateNotification" object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         NSString *fontFamily = notification.userInfo[@"FontActivateNotificationFontFamilyKey"];
         if ([fontFamily isKindOfClass:[NSString class]]) {
@@ -1006,6 +1020,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
     removeCFNotificationObserver((__bridge CFStringRef)notificationName.get());
 #endif
+
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+#if PLATFORM(MAC)
+    [[NSNotificationCenter defaultCenter] removeObserver:m_beginSuppressingHDRObserver.get()];
+    [[NSNotificationCenter defaultCenter] removeObserver:m_endSuppressingHDRObserver.get()];
+#endif // PLATFORM(MAC)
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 
     [[NSNotificationCenter defaultCenter] removeObserver:m_activationObserver.get()];
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2773,6 +2773,12 @@ Color WebPageProxy::underlayColor() const
     return internals().underlayColor;
 }
 
+void WebPageProxy::setShouldSuppressHDR(bool shouldSuppressHDR)
+{
+    if (hasRunningProcess())
+        send(Messages::WebPage::SetShouldSuppressHDR(shouldSuppressHDR));
+}
+
 void WebPageProxy::setUnderlayColor(const Color& color)
 {
     if (internals().underlayColor == color)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -945,6 +945,8 @@ public:
     std::optional<WebCore::SpatialBackdropSource> spatialBackdropSource() const;
 #endif
 
+    void setShouldSuppressHDR(bool);
+
     WebCore::Color underlayColor() const;
     void setUnderlayColor(const WebCore::Color&);
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -836,6 +836,13 @@ private:
     RetainPtr<WKProcessPoolWeakObserver> m_weakObserver;
 #endif
 
+#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
+#if PLATFORM(MAC)
+    RetainPtr<NSObject> m_beginSuppressingHDRObserver;
+    RetainPtr<NSObject> m_endSuppressingHDRObserver;
+#endif // PLATFORM(MAC)
+#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
+
     bool m_processTerminationEnabled { true };
 
     bool m_memoryCacheDisabled { false };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2966,6 +2966,11 @@ void WebPage::setUnderPageBackgroundColorOverride(WebCore::Color&& underPageBack
     protectedCorePage()->setUnderPageBackgroundColorOverride(WTFMove(underPageBackgroundColorOverride));
 }
 
+void WebPage::setShouldSuppressHDR(bool shouldSuppressHDR)
+{
+    protectedCorePage()->setShouldSuppressHDR(shouldSuppressHDR);
+}
+
 #if !PLATFORM(IOS_FAMILY)
 
 void WebPage::setHeaderPageBanner(PageBanner* pageBanner)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -842,6 +842,8 @@ public:
 
     void setUnderPageBackgroundColorOverride(WebCore::Color&&);
 
+    void setShouldSuppressHDR(bool);
+
     void setUnderlayColor(const WebCore::Color& color) { m_underlayColor = color; }
     WebCore::Color underlayColor() const { return m_underlayColor; }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -46,6 +46,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     SetObscuredContentInsets(WebCore::FloatBoxExtent obscuredContentInsets)
 #endif
 
+    SetShouldSuppressHDR(bool shouldSuppressHDR)
+
     SetUnderlayColor(WebCore::Color color)
     SetUnderPageBackgroundColorOverride(WebCore::Color underPageBackgroundColorOverride)
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -965,6 +965,9 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
         accessibilityRelayProcessSuspended(false);
     }
     ASSERT(result.iterator->value);
+
+    if (m_shouldSuppressHDR)
+        RefPtr { result.iterator->value }->setShouldSuppressHDR(m_shouldSuppressHDR);
 }
 
 void WebProcess::removeWebPage(PageIdentifier pageID)
@@ -1556,6 +1559,16 @@ void WebProcess::setTextCheckerState(OptionSet<TextCheckerState> textCheckerStat
         if (grammarCheckingTurnedOff)
             page->unmarkAllBadGrammar();
     }
+}
+
+void WebProcess::setShouldSuppressHDR(bool shouldSuppressHDR)
+{
+    m_shouldSuppressHDR = shouldSuppressHDR;
+
+#if ENABLE(VIDEO)
+    for (auto& page : m_pageMap.values())
+        page->setShouldSuppressHDR(shouldSuppressHDR);
+#endif // ENABLE(VIDEO)
 }
 
 void WebProcess::fetchWebsiteData(OptionSet<WebsiteDataType> websiteDataTypes, CompletionHandler<void(WebsiteData&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -257,6 +257,9 @@ public:
     OptionSet<TextCheckerState> textCheckerState() const { return m_textCheckerState; }
     void setTextCheckerState(OptionSet<TextCheckerState>);
 
+    bool shouldSuppressHDR() const { return m_shouldSuppressHDR; }
+    void setShouldSuppressHDR(bool);
+
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
     Ref<EventDispatcher> protectedEventDispatcher() { return m_eventDispatcher; }
     Ref<WebInspectorInterruptDispatcher> protectedWebInspectorInterruptDispatcher() { return m_webInspectorInterruptDispatcher; }
@@ -762,6 +765,8 @@ private:
     WebProcessSupplementMap m_supplements;
 
     OptionSet<TextCheckerState> m_textCheckerState;
+
+    bool m_shouldSuppressHDR { false };
 
     String m_uiProcessBundleIdentifier;
     RefPtr<NetworkProcessConnection> m_networkProcessConnection;

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -75,6 +75,8 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     SetTextCheckerState(OptionSet<WebKit::TextCheckerState> textCheckerState)
 
+    SetShouldSuppressHDR(bool shouldSuppressHDR)
+
     SetEnhancedAccessibility(bool flag)
     BindAccessibilityFrameWithData(WebCore::FrameIdentifier frameID, std::span<const uint8_t> data);
 


### PR DESCRIPTION
#### 1285af2e9967b3e26c6c8b67a60f73d1b3f9594e
<pre>
Handle suppress-HDR notifications for videos
<a href="https://bugs.webkit.org/show_bug.cgi?id=288690">https://bugs.webkit.org/show_bug.cgi?id=288690</a>
<a href="https://rdar.apple.com/145717196">rdar://145717196</a>

Reviewed by Simon Fraser.

This patch observes notifications or trait changes that
request the application or view to suppress HDR content
in videos (by constraining it).

This signal gets combined with the existing CSS
`dynamic-range-limit` to enforce the minimum of the two
constraints.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _registerForNotifications]):
(-[WKWebView _UITraitHDRHeadroomUsageDidChange]):
Trait change entry point on iOS, forwarded to WebPageProxy.
The initial value is also sent.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setShouldSuppressHDR):
* Source/WebKit/UIProcess/WebPageProxy.h:
Forwarded to WebPage. (To be continued further below...)

* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
Notification entry point on macOS, forwarded to all WebProcess&apos;es.

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::setShouldSuppressHDR):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
Cache the shouldSuppressHDR flag (for future page creations),
and forward to WebPage&apos;s.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setShouldSuppressHDR):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Meeting point between iOS trait changes and macOS notifications.
Forward to Page.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::setShouldSuppressHDR):
* Source/WebCore/page/Page.h:
(WebCore::Page::shouldSuppressHDR const):
Store the flag (for use by document and elements).
Notify Document if the flag changed.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::shouldSuppressHDRDidChange):
* Source/WebCore/dom/Document.h:
Notify all media elements.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::computePlayerDynamicRangeLimit const):
(WebCore::HTMLMediaElement::dynamicRangeLimitDidChange):
(WebCore::HTMLMediaElement::shouldSuppressHDRDidChange):
* Source/WebCore/html/HTMLMediaElement.h:
On notification (or dynamic-range-limit change), combine Page&apos;s
suppress-HDR with dynamic-range-limit, and update MediaPlayer&apos;s
effective dynamic range limit (already implemented in previous patch).

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
Add include relevant to notifications.

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::effectiveDynamicRangeLimitValue):
(WebCore::Internals::setPageShouldSuppressHDR):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
Simulate notifications at the Page level, examine effective
dynamic range limit in media elements.

* LayoutTests/media/video-suppress-hdr-dynamic-range-limit-expected.txt: Added.
* LayoutTests/media/video-suppress-hdr-dynamic-range-limit.html: Added.
* LayoutTests/media/video-suppress-hdr-expected.txt: Added.
* LayoutTests/media/video-suppress-hdr.html: Added.
Test combinations of notifications and video creations.

Canonical link: <a href="https://commits.webkit.org/291383@main">https://commits.webkit.org/291383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d185f00ae15fc3204f7645dc955ab12dcfe26307

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92780 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1972 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20783 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95782 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99798 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19832 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20083 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79321 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19670 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23849 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19816 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22963 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->