### PR TITLE
WebCodecs decoder frames format is always I420

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/vp9-p2-decoder-expected.txt
+++ b/LayoutTests/http/wpt/webcodecs/vp9-p2-decoder-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test copyTo on different contexts
+

--- a/LayoutTests/http/wpt/webcodecs/vp9-p2-decoder.html
+++ b/LayoutTests/http/wpt/webcodecs/vp9-p2-decoder.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+<header>
+<script src='/resources/testharness.js'></script>
+<script src='/resources/testharnessreport.js'></script>
+</header>
+<body>
+<script>
+promise_test(async (test) => {
+    let encodedFrame;
+    let resolve, reject;
+    const encoderPromise = new Promise((res,rej) => {
+        resolve = res;
+        reject = rej;
+     });
+
+    const encoder = new VideoEncoder({
+        output: chunk => {
+           resolve(chunk);
+        },
+        error: e => reject(e),
+    });
+    setTimeout(() => {
+        reject("timed out waiting for encoded chunks");
+    }, 5000);
+    encoder.configure({
+        codec: 'vp09.02.10.10',
+        width: 1024,
+        height: 1024,
+        bitrate: 10e6,
+        framerate: 1,
+    });
+
+    const frame = new VideoFrame(new ArrayBuffer(1024 * 1024 * 4), {format: 'RGBA', codedWidth: 1024, codedHeight: 1024, timestamp: 0});
+    encoder.encode(frame, {keyFrame: true});
+    frame.close();
+    const chunk = await encoderPromise;
+
+    const decoderPromise = new Promise((res,rej) => {
+        resolve = res;
+        reject = rej;
+     });
+
+    const decoder = new VideoDecoder({
+        output: frame => {
+           test.add_cleanup(() => frame.close());
+           resolve(frame);
+        },
+        error: e => reject(e),
+    });
+    setTimeout(() => {
+        reject("timed out waiting for decoded frames");
+    }, 5000);
+
+    decoder.configure({
+        codec: 'vp09.02.10.10',
+        codedWidth: 1024,
+        codedHeight: 1024,
+        hardwareAcceleration: 'prefer-software'
+    });
+
+    decoder.decode(chunk);
+
+    const decodedFrame = await decoderPromise;
+    assert_equals(decodedFrame.format, null);
+    return promise_rejects_dom(test, 'NotSupportedError', decodedFrame.copyTo(new Uint8Array(1)));
+}, "Test copyTo on different contexts");
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -172,12 +172,14 @@ ExceptionOr<void> WebCodecsVideoDecoder::configure(ScriptExecutionContext& conte
                 }
 
                 auto decodedResult = WTFMove(result).value();
-                WebCodecsVideoFrame::BufferInit init;
-                init.codedWidth = decodedResult.frame->presentationSize().width();
-                init.codedHeight = decodedResult.frame->presentationSize().height();
-                init.timestamp = decodedResult.timestamp;
-                init.duration = decodedResult.duration;
-                init.colorSpace = decodedResult.frame->colorSpace();
+                WebCodecsVideoFrame::BufferInit init {
+                    .format = convertVideoFramePixelFormat(decodedResult.frame->pixelFormat()),
+                    .codedWidth = static_cast<size_t>(decodedResult.frame->presentationSize().width()),
+                    .codedHeight = static_cast<size_t>(decodedResult.frame->presentationSize().height()),
+                    .timestamp = decodedResult.timestamp,
+                    .duration = decodedResult.duration,
+                    .colorSpace = decodedResult.frame->colorSpace()
+                };
 
                 auto videoFrame = WebCodecsVideoFrame::create(*decoder.scriptExecutionContext(), WTFMove(decodedResult.frame), WTFMove(init));
                 decoder.m_output->handleEvent(WTFMove(videoFrame));

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp
@@ -284,16 +284,19 @@ static std::optional<Exception> validateI420Sizes(const WebCodecsVideoFrame::Buf
 // https://w3c.github.io/webcodecs/#dom-videoframe-videoframe-data-init
 ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutionContext& context, BufferSource&& data, BufferInit&& init)
 {
+    ASSERT(init.format);
+    auto pixelFormat = init.format.value_or(VideoPixelFormat::I420);
+
     if (!isValidVideoFrameBufferInit(init))
         return Exception { ExceptionCode::TypeError, "buffer init is not valid"_s };
 
     DOMRectInit defaultRect { 0, 0, static_cast<double>(init.codedWidth), static_cast<double>(init.codedHeight) };
-    auto parsedRectOrExtension = parseVisibleRect(defaultRect, init.visibleRect, init.codedWidth, init.codedHeight, init.format);
+    auto parsedRectOrExtension = parseVisibleRect(defaultRect, init.visibleRect, init.codedWidth, init.codedHeight, pixelFormat);
     if (parsedRectOrExtension.hasException())
         return parsedRectOrExtension.releaseException();
 
     auto parsedRect = parsedRectOrExtension.releaseReturnValue();
-    auto layoutOrException = computeLayoutAndAllocationSize(defaultRect, init.layout, init.format);
+    auto layoutOrException = computeLayoutAndAllocationSize(defaultRect, init.layout, pixelFormat);
     if (layoutOrException.hasException())
         return layoutOrException.releaseException();
     
@@ -301,23 +304,23 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::create(ScriptExecutio
     if (data.length() < layout.allocationSize)
         return Exception { ExceptionCode::TypeError, makeString("Data is too small "_s, data.length(), " / "_s, layout.allocationSize) };
 
-    auto colorSpace = videoFramePickColorSpace(init.colorSpace, init.format);
+    auto colorSpace = videoFramePickColorSpace(init.colorSpace, pixelFormat);
     RefPtr<VideoFrame> videoFrame;
-    if (init.format == VideoPixelFormat::NV12) {
+    if (pixelFormat == VideoPixelFormat::NV12) {
         if (init.codedWidth % 2 || init.codedHeight % 2)
             return Exception { ExceptionCode::TypeError, "coded width or height is odd"_s };
         if (init.visibleRect && (static_cast<size_t>(init.visibleRect->x) % 2 || static_cast<size_t>(init.visibleRect->x) % 2))
             return Exception { ExceptionCode::TypeError, "visible x or y is odd"_s };
         videoFrame = VideoFrame::createNV12(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], WTFMove(colorSpace));
-    } else if (init.format == VideoPixelFormat::RGBA || init.format == VideoPixelFormat::RGBX)
+    } else if (pixelFormat == VideoPixelFormat::RGBA || init.format == VideoPixelFormat::RGBX)
         videoFrame = VideoFrame::createRGBA(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTFMove(colorSpace));
-    else if (init.format == VideoPixelFormat::BGRA || init.format == VideoPixelFormat::BGRX)
+    else if (pixelFormat == VideoPixelFormat::BGRA || init.format == VideoPixelFormat::BGRX)
         videoFrame = VideoFrame::createBGRA(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], WTFMove(colorSpace));
-    else if (init.format == VideoPixelFormat::I420) {
+    else if (pixelFormat == VideoPixelFormat::I420) {
         if (auto exception = validateI420Sizes(init))
             return WTFMove(*exception);
         videoFrame = VideoFrame::createI420(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], WTFMove(colorSpace));
-    } else if (init.format == VideoPixelFormat::I420A) {
+    } else if (pixelFormat == VideoPixelFormat::I420A) {
         if (auto exception = validateI420Sizes(init))
             return WTFMove(*exception);
         videoFrame = VideoFrame::createI420A(data.span(), parsedRect.width, parsedRect.height, layout.computedLayouts[0], layout.computedLayouts[1], layout.computedLayouts[2], layout.computedLayouts[3], WTFMove(colorSpace));
@@ -416,7 +419,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameFromOt
     auto codedWidth = internalVideoFrame->presentationSize().width();
     auto codedHeight = internalVideoFrame->presentationSize().height();
     auto format = convertVideoFramePixelFormat(internalVideoFrame->pixelFormat(), init.alpha == WebCodecsAlphaOption::Discard);
-    if (!validateVideoFrameInit(init, codedWidth, codedHeight, format))
+    if (!validateVideoFrameInit(init, codedWidth, codedHeight, format.value_or(VideoPixelFormat::I420)))
         return Exception { ExceptionCode::TypeError,  "VideoFrameInit is not valid"_s };
 
     auto result = adoptRef(*new WebCodecsVideoFrame(context));
@@ -445,7 +448,7 @@ ExceptionOr<Ref<WebCodecsVideoFrame>> WebCodecsVideoFrame::initializeFrameWithRe
     auto codedWidth = image->size().width();
     auto codedHeight = image->size().height();
     auto format = convertVideoFramePixelFormat(internalVideoFrame->pixelFormat(), init.alpha == WebCodecsAlphaOption::Discard);
-    if (!validateVideoFrameInit(init, codedWidth, codedHeight, format))
+    if (!validateVideoFrameInit(init, codedWidth, codedHeight, format.value_or(VideoPixelFormat::I420)))
         return Exception { ExceptionCode::TypeError,  "VideoFrameInit is not valid"_s };
 
     auto result = adoptRef(*new WebCodecsVideoFrame(context));

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h
@@ -81,7 +81,7 @@ public:
         std::optional<size_t> displayHeight;
     };
     struct BufferInit {
-        VideoPixelFormat format { VideoPixelFormat::I420 };
+        std::optional<VideoPixelFormat> format;
         size_t codedWidth { 0 };
         size_t codedHeight { 0 };
         int64_t timestamp { 0 };

--- a/Source/WebCore/platform/VideoPixelFormat.cpp
+++ b/Source/WebCore/platform/VideoPixelFormat.cpp
@@ -37,7 +37,7 @@
 
 namespace WebCore {
 
-VideoPixelFormat convertVideoFramePixelFormat(uint32_t format, bool shouldDiscardAlpha)
+std::optional<VideoPixelFormat> convertVideoFramePixelFormat(uint32_t format, bool shouldDiscardAlpha)
 {
 #if PLATFORM(COCOA)
     if (format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange || format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange || format == kCVPixelFormatType_Lossless_420YpCbCr8BiPlanarVideoRange)
@@ -75,7 +75,7 @@ VideoPixelFormat convertVideoFramePixelFormat(uint32_t format, bool shouldDiscar
     UNUSED_PARAM(format);
     UNUSED_PARAM(shouldDiscardAlpha);
 #endif
-    return VideoPixelFormat::I420;
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/VideoPixelFormat.h
+++ b/Source/WebCore/platform/VideoPixelFormat.h
@@ -39,7 +39,7 @@ enum class VideoPixelFormat {
     BGRX
 };
 
-VideoPixelFormat convertVideoFramePixelFormat(uint32_t, bool shouldDiscardAlpha = false);
+std::optional<VideoPixelFormat> convertVideoFramePixelFormat(uint32_t, bool shouldDiscardAlpha = false);
 
 inline bool isRGBVideoPixelFormat(VideoPixelFormat format)
 {


### PR DESCRIPTION
#### d0d68fb2f7179d3c1ee7eedc1615455a8a619456
<pre>
WebCodecs decoder frames format is always I420
<a href="https://rdar.apple.com/145731406">rdar://145731406</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288711">https://bugs.webkit.org/show_bug.cgi?id=288711</a>

Reviewed by Jer Noble.

We were reporting all decoded frames to be I420, which is false.
For VP9 p2 in software, frames are 10 bits.
Given we do not yet support I420P10, we should expose null instead of &apos;I420&apos;.
Update code accordingly.

* LayoutTests/http/wpt/webcodecs/vp9-p2-decoder-expected.txt: Added.
* LayoutTests/http/wpt/webcodecs/vp9-p2-decoder.html: Added.
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::configure):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.cpp:
(WebCore::WebCodecsVideoFrame::create):
(WebCore::WebCodecsVideoFrame::initializeFrameFromOtherFrame):
(WebCore::WebCodecsVideoFrame::initializeFrameWithResourceAndSize):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoFrame.h:
* Source/WebCore/platform/VideoPixelFormat.cpp:
(WebCore::convertVideoFramePixelFormat):
* Source/WebCore/platform/VideoPixelFormat.h:

Canonical link: <a href="https://commits.webkit.org/291499@main">https://commits.webkit.org/291499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee222eec2b3131ed455976aa93ce9e8e2e43eacb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93060 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12611 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/2351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43586 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12892 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21066 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71158 "Found 1 new test failure: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/disable_controls_reposition.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28574 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96062 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9717 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51486 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1853 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42899 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79702 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1831 "Unable to confirm if test failures are introduced by change, retrying build") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100085 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14752 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80181 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79483 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24029 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13192 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25272 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19783 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23243 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->