### PR TITLE
Use drag recognizer in WebKit to send transform updates to Model Process for Stage Mode behavior

### DIFF
--- a/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
+++ b/Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h
@@ -135,6 +135,7 @@ public:
     void beginStageModeTransform(const WebCore::TransformationMatrix&) final;
     void updateStageModeTransform(const WebCore::TransformationMatrix&) final;
     void endStageModeInteraction() final;
+    void stageModeInteractionDidUpdateModel();
 
     USING_CAN_MAKE_WEAKPTR(WebCore::REModelLoaderClient);
 
@@ -144,6 +145,7 @@ private:
     void computeTransform();
     void applyEnvironmentMapDataAndRelease();
     void applyStageModeOperationToDriver();
+    bool stageModeInteractionInProgress() const;
 
     WebCore::ModelPlayerIdentifier m_id;
     Ref<IPC::Connection> m_webProcessConnection;

--- a/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
+++ b/Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h
@@ -66,6 +66,7 @@ typedef struct {
 - (void)setUpAnimationWithAutoPlay:(BOOL)autoPlay;
 - (void)applyIBLData:(NSData *)data withCompletion:(void (^)(BOOL success))completion;
 - (void)removeIBL;
+- (void)interactionContainerDidRecenterFromTransform:(simd_float4x4)transform NS_SWIFT_NAME(interactionContainerDidRecenter(_:));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.h
@@ -35,10 +35,15 @@ typedef NS_ENUM(NSInteger, WKStageModeOperation) {
     WKStageModeOperationOrbit,
 };
 
+@protocol WKStageModeInteractionAware <NSObject>
+- (void)stageModeInteractionDidUpdateModel;
+@end
+
 @interface WKStageModeInteractionDriver : NSObject
 @property (nonatomic, readonly) REEntityRef interactionContainerRef;
+@property (nonatomic, readonly) bool stageModeInteractionInProgress;
 
-- (instancetype)initWithModel:(WKSRKEntity *)model container:(REEntityRef)container NS_SWIFT_NAME(init(with:container:));
+- (instancetype)initWithModel:(WKSRKEntity *)model container:(REEntityRef)container delegate:(id<WKStageModeInteractionAware> _Nullable)delegate NS_SWIFT_NAME(init(with:container:delegate:));
 - (void)setContainerTransformInPortal NS_SWIFT_NAME(setContainerTransformInPortal());
 - (void)interactionDidBegin:(simd_float4x4)transform NS_SWIFT_NAME(interactionDidBegin(_:));
 - (void)interactionDidUpdate:(simd_float4x4)transform NS_SWIFT_NAME(interactionDidUpdate(_:));


### PR DESCRIPTION
#### fb4a182edf1cb341f664c5315434936d95ebf267
<pre>
Use drag recognizer in WebKit to send transform updates to Model Process for Stage Mode behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=287601">https://bugs.webkit.org/show_bug.cgi?id=287601</a>
<a href="https://rdar.apple.com/141251753">rdar://141251753</a>

Reviewed by Wenson Hsieh.

This PR implements the WKStageModeInteractionDriver to read the updates set from the modelInteractionPanGestureRecognizer
and then transform the model accordingly based on the type of model interaction that is defined. It also adds a new
delegate called WKStageModeInteractionAware that is implemented by the model player that is used to receive transform
updates and report them back to the entityTransform. In order to do so, we have to also modify the coordinate space in which
the entityTransform is reported, as it is currently relative to the interaction container rather than the scene.

* Source/WebKit/ModelProcess/StageMode/WKStageMode.h:
* Source/WebKit/ModelProcess/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.delegate):
(WKStageModeInteractionDriver.driverInitialized):
(WKStageModeInteractionDriver.initialManipulationPose):
(WKStageModeInteractionDriver.previousManipulationPose):
(WKStageModeInteractionDriver.initialTargetPose):
(WKStageModeInteractionDriver.interactionDidBegin(_:)):
(WKStageModeInteractionDriver.interactionDidUpdate(_:)):
(WKStageModeInteractionDriver.interactionDidEnd):
(WKStageModeInteractionDriver.stageModeInteractionInProgress):
- Updated all the interaction update calls with the appropriate implementation to orbit model when stagemode is set

(simd_float3._inMeters):
(simd_float3.xy):
(simd_float3.double3):
(simd_quatd.quatf):
- Added helper calls to properly convert between the right data types

* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(-[WKModelProcessModelPlayerProxyObjCAdapter stageModeInteractionDidUpdateModel]):i
(WebKit::ModelProcessModelPlayerProxy::computeTransform):
(WebKit::ModelProcessModelPlayerProxy::updateTransform):
(WebKit::ModelProcessModelPlayerProxy::stageModeInteractionDidUpdateModel):
(WebKit::ModelProcessModelPlayerProxy::stageModeInteractionInProgress):
- Added the appropriate calls to update entityTransform when the stage mode interaction is in progress

* Source/WebKit/WebKitSwift/RealityKit/RKEntity.swift:
(WKSRKEntity.interactionContainerDidRecenter(_:)):
(WKSRKEntity.transform):
* Source/WebKit/WebKitSwift/RealityKit/RealityKitBridging.h:
- Adds calls to the RKEntity to recenter the entity transform after javascript changes
- Updates the transform such that it tracks the entity&apos;s world transform such that it reports the correct
transform updates back to the HTMLModelElement

Canonical link: <a href="https://commits.webkit.org/291305@main">https://commits.webkit.org/291305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b5b5e138a38fa9cbd2a1efcdec5aed8492aa12d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43031 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20527 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70877 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28328 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51209 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9065 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42362 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99535 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19575 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23699 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24731 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20986 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->