### PR TITLE
Add Mac style menulist-button appearance for Catalyst

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -819,6 +819,8 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
         return paintButton(box, paintInfo, integralSnappedRect);
     case StyleAppearance::Menulist:
         return paintMenuList(box, paintInfo, devicePixelSnappedRect);
+    case StyleAppearance::MenulistButton:
+        return paintMenuListButton(box, paintInfo, integralSnappedRect);
     case StyleAppearance::Meter:
         return paintMeter(box, paintInfo, integralSnappedRect);
     case StyleAppearance::ProgressBar:
@@ -829,7 +831,6 @@ bool RenderTheme::paint(const RenderBox& box, const PaintInfo& paintInfo, const 
     case StyleAppearance::SliderThumbHorizontal:
     case StyleAppearance::SliderThumbVertical:
         return paintSliderThumb(box, paintInfo, integralSnappedRect);
-    case StyleAppearance::MenulistButton:
     case StyleAppearance::TextField:
     case StyleAppearance::TextArea:
     case StyleAppearance::Listbox:

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -303,6 +303,7 @@ protected:
 
     virtual void adjustMenuListButtonStyle(RenderStyle&, const Element*) const { }
     virtual void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) { }
+    virtual bool paintMenuListButton(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }
 
     virtual void adjustMeterStyle(RenderStyle&, const Element*) const;
     virtual bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) { return true; }

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -80,6 +80,7 @@ protected:
 
     void adjustMenuListButtonStyle(RenderStyle&, const Element*) const override;
     void paintMenuListButtonDecorations(const RenderBox&, const PaintInfo&, const FloatRect&) override;
+    bool paintMenuListButton(const RenderObject&, const PaintInfo&, const IntRect&) final;
 
     void adjustMeterStyle(RenderStyle&, const Element*) const override;
     bool paintMeter(const RenderObject&, const PaintInfo&, const IntRect&) override;
@@ -116,6 +117,8 @@ protected:
     void adjustSwitchStyle(RenderStyle&, const Element*) const override;
     bool paintSwitchThumb(const RenderObject&, const PaintInfo&, const FloatRect&) override;
     bool paintSwitchTrack(const RenderObject&, const PaintInfo&, const FloatRect&) override;
+
+    bool supportsFocusRing(const RenderObject&, const RenderStyle&) const override;
 
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/RenderThemeCocoaAdditions.h>

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -29,15 +29,19 @@
 #import "AttachmentLayout.h"
 #import "CaretRectComputation.h"
 #import "ColorBlending.h"
+#import "DateComponents.h"
 #import "DrawGlyphsRecorder.h"
 #import "FloatRoundedRect.h"
 #import "FontCacheCoreText.h"
 #import "GraphicsContextCG.h"
+#import "HTMLButtonElement.h"
 #import "HTMLDataListElement.h"
 #import "HTMLInputElement.h"
 #import "HTMLMeterElement.h"
 #import "HTMLOptionElement.h"
+#import "HTMLSelectElement.h"
 #import "ImageBuffer.h"
+#import "LocalizedDateCache.h"
 #import "NodeRenderStyle.h"
 #import "Page.h"
 #import "RenderButton.h"
@@ -550,6 +554,16 @@ void RenderThemeCocoa::paintMenuListButtonDecorations(const RenderBox& box, cons
     RenderTheme::paintMenuListButtonDecorations(box, paintInfo, rect);
 }
 
+bool RenderThemeCocoa::paintMenuListButton(const RenderObject& box, const PaintInfo& paintInfo, const IntRect& rect)
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+    if (paintMenuListButtonForVectorBasedControls(box, paintInfo, rect))
+        return false;
+#endif
+
+    return RenderTheme::paintMenuListButton(box, paintInfo, rect);
+}
+
 void RenderThemeCocoa::adjustMeterStyle(RenderStyle& style, const Element* element) const
 {
 #if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
@@ -823,6 +837,23 @@ bool RenderThemeCocoa::paintSwitchTrack(const RenderObject& renderer, const Pain
 #endif
 
     return renderThemePaintSwitchTrack(extractControlStyleStatesForRenderer(renderer), renderer, paintInfo, rect);
+}
+
+bool RenderThemeCocoa::supportsFocusRing(const RenderObject& renderer, const RenderStyle& style) const
+{
+#if ENABLE(VECTOR_BASED_CONTROLS_ON_MAC)
+
+#if PLATFORM(MAC)
+    auto tryFocusRingForVectorBasedControls = renderer.settings().vectorBasedControlsOnMacEnabled();
+#else
+    auto tryFocusRingForVectorBasedControls = renderer.settings().macStyleControlsOnCatalyst();
+#endif
+    if (tryFocusRingForVectorBasedControls)
+        return supportsFocusRingForVectorBasedControls(renderer, style);
+
+#endif
+
+    return RenderTheme::supportsFocusRing(renderer, style);
 }
 
 }


### PR DESCRIPTION
#### 33a5d0988ee5587d7164deab9d0c8083e9446d25
<pre>
Add Mac style menulist-button appearance for Catalyst
<a href="https://bugs.webkit.org/show_bug.cgi?id=288733">https://bugs.webkit.org/show_bug.cgi?id=288733</a>
<a href="https://rdar.apple.com/145672619">rdar://145672619</a>

Reviewed by Aditya Keerthi.

Allow Catalyst to paint menulist-buttons when using
Mac-style controls, and to adjust CSS styles accordingly.
Removed a few unused variables from RenderThemeIOS.
Updated codepath for focus ring support on Catalyst.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::paint):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::paintMenuListButton):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintMenuListButton):
(WebCore::RenderThemeCocoa::supportsFocusRing const):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::applyCommonButtonPaddingToStyle):
(WebCore::adjustInputElementButtonStyle):
(WebCore::RenderThemeIOS::adjustMenuListButtonStyle const):
(WebCore::RenderThemeIOS::paintMenuListButtonDecorations):
(WebCore::RenderThemeIOS::supportsFocusRing const):

Canonical link: <a href="https://commits.webkit.org/291291@main">https://commits.webkit.org/291291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f6e004a6417e6dc452467cb5f6d2d0945a70d30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92574 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1731 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12398 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20577 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95576 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99585 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19625 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/19875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79192 "Passed tests") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14747 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19609 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21036 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->