### PR TITLE
REGRESSION(290300@main): SaveAsPDF crashes if site-isolation is enabled

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2001,10 +2001,6 @@ webkit.org/b/288660 [ Sonoma Release x86_64 ] media/media-hevc-video-as-img.html
 
 webkit.org/b/288670 [ Release x86_64 ] media/media-source/media-source-vp8-hiddenframes.html [ Pass ImageOnlyFailure ]
 
-# webkit.org/b/288620 REGRESSION(290300@main): SaveAsPDF crashes if site-isolation is enabled
-[ Debug ] ipc/large-vector-allocate-failure-crash.html [ Skip ]
-[ Debug ] ipc/invalid-path-segments-crash.html [ Skip ]
-
 webkit.org/b/288742 [ Debug ] ipc/media-player-invalid-test.html [ Crash ]
 
 # webkit.org/b/288732 [Sonoma Release wk2] Multiple tests in imported/w3c/web-platform-tests/html/semantics/embedded-content/the-canvas-element are flaky failure

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -106,6 +106,15 @@ public:
         return create<ImageBufferType>(parameters, backendInfo, creationContext, WTFMove(backend), std::forward<Arguments>(arguments)...);
     }
 
+    template<typename BackendType, typename ImageBufferType = ImageBuffer, typename... Arguments>
+    static RefPtr<ImageBufferType> create(const FloatSize& size, const ImageBufferCreationContext& creationContext, std::unique_ptr<ImageBufferBackend>&& backend, Arguments&&... arguments)
+    {
+        auto backendParameters = backend->parameters();
+        auto parameters = Parameters { size, backendParameters.resolutionScale, backendParameters.colorSpace, backendParameters.pixelFormat, backendParameters.purpose };
+        auto backendInfo = populateBackendInfo<BackendType>(backendParameters);
+        return create<ImageBufferType>(parameters, backendInfo, creationContext, WTFMove(backend), std::forward<Arguments>(arguments)...);
+    }
+
     template<typename ImageBufferType = ImageBuffer, typename... Arguments>
     static RefPtr<ImageBufferType> create(Parameters parameters, const ImageBufferBackend::Info& backendInfo, const WebCore::ImageBufferCreationContext& creationContext, std::unique_ptr<ImageBufferBackend>&& backend, Arguments&&... arguments)
     {

--- a/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
+++ b/Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h
@@ -33,12 +33,14 @@ namespace WebCore {
 class ImageBufferDisplayListBackend : public ImageBufferBackend {
 public:
     WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const Parameters&, const ImageBufferCreationContext&);
+    WEBCORE_EXPORT static std::unique_ptr<ImageBufferDisplayListBackend> create(const FloatSize&, float resolutionScale, const DestinationColorSpace&, ImageBufferPixelFormat, RenderingPurpose, RefPtr<ControlFactory>&&);
+
     static size_t calculateMemoryCost(const Parameters&) { return 0; }
 
     static constexpr RenderingMode renderingMode = RenderingMode::DisplayList;
 
 private:
-    ImageBufferDisplayListBackend(const Parameters&);
+    ImageBufferDisplayListBackend(const Parameters&, RefPtr<ControlFactory>&& = nullptr);
 
     bool canMapBackingStore() const final { return false; }
     unsigned bytesPerRow() const final { return 0; }
@@ -54,6 +56,7 @@ private:
 
     String debugDescription() const final;
 
+    RefPtr<WebCore::ControlFactory> m_controlFactory;
     DisplayList::DrawingContext m_drawingContext;
 };
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp
@@ -49,12 +49,13 @@ void DrawingContext::setTracksDisplayListReplay(bool tracksDisplayListReplay)
     m_replayedDisplayList.reset();
 }
 
-void DrawingContext::replayDisplayList(GraphicsContext& destContext)
+void DrawingContext::replayDisplayList(GraphicsContext& destContext, ControlFactory* controlFactory)
 {
     if (m_displayList.isEmpty())
         return;
 
-    Replayer replayer(destContext, m_displayList);
+    ASSERT_IMPLIES(!controlFactory, isMainThread());
+    Replayer replayer(destContext, m_displayList.items(), m_displayList.resourceHeap(), controlFactory ? *controlFactory : ControlFactory::shared());
     if (m_tracksDisplayListReplay)
         m_replayedDisplayList = replayer.replay({ }, m_tracksDisplayListReplay).trackedDisplayList;
     else

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.h
@@ -46,7 +46,7 @@ public:
     const DisplayList* replayedDisplayList() const { return m_replayedDisplayList.get(); }
 
     WEBCORE_EXPORT void setTracksDisplayListReplay(bool);
-    WEBCORE_EXPORT void replayDisplayList(GraphicsContext&);
+    WEBCORE_EXPORT void replayDisplayList(GraphicsContext&, ControlFactory* = nullptr);
 
 protected:
     RecorderImpl m_context;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -305,7 +305,8 @@ static RefPtr<ImageBuffer> allocateImageBufferInternal(const FloatSize& logicalS
         break;
 
     case RenderingMode::DisplayList:
-        imageBuffer = ImageBuffer::create<ImageBufferDisplayListBackend, ImageBufferType>(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, creationContext, imageBufferIdentifier);
+        if (auto backend = ImageBufferDisplayListBackend::create(logicalSize, resolutionScale, colorSpace, pixelFormat, purpose, ControlFactory::create()))
+            imageBuffer = ImageBuffer::create<ImageBufferDisplayListBackend, ImageBufferType>(logicalSize, creationContext, WTFMove(backend), imageBufferIdentifier);
         break;
     }
 


### PR DESCRIPTION
#### 24861604232cde7d8f66d33fbd01ce388f8ff5e8
<pre>
REGRESSION(290300@main): SaveAsPDF crashes if site-isolation is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=288620">https://bugs.webkit.org/show_bug.cgi?id=288620</a>
<a href="https://rdar.apple.com/145673736">rdar://145673736</a>

Reviewed by Simon Fraser.

290300@main made the snapshot for site-isolation happens through a DisplayList.
But generating the PDFDocument was happening on the main thread. This caused a
threading issue which was fixed in 291031@main.

The fix of this threading issue in 291031@main was to move generating the PDFDocument
back to the `RemoteRendering WorkQueue` which is the correct approach.

But DrawingContext::replayDisplayList() requires a ControlFactory to be created
on the same thread. Otherwise it will call ControlFactory::shared() which creates
a MainThreadNeverDestroyed ControlFactory. This causes this crash because
ControlFactory::shared() has to be called only from the main thread.

The fix is to make RemoteRenderingBackend create a ControlFactory and pass it to
ImageBufferDisplayListBackend::create().

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::ImageBuffer::create):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.cpp:
(WebCore::ImageBufferDisplayListBackend::create):
(WebCore::ImageBufferDisplayListBackend::ImageBufferDisplayListBackend):
(WebCore::ImageBufferDisplayListBackend::copyNativeImage):
(WebCore::ImageBufferDisplayListBackend::sinkIntoPDFDocument):
* Source/WebCore/platform/graphics/ImageBufferDisplayListBackend.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.cpp:
(WebCore::DisplayList::DrawingContext::replayDisplayList):
* Source/WebCore/platform/graphics/displaylists/DisplayListDrawingContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::allocateImageBufferInternal):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DrawingToPDF.mm:
(TestWebKitAPI::enableSiteIsolation):
(TestWebKitAPI::TEST(DrawingToPDF, SiteIsolationFormControl)):

Canonical link: <a href="https://commits.webkit.org/291521@main">https://commits.webkit.org/291521@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b02dc879d46b14c936da8cf12cf5f92cc98f331e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95185 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21143 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28614 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96137 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84267 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51535 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9462 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1901 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42974 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100161 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20187 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79536 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19757 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1396 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20171 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25348 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23318 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21599 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->