### PR TITLE
In UA stylesheet, set *:root dynamic-range-limit: standard, except videos no-limit

### DIFF
--- a/LayoutTests/fast/css/dynamic-range-limit-default-expected.txt
+++ b/LayoutTests/fast/css/dynamic-range-limit-default-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/css/dynamic-range-limit-default.html
+++ b/LayoutTests/fast/css/dynamic-range-limit-default.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true ] -->
+<html id="html">
+<body>
+<script src='../../resources/js-test-pre.js'></script>
+<div id="div"></div>
+<video id="video"></video>
+<div id="div-standard" style="dynamic-range-limit: standard">
+    <div id="div-under-standard"></div>
+    <video id="video-under-standard"></video>
+    <video id="video-constrained-high" style="dynamic-range-limit: constrained-high"></video>
+</div>
+<script>
+if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "constrained-high") && CSS.supports("dynamic-range-limit", "no-limit")) {
+    const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+
+    shouldBe('document.documentElement.style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.documentElement)["dynamic-range-limit"]', '"constrained-high"', quiet);
+
+    shouldBe('document.getElementById("html").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("html"))["dynamic-range-limit"]', '"constrained-high"', quiet);
+
+    shouldBe('document.getElementById("div").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("div"))["dynamic-range-limit"]', '"constrained-high"', quiet);
+
+    shouldBe('document.getElementById("video").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video"))["dynamic-range-limit"]', '"no-limit"', quiet);
+
+    shouldBe('document.getElementById("div-standard").style["dynamic-range-limit"]', '"standard"', quiet);
+    shouldBe('getComputedStyle(document.getElementById("div-standard"))["dynamic-range-limit"]', '"standard"', quiet);
+
+    shouldBe('document.getElementById("div-under-standard").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("div-under-standard"))["dynamic-range-limit"]', '"standard"', quiet);
+
+    shouldBe('document.getElementById("video-under-standard").style["dynamic-range-limit"]', '""', quiet);
+    // Note: The UA stylesheet overrides the inherited property.
+    shouldBe('getComputedStyle(document.getElementById("video-under-standard"))["dynamic-range-limit"]', '"no-limit"', quiet);
+
+    shouldBe('document.getElementById("video-constrained-high").style["dynamic-range-limit"]', '"constrained-high"', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video-constrained-high"))["dynamic-range-limit"]', '"constrained-high"', quiet);
+}
+</script>
+<script src='../../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/infrastructure/assumptions/html-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/infrastructure/assumptions/html-elements-expected.txt
@@ -1,8 +1,8 @@
 
 PASS (pre-req for comparison tests) all CSS short-hand supported
 PASS (pre-req for comparison tests) initial CSS value supported
-PASS Compare CSS div definitions (only valid if pre-reqs pass)
-PASS Compare CSS span definitions (only valid if pre-reqs pass)
+FAIL Compare CSS div definitions (only valid if pre-reqs pass) assert_equals: Different value for dynamic-range-limit expected "no-limit" but got "constrained-high"
+FAIL Compare CSS span definitions (only valid if pre-reqs pass) assert_equals: Different value for dynamic-range-limit expected "no-limit" but got "constrained-high"
 PASS p is display: block
 PASS ul > li is display: list-item
 PASS ol > li is display: list-item

--- a/LayoutTests/inspector/css/shadow-scoped-style-expected.txt
+++ b/LayoutTests/inspector/css/shadow-scoped-style-expected.txt
@@ -23,6 +23,8 @@ address, blockquote, center, div, figure, figcaption, footer, form, header, hr, 
 }
 address, article, aside, div, footer, header, hgroup, main, nav, search, section {
 }
+:root {
+}
 html {
 }
 

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -161,12 +161,17 @@ body:-internal-media-document {
     background-color: rgb(38, 38, 38);
 }
 
+*:root {
+    dynamic-range-limit: constrained-high;
+}
+
 video {
     object-fit: contain;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     -webkit-tap-highlight-color: transparent;
 #endif
     content: normal !important;
+    dynamic-range-limit: no-limit;
 }
 
 audio {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -58,6 +58,7 @@ static void applyUASheetBehaviorsToContext(CSSParserContext& context)
     context.popoverAttributeEnabled = true;
     context.propertySettings.cssInputSecurityEnabled = true;
     context.propertySettings.cssCounterStyleAtRulesEnabled = true;
+    context.propertySettings.supportHDRDisplayEnabled = true;
     context.propertySettings.viewTransitionsEnabled = true;
 #if HAVE(CORE_MATERIAL)
     context.propertySettings.useSystemAppearance = true;


### PR DESCRIPTION
#### 46334357a3603c5e2dbbfbb9b8648e0a5dd0d5de
<pre>
In UA stylesheet, set *:root dynamic-range-limit: standard, except videos no-limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=288748">https://bugs.webkit.org/show_bug.cgi?id=288748</a>
<a href="https://rdar.apple.com/145784202">rdar://145784202</a>

Reviewed by NOBODY (OOPS!).

As initial UA policy, unless explicitly specified by
websites, all HDR content will start constrained (from
the root element), except for videos starting unconstrained.

* LayoutTests/fast/css/dynamic-range-limit-default-expected.txt: Added.
* LayoutTests/fast/css/dynamic-range-limit-default.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/infrastructure/assumptions/html-elements-expected.txt:
* LayoutTests/inspector/css/shadow-scoped-style-expected.txt:
* Source/WebCore/css/html.css:
(*:root):
(video):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::applyUASheetBehaviorsToContext):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46334357a3603c5e2dbbfbb9b8648e0a5dd0d5de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12346 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97791 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94845 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20798 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71011 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28444 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83975 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51340 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1607 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42634 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99813 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19847 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14585 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80027 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79329 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1127 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19831 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25007 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19518 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22978 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21259 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->