### PR TITLE
Introduce xpc_string_get_wtfstring() for bounds safety and efficiency

### DIFF
--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -216,6 +216,7 @@ const char* xpc_type_get_name(xpc_type_t);
 void xpc_main(xpc_connection_handler_t);
 xpc_object_t xpc_string_create(const char *string);
 const char* xpc_string_get_string_ptr(xpc_object_t);
+size_t xpc_string_get_length(xpc_object_t);
 os_transaction_t os_transaction_create(const char *description);
 void xpc_transaction_exit_clean(void);
 void xpc_track_activity(void);
@@ -274,4 +275,9 @@ inline String xpc_dictionary_get_wtfstring(xpc_object_t xdict, ASCIILiteral key)
     if (!cstring)
         return { };
     return String::fromUTF8(cstring);
+}
+
+inline String xpc_string_get_wtfstring(xpc_object_t xvalue)
+{
+    return String::fromUTF8(unsafeMakeSpan(xpc_string_get_string_ptr(xvalue), xpc_string_get_length(xvalue))); // NOLINT
 }

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -169,7 +169,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 Vector<String> newLanguages;
                 @autoreleasepool {
                     xpc_array_apply(languages, makeBlockPtr([&newLanguages](size_t index, xpc_object_t value) {
-                        newLanguages.append(String::fromUTF8(xpc_string_get_string_ptr(value)));
+                        newLanguages.append(xpc_string_get_wtfstring(value));
                         return true;
                     }).get());
                 }
@@ -185,7 +185,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
 #if PLATFORM(IOS_FAMILY)
             auto containerEnvironmentVariables = xpc_dictionary_get_value(event, "ContainerEnvironmentVariables");
             xpc_dictionary_apply(containerEnvironmentVariables, ^(const char *key, xpc_object_t value) {
-                setenv(key, xpc_string_get_string_ptr(value), 1);
+                setenv(key, xpc_string_get_string_ptr(value), 1);  // NOLINT
                 return true;
             });
 #endif

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2009, 2010, 2012 Google Inc. All rights reserved.
 # Copyright (C) 2009 Torch Mobile Inc.
-# Copyright (C) 2009-2023 Apple Inc. All rights reserved.
+# Copyright (C) 2009-2025 Apple Inc. All rights reserved.
 # Copyright (C) 2010 Chris Jerdonek (cjerdonek@webkit.org)
 #
 # Redistribution and use in source and binary forms, with or without
@@ -3567,6 +3567,10 @@ def check_safer_cpp(clean_lines, line_number, error):
     if uses_xpc_dictionary_get_string:
         error(line_number, 'safercpp/xpc_dictionary_get_string', 4, "Use xpc_dictionary_get_wtfstring() instead of xpc_dictionary_get_string().")
 
+    uses_xpc_string_get_string_ptr = search(r'xpc_string_get_string_ptr\(', line)
+    if uses_xpc_string_get_string_ptr:
+        error(line_number, 'safercpp/xpc_string_get_string_ptr', 4, "Use xpc_string_get_wtfstring() instead of xpc_string_get_string_ptr().")
+
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):
     """Checks rules from the 'C++ style rules' section of cppguide.html.
@@ -4916,6 +4920,7 @@ class CppChecker(object):
         'safercpp/timer_exception',
         'safercpp/xpc_dictionary_get_data',
         'safercpp/xpc_dictionary_get_string',
+        'safercpp/xpc_string_get_string_ptr',
         'security/assertion',
         'security/assertion_fallthrough',
         'security/javascriptcore_wtf_blockptr',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2011 Google Inc. All rights reserved.
 # Copyright (C) 2009 Torch Mobile Inc.
-# Copyright (C) 2009-2020 Apple Inc. All rights reserved.
+# Copyright (C) 2009-2025 Apple Inc. All rights reserved.
 # Copyright (C) 2010 Chris Jerdonek (cjerdonek@webkit.org)
 #
 # Redistribution and use in source and binary forms, with or without
@@ -6346,6 +6346,11 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint(
             'auto* result = xpc_dictionary_get_string(dictionary, "foo");',
             'Use xpc_dictionary_get_wtfstring() instead of xpc_dictionary_get_string().  [safercpp/xpc_dictionary_get_string] [4]',
+            'foo.cpp')
+
+        self.assert_lint(
+            'auto* result = xpc_string_get_string_ptr(value);',
+            'Use xpc_string_get_wtfstring() instead of xpc_string_get_string_ptr().  [safercpp/xpc_string_get_string_ptr] [4]',
             'foo.cpp')
 
     def test_ctype_fucntion(self):


### PR DESCRIPTION
#### a33eba312fbbd5b863c3c65504b3bef9fa659dd8
<pre>
Introduce xpc_string_get_wtfstring() for bounds safety and efficiency
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=288750">https://bugs.webkit.org/show_bug.cgi?id=288750</a>&gt;
&lt;<a href="https://rdar.apple.com/145785145">rdar://145785145</a>&gt;

Reviewed by Geoffrey Garen.

* Source/WTF/wtf/spi/darwin/XPCSPI.h:
(xpc_string_get_length):
- Add declaration for open source builds.
(xpc_string_get_wtfstring): Add.
- Convenience method for converting C-string returned from
  xpc_string_get_string_ptr() into a WTF::String.  This is more
  efficient since it creates a span with the known length of the
  C-string to construct the WTF::String.
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceEventHandler):
- Make use of xpc_string_get_wtfstring().
- Add a `NOLINT` comment to avoid check-webkit-style warnings for the
  second use of xpc_string_get_string_ptr() which doesn&apos;t need a
  WTF::String.
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
- Add check for xpc_string_get_string_ptr().
(CppChecker):
- Enable &apos;safercpp/xpc_string_get_string_ptr&apos; checker by default.
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
- Add test for &apos;safercpp/xpc_string_get_string_ptr&apos; checker.

Canonical link: <a href="https://commits.webkit.org/291513@main">https://commits.webkit.org/291513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b3f1abb86edcb75152942c262b471c803dab45a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92547 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1701 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70889 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95549 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9379 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51221 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/92042 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1428 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42385 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85257 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99558 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91213 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79895 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79672 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79177 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12610 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14893 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24754 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113861 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19269 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32913 "Found 316 new JSC stress test failures: jsc-layout-tests.yaml/js/script-tests/function-apply-many-args.js.layout-no-llint, microbenchmarks/array-from-object.js.lockdown, microbenchmarks/array-prototype-with-storage.js.bytecode-cache, microbenchmarks/array-prototype-with-storage.js.default, microbenchmarks/array-prototype-with-storage.js.dfg-eager, microbenchmarks/array-prototype-with-storage.js.dfg-eager-no-cjit-validate, microbenchmarks/array-prototype-with-storage.js.eager-jettison-no-cjit, microbenchmarks/array-prototype-with-storage.js.lockdown, microbenchmarks/array-prototype-with-storage.js.mini-mode, microbenchmarks/array-prototype-with-storage.js.no-cjit-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->