### PR TITLE
Support multiple stylesheets in the media controls shadow root

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -398,9 +398,11 @@ String MediaControlsHost::generateUUID()
     return createVersion4UUIDString();
 }
 
-String MediaControlsHost::shadowRootCSSText()
+Vector<String> MediaControlsHost::shadowRootStyleSheets() const
 {
-    return RenderTheme::singleton().mediaControlsStyleSheet();
+    if (RefPtr mediaElement = m_mediaElement.get())
+        return RenderTheme::singleton().mediaControlsStyleSheets(*mediaElement);
+    return { };
 }
 
 String MediaControlsHost::base64StringForIconNameAndType(const String& iconName, const String& iconType)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -112,7 +112,7 @@ public:
 
     static String generateUUID();
 
-    static String shadowRootCSSText();
+    Vector<String> shadowRootStyleSheets() const;
     static String base64StringForIconNameAndType(const String& iconName, const String& iconType);
     static String formattedStringForDuration(double);
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -80,7 +80,7 @@ enum DeviceType {
 
     readonly attribute SourceType? sourceType;
 
-    readonly attribute DOMString shadowRootCSSText;
+    readonly attribute sequence<DOMString> shadowRootStyleSheets;
     DOMString base64StringForIconNameAndType(DOMString iconName, DOMString iconType);
     DOMString formattedStringForDuration(unrestricted double durationInSeconds);
     [Conditional=MEDIA_CONTROLS_CONTEXT_MENUS, EnabledBySetting=MediaControlsContextMenusEnabled] boolean showMediaControlsContextMenu(HTMLElement target, JSON options, VoidCallback callback);

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -37,7 +37,8 @@ function createControls(shadowRoot, media, host)
         iconService.shadowRoot = shadowRoot;
         iconService.mediaControlsHost = host;
 
-        shadowRoot.appendChild(document.createElement("style")).textContent = host.shadowRootCSSText;
+        for (let styleSheet of host.shadowRootStyleSheets)
+            shadowRoot.appendChild(document.createElement("style")).textContent = styleSheet;
     }
 
     return new MediaController(shadowRoot, media, host);

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -91,7 +91,7 @@ public:
 
     virtual String extraDefaultStyleSheet() { return String(); }
 #if ENABLE(VIDEO)
-    virtual String mediaControlsStyleSheet() { return String(); }
+    virtual Vector<String> mediaControlsStyleSheets(const HTMLMediaElement&) { return { }; }
     virtual Vector<String, 2> mediaControlsScripts() { return { }; }
     virtual String mediaControlsBase64StringForIconNameAndType(const String&, const String&) { return String(); }
     virtual String mediaControlsFormattedStringForDuration(double) { return String(); }

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -206,11 +206,11 @@ Vector<String, 2> RenderThemeAdwaita::mediaControlsScripts()
     return { StringImpl::createWithoutCopying(ModernMediaControlsJavaScript) };
 }
 
-String RenderThemeAdwaita::mediaControlsStyleSheet()
+Vector<String> RenderThemeAdwaita::mediaControlsStyleSheets(const HTMLMediaElement&)
 {
     if (m_mediaControlsStyleSheet.isEmpty())
         m_mediaControlsStyleSheet = StringImpl::createWithoutCopying(ModernMediaControlsUserAgentStyleSheet);
-    return m_mediaControlsStyleSheet;
+    return { m_mediaControlsStyleSheet };
 }
 
 String RenderThemeAdwaita::mediaControlsBase64StringForIconNameAndType(const String& iconName, const String& iconType)

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h
@@ -48,7 +48,7 @@ private:
     String extraDefaultStyleSheet() final;
 #if ENABLE(VIDEO)
     Vector<String, 2> mediaControlsScripts() final;
-    String mediaControlsStyleSheet() final;
+    Vector<String> mediaControlsStyleSheets(const HTMLMediaElement&) final;
 #endif
 
 #if ENABLE(VIDEO)

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.h
@@ -139,7 +139,7 @@ private:
 #endif
 
 #if ENABLE(VIDEO)
-    String mediaControlsStyleSheet() override;
+    Vector<String> mediaControlsStyleSheets(const HTMLMediaElement&) override;
     Vector<String, 2> mediaControlsScripts() override;
     String mediaControlsBase64StringForIconNameAndType(const String&, const String&) override;
     String mediaControlsFormattedStringForDuration(double) override;

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -102,7 +102,12 @@ static bool renderThemePaintSwitchTrack(OptionSet<ControlStyle::State>, const Re
     return true;
 }
 
+static Vector<String> additionalMediaControlsStyleSheets(const HTMLMediaElement&)
+{
+    return { };
 }
+
+} // namespace WebCore
 
 #endif
 
@@ -217,11 +222,15 @@ void RenderThemeCocoa::adjustApplePayButtonStyle(RenderStyle& style, const Eleme
 
 #if ENABLE(VIDEO)
 
-String RenderThemeCocoa::mediaControlsStyleSheet()
+Vector<String> RenderThemeCocoa::mediaControlsStyleSheets(const HTMLMediaElement& mediaElement)
 {
     if (m_mediaControlsStyleSheet.isEmpty())
         m_mediaControlsStyleSheet = StringImpl::createWithoutCopying(ModernMediaControlsUserAgentStyleSheet);
-    return m_mediaControlsStyleSheet;
+
+    auto mediaControlsStyleSheets = Vector<String>::from(m_mediaControlsStyleSheet);
+    mediaControlsStyleSheets.appendVector(additionalMediaControlsStyleSheets(mediaElement));
+
+    return mediaControlsStyleSheets;
 }
 
 Vector<String, 2> RenderThemeCocoa::mediaControlsScripts()


### PR DESCRIPTION
#### f6c402be75a06084d64e11ffe23eb4012f98acf9
<pre>
Support multiple stylesheets in the media controls shadow root
<a href="https://bugs.webkit.org/show_bug.cgi?id=288764">https://bugs.webkit.org/show_bug.cgi?id=288764</a>
<a href="https://rdar.apple.com/145789376">rdar://145789376</a>

Reviewed by Aditya Keerthi.

Added the ability for media controls&apos; shadow root to contain multiple &lt;style&gt; elements.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::shadowRootStyleSheets):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
Renamed from shadowRootCSSText. Changed to return a Vector&lt;String&gt;.

* Source/WebCore/Modules/modern-media-controls/main.js:
(createControls):
Inserted a &lt;style&gt; element for each item in host.shadowRootStyleSheets.

* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::mediaControlsStyleSheets):
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::mediaControlsStyleSheets):
(WebCore::RenderThemeAdwaita::mediaControlsStyleSheet): Deleted.
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.h:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::additionalMediaControlsStyleSheets):
(WebCore::RenderThemeCocoa::mediaControlsStyleSheets):
Renamed from mediaControlsStyleSheet. Changed to return a Vector&lt;String&gt; containing
m_mediaControlsStyleSheet and the style sheets from additionalMediaControlsStyleSheets().

Canonical link: <a href="https://commits.webkit.org/291343@main">https://commits.webkit.org/291343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/360a256afc4a3d33731f5bfe838f7f4478d5a084

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92630 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43137 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70934 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28373 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95632 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9434 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1490 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42468 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99642 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19681 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79948 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79237 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19654 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23762 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1050 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24837 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19352 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22812 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->