### PR TITLE
AX: [Site Isolation] [Accessibility Isolated Tree] In isolated tree mode, ATs can't access isolated iframes

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -254,6 +254,7 @@ static const Seconds updateTreeSnapshotTimerInterval { 100_ms };
 AXObjectCache::AXObjectCache(Page& page, Document* document)
     : m_document(document)
     , m_pageID(page.identifier())
+    , m_page(page)
     , m_notificationPostTimer(*this, &AXObjectCache::notificationPostTimerFired)
     , m_passwordNotificationPostTimer(*this, &AXObjectCache::passwordNotificationPostTimerFired)
     , m_liveRegionChangedPostTimer(*this, &AXObjectCache::liveRegionChangedNotificationPostTimerFired)
@@ -1010,7 +1011,7 @@ AccessibilityObject* AXObjectCache::getOrCreate(RenderObject& renderer)
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
+RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree(std::optional<FrameIdentifier> frameID)
 {
     AXTRACE(makeString("AXObjectCache::getOrCreateIsolatedTree 0x"_s, hex(reinterpret_cast<uintptr_t>(this))));
     ASSERT(isMainThread());
@@ -1032,11 +1033,11 @@ RefPtr<AXIsolatedTree> AXObjectCache::getOrCreateIsolatedTree()
     // Then we schedule building the entire isolated tree on a Timer.
     // For test clients, LayoutTests or XCTests, build the whole isolated tree.
     if (LIKELY(!clientIsInTestMode())) {
-        tree = AXIsolatedTree::createEmpty(*this);
+        tree = AXIsolatedTree::createEmpty(*this, frameID);
         if (!m_buildIsolatedTreeTimer.isActive())
             m_buildIsolatedTreeTimer.startOneShot(0_s);
     } else
-        tree = AXIsolatedTree::create(*this);
+        tree = AXIsolatedTree::create(*this, frameID);
 
     initializeAXThreadIfNeeded();
 
@@ -1057,9 +1058,9 @@ void AXObjectCache::buildIsolatedTree()
     }
 }
 
-AXCoreObject* AXObjectCache::isolatedTreeRootObject()
+AXCoreObject* AXObjectCache::isolatedTreeRootObject(std::optional<FrameIdentifier> frameID)
 {
-    if (auto tree = getOrCreateIsolatedTree())
+    if (auto tree = getOrCreateIsolatedTree(frameID))
         return tree->rootNode();
 
     // Should not get here, couldn't create the IsolatedTree.
@@ -1067,11 +1068,23 @@ AXCoreObject* AXObjectCache::isolatedTreeRootObject()
     return nullptr;
 }
 
-void AXObjectCache::setIsolatedTreeRoot(AXCoreObject* root)
+void AXObjectCache::setIsolatedTreeRoot(AXCoreObject* root, std::optional<FrameIdentifier> frameID)
 {
     ASSERT(isMainThread());
     if (RefPtr frame = m_document ? m_document->frame() : nullptr)
         frame->loader().client().setAXIsolatedTreeRoot(root);
+    else if (RefPtr localFrame = localFrameForFrameID(frameID))
+        localFrame->loader().client().setAXIsolatedTreeRoot(root);
+}
+
+LocalFrame* AXObjectCache::localFrameForFrameID(std::optional<FrameIdentifier> frameID)
+{
+    for (auto& rootFrame : m_page->rootFrames()) {
+        if (!frameID || rootFrame->frameID() == *frameID)
+            return rootFrame.ptr();
+    }
+
+    return nullptr;
 }
 #endif
 
@@ -1082,7 +1095,7 @@ AXCoreObject* AXObjectCache::rootObjectForFrame(LocalFrame& frame)
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (isIsolatedTreeEnabled())
-        return isolatedTreeRootObject();
+        return isolatedTreeRootObject(frame.frameID());
 #endif
 
     return getOrCreate(frame.view());

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -290,6 +290,9 @@ public:
 
     // Returns the root object for a specific frame.
     WEBCORE_EXPORT AXCoreObject* rootObjectForFrame(LocalFrame&);
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    WEBCORE_EXPORT AXCoreObject* isolatedTreeRootObject(std::optional<FrameIdentifier>);
+#endif
 
     // Creation/retrieval of AX objects associated with a DOM or RenderTree object.
     inline AccessibilityObject* getOrCreate(RenderObject* renderer)
@@ -610,15 +613,17 @@ public:
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     void scheduleObjectRegionsUpdate(bool scheduleImmediately = false) { m_geometryManager->scheduleObjectRegionsUpdate(scheduleImmediately); }
     void willUpdateObjectRegions() { m_geometryManager->willUpdateObjectRegions(); }
-    WEBCORE_EXPORT static bool isIsolatedTreeEnabled();
+    WEBCORE_EXPORT static bool isIsolatedTreeEnabled(bool ignoreClient = false);
     WEBCORE_EXPORT static void initializeAXThreadIfNeeded();
+    WEBCORE_EXPORT RefPtr<AXIsolatedTree> getOrCreateIsolatedTree(std::optional<FrameIdentifier> = std::nullopt);
 private:
     static bool clientSupportsIsolatedTree();
-    AXCoreObject* isolatedTreeRootObject();
     // Propagates the root of the isolated tree back into the Core and WebKit.
-    void setIsolatedTreeRoot(AXCoreObject*);
+    void setIsolatedTreeRoot(AXCoreObject*, std::optional<FrameIdentifier> = std::nullopt);
     void setIsolatedTreeFocusedObject(AccessibilityObject*);
-    RefPtr<AXIsolatedTree> getOrCreateIsolatedTree();
+    // Used in site isolation contexts to traverse a page's root local frames and find the one matching the frameID.
+    // Falls back to the first frame in the list of root frames if frameID is nullopt.
+    LocalFrame* localFrameForFrameID(std::optional<FrameIdentifier> = std::nullopt);
     void buildIsolatedTree();
     void updateIsolatedTree(AccessibilityObject&, AXNotification);
     void updateIsolatedTree(AccessibilityObject*, AXNotification);
@@ -777,6 +782,7 @@ private:
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const std::optional<PageIdentifier> m_pageID; // constant for object's lifetime.
+    WeakRef<Page> m_page;
     OptionSet<ActivityState> m_pageActivityState;
     UncheckedKeyHashMap<AXID, Ref<AccessibilityObject>> m_objects;
 

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -244,7 +244,12 @@ void AccessibilityScrollView::addRemoteFrameChild()
         // Generate a new token and pass it back to the other remote frame so it can bind these objects together.
         Ref remoteFrame = remoteFrameView->frame();
         m_remoteFrame->setFrameID(remoteFrame->frameID());
-        remoteFrame->bindRemoteAccessibilityFrames(getpid(), { m_remoteFrame->generateRemoteToken() }, [this, &remoteFrame, protectedAccessbilityRemoteFrame = RefPtr { m_remoteFrame }] (Vector<uint8_t> token, int processIdentifier) mutable {
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+        bool isolatedTreeEnabled = AXObjectCache::isIsolatedTreeEnabled();
+#else
+        bool isolatedTreeEnabled = false;
+#endif
+        remoteFrame->bindRemoteAccessibilityFrames(getpid(), { m_remoteFrame->generateRemoteToken() }, isolatedTreeEnabled, [this, &remoteFrame, protectedAccessbilityRemoteFrame = RefPtr { m_remoteFrame }] (Vector<uint8_t> token, int processIdentifier) mutable {
             protectedAccessbilityRemoteFrame->initializePlatformElementWithRemoteToken(token.span(), processIdentifier);
 
             // Update the remote side with the offset of this object so it can calculate frames correctly.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -79,7 +79,7 @@ void AXIsolatedTree::queueForDestruction()
     m_queuedForDestruction = true;
 }
 
-Ref<AXIsolatedTree> AXIsolatedTree::createEmpty(AXObjectCache& axObjectCache)
+Ref<AXIsolatedTree> AXIsolatedTree::createEmpty(AXObjectCache& axObjectCache, std::optional<FrameIdentifier> frameID)
 {
     AXTRACE("AXIsolatedTree::createEmpty"_s);
     ASSERT(isMainThread());
@@ -90,10 +90,20 @@ Ref<AXIsolatedTree> AXIsolatedTree::createEmpty(AXObjectCache& axObjectCache)
     if (RefPtr axRoot = axObjectCache.document() ? axObjectCache.getOrCreate(axObjectCache.document()->view()) : nullptr) {
         tree->updatingSubtree(axRoot.get());
         tree->createEmptyContent(*axRoot);
+    } else {
+        // We are likely here because site isolation is enabled, and the current page has a root frame that is a RemoteFrame.
+        // Find the LocalFrame based on the passed in FrameID.
+        if (RefPtr localFrame = axObjectCache.localFrameForFrameID(frameID)) {
+            if (RefPtr axRoot = axObjectCache.getOrCreate(localFrame->view())) {
+                tree->updatingSubtree(axRoot.get());
+                tree->createEmptyContent(*axRoot);
+            }
+        }
     }
 
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
     tree->m_processingProgress = 0;
+    tree->setRootLocalFrameID(frameID);
 
     // Now that the tree is ready to take client requests, add it to the tree maps so that it can be found.
     storeTree(axObjectCache, tree);
@@ -140,7 +150,7 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
     queueAppendsAndRemovals({ rootAppend, webAreaAppend }, { });
 }
 
-RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
+RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache, std::optional<FrameIdentifier> frameID)
 {
     AXTRACE("AXIsolatedTree::create"_s);
     ASSERT(isMainThread());
@@ -151,6 +161,11 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
         tree->m_replacingTree = existingTree;
 
     RefPtr document = axObjectCache.document();
+    if (!document) {
+        if (RefPtr localFrame = axObjectCache.localFrameForFrameID(frameID))
+            document = localFrame->document();
+    }
+
     if (!document)
         return nullptr;
     if (!Accessibility::inRenderTreeOrStyleUpdate(*document))
@@ -181,6 +196,8 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
             tree->addUnconnectedNode(axObject.releaseNonNull());
     }
 
+    tree->setRootLocalFrameID(frameID);
+
     // Now that the tree is ready to take client requests, add it to the tree maps so that it can be found.
     storeTree(axObjectCache, tree);
     return tree;
@@ -200,7 +217,7 @@ void AXIsolatedTree::storeTree(AXObjectCache& cache, const Ref<AXIsolatedTree>& 
     // Once we set this tree in the AXTreeStore, the secondary thread can start using it,
     // and we can no longer access AXIsolatedTree::rootNode off the main-thread. Set the
     // root now while we still can.
-    cache.setIsolatedTreeRoot(tree->rootNode());
+    cache.setIsolatedTreeRoot(tree->rootNode(), tree->rootLocalFrameID());
     AXTreeStore::set(tree->treeID(), tree.ptr());
     tree->m_replacingTree = nullptr;
     Locker locker { s_storeLock };

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -356,9 +356,9 @@ class AXIsolatedTree : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<AX
     friend WTF::TextStream& operator<<(WTF::TextStream&, AXIsolatedTree&);
     friend void streamIsolatedSubtreeOnMainThread(TextStream&, const AXIsolatedTree&, AXID, const OptionSet<AXStreamOptions>&);
 public:
-    static RefPtr<AXIsolatedTree> create(AXObjectCache&);
+    static RefPtr<AXIsolatedTree> create(AXObjectCache&, std::optional<FrameIdentifier> = std::nullopt);
     // Creates a tree consisting of only the Scrollview and the WebArea objects. This tree is used as a temporary placeholder while the whole tree is being built.
-    static Ref<AXIsolatedTree> createEmpty(AXObjectCache&);
+    static Ref<AXIsolatedTree> createEmpty(AXObjectCache&, std::optional<FrameIdentifier> = std::nullopt);
     constexpr bool isEmptyContentTree() const { return m_isEmptyContentTree; }
     virtual ~AXIsolatedTree();
 
@@ -373,6 +373,8 @@ public:
     RefPtr<AXIsolatedObject> rootWebArea();
     std::optional<AXID> focusedNodeID();
     WEBCORE_EXPORT RefPtr<AXIsolatedObject> focusedNode();
+    std::optional<FrameIdentifier> rootLocalFrameID() const { return m_rootLocalFrameID; }
+    void setRootLocalFrameID(std::optional<FrameIdentifier> frameID) { m_rootLocalFrameID = frameID; }
 
     AXIsolatedObject* objectForID(AXID) const;
     inline AXIsolatedObject* objectForID(std::optional<AXID> axID) const
@@ -608,6 +610,9 @@ private:
     UncheckedKeyHashMap<AXID, AXPropertySet> m_needsPropertyUpdates;
     // The key is the ID of the node being removed. The value is the ID of the parent in the core tree (if it exists).
     UncheckedKeyHashMap<AXID, std::optional<AXID>> m_needsNodeRemoval;
+
+    // The frame ID associated with this tree.
+    std::optional<FrameIdentifier> m_rootLocalFrameID;
 };
 
 inline AXObjectCache* AXIsolatedTree::axObjectCache() const

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -674,7 +674,7 @@ bool AXObjectCache::clientSupportsIsolatedTree()
         || client == kAXClientTypeXCTest);
 }
 
-bool AXObjectCache::isIsolatedTreeEnabled()
+bool AXObjectCache::isIsolatedTreeEnabled(bool ignoreClient)
 {
     static std::atomic<bool> enabled { false };
     if (enabled)
@@ -687,7 +687,7 @@ bool AXObjectCache::isIsolatedTreeEnabled()
         enabled = DeprecatedGlobalSettings::isAccessibilityIsolatedTreeEnabled() // Used to turn off in apps other than Safari, e.g., Mail.
             && _AXSIsolatedTreeModeFunctionIsAvailable()
             && _AXSIsolatedTreeMode_Soft() != AXSIsolatedTreeModeOff // Used to switch via system defaults.
-            && clientSupportsIsolatedTree();
+            && (ignoreClient || clientSupportsIsolatedTree());
     }
 
     return enabled;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -105,9 +105,9 @@ void RemoteFrame::unbindRemoteAccessibilityFrames(int processIdentifier)
     m_client->unbindRemoteAccessibilityFrames(processIdentifier);
 }
 
-void RemoteFrame::bindRemoteAccessibilityFrames(int processIdentifier, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
+void RemoteFrame::bindRemoteAccessibilityFrames(int processIdentifier, Vector<uint8_t>&& dataToken, bool parentHasIsolatedTreeEnabled, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
 {
-    return m_client->bindRemoteAccessibilityFrames(processIdentifier, frameID(), WTFMove(dataToken), WTFMove(completionHandler));
+    return m_client->bindRemoteAccessibilityFrames(processIdentifier, frameID(), parentHasIsolatedTreeEnabled, WTFMove(dataToken), WTFMove(completionHandler));
 }
 
 FrameView* RemoteFrame::virtualView() const

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -61,7 +61,7 @@ public:
     Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
     String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>);
-    void bindRemoteAccessibilityFrames(int processIdentifier, Vector<uint8_t>&&, CompletionHandler<void(Vector<uint8_t>, int)>&&);
+    void bindRemoteAccessibilityFrames(int processIdentifier, Vector<uint8_t>&&, bool, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemoteFrameAccessibilityOffset(IntPoint);
     void unbindRemoteAccessibilityFrames(int);
 

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -51,7 +51,7 @@ public:
     virtual String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>) = 0;
     virtual String layerTreeAsText(size_t baseIndent, OptionSet<LayerTreeAsTextOptions>) = 0;
     virtual void closePage() = 0;
-    virtual void bindRemoteAccessibilityFrames(int processIdentifier, FrameIdentifier target, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&&) = 0;
+    virtual void bindRemoteAccessibilityFrames(int processIdentifier, FrameIdentifier target, bool parentHasIsolatedTreeEnabled, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&&) = 0;
     virtual void updateRemoteFrameAccessibilityOffset(FrameIdentifier target, IntPoint) = 0;
     virtual void unbindRemoteAccessibilityFrames(int) = 0;
     virtual void focus() = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5627,6 +5627,15 @@ void WebPageProxy::enableAccessibilityForAllProcesses()
     });
 }
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+void WebPageProxy::initializeIsolatedTreeInAllProcesses()
+{
+    forEachWebContentProcess([&](auto& webProcess, auto pageID) {
+        webProcess.send(Messages::WebPage::InitializeIsolatedTree(), pageID);
+    });
+}
+#endif
+
 void WebPageProxy::setUseFixedLayout(bool fixed)
 {
     // This check is fine as the value is initialized in the web
@@ -15973,9 +15982,9 @@ void WebPageProxy::sendScrollPositionChangedForNode(std::optional<WebCore::Frame
 }
 #endif
 
-void WebPageProxy::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
+void WebPageProxy::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, bool parentHasIsolatedTreeEnabled, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
 {
-    auto sendResult = sendSyncToProcessContainingFrame(frameID, Messages::WebPage::BindRemoteAccessibilityFrames(processIdentifier, frameID, WTFMove(dataToken)));
+    auto sendResult = sendSyncToProcessContainingFrame(frameID, Messages::WebPage::BindRemoteAccessibilityFrames(processIdentifier, frameID, parentHasIsolatedTreeEnabled, WTFMove(dataToken)));
     if (!sendResult.succeeded())
         return completionHandler({ }, 0);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1416,6 +1416,10 @@ public:
     void accessibilitySettingsDidChange();
     void enableAccessibilityForAllProcesses();
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    void initializeIsolatedTreeInAllProcesses();
+#endif
+
     void windowScreenDidChange(WebCore::PlatformDisplayID);
     std::optional<WebCore::PlatformDisplayID> displayID() const { return m_displayID; }
 
@@ -3297,7 +3301,7 @@ private:
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
-    void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&&);
+    void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, bool parentHasIsolatedTreeEnabled, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
     void documentURLForConsoleLog(WebCore::FrameIdentifier, CompletionHandler<void(const URL&)>&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -62,6 +62,9 @@ messages -> WebPageProxy {
     RelayAccessibilityNotification(String notificationName, std::span<const uint8_t> notificationData)
 #endif
     EnableAccessibilityForAllProcesses()
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    InitializeIsolatedTreeInAllProcesses();
+#endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)
     ShowValidationMessage(WebCore::IntRect anchorRect, String message)
@@ -658,7 +661,7 @@ messages -> WebPageProxy {
     [EnabledBy=SiteIsolationEnabled] RenderTreeAsTextForTesting(WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
     [EnabledBy=SiteIsolationEnabled] FrameTextForTesting(WebCore::FrameIdentifier frameID) -> (String text) Synchronous
     [EnabledBy=SiteIsolationEnabled] LayerTreeAsTextForTesting(WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions> options) -> (String layerTreeDump) Synchronous
-    [EnabledBy=SiteIsolationEnabled] BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
+    [EnabledBy=SiteIsolationEnabled] BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, bool parentHasIsolatedTreeEnabled, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
     [EnabledBy=SiteIsolationEnabled] UpdateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset)
     [EnabledBy=SiteIsolationEnabled] DocumentURLForConsoleLog(WebCore::FrameIdentifier frameID) -> (URL url)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -125,7 +125,7 @@ void WebRemoteFrameClient::updateRemoteFrameAccessibilityOffset(WebCore::FrameId
         page->send(Messages::WebPageProxy::UpdateRemoteFrameAccessibilityOffset(frameID, offset));
 }
 
-void WebRemoteFrameClient::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
+void WebRemoteFrameClient::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, bool parentHasIsolatedTreeEnabled, Vector<uint8_t>&& dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
 {
     RefPtr page = m_frame->page();
     if (!page) {
@@ -133,7 +133,7 @@ void WebRemoteFrameClient::bindRemoteAccessibilityFrames(int processIdentifier, 
         return;
     }
 
-    auto sendResult = page->sendSync(Messages::WebPageProxy::BindRemoteAccessibilityFrames(processIdentifier, frameID, WTFMove(dataToken)));
+    auto sendResult = page->sendSync(Messages::WebPageProxy::BindRemoteAccessibilityFrames(processIdentifier, frameID, parentHasIsolatedTreeEnabled, WTFMove(dataToken)));
     if (!sendResult.succeeded()) {
         completionHandler({ }, 0);
         return;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -48,7 +48,7 @@ private:
     void changeLocation(WebCore::FrameLoadRequest&&) final;
     String renderTreeAsText(size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>) final;
     String layerTreeAsText(size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>) final;
-    void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>&&, CompletionHandler<void(Vector<uint8_t>, int)>&&) final;
+    void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, bool parentHasIsolatedTreeEnabled, Vector<uint8_t>&&, CompletionHandler<void(Vector<uint8_t>, int)>&&) final;
     void unbindRemoteAccessibilityFrames(int) final;
     void updateRemoteFrameAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint) final;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -457,7 +457,7 @@ void WebPage::accessibilityManageRemoteElementStatus(bool registerStatus, int pr
 #endif
 }
 
-void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t> dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
+void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, bool parentHasIsolatedTreeEnabled, Vector<uint8_t> dataToken, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
 {
     RefPtr webFrame = WebProcess::singleton().webFrame(frameID);
     if (!webFrame) {
@@ -477,7 +477,7 @@ void WebPage::bindRemoteAccessibilityFrames(int processIdentifier, WebCore::Fram
         return completionHandler({ }, 0);
     }
 
-    registerRemoteFrameAccessibilityTokens(processIdentifier, dataToken.span(), frameID);
+    registerRemoteFrameAccessibilityTokens(processIdentifier, dataToken.span(), frameID, parentHasIsolatedTreeEnabled);
 
     // Get our remote token data and send back to the RemoteFrame.
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1671,7 +1671,7 @@ std::pair<URL, WebCore::DidFilterLinkDecoration> WebPage::applyLinkDecorationFil
     return { url, WebCore::DidFilterLinkDecoration::No };
 }
 
-void WebPage::bindRemoteAccessibilityFrames(int, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
+void WebPage::bindRemoteAccessibilityFrames(int, WebCore::FrameIdentifier, bool, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&& completionHandler)
 {
     completionHandler({ }, { });
 }
@@ -2719,6 +2719,27 @@ void WebPage::enableAccessibilityForAllProcesses()
 {
     send(Messages::WebPageProxy::EnableAccessibilityForAllProcesses());
 }
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+void WebPage::initializeIsolatedTreeInAllProcesses()
+{
+    send(Messages::WebPageProxy::InitializeIsolatedTreeInAllProcesses());
+}
+
+void WebPage::initializeIsolatedTree()
+{
+    // Ignore the client when determining ITM in this case, because we're calling isIsolatedTree not as a result of a client
+    // request so the client will always return false here.
+    if (WebCore::AXObjectCache::isIsolatedTreeEnabled(/* ignoreClient */ true)) {
+        WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+        CheckedPtr cache = protectedCorePage()->axObjectCache();
+        if (!cache)
+            return;
+
+        cache->getOrCreateIsolatedTree();
+    }
+}
+#endif
 
 void WebPage::enableAccessibility()
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -781,6 +781,11 @@ public:
     void enableAccessibilityForAllProcesses();
     void enableAccessibility();
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    void initializeIsolatedTreeInAllProcesses();
+    void initializeIsolatedTree();
+#endif
+
     void screenPropertiesDidChange();
 
     // FIXME(site-isolation): Calls to these should be removed in favour of setting via WebPageProxy.
@@ -1176,7 +1181,7 @@ public:
 #if PLATFORM(COCOA)
     void platformInitializeAccessibility();
     void registerUIProcessAccessibilityTokens(std::span<const uint8_t> elementToken, std::span<const uint8_t> windowToken);
-    void registerRemoteFrameAccessibilityTokens(pid_t, std::span<const uint8_t>, WebCore::FrameIdentifier);
+    void registerRemoteFrameAccessibilityTokens(pid_t, std::span<const uint8_t>, WebCore::FrameIdentifier, bool);
     WKAccessibilityWebPageObject* accessibilityRemoteObject();
     WebCore::IntPoint accessibilityRemoteFrameOffset();
     void createMockAccessibilityElement(pid_t);
@@ -2470,7 +2475,7 @@ private:
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);
     void frameTextForTesting(WebCore::FrameIdentifier, CompletionHandler<void(String&&)>&&);
-    void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&&);
+    void bindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier, bool, Vector<uint8_t>, CompletionHandler<void(Vector<uint8_t>, int)>&&);
     void updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebCore::IntPoint);
     void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -497,10 +497,14 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     CopyLinkWithHighlight()
 
-    BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
+    BindRemoteAccessibilityFrames(int processIdentifier, WebCore::FrameIdentifier frameID, bool parentHasIsolatedTreeEnabled, Vector<uint8_t> dataToken) -> (Vector<uint8_t> token, int processIdentifier) Synchronous
     UpdateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frameID, WebCore::IntPoint offset);
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
     EnableAccessibility()
+    
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    InitializeIsolatedTree()
+#endif
 
 #if PLATFORM(COCOA)
     WindowAndViewFramesChanged(struct WebKit::ViewWindowCoordinates coordinates)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -703,7 +703,7 @@ void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier, WebC
     [accessibilityRemoteObject() setRemoteFrameOffset:offset];
 }
 
-void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const uint8_t> elementToken, WebCore::FrameIdentifier frameID)
+void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const uint8_t> elementToken, WebCore::FrameIdentifier frameID, bool)
 {
     createMockAccessibilityElement(pid);
     [m_mockAccessibilityElement setRemoteTokenData:toNSData(elementToken).get()];

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
@@ -96,6 +96,15 @@ namespace ax = WebCore::Accessibility;
     return [self accessibilityRootObjectWrapper:[self focusedLocalFrame]];
 }
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+- (void)initializeIsolatedTreeInAllProcesses
+{
+    WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+    if (m_page)
+        m_page->initializeIsolatedTreeInAllProcesses();
+}
+#endif
+
 - (id)accessibilityRootObjectWrapper:(WebCore::LocalFrame*)frame
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -115,6 +124,13 @@ namespace ax = WebCore::Accessibility;
         if (auto cache = protectedSelf.get().axObjectCache) {
             if (auto* root = frame ? cache->rootObjectForFrame(*frame) : nullptr)
                 return root->wrapper();
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+            // In site isolation + isolated tree mode, we don't return a frame for thread safety reasons (see `focusedLocalFrame`). In this case, fallback
+            // to the frameID we have stored on the root object to let us search for the root frame when building the isolated tree.
+            if (auto* root = WebCore::AXObjectCache::isIsolatedTreeEnabled() ? cache->isolatedTreeRootObject(protectedSelf.get()->m_frameID) : nullptr)
+                return root->wrapper();
+#endif
         }
 
         return nil;

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -169,8 +169,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
                 [protectedSelf enableAccessibilityForAllProcesses];
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-            if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
+            if (WebCore::AXObjectCache::isIsolatedTreeEnabled()) {
                 WebCore::AXObjectCache::initializeAXThreadIfNeeded();
+                // When site isolation is enabled, we need to inform the isolated frames to initialize their trees. This will pre-warm
+                // the trees for those frames, and allow ATs to make their first request without waiting for the tree to build.
+                auto* page = protectedSelf->m_page->corePage();
+                if (page && page->settings().siteIsolationEnabled())
+                    [protectedSelf initializeIsolatedTreeInAllProcesses];
+            }
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 
             float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -436,7 +436,7 @@ void WebPage::updateRemotePageAccessibilityOffset(WebCore::FrameIdentifier frame
     [accessibilityRemoteObject() setRemoteFrameOffset:offset];
 }
 
-void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const uint8_t> elementToken, WebCore::FrameIdentifier frameID)
+void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const uint8_t> elementToken, WebCore::FrameIdentifier frameID, bool parentHasIsolatedTreeEnabled)
 {
     RetainPtr elementTokenData = toNSData(elementToken);
     auto remoteElement = [elementTokenData length] ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData.get()]) : nil;
@@ -444,6 +444,14 @@ void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, std::span<const 
     createMockAccessibilityElement(pid);
     [accessibilityRemoteObject() setRemoteParent:remoteElement.get()];
     [accessibilityRemoteObject() setFrameIdentifier:frameID];
+
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // We need to propagate ITM downwards, so that the isolated frame's isolated tree is prewarmed before any AT requests.
+    if (parentHasIsolatedTreeEnabled)
+        initializeIsolatedTree();
+#else
+    UNUSED_PARAM(parentHasIsolatedTreeEnabled);
+#endif
 }
 
 void WebPage::registerUIProcessAccessibilityTokens(std::span<const uint8_t> elementToken, std::span<const uint8_t> windowToken)


### PR DESCRIPTION
#### d97f78a02fb122aeca76901dd8074b90d509a1a4
<pre>
AX: [Site Isolation] [Accessibility Isolated Tree] In isolated tree mode, ATs can&apos;t access isolated iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=288759">https://bugs.webkit.org/show_bug.cgi?id=288759</a>
<a href="https://rdar.apple.com/145788108">rdar://145788108</a>

Reviewed by NOBODY (OOPS!).

After 289891@main, `rootObjectForFrame` was not called inside `accessibilityRootObjectWrapper` when there was no local frame passed in.
`rootObjectForFrame` is where building the isolated tree is kicked off, since that method calls `getOrCreateIsolatedTree`. So, an isolated
tree wasn&apos;t being constructed for iframes, leading to missing content.

Another issue that surfaced here was that these isolated trees weren&apos;t being built until after the first VoiceOver request. So, if a user is
navigating on a page with an isolated iframe, the AT will skip over that since the isolated tree isn&apos;t built yet, and only on the second
request will its contents be available since the tree will have been built at this point.

The solution to this problem is to &quot;pre-warm&quot; the subframes&apos; trees if isolated tree mode is active in the parent webpage.

There are some other known site isolation + accessibility isolated tree mode issues that need to be fixed in follow up PRs:
* The webcontent isn&apos;t always available to ATs on pages that contain site-isolated frames, and a reload is required to get out of this state.
* The frame/bounds of the iframe can sometimes be misaligned, a reload typically get&apos;s out of this state.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
(WebCore::AXObjectCache::getOrCreateIsolatedTree):
(WebCore::AXObjectCache::isolatedTreeRootObject):
(WebCore::AXObjectCache::setIsolatedTreeRoot):
(WebCore::AXObjectCache::localFrameForFrameID):
(WebCore::AXObjectCache::rootObjectForFrame):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::addRemoteFrameChild):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmpty):
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::storeTree):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::rootLocalFrameID const):
(WebCore::AXIsolatedTree::setRootLocalFrameID):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::isIsolatedTreeEnabled):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::bindRemoteAccessibilityFrames):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeIsolatedTreeInAllProcesses):
(WebKit::WebPageProxy::bindRemoteAccessibilityFrames):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::bindRemoteAccessibilityFrames):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::bindRemoteAccessibilityFrames):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::bindRemoteAccessibilityFrames):
(WebKit::WebPage::initializeIsolatedTreeInAllProcesses):
(WebKit::WebPage::initializeIsolatedTree):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::registerRemoteFrameAccessibilityTokens):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm:
(-[WKAccessibilityWebPageObjectBase initializeIsolatedTreeInAllProcesses]):
(-[WKAccessibilityWebPageObjectBase accessibilityRootObjectWrapper:]):
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::registerRemoteFrameAccessibilityTokens):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d97f78a02fb122aeca76901dd8074b90d509a1a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97503 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43026 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70880 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28324 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51212 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1415 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42357 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79382 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99530 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14439 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79884 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19820 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79163 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23695 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/990 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12582 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20981 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->