### PR TITLE
[WTF] Fix initialization of SequesteredImmortalHeap

### DIFF
--- a/Source/WTF/wtf/SequesteredImmortalHeap.cpp
+++ b/Source/WTF/wtf/SequesteredImmortalHeap.cpp
@@ -25,10 +25,22 @@
 #include "config.h"
 #include <wtf/SequesteredImmortalHeap.h>
 #include <wtf/Compiler.h>
+#include <wtf/NeverDestroyed.h>
 
 #if USE(PROTECTED_JIT)
 
 namespace WTF {
+
+SequesteredImmortalHeap& SequesteredImmortalHeap::instance()
+{
+    // FIXME: this storage is not contained within the sequestered region
+    static LazyNeverDestroyed<SequesteredImmortalHeap> instance;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        instance.construct();
+    });
+    return instance.get();
+}
 
 void ConcurrentDecommitQueue::decommit()
 {


### PR DESCRIPTION
#### 4738abe95a97ea8d3f502a1982e0ca7ff232be56
<pre>
[WTF] Fix initialization of SequesteredImmortalHeap
<a href="https://rdar.apple.com/145788964">rdar://145788964</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288762">https://bugs.webkit.org/show_bug.cgi?id=288762</a>

Reviewed by Yusuke Suzuki and Yijia Huang.

Using LazyNeverDestroyed avoids the bespoke singleton code for now
(though eventually we will need a custom solution to handle the
sequestering constraint), and moving the once_flag to the cpp file
avoids duplication per TU.

* Source/WTF/wtf/SequesteredImmortalHeap.cpp:
(WTF::SequesteredImmortalHeap::instance):
* Source/WTF/wtf/SequesteredImmortalHeap.h:
(WTF::SequesteredImmortalHeap::instance): Deleted.
(WTF::SequesteredImmortalHeap::allocateAndInstall): Deleted.
(WTF::SequesteredImmortalHeap::getSlot): Deleted.
(WTF::SequesteredImmortalHeap::computeSlotIndex): Deleted.
(WTF::SequesteredImmortalHeap::scavenge): Deleted.
(WTF::SequesteredImmortalHeap::mapGranule): Deleted.
(WTF::SequesteredImmortalHeap::decommitGranule): Deleted.
(WTF::SequesteredImmortalHeap::SequesteredImmortalHeap): Deleted.
(WTF::SequesteredImmortalHeap::getUnchecked): Deleted.

Canonical link: <a href="https://commits.webkit.org/291289@main">https://commits.webkit.org/291289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d029ad0ca017982b737d08a01de414255a7ecd49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97511 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20530 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51210 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9064 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1418 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85237 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1360 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99538 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91193 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19578 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79176 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23698 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14745 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19562 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/113841 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32911 "Found 14 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.no-llint, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/spec-tests/float_exprs.wast.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-collect-continuously, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-collect-continuously, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager ... (failure)") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/20989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->