### PR TITLE
Measure glyphs in a single CoreText call rather than repeated calls

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -171,6 +171,10 @@ public:
     void setAvgCharWidth(float avgCharWidth) { m_avgCharWidth = avgCharWidth; }
 
     FloatRect boundsForGlyph(Glyph) const;
+#if USE(CORE_TEXT)
+    static constexpr size_t inlineGlyphRunCapacity = 128;
+    Vector<FloatRect, inlineGlyphRunCapacity> boundsForGlyphs(std::span<const Glyph>) const;
+#endif
 
     // Should the result of this function include the results of synthetic bold?
     enum class SyntheticBoldInclusion {
@@ -277,6 +281,9 @@ private:
     DerivedFonts& ensureDerivedFontData() const;
 
     FloatRect platformBoundsForGlyph(Glyph) const;
+#if USE(CORE_TEXT)
+    Vector<FloatRect, inlineGlyphRunCapacity> platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>&) const;
+#endif
     float platformWidthForGlyph(Glyph) const;
     Path platformPathForGlyph(Glyph) const;
 
@@ -424,6 +431,58 @@ ALWAYS_INLINE FloatRect Font::boundsForGlyph(Glyph glyph) const
     m_glyphToBoundsMap->setMetricsForGlyph(glyph, bounds);
     return bounds;
 }
+
+#if USE(CORE_TEXT)
+ALWAYS_INLINE Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::boundsForGlyphs(std::span<const Glyph> glyphs) const
+{
+    const auto glyphCount = glyphs.size();
+    if (!glyphCount)
+        return { };
+
+    if (glyphCount == 1)
+        return { boundsForGlyph(glyphs[0]) };
+
+    Vector<Glyph, inlineGlyphRunCapacity> glyphsNeedingMeasurement;
+    Vector<size_t, inlineGlyphRunCapacity> positionsNeedingMeasurement;
+
+    Vector<FloatRect, inlineGlyphRunCapacity> glyphBounds(glyphCount, FloatRect());
+    for (size_t glyphIndex = 0; glyphIndex < glyphCount; ++glyphIndex) {
+        const auto& glyph = glyphs[glyphIndex];
+        if (isZeroWidthSpaceGlyph(glyph))
+            continue;
+
+        if (m_glyphToBoundsMap) {
+            auto bounds = m_glyphToBoundsMap->metricsForGlyph(glyph);
+            if (bounds.width() != cGlyphSizeUnknown) {
+                glyphBounds[glyphIndex] = bounds;
+                continue;
+            }
+        }
+
+        glyphsNeedingMeasurement.append(glyph);
+        positionsNeedingMeasurement.append(glyphIndex);
+    }
+
+    if (glyphsNeedingMeasurement.isEmpty())
+        return glyphBounds;
+
+    if (!m_glyphToBoundsMap)
+        m_glyphToBoundsMap = makeUnique<GlyphMetricsMap<FloatRect>>();
+
+    auto measuredBounds = platformBoundsForGlyphs(glyphsNeedingMeasurement);
+
+    size_t index = 0;
+    for (auto& bounds : measuredBounds) {
+        const auto measuredGlyph = glyphsNeedingMeasurement[index];
+        const auto measuredGlyphPosition = positionsNeedingMeasurement[index];
+
+        m_glyphToBoundsMap->setMetricsForGlyph(measuredGlyph, bounds);
+        glyphBounds[measuredGlyphPosition] = bounds;
+        ++index;
+    }
+    return glyphBounds;
+}
+#endif
 
 ALWAYS_INLINE float Font::widthForGlyph(Glyph glyph, SyntheticBoldInclusion SyntheticBoldInclusion) const
 {

--- a/Source/WebCore/platform/graphics/Glyph.h
+++ b/Source/WebCore/platform/graphics/Glyph.h
@@ -27,13 +27,10 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef Glyph_h
-#define Glyph_h
+#pragma once
 
 namespace WebCore {
 
 typedef unsigned short Glyph;
 
 } // namespace WebCore
-
-#endif // Glyph_h

--- a/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp
@@ -430,8 +430,16 @@ void DrawGlyphsRecorder::drawOTSVGRun(const Font& font, std::span<const GlyphBuf
 {
     FloatPoint penPosition = startPoint;
 
+#if USE(CORE_TEXT)
+    auto glyphBounds = font.boundsForGlyphs(glyphs);
+#endif
+
     for (size_t i = 0; i < glyphs.size(); ++i) {
+#if USE(CORE_TEXT)
+        const auto& bounds = glyphBounds[i];
+#else
         auto bounds = font.boundsForGlyph(glyphs[i]);
+#endif
 
         // Create a local ImageBuffer because decoding the SVG fonts has to happen in WebProcess.
         if (auto imageBuffer = m_owner.createAlignedImageBuffer(bounds, DestinationColorSpace::SRGB(), RenderingMethod::Local)) {

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2025 Apple Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov
  *
  * Redistribution and use in source and binary forms, with or without
@@ -778,6 +778,19 @@ FloatRect Font::platformBoundsForGlyph(Glyph glyph) const
     boundingBox.setWidth(boundingBox.width() + m_syntheticBoldOffset);
 
     return boundingBox;
+}
+
+Vector<FloatRect, Font::inlineGlyphRunCapacity> Font::platformBoundsForGlyphs(const Vector<Glyph, inlineGlyphRunCapacity>& glyphs) const
+{
+    Vector<CGRect, inlineGlyphRunCapacity> rectsForGlyphs(glyphs.size());
+    CTFontGetBoundingRectsForGlyphs(getCTFont(), platformData().orientation() == FontOrientation::Vertical ? kCTFontOrientationVertical : kCTFontOrientationHorizontal, glyphs.data(), rectsForGlyphs.data(), rectsForGlyphs.size());
+
+    return rectsForGlyphs.map<Vector<FloatRect, inlineGlyphRunCapacity>>([&](const auto& rect) -> auto {
+        FloatRect boundingBox(rect);
+        boundingBox.setY(-boundingBox.maxY());
+        boundingBox.setWidth(boundingBox.width() + m_syntheticBoldOffset);
+        return boundingBox;
+    });
 }
 
 Path Font::platformPathForGlyph(Glyph glyph) const


### PR DESCRIPTION
#### 9c7a8b92644023967579ef9b941cc94fba9009f6
<pre>
Measure glyphs in a single CoreText call rather than repeated calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=288780">https://bugs.webkit.org/show_bug.cgi?id=288780</a>
<a href="https://rdar.apple.com/145797633">rdar://145797633</a>

Reviewed by Ryan Reno.

Rather than calling `CTFontGetBoundingRectsForGlyphs` once for each glyph (and passing a
single `CGRect` to get the size), collect all glyphs needing measurement and ask CoreText
to measure the entire set of glyphs in a single API call.

In theory, this will avoid the repeated work of creating graphics contexts, selecting a
specific font face into it, transforming, etc., before making the measurement.

* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::enclosingGlyphBoundsForTextRun): Adopt bulk font measuring.
(WebCore::ComplexTextController::adjustGlyphsAndAdvances): Ditto.
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::boundsForGlyphs const): Added.
* Source/WebCore/platform/graphics/Glyph.h:Use #pragma once
* Source/WebCore/platform/graphics/coretext/DrawGlyphsRecorderCoreText.cpp:
(WebCore::DrawGlyphsRecorder::drawOTSVGRun): Adopt bulk font measuring.
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::platformBoundsForGlyphs const): Added.

Canonical link: <a href="https://commits.webkit.org/292198@main">https://commits.webkit.org/292198@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/010314fb3f2969cf53cd77566e2429d4b13c87af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4647 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45690 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97237 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72603 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29883 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52934 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45028 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/81168 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3774 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102270 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81604 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81001 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/20263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2966 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15490 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15297 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27333 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21866 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25340 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->