### PR TITLE
[Screen Time Refactoring] Web content behind shield is still clickable

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -256,34 +256,6 @@ static void *screenTimeWebpageControllerBlockedKVOContext = &screenTimeWebpageCo
 @interface STWebpageController (Staging_138865295)
 @property (nonatomic, copy) NSString *profileIdentifier;
 @end
-#if PLATFORM(MAC)
-@interface WKSTVisualEffectView : NSVisualEffectView
-@end
-
-@implementation WKSTVisualEffectView
-
-- (void)mouseDown:(NSEvent *)event
-{
-}
-
-- (void)rightMouseDown:(NSEvent *)event
-{
-}
-
-- (void)mouseMoved:(NSEvent *)event
-{
-}
-
-- (void)mouseEntered:(NSEvent *)event
-{
-}
-
-- (void)mouseExited:(NSEvent *)event
-{
-}
-
-@end
-#endif
 #endif
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -526,7 +498,7 @@ static uint32_t convertSystemLayoutDirection(NSUserInterfaceLayoutDirection dire
         if (wasBlockedByScreenTime != _isBlockedByScreenTime) {
             if (!_screenTimeBlurredSnapshot && ![_configuration _showsSystemScreenTimeBlockingView]) {
 #if PLATFORM(MAC)
-                _screenTimeBlurredSnapshot = adoptNS([[WKSTVisualEffectView alloc] init]);
+                _screenTimeBlurredSnapshot = adoptNS([[NSVisualEffectView alloc] init]);
                 [_screenTimeBlurredSnapshot setMaterial:NSVisualEffectMaterialUnderWindowBackground];
                 [_screenTimeBlurredSnapshot setBlendingMode:NSVisualEffectBlendingModeWithinWindow];
 #else

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5777,6 +5777,10 @@ void WebViewImpl::nativeMouseEventHandlerInternal(NSEvent *event)
 {
     if (m_warningView)
         return;
+#if ENABLE(SCREEN_TIME)
+    if ([[m_view _screenTimeWebpageController] URLIsBlocked])
+        return;
+#endif
 
     nativeMouseEventHandler(event);
 }


### PR DESCRIPTION
#### 5569b5afe8b5673cb3cca273a283da14a75ed525
<pre>
[Screen Time Refactoring] Web content behind shield is still clickable
<a href="https://bugs.webkit.org/show_bug.cgi?id=288505">https://bugs.webkit.org/show_bug.cgi?id=288505</a>
<a href="https://rdar.apple.com/144999810">rdar://144999810</a>

Reviewed by Aditya Keerthi.

If the system Screen Time shield is up and we click on the shield,
we may accidently click on a link or other elements underneath the shield.
The web content underneath should not be interactive while the shield is up.
Thus, do not process the mouse events while the shield is up and URL is blocked.

The blurred view that is installed when `_showsSystemScreenTimeBlockingView` is false
also had this issue. Due to this change, we can remove WKSTVisualEffectView, which
was used to prevent navigation to links via clicking links that are &quot;underneath&quot;
the blurred view.

This change fixes this issue for both the system Screen Time shield and
the blurred view.

Add API tests to make sure the web content is not clickable or interactive
while the system Screen Time shield or blocking view is up.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView observeValueForKeyPath:ofObject:change:context:]):
(-[WKSTVisualEffectView mouseDown:]): Deleted.
(-[WKSTVisualEffectView rightMouseDown:]): Deleted.
(-[WKSTVisualEffectView mouseMoved:]): Deleted.
(-[WKSTVisualEffectView mouseEntered:]): Deleted.
(-[WKSTVisualEffectView mouseExited:]): Deleted.
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::nativeMouseEventHandlerInternal):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScreenTime.mm:
(testWebContentIsNotClickableShowingSystemScreenTimeBlockingView):
(TEST(ScreenTime, WebContentIsNotClickableBehindSystemScreenTimeBlockingView)):
(TEST(ScreenTime, WebContentIsNotClickableBehindBlurredBlockingView)):

Canonical link: <a href="https://commits.webkit.org/291344@main">https://commits.webkit.org/291344@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cb4dd8dbbff51e31a287e16cc0383f934a5734e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97622 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43143 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70935 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28375 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1492 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42474 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79454 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1450 "Found 1 new test failure: http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99648 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19687 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14507 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79950 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19937 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79243 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1052 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12702 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14783 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19671 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24843 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->