### PR TITLE
[scroll-animations] obtaining view timeline `source` from bindings should trigger a style recalc

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL Creating a view timeline with a subject that is not attached to the document works as expected assert_equals: Source resolved once attached expected Element node <div id="container">
-    <div class="filler"></div>
-  <di... but got null
+PASS Creating a view timeline with a subject that is not attached to the document works as expected
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt
@@ -1,6 +1,5 @@
 
-FAIL Default source for a View timeline is the nearest scroll ancestor to the subject assert_equals: expected "outer" but got "inner"
+PASS Default source for a View timeline is the nearest scroll ancestor to the subject
 PASS View timeline ignores explicitly set source
-FAIL View timeline source is null when display:none assert_equals: expected null but got Element node <div id="inner" class="scroller">
-      <div id="target" ...
+PASS View timeline source is null when display:none
 

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -105,6 +105,11 @@ ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
     m_scroller = scroller;
 }
 
+Element* ScrollTimeline::bindingsSource() const
+{
+    return source();
+}
+
 Element* ScrollTimeline::source() const
 {
     auto source = m_source.styleable();

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -54,6 +54,7 @@ public:
     static Ref<ScrollTimeline> createInactiveStyleOriginatedTimeline(const AtomString& name);
 
     const WeakStyleable& sourceStyleable() const { return m_source; }
+    virtual Element* bindingsSource() const;
     virtual Element* source() const;
     void setSource(Element*);
     void setSource(const Styleable&);

--- a/Source/WebCore/animation/ScrollTimeline.idl
+++ b/Source/WebCore/animation/ScrollTimeline.idl
@@ -29,6 +29,6 @@
     JSGenerateToJSObject
 ] interface ScrollTimeline : AnimationTimeline {
     [CallWith=CurrentDocument] constructor(optional ScrollTimelineOptions options = {});
-    readonly attribute Element? source;
+    [ImplementedAs=bindingsSource] readonly attribute Element? source;
     readonly attribute ScrollAxis axis;
 };

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -438,6 +438,13 @@ TimelineRange ViewTimeline::defaultRange() const
     return TimelineRange::defaultForViewTimeline();
 }
 
+Element* ViewTimeline::bindingsSource() const
+{
+    if (auto subject = m_subject.styleable())
+        subject->element.protectedDocument()->updateStyleIfNeeded();
+    return ScrollTimeline::bindingsSource();
+}
+
 Element* ViewTimeline::source() const
 {
     if (CheckedPtr sourceRender = sourceScrollerRenderer())

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -89,6 +89,7 @@ public:
 
     const RenderBox* sourceScrollerRenderer() const;
     const RenderElement* stickyContainer() const;
+    Element* bindingsSource() const override;
     Element* source() const override;
     TimelineRange defaultRange() const final;
 


### PR DESCRIPTION
#### 2bd73e9036d6bf9fd2d9acd8b2da71dbc01b3193
<pre>
[scroll-animations] obtaining view timeline `source` from bindings should trigger a style recalc
<a href="https://bugs.webkit.org/show_bug.cgi?id=288781">https://bugs.webkit.org/show_bug.cgi?id=288781</a>

Reviewed by Cameron McCormack.

The source of a view timeline is dependent on style-related information. Indeed, since only the
view timeline subject is provided, the source is determined as the nearest scroller to that element
and pending CSS changes could make a difference.

To address this, we add a dedicated method for when the source is queried via the bindings and trigger
a style recalc in that case alone. This fixes 3 failing WPT subtests and 2 failing WPT files.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/unattached-subject-inset-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-source.tentative-expected.txt:
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::bindingsSource const):
* Source/WebCore/animation/ScrollTimeline.h:
* Source/WebCore/animation/ScrollTimeline.idl:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::bindingsSource const):
* Source/WebCore/animation/ViewTimeline.h:

Canonical link: <a href="https://commits.webkit.org/291310@main">https://commits.webkit.org/291310@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/066f28f4a515f9f8b612926b327c240d4e47df4d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97530 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43052 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20548 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70893 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28334 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51225 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1435 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42383 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99556 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19596 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14449 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79896 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79178 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23706 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14761 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24752 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19267 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22727 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21007 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->