### PR TITLE
Cache MatchResult for presentational hints mutation

### DIFF
--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -105,7 +105,7 @@ void StyledElement::attributeChanged(const QualifiedName& name, const AtomString
             styleAttributeChanged(newValue, reason);
         else if (hasPresentationalHintsForAttribute(name)) {
             elementData()->setPresentationalHintStyleIsDirty(true);
-            invalidateStyleInternal();
+            Node::invalidateStyle(Style::Validity::InlineStyleOrPresentionalHintInvalid);
         }
     }
 }
@@ -157,7 +157,7 @@ void StyledElement::styleAttributeChanged(const AtomString& newStyleString, Attr
 
     elementData()->setStyleAttributeIsDirty(false);
 
-    Node::invalidateStyle(Style::Validity::InlineStyleInvalid);
+    Node::invalidateStyle(Style::Validity::InlineStyleOrPresentionalHintInvalid);
     InspectorInstrumentation::didInvalidateStyleAttr(*this);
 }
 
@@ -187,7 +187,7 @@ void StyledElement::invalidateStyleAttribute()
     // Inline style invalidation optimization does not work if there are selectors targeting the style attribute
     // as some rule may start or stop matching.
     auto selectorsForStyleAttribute = styleResolver().ruleSets().selectorsForStyleAttribute();
-    auto validity = selectorsForStyleAttribute == Style::SelectorsForStyleAttribute::None ? Style::Validity::InlineStyleInvalid : Style::Validity::ElementInvalid;
+    auto validity = selectorsForStyleAttribute == Style::SelectorsForStyleAttribute::None ? Style::Validity::InlineStyleOrPresentionalHintInvalid : Style::Validity::ElementInvalid;
 
     Node::invalidateStyle(validity);
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -163,7 +163,7 @@ Invalidator::CheckDescendants Invalidator::invalidateIfNeeded(Element& element, 
     switch (element.styleValidity()) {
     case Validity::Valid:
     case Validity::AnimationInvalid:
-    case Validity::InlineStyleInvalid: {
+    case Validity::InlineStyleOrPresentionalHintInvalid: {
         for (auto& ruleSet : m_ruleSets) {
             ElementRuleCollector ruleCollector(element, *ruleSet.ruleSet, selectorMatchingState);
             ruleCollector.setMode(SelectorChecker::Mode::CollectingRulesIgnoringVirtualPseudoElements);

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1009,7 +1009,7 @@ void Scope::updateCachedMatchResult(const Element& element, const MatchResult& m
     // For now we cache match results if there is mutable inline style. This way we can avoid
     // selector matching when it gets mutated again.
     auto* styledElement = dynamicDowncast<StyledElement>(element);
-    if (styledElement && styledElement->inlineStyle() && styledElement->inlineStyle()->isMutable())
+    if (styledElement && ((styledElement->inlineStyle() && styledElement->inlineStyle()->isMutable()) || styledElement->presentationalHintStyle()))
         m_cachedMatchResults.set(element, makeUniqueRef<MatchResult>(matchResult));
     else
         m_cachedMatchResults.remove(element);

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -965,7 +965,7 @@ auto TreeResolver::determineResolutionType(const Element& element, const RenderS
             return ResolutionType::AnimationOnly;
         if (combinedValidity == Validity::Valid && element.hasInvalidRenderer())
             return existingStyle ? ResolutionType::RebuildUsingExisting : ResolutionType::Full;
-        if (combinedValidity == Validity::InlineStyleInvalid && existingStyle)
+        if (combinedValidity == Validity::InlineStyleOrPresentionalHintInvalid && existingStyle)
             return ResolutionType::FullWithMatchResultCache;
     }
 

--- a/Source/WebCore/style/StyleValidity.h
+++ b/Source/WebCore/style/StyleValidity.h
@@ -31,7 +31,7 @@ namespace Style {
 enum class Validity : uint8_t {
     Valid,
     AnimationInvalid,
-    InlineStyleInvalid,
+    InlineStyleOrPresentionalHintInvalid,
     ElementInvalid,
     SubtreeInvalid,
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -855,8 +855,8 @@ static String styleValidityToToString(Style::Validity validity)
         return "NoStyleChange"_s;
     case Style::Validity::AnimationInvalid:
         return "AnimationInvalid"_s;
-    case Style::Validity::InlineStyleInvalid:
-        return "InlineStyleInvalid"_s;
+    case Style::Validity::InlineStyleOrPresentionalHintInvalid:
+        return "InlineStyleOrPresentionalHintInvalid"_s;
     case Style::Validity::ElementInvalid:
         return "InlineStyleChange"_s;
     case Style::Validity::SubtreeInvalid:


### PR DESCRIPTION
#### 2f5daef3e82b66bef63cfb471184a3fc05f16df8
<pre>
Cache MatchResult for presentational hints mutation
<a href="https://bugs.webkit.org/show_bug.cgi?id=288782">https://bugs.webkit.org/show_bug.cgi?id=288782</a>
<a href="https://rdar.apple.com/144105252">rdar://144105252</a>

Reviewed by NOBODY (OOPS!).

In StyledElement::attributeChanged, we already detect
when an attribute with presentational hints is mutuated.
Rather than entirely invalidating style, we trigger the
same mechanism that allows us to skip selector matching
for inline style mutation using Style Scope
m_cachedMatchResults, which caches MatchResult.

* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::attributeChanged):
(WebCore::StyledElement::styleAttributeChanged):
(WebCore::StyledElement::invalidateStyleAttribute):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateIfNeeded):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateCachedMatchResult):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::determineResolutionType):
* Source/WebCore/style/StyleValidity.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::styleValidityToToString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f5daef3e82b66bef63cfb471184a3fc05f16df8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97528 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43050 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94593 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12366 "Hash 2f5daef3 for PR 41579 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20546 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70891 "Found 10 new test failures: fast/css/style-invalidation-inline-csstext.html fast/table/border-changes.html imported/w3c/web-platform-tests/css/css-pseudo/marker-computed-size.html imported/w3c/web-platform-tests/css/css-sizing/dynamic-available-size-iframe.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-handleEvent.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-removeListener.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-change-event-matches-value.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget-interop.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryListEvent.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28333 "Found 1 new test failure: fast/css/style-invalidation-inline-csstext.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95545 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/12366 "Hash 2f5daef3 for PR 41579 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83802 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51223 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/12366 "Hash 2f5daef3 for PR 41579 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1441 "Found 10 new test failures: editing/inserting/edited-whitespace-1.html fast/css/style-invalidation-inline-csstext.html fast/table/border-changes.html imported/w3c/web-platform-tests/css/css-pseudo/marker-computed-size.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-handleEvent.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-removeListener.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-change-event-matches-value.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget-interop.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryListEvent.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42381 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/12366 "Hash 2f5daef3 for PR 41579 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1381 "Found 11 new test failures: editing/inserting/edited-whitespace-1.html fast/css/style-invalidation-inline-csstext.html fast/table/border-changes.html imported/w3c/web-platform-tests/css/css-pseudo/marker-computed-size.html imported/w3c/web-platform-tests/css/css-sizing/dynamic-available-size-iframe.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-handleEvent.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-removeListener.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-change-event-matches-value.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget-interop.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19594 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14450 "Found 11 new test failures: editing/inserting/edited-whitespace-1.html fast/css/style-invalidation-inline-csstext.html fast/table/border-changes.html imported/w3c/web-platform-tests/css/css-pseudo/marker-computed-size.html imported/w3c/web-platform-tests/css/css-sizing/dynamic-available-size-iframe.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-handleEvent.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-removeListener.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-change-event-matches-value.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget-interop.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79899 "Found 12 new test failures: editing/inserting/edited-whitespace-1.html fast/css/style-invalidation-inline-csstext.html fast/table/border-changes.html imported/w3c/web-platform-tests/css/css-pseudo/marker-computed-size.html imported/w3c/web-platform-tests/css/css-sizing/dynamic-available-size-iframe.html imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-handleEvent.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-removeListener.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-change-event-matches-value.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget-interop.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79685 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79181 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23705 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1016 "Found 11 new test failures: editing/inserting/edited-whitespace-1.html fast/css/style-invalidation-inline-csstext.html fast/table/border-changes.html imported/w3c/web-platform-tests/css/css-pseudo/marker-computed-size.html imported/w3c/web-platform-tests/css/css-sizing/dynamic-available-size-iframe.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-handleEvent.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-addListener-removeListener.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-change-event-matches-value.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget-interop.html imported/w3c/web-platform-tests/css/cssom-view/MediaQueryList-extends-EventTarget.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12606 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24750 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22725 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->