### PR TITLE
Add support for match_about_blank and match_origin_as_fallback.

### DIFF
--- a/Source/WebCore/dom/ExtensionStyleSheets.cpp
+++ b/Source/WebCore/dom/ExtensionStyleSheets.cpp
@@ -158,7 +158,26 @@ void ExtensionStyleSheets::updateInjectedStyleSheetCache() const
         if (userStyleSheet.injectedFrames() == UserContentInjectedFrames::InjectInTopFrameOnly && m_document->ownerElement())
             return;
 
-        if (!UserContentURLPattern::matchesPatterns(m_document->url(), userStyleSheet.allowlist(), userStyleSheet.blocklist()))
+        auto url = m_document->url();
+
+        if (RefPtr parentDocument = m_document->parentDocument()) {
+            switch (userStyleSheet.matchParentFrame()) {
+            case UserContentMatchParentFrame::ForOpaqueOrigins:
+                if (url.protocolIsAbout() || url.protocolIsBlob() || url.protocolIsData())
+                    url = parentDocument->url();
+                break;
+
+            case UserContentMatchParentFrame::ForAboutBlank:
+                if (url.isAboutBlank())
+                    url = parentDocument->url();
+                break;
+
+            case UserContentMatchParentFrame::Never:
+                break;
+            }
+        }
+
+        if (!UserContentURLPattern::matchesPatterns(url, userStyleSheet.allowlist(), userStyleSheet.blocklist()))
             return;
 
         addStyleSheet(userStyleSheet);

--- a/Source/WebCore/page/UserContentTypes.h
+++ b/Source/WebCore/page/UserContentTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,5 +28,6 @@
 namespace WebCore {
 
 enum class UserContentInjectedFrames : bool { InjectInAllFrames, InjectInTopFrameOnly };
+enum class UserContentMatchParentFrame : uint8_t { Never, ForAboutBlank, ForOpaqueOrigins };
 
 } // namespace WebCore

--- a/Source/WebCore/page/UserScript.cpp
+++ b/Source/WebCore/page/UserScript.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,13 +40,14 @@ static WTF::URL generateUserScriptUniqueURL()
     return { { }, makeString("user-script:"_s, ++identifier) };
 }
 
-UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserScriptInjectionTime injectionTime, UserContentInjectedFrames injectedFrames)
+UserScript::UserScript(String&& source, URL&& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserScriptInjectionTime injectionTime, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame)
     : m_source(WTFMove(source))
     , m_url(url.isEmpty() ? generateUserScriptUniqueURL() : WTFMove(url))
     , m_allowlist(WTFMove(allowlist))
     , m_blocklist(WTFMove(blocklist))
     , m_injectionTime(injectionTime)
     , m_injectedFrames(injectedFrames)
+    , m_matchParentFrame(matchParentFrame)
 {
 }
 

--- a/Source/WebCore/page/UserScript.h
+++ b/Source/WebCore/page/UserScript.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@ public:
     UserScript& operator=(const UserScript&) = default;
     UserScript& operator=(UserScript&&) = default;
 
-    WEBCORE_EXPORT UserScript(String&&, URL&&, Vector<String>&&, Vector<String>&&, UserScriptInjectionTime, UserContentInjectedFrames);
+    WEBCORE_EXPORT UserScript(String&& source, URL&& = { }, Vector<String>&& allowlist = { }, Vector<String>&& blocklist = { }, UserScriptInjectionTime = UserScriptInjectionTime::DocumentStart, UserContentInjectedFrames = UserContentInjectedFrames::InjectInAllFrames, UserContentMatchParentFrame = UserContentMatchParentFrame::Never);
 
     const String& source() const { return m_source; }
     const URL& url() const { return m_url; }
@@ -50,6 +50,7 @@ public:
     const Vector<String>& blocklist() const { return m_blocklist; }
     UserScriptInjectionTime injectionTime() const { return m_injectionTime; }
     UserContentInjectedFrames injectedFrames() const { return m_injectedFrames; }
+    UserContentMatchParentFrame matchParentFrame() const { return m_matchParentFrame; }
 
 private:
     String m_source;
@@ -58,6 +59,7 @@ private:
     Vector<String> m_blocklist;
     UserScriptInjectionTime m_injectionTime { UserScriptInjectionTime::DocumentStart };
     UserContentInjectedFrames m_injectedFrames { UserContentInjectedFrames::InjectInAllFrames };
+    UserContentMatchParentFrame m_matchParentFrame { UserContentMatchParentFrame::Never };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2024 Igalia S.L. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,12 +40,13 @@ static WTF::URL generateUserStyleUniqueURL()
     return { { }, makeString("user-style:"_s, ++identifier) };
 }
 
-UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserContentInjectedFrames injectedFrames, UserStyleLevel level, std::optional<PageIdentifier> pageID)
+UserStyleSheet::UserStyleSheet(const String& source, const URL& url, Vector<String>&& allowlist, Vector<String>&& blocklist, UserContentInjectedFrames injectedFrames, UserContentMatchParentFrame matchParentFrame, UserStyleLevel level, std::optional<PageIdentifier> pageID)
     : m_source(source)
     , m_url(url.isEmpty() ? generateUserStyleUniqueURL() : url)
     , m_allowlist(WTFMove(allowlist))
     , m_blocklist(WTFMove(blocklist))
     , m_injectedFrames(injectedFrames)
+    , m_matchParentFrame(matchParentFrame)
     , m_level(level)
     , m_pageID(pageID)
 {

--- a/Source/WebCore/page/UserStyleSheet.h
+++ b/Source/WebCore/page/UserStyleSheet.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,13 +43,14 @@ public:
     {
     }
 
-    WEBCORE_EXPORT UserStyleSheet(const String&, const URL&, Vector<String>&&, Vector<String>&&, UserContentInjectedFrames, UserStyleLevel, std::optional<PageIdentifier> = std::nullopt);
+    WEBCORE_EXPORT UserStyleSheet(const String&, const URL&, Vector<String>&& = { }, Vector<String>&& = { }, UserContentInjectedFrames = UserContentInjectedFrames::InjectInAllFrames, UserContentMatchParentFrame = UserContentMatchParentFrame::Never, UserStyleLevel = UserStyleLevel::User, std::optional<PageIdentifier> = std::nullopt);
 
     const String& source() const { return m_source; }
     const URL& url() const { return m_url; }
     const Vector<String>& allowlist() const { return m_allowlist; }
     const Vector<String>& blocklist() const { return m_blocklist; }
     UserContentInjectedFrames injectedFrames() const { return m_injectedFrames; }
+    UserContentMatchParentFrame matchParentFrame() const { return m_matchParentFrame; }
     UserStyleLevel level() const { return m_level; }
     std::optional<PageIdentifier> pageID() const { return m_pageID; }
 
@@ -58,8 +59,9 @@ private:
     URL m_url;
     Vector<String> m_allowlist;
     Vector<String> m_blocklist;
-    UserContentInjectedFrames m_injectedFrames;
-    UserStyleLevel m_level;
+    UserContentInjectedFrames m_injectedFrames { UserContentInjectedFrames::InjectInAllFrames };
+    UserContentMatchParentFrame m_matchParentFrame { UserContentMatchParentFrame::Never };
+    UserStyleLevel m_level { UserStyleLevel::User };
     std::optional<PageIdentifier> m_pageID;
 };
 

--- a/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
+++ b/Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in
@@ -59,6 +59,8 @@ struct WebKit::WebExtensionRegisteredScriptParameters {
     std::optional<Vector<String>> matchPatterns;
 
     std::optional<bool> allFrames;
+    std::optional<WebCore::UserContentMatchParentFrame> matchParentFrame;
+
     std::optional<bool> persistent;
 
     std::optional<WebKit::WebExtensionContentWorldType> world;

--- a/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h
@@ -44,6 +44,8 @@ struct WebExtensionRegisteredScriptParameters {
     std::optional<Vector<String>> matchPatterns;
 
     std::optional<bool> allFrames;
+    std::optional<WebCore::UserContentMatchParentFrame> matchParentFrame;
+
     std::optional<bool> persistent;
 
     std::optional<WebExtensionContentWorldType> world;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2839,6 +2839,7 @@ class WebCore::UserStyleSheet {
     Vector<String> allowlist();
     Vector<String> blocklist();
     WebCore::UserContentInjectedFrames injectedFrames();
+    WebCore::UserContentMatchParentFrame matchParentFrame();
     WebCore::UserStyleLevel level();
     std::optional<WebCore::PageIdentifier> pageID();
 };
@@ -7536,6 +7537,12 @@ enum class WebCore::UserScriptInjectionTime : bool;
 
 enum class WebCore::UserContentInjectedFrames : bool;
 
+enum class WebCore::UserContentMatchParentFrame : uint8_t {
+    Never,
+    ForAboutBlank,
+    ForOpaqueOrigins
+}
+
 class WebCore::UserScript {
     String source();
     URL url();
@@ -7543,6 +7550,7 @@ class WebCore::UserScript {
     Vector<String> blocklist();
     WebCore::UserScriptInjectionTime injectionTime();
     WebCore::UserContentInjectedFrames injectedFrames();
+    WebCore::UserContentMatchParentFrame matchParentFrame();
 }
 
 header: <WebCore/GraphicsContextState.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm
@@ -46,7 +46,7 @@
 
     WebKit::InitializeWebKit2();
 
-    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, { }, { }, { }, forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserStyleLevel::User }, API::ContentWorld::pageContentWorldSingleton());
+    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, { }, { }, { }, forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserContentMatchParentFrame::Never, WebCore::UserStyleLevel::User }, API::ContentWorld::pageContentWorldSingleton());
 
     return self;
 }
@@ -56,7 +56,7 @@
 
     WebKit::InitializeWebKit2();
 
-    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, API::toWebCoreUserStyleLevel(level), webView ? std::optional<WebCore::PageIdentifier>([webView _page]->webPageIDInMainFrameProcess()) : std::nullopt }, contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorldSingleton());
+    API::Object::constructInWrapper<API::UserStyleSheet>(self, WebCore::UserStyleSheet { source, baseURL, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserContentMatchParentFrame::Never, API::toWebCoreUserStyleLevel(level), webView ? std::optional<WebCore::PageIdentifier>([webView _page]->webPageIDInMainFrameProcess()) : std::nullopt }, contentWorld ? *contentWorld->_contentWorld : API::ContentWorld::pageContentWorldSingleton());
 
     return self;
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp
@@ -103,6 +103,7 @@ struct _WebKitUserStyleSheet {
             String::fromUTF8(source), URL { },
             toStringVector(allowList), toStringVector(blockList),
             toUserContentInjectedFrames(injectedFrames),
+            UserContentMatchParentFrame::Never,
             toUserStyleLevel(level) }, world)))
         , referenceCount(1)
     {

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm
@@ -427,6 +427,7 @@ bool WebExtensionContext::createInjectedContentForScripts(const Vector<WebExtens
         injectedContentData.excludeMatchPatterns = WTFMove(excludeMatchPatterns);
         injectedContentData.injectionTime = parameters.injectionTime.value_or(WebExtension::InjectionTime::DocumentIdle);
         injectedContentData.injectsIntoAllFrames = parameters.allFrames.value_or(false);
+        injectedContentData.matchParentFrame = parameters.matchParentFrame.value_or(WebCore::UserContentMatchParentFrame::Never);
         injectedContentData.contentWorldType = parameters.world.value_or(WebExtensionContentWorldType::ContentScript);
         injectedContentData.styleLevel = parameters.styleLevel.value_or(WebCore::UserStyleLevel::Author);
         injectedContentData.scriptPaths = makeVector<String>(scriptPaths);

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -4532,6 +4532,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
         auto injectionTime = toImpl(injectedContentData.injectionTime);
         Ref executionWorld = toContentWorld(injectedContentData.contentWorldType);
         auto styleLevel = injectedContentData.styleLevel;
+        auto matchParentFrame = injectedContentData.matchParentFrame;
 
         auto scriptID = injectedContentData.identifier;
         bool isRegisteredScript = !scriptID.isEmpty();
@@ -4546,7 +4547,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
                 continue;
             }
 
-            Ref userScript = API::UserScript::create(WebCore::UserScript { WTFMove(scriptString), URL { m_baseURL, scriptPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectionTime, injectedFrames }, executionWorld);
+            Ref userScript = API::UserScript::create(WebCore::UserScript { WTFMove(scriptString), URL { m_baseURL, scriptPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectionTime, injectedFrames, matchParentFrame }, executionWorld);
             originInjectedScripts.append(userScript);
 
             for (Ref userContentController : userContentControllers)
@@ -4572,7 +4573,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
 
             styleSheetString = localizedResourceString(styleSheetString, "text/css"_s);
 
-            Ref userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { WTFMove(styleSheetString), URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, styleLevel, std::nullopt }, executionWorld);
+            Ref userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { WTFMove(styleSheetString), URL { m_baseURL, styleSheetPath }, makeVector<String>(includeMatchPatterns), makeVector<String>(excludeMatchPatterns), injectedFrames, matchParentFrame, styleLevel, std::nullopt }, executionWorld);
             originInjectedStyleSheets.append(userStyleSheet);
 
             for (Ref userContentController : userContentControllers)

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm
@@ -181,7 +181,7 @@ void injectStyleSheets(const SourcePairs& styleSheetPairs, WKWebView *webView, A
     auto pageID = page->webPageIDInMainFrameProcess();
 
     for (auto& styleSheet : styleSheetPairs) {
-        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, Vector<String> { }, Vector<String> { }, injectedFrames, styleLevel, pageID }, executionWorld);
+        auto userStyleSheet = API::UserStyleSheet::create(WebCore::UserStyleSheet { styleSheet.first, styleSheet.second, { }, { }, injectedFrames, WebCore::UserContentMatchParentFrame::Never, styleLevel, pageID }, executionWorld);
 
         Ref controller = page.get()->userContentController();
         controller->addUserStyleSheet(userStyleSheet);
@@ -255,6 +255,9 @@ void WebExtensionRegisteredScript::merge(WebExtensionRegisteredScriptParameters&
 
     if (!parameters.allFrames)
         parameters.allFrames = m_parameters.allFrames.value();
+
+    if (!parameters.matchParentFrame && m_parameters.matchParentFrame)
+        parameters.matchParentFrame = m_parameters.matchParentFrame.value();
 
     if (!parameters.persistent)
         parameters.persistent = m_parameters.persistent.value();

--- a/Source/WebKit/UIProcess/Extensions/WebExtension.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtension.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,6 +34,7 @@
 #include "WebExtensionMatchPattern.h"
 #include <WebCore/FloatSize.h>
 #include <WebCore/Icon.h>
+#include <WebCore/UserContentTypes.h>
 #include <WebCore/UserStyleSheetTypes.h>
 #include <wtf/Forward.h>
 #include <wtf/HashSet.h>
@@ -168,11 +169,11 @@ public:
         MatchPatternSet includeMatchPatterns;
         MatchPatternSet excludeMatchPatterns;
 
-        InjectionTime injectionTime = InjectionTime::DocumentIdle;
+        InjectionTime injectionTime { InjectionTime::DocumentIdle };
+        WebCore::UserContentMatchParentFrame matchParentFrame { WebCore::UserContentMatchParentFrame::Never };
 
         String identifier { ""_s };
 
-        bool matchesAboutBlank { false };
         bool injectsIntoAllFrames { false };
         WebExtensionContentWorldType contentWorldType { WebExtensionContentWorldType::ContentScript };
         WebCore::UserStyleLevel styleLevel { WebCore::UserStyleLevel::Author };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -69,6 +69,7 @@ static NSString * const excludeMatchesKey = @"excludeMatches";
 static NSString * const idKey = @"id";
 static NSString * const idsKey = @"ids";
 static NSString * const jsKey = @"js";
+static NSString * const matchOriginAsFallbackKey = @"matchOriginAsFallback";
 static NSString * const matchesKey = @"matches";
 static NSString * const persistAcrossSessionsKey = @"persistAcrossSessions";
 static NSString * const runAtKey = @"runAt";
@@ -149,6 +150,9 @@ NSDictionary *toWebAPI(const WebExtensionRegisteredScriptParameters& parameters)
 
     if (parameters.allFrames)
         result[allFramesKey] = parameters.allFrames.value() ? @YES : @NO;
+
+    if (parameters.matchParentFrame)
+        result[matchOriginAsFallbackKey] = parameters.matchParentFrame.value() == WebCore::UserContentMatchParentFrame::ForOpaqueOrigins ? @YES : @NO;
 
     if (parameters.injectionTime)
         result[runAtKey] = toWebAPI(parameters.injectionTime.value());
@@ -557,6 +561,7 @@ bool WebExtensionAPIScripting::parseRegisteredContentScripts(NSArray *scripts, F
         excludeMatchesKey: @[ NSString.class ],
         idKey: NSString.class,
         jsKey: @[ NSString.class ],
+        matchOriginAsFallbackKey: @YES.class,
         matchesKey: @[ NSString.class ],
         persistAcrossSessionsKey: @YES.class,
         runAtKey: NSString.class,
@@ -642,6 +647,9 @@ bool WebExtensionAPIScripting::parseRegisteredContentScripts(NSArray *scripts, F
 
         if (script[allFramesKey])
             parameters.allFrames = boolForKey(script, allFramesKey, false);
+
+        if (script[matchOriginAsFallbackKey])
+            parameters.matchParentFrame = boolForKey(script, matchOriginAsFallbackKey, false) ? WebCore::UserContentMatchParentFrame::ForOpaqueOrigins : WebCore::UserContentMatchParentFrame::Never;
 
         if (firstTimeRegistration == FirstTimeRegistration::Yes || script[persistAcrossSessionsKey])
             parameters.persistent = boolForKey(script, persistAcrossSessionsKey, true);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8329,16 +8329,16 @@ void WebPage::imageOrMediaDocumentSizeChanged(const IntSize& newSize)
     send(Messages::WebPageProxy::ImageOrMediaDocumentSizeChanged(newSize));
 }
 
-void WebPage::addUserScript(String&& source, InjectedBundleScriptWorld& world, WebCore::UserContentInjectedFrames injectedFrames, WebCore::UserScriptInjectionTime injectionTime)
+void WebPage::addUserScript(String&& source, InjectedBundleScriptWorld& world, WebCore::UserContentInjectedFrames injectedFrames, WebCore::UserScriptInjectionTime injectionTime, WebCore::UserContentMatchParentFrame matchParentFrame)
 {
-    WebCore::UserScript userScript { WTFMove(source), URL(aboutBlankURL()), Vector<String>(), Vector<String>(), injectionTime, injectedFrames };
+    WebCore::UserScript userScript { WTFMove(source), URL(aboutBlankURL()), Vector<String>(), Vector<String>(), injectionTime, injectedFrames, matchParentFrame };
 
     Ref { m_userContentController }->addUserScript(world, WTFMove(userScript));
 }
 
 void WebPage::addUserStyleSheet(const String& source, WebCore::UserContentInjectedFrames injectedFrames)
 {
-    WebCore::UserStyleSheet userStyleSheet { source, aboutBlankURL(), Vector<String>(), Vector<String>(), injectedFrames, UserStyleLevel::User };
+    WebCore::UserStyleSheet userStyleSheet { source, aboutBlankURL(), Vector<String>(), Vector<String>(), injectedFrames };
 
     Ref { m_userContentController }->addUserStyleSheet(InjectedBundleScriptWorld::normalWorldSingleton(), WTFMove(userStyleSheet));
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -63,6 +63,7 @@
 #include <WebCore/TextManipulationItem.h>
 #include <WebCore/Timer.h>
 #include <WebCore/UserActivity.h>
+#include <WebCore/UserContentTypes.h>
 #include <WebCore/UserMediaRequestIdentifier.h>
 #include <WebCore/UserScriptTypes.h>
 #include <WebCore/VisibilityState.h>
@@ -260,7 +261,6 @@ enum class TextAnimationRunMode : uint8_t;
 enum class TextAnimationType : uint8_t;
 enum class TextIndicatorPresentationTransition : uint8_t;
 enum class TextGranularity : uint8_t;
-enum class UserContentInjectedFrames : bool;
 enum class UserInterfaceLayoutDirection : bool;
 enum class ViolationReportType : uint8_t;
 enum class WheelEventProcessingSteps : uint8_t;
@@ -1515,7 +1515,7 @@ public:
     void triggerMockCaptureConfigurationChange(bool forCamera, bool forMicrophone, bool forDisplay);
 #endif
 
-    void addUserScript(String&& source, InjectedBundleScriptWorld&, WebCore::UserContentInjectedFrames, WebCore::UserScriptInjectionTime);
+    void addUserScript(String&& source, InjectedBundleScriptWorld&, WebCore::UserContentInjectedFrames = WebCore::UserContentInjectedFrames::InjectInAllFrames, WebCore::UserScriptInjectionTime = WebCore::UserScriptInjectionTime::DocumentStart, WebCore::UserContentMatchParentFrame = WebCore::UserContentMatchParentFrame::Never);
     void addUserStyleSheet(const String& source, WebCore::UserContentInjectedFrames);
     void removeAllUserContent();
 

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -4313,7 +4313,7 @@ IGNORE_WARNINGS_END
     if (!world)
         return;
 
-    auto styleSheet = makeUnique<WebCore::UserStyleSheet>(source, url, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), injectedFrames == WebInjectInAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly, WebCore::UserStyleLevel::User);
+    auto styleSheet = makeUnique<WebCore::UserStyleSheet>(source, url, makeVector<String>(includeMatchPatternStrings), makeVector<String>(excludeMatchPatternStrings), injectedFrames == WebInjectInAllFrames ? WebCore::UserContentInjectedFrames::InjectInAllFrames : WebCore::UserContentInjectedFrames::InjectInTopFrameOnly);
     viewGroup->userContentController().addUserStyleSheet(*core(world), WTFMove(styleSheet), WebCore::InjectInExistingDocuments);
 }
 


### PR DESCRIPTION
#### 8f690ea0194be50ad844294dcd88df0224b270cd
<pre>
Add support for match_about_blank and match_origin_as_fallback.
<a href="https://webkit.org/b/275622">https://webkit.org/b/275622</a>
<a href="https://rdar.apple.com/57613243">rdar://57613243</a>

Reviewed by Brian Weinstein.

Added support for WebCore::UserScript and WebCore::UserStylesheet to match against the parent
document&apos;s URL when the frame is about:blank, data: or blob:.

Hook that up to match_about_blank and match_origin_as_fallback in content_scripts, and
matchOriginAsFallback in registered content scripts.

* Source/WebCore/dom/ExtensionStyleSheets.cpp:
(WebCore::ExtensionStyleSheets::updateInjectedStyleSheetCache const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::injectUserScriptImmediately):
* Source/WebCore/page/UserContentTypes.h:
* Source/WebCore/page/UserScript.cpp:
(WebCore::UserScript::UserScript):
* Source/WebCore/page/UserScript.h:
(WebCore::UserScript::UserScript):
(WebCore::UserScript::matchParentFrame const):
* Source/WebCore/page/UserStyleSheet.cpp:
(WebCore::UserStyleSheet::UserStyleSheet):
* Source/WebCore/page/UserStyleSheet.h:
(WebCore::UserStyleSheet::UserStyleSheet):
(WebCore::UserStyleSheet::matchParentFrame const):
* Source/WebKit/Shared/Extensions/WebExtensionDynamicScripts.serialization.in:
* Source/WebKit/Shared/Extensions/WebExtensionRegisteredScriptParameters.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKUserStyleSheet.mm:
(-[_WKUserStyleSheet initWithSource:forMainFrameOnly:]):
(-[_WKUserStyleSheet initWithSource:forWKWebView:forMainFrameOnly:includeMatchPatternStrings:excludeMatchPatternStrings:baseURL:level:contentWorld:]):
* Source/WebKit/UIProcess/API/glib/WebKitUserContent.cpp:
(_WebKitUserStyleSheet::_WebKitUserStyleSheet):
* Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIScriptingCocoa.mm:
(WebKit::WebExtensionContext::createInjectedContentForScripts):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::addInjectedContent):
* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionDynamicScriptsCocoa.mm:
(WebKit::WebExtensionDynamicScripts::injectStyleSheets):
(WebKit::WebExtensionDynamicScripts::WebExtensionRegisteredScript::merge):
* Source/WebKit/UIProcess/Extensions/WebExtension.cpp:
(WebKit::WebExtension::populateContentScriptPropertiesIfNeeded):
* Source/WebKit/UIProcess/Extensions/WebExtension.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
(WebKit::toWebAPI):
(WebKit::WebExtensionAPIScripting::parseRegisteredContentScripts):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::addUserScript):
(WebKit::WebPage::addUserStyleSheet):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(+[WebView _addUserStyleSheetToGroup:world:source:url:includeMatchPatternStrings:excludeMatchPatternStrings:injectedFrames:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, RegisterContentScriptsMatchOriginAsFallback)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, MatchAboutBlank)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithAboutBlank)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithData)): Added.
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, MatchOriginAsFallbackWithBlob)): Added.

Canonical link: <a href="https://commits.webkit.org/291359@main">https://commits.webkit.org/291359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4ec9a0dfe53b4c818a486b0bec651b6f064ae5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92774 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94824 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/12605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/20777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95776 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/12605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/12605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/12605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/20777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/20077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14795 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->