### PR TITLE
[JSC] Detect trimming pattern in RegExp

### DIFF
--- a/JSTests/stress/trim-regexp.js
+++ b/JSTests/stress/trim-regexp.js
@@ -1,0 +1,37 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const trimStart = /^\s+/;
+const trimEnd = /\s+$/;
+
+{
+    let result = "    Hello".replace(trimStart, "");
+    shouldBe(result, "Hello");
+    shouldBe(RegExp.input, "    Hello");
+    shouldBe(RegExp.leftContext, "");
+    shouldBe(RegExp.rightContext, "Hello");
+}
+{
+    let result = "Hello    ".replace(trimEnd, "");
+    shouldBe(result, "Hello");
+    shouldBe(RegExp.input, "Hello    ");
+    shouldBe(RegExp.leftContext, "Hello");
+    shouldBe(RegExp.rightContext, "");
+}
+"errorHelloerror".replace(/Hello/, "");
+{
+    let result = "Hello".replace(trimStart, "");
+    shouldBe(result, "Hello");
+    shouldBe(RegExp.input, "errorHelloerror");
+    shouldBe(RegExp.leftContext, "error");
+    shouldBe(RegExp.rightContext, "error");
+}
+{
+    let result = "Hello".replace(trimEnd, "");
+    shouldBe(result, "Hello");
+    shouldBe(RegExp.input, "errorHelloerror");
+    shouldBe(RegExp.leftContext, "error");
+    shouldBe(RegExp.rightContext, "error");
+}

--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -164,7 +164,8 @@ void RegExp::finishCreation(VM& vm)
         return;
     }
 
-    setAtom(WTFMove(pattern.m_atom));
+    m_atom = WTFMove(pattern.m_atom);
+    m_specificPattern = pattern.m_specificPattern;
 
     m_numSubpatterns = pattern.m_numSubpatterns;
     if (!pattern.m_captureGroupNames.isEmpty() || !pattern.m_namedGroupToParenIndices.isEmpty()) {
@@ -225,7 +226,8 @@ void RegExp::byteCodeCompileIfNecessary(VM* vm)
     }
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
-    setAtom(WTFMove(pattern.m_atom));
+    m_atom = WTFMove(pattern.m_atom);
+    m_specificPattern = pattern.m_specificPattern;
 
     m_regExpBytecode = byteCodeCompilePattern(vm, pattern, m_constructionErrorCode);
     if (!m_regExpBytecode) {
@@ -245,7 +247,8 @@ void RegExp::compile(VM* vm, Yarr::CharSize charSize, std::optional<StringView> 
     }
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
-    setAtom(WTFMove(pattern.m_atom));
+    m_atom = WTFMove(pattern.m_atom);
+    m_specificPattern = pattern.m_specificPattern;
 
     if (!hasCode()) {
         ASSERT(m_state == NotCompiled);
@@ -312,7 +315,8 @@ void RegExp::compileMatchOnly(VM* vm, Yarr::CharSize charSize, std::optional<Str
     }
     ASSERT(m_numSubpatterns == pattern.m_numSubpatterns);
 
-    setAtom(WTFMove(pattern.m_atom));
+    m_atom = WTFMove(pattern.m_atom);
+    m_specificPattern = pattern.m_specificPattern;
 
     if (!hasCode()) {
         ASSERT(m_state == NotCompiled);
@@ -373,6 +377,7 @@ void RegExp::deleteCode()
         return;
     m_state = NotCompiled;
     m_atom = String();
+    m_specificPattern = Yarr::SpecificPattern::None;
 #if ENABLE(YARR_JIT)
     if (m_regExpJITCode)
         m_regExpJITCode->clear(locker);

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -172,7 +172,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     bool hasValidAtom() const { return !m_atom.isNull(); }
     const String& atom() const { return m_atom; }
-    void setAtom(String&& atom) { m_atom = WTFMove(atom); }
+    Yarr::SpecificPattern specificPattern() const { return m_specificPattern; }
 
 private:
     friend class RegExpCache;
@@ -223,6 +223,7 @@ private:
     String m_patternString;
     String m_atom;
     RegExpState m_state { NotCompiled };
+    Yarr::SpecificPattern m_specificPattern { Yarr::SpecificPattern::None };
     OptionSet<Yarr::Flags> m_flags;
     Yarr::ErrorCode m_constructionErrorCode { Yarr::ErrorCode::NoError };
     unsigned m_numSubpatterns { 0 };

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -75,6 +75,15 @@ enum class BuiltInCharacterClassID : unsigned {
     BaseUnicodePropertyID,
 };
 
+enum class SpecificPattern : uint8_t {
+    None,
+    Atom,
+    LeadingSpacesStar,
+    LeadingSpacesPlus,
+    TrailingSpacesStar,
+    TrailingSpacesPlus,
+};
+
 struct BytecodePattern;
 
 } } // namespace JSC::Yarr

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -736,6 +736,7 @@ struct YarrPattern {
     bool m_hasNamedCaptureGroups : 1;
     bool m_saveInitialStartValue : 1;
     OptionSet<Flags> m_flags;
+    SpecificPattern m_specificPattern { SpecificPattern::None };
     unsigned m_numSubpatterns { 0 };
     unsigned m_initialStartValueFrameLocation { 0 };
     unsigned m_numDuplicateNamedCaptureGroups { 0 };


### PR DESCRIPTION
#### 04edf7716a74170fb0967ffe7df687ff6b654b93
<pre>
[JSC] Detect trimming pattern in RegExp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288784">https://bugs.webkit.org/show_bug.cgi?id=288784</a>
<a href="https://rdar.apple.com/145802871">rdar://145802871</a>

Reviewed by Yijia Huang.

Because of old lack of trimming function, we tend to see RegExp based
trimming operation (trimStart / trimEnd), and we would like to make them
super efficient since it is too frequently happening. This patch
extracts this pattern from Yarr and do C++ implementation for that.

* JSTests/stress/trim-regexp.js: Added.
(shouldBe):
(string_appeared_here.replace):
* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::finishCreation):
(JSC::RegExp::byteCodeCompileIfNecessary):
(JSC::RegExp::compile):
(JSC::RegExp::compileMatchOnly):
(JSC::RegExp::deleteCode):
* Source/JavaScriptCore/runtime/RegExp.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::tryTrimSpaces):
(JSC::replaceUsingRegExpSearch):
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::extractSpecificPattern):
(JSC::Yarr::YarrPattern::compile):
(JSC::Yarr::YarrPattern::dumpPattern):
(JSC::Yarr::YarrPatternConstructor::extractAtom): Deleted.
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/291345@main">https://commits.webkit.org/291345@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1ebad040b313c77c2f1dd4050c93bf6d28e55c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92723 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/1909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12549 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20726 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9499 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/1909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9191 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/1909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/85433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99740 "Built successfully") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/91389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/20026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/1909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/1909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14784 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19759 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114037 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->