### PR TITLE
Replace JavaScriptEvaluationResult's IPC format with a structured map

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -899,10 +899,8 @@ static JSContainerConvertor::Task valueToObjectWithoutCopy(JSGlobalContextRef co
             primitive = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, jsstring.get())).bridgingAutorelease();
         } else if (JSValueIsNull(context, value))
             primitive = [NSNull null];
-        else {
-            ASSERT(JSValueIsUndefined(context, value));
+        else
             primitive = nil;
-        }
         return { value, primitive, ContainerNone };
     }
 

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4905,7 +4905,6 @@ private:
             unsigned length = 0;
             if (!read(length))
                 return JSValue();
-            ASSERT(m_globalObject->inherits<JSDOMGlobalObject>());
             Vector<Ref<File>> files;
             for (unsigned i = 0; i < length; i++) {
                 RefPtr<File> file;

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -97,6 +97,8 @@ public:
         });
     }
 
+    void append(RefPtr<Object>&& element) { m_elements.append(WTFMove(element)); }
+
 private:
     explicit Array(Vector<RefPtr<Object>>&& elements)
         : m_elements(WTFMove(elements))

--- a/Source/WebKit/Shared/API/APISerializedScriptValue.h
+++ b/Source/WebKit/Shared/API/APISerializedScriptValue.h
@@ -27,6 +27,7 @@
 
 #include "APIObject.h"
 #include "WKRetainPtr.h"
+#include <JavaScriptCore/JSRetainPtr.h>
 #include <WebCore/CryptoKey.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/RefPtr.h>
@@ -74,6 +75,7 @@ public:
 #if PLATFORM(COCOA) && defined(__OBJC__)
     static id deserialize(WebCore::SerializedScriptValue&);
     static RefPtr<SerializedScriptValue> createFromNSObject(id);
+    static JSRetainPtr<JSGlobalContextRef> deserializationContext();
 #endif
 
 #if USE(GLIB)

--- a/Source/WebKit/Shared/InspectorExtensionTypes.h
+++ b/Source/WebKit/Shared/InspectorExtensionTypes.h
@@ -29,6 +29,10 @@
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
 
+namespace WebKit {
+class JavaScriptEvaluationResult;
+}
+
 namespace API {
 class SerializedScriptValue;
 }
@@ -43,7 +47,7 @@ enum class ExtensionError : uint8_t;
 using ExtensionTabID = WTF::String;
 using ExtensionID = WTF::String;
 using ExtensionVoidResult = Expected<void, ExtensionError>;
-using ExtensionEvaluationResult = Expected<Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails>, ExtensionError>;
+using ExtensionEvaluationResult = Expected<Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, ExtensionError>;
 
 enum class ExtensionAppearance : bool {
     Light,

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -26,20 +26,34 @@
 #include "config.h"
 #include "JavaScriptEvaluationResult.h"
 
+#include "APIArray.h"
+#include "APIDictionary.h"
 #include "APISerializedScriptValue.h"
 #include <WebCore/ExceptionDetails.h>
 
+#if PLATFORM(COCOA)
+#include "CoreIPCNumber.h"
+#endif
+
 namespace WebKit {
 
+#if !PLATFORM(COCOA)
 Ref<API::SerializedScriptValue> JavaScriptEvaluationResult::legacySerializedScriptValue() const
 {
     return API::SerializedScriptValue::createFromWireBytes(Vector(wireBytes()));
 }
 
-WKRetainPtr<WKTypeRef> JavaScriptEvaluationResult::toWK() const
+WKRetainPtr<WKTypeRef> JavaScriptEvaluationResult::toWK()
 {
     return API::SerializedScriptValue::deserializeWK(legacySerializedScriptValue()->internalRepresentation());
 }
+#endif
+
+JavaScriptEvaluationResult::JavaScriptEvaluationResult(JavaScriptEvaluationResult&&) = default;
+
+JavaScriptEvaluationResult& JavaScriptEvaluationResult::operator=(JavaScriptEvaluationResult&&) = default;
+
+JavaScriptEvaluationResult::~JavaScriptEvaluationResult() = default;
 
 } // namespace WebKit
 
@@ -48,6 +62,11 @@ namespace IPC {
 Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> AsyncReplyError<Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>>::create()
 {
     return makeUnexpected(std::nullopt);
+}
+
+Expected<Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, String> AsyncReplyError<Expected<Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, String>>::create()
+{
+    return makeUnexpected(String());
 }
 
 } // namespace IPC

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in
@@ -21,5 +21,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class WebKit::JavaScriptEvaluationResult {
+#if PLATFORM(COCOA)
+    WebKit::JSObjectID root()
+    HashMap<WebKit::JSObjectID, std::variant<WebKit::JavaScriptEvaluationResult::NullType, bool, WebKit::CoreIPCNumber, String, Seconds, Vector<WebKit::JSObjectID>, HashMap<WebKit::JSObjectID, WebKit::JSObjectID>>> map()
+#else
     std::span<const uint8_t> wireBytes()
+#endif
 }
+
+#if PLATFORM(COCOA)
+[Nested] enum class WebKit::JavaScriptEvaluationResult::NullType : bool
+#endif

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -143,6 +143,7 @@ template: struct WebKit::DrawingAreaIdentifierType
 template: struct WebKit::GeolocationIdentifierType
 template: struct WebKit::IPCConnectionTesterIdentifierType
 template: struct WebKit::IPCStreamTesterIdentifierType
+template: struct WebKit::JSObjectIDType
 template: struct WebKit::MarkSurfacesAsVolatileRequestIdentifierType
 template: struct WebKit::NetworkResourceLoadIdentifierType
 template: struct WebKit::PDFPluginIdentifierType

--- a/Source/WebKit/Shared/cf/CoreIPCNumber.mm
+++ b/Source/WebKit/Shared/cf/CoreIPCNumber.mm
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CoreIPCNumber.h"
+
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+namespace WebKit {
+
+auto CoreIPCNumber::numberHolderForNumber(CFNumberRef cfNumber) -> NumberHolder
+{
+    NSNumber *number = bridge_cast(cfNumber);
+    bool isNegative = [number compare:@(0)] == NSOrderedAscending;
+
+    switch (CFNumberGetType(cfNumber)) {
+    case kCFNumberSInt8Type:
+        return number.charValue;
+    case kCFNumberSInt16Type:
+        return number.shortValue;
+    case kCFNumberSInt32Type:
+        return number.intValue;
+    case kCFNumberSInt64Type:
+        if (isNegative)
+            return number.longLongValue;
+        return number.unsignedLongLongValue;
+    case kCFNumberFloat32Type:
+        return number.floatValue;
+    case kCFNumberFloat64Type:
+        return number.doubleValue;
+    case kCFNumberCharType:
+        if (isNegative)
+            return number.charValue;
+        return number.unsignedCharValue;
+    case kCFNumberShortType:
+        if (isNegative)
+            return number.shortValue;
+        return number.unsignedShortValue;
+    case kCFNumberIntType:
+        if (isNegative)
+            return number.intValue;
+        return number.unsignedIntValue;
+    case kCFNumberLongType:
+        if (isNegative)
+            return number.longValue;
+        return number.unsignedLongValue;
+    case kCFNumberLongLongType:
+        if (isNegative)
+            return number.longLongValue;
+        return number.unsignedLongLongValue;
+    case kCFNumberFloatType:
+        return number.floatValue;
+    case kCFNumberDoubleType:
+        return number.doubleValue;
+    case kCFNumberCFIndexType:
+        return number.longValue;
+    case kCFNumberNSIntegerType:
+        return number.longValue;
+    case kCFNumberCGFloatType:
+        return number.doubleValue;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+CoreIPCNumber::CoreIPCNumber(NSNumber *number)
+    : CoreIPCNumber(bridge_cast(number)) { }
+
+CoreIPCNumber::CoreIPCNumber(CFNumberRef number)
+    : m_numberHolder(numberHolderForNumber(number)) { }
+
+CoreIPCNumber::CoreIPCNumber(NumberHolder numberHolder)
+    : m_numberHolder(numberHolder) { }
+
+RetainPtr<CFNumberRef> CoreIPCNumber::createCFNumber() const
+{
+    return bridge_cast(WTF::switchOn(m_numberHolder,
+        [] (const char n) {
+            return adoptNS([[NSNumber alloc] initWithChar:n]);
+        }, [] (const unsigned char n) {
+            return adoptNS([[NSNumber alloc] initWithUnsignedChar:n]);
+        }, [] (const short n) {
+            return adoptNS([[NSNumber alloc] initWithShort:n]);
+        }, [] (const unsigned short n) {
+            return adoptNS([[NSNumber alloc] initWithUnsignedShort:n]);
+        }, [] (const int n) {
+            return adoptNS([[NSNumber alloc] initWithInt:n]);
+        }, [] (const unsigned n) {
+            return adoptNS([[NSNumber alloc] initWithUnsignedInt:n]);
+        }, [] (const long n) {
+            return adoptNS([[NSNumber alloc] initWithLong:n]);
+        }, [] (const unsigned long n) {
+            return adoptNS([[NSNumber alloc] initWithUnsignedLong:n]);
+        }, [] (const long long n) {
+            return adoptNS([[NSNumber alloc] initWithLongLong:n]);
+        }, [] (const unsigned long long n) {
+            return adoptNS([[NSNumber alloc] initWithUnsignedLongLong:n]);
+        }, [] (const float n) {
+            return adoptNS([[NSNumber alloc] initWithFloat:n]);
+        }, [] (const double n) {
+            return adoptNS([[NSNumber alloc] initWithDouble:n]);
+        }
+    ));
+}
+
+CoreIPCNumber::NumberHolder CoreIPCNumber::get() const
+{
+    return m_numberHolder;
+}
+
+RetainPtr<id> CoreIPCNumber::toID() const
+{
+    return bridge_cast(createCFNumber().get());
+}
+
+}

--- a/Source/WebKit/UIProcess/API/APIInspectorExtension.cpp
+++ b/Source/WebKit/UIProcess/API/APIInspectorExtension.cpp
@@ -30,6 +30,7 @@
 
 #include "APISerializedScriptValue.h"
 #include "InspectorExtensionTypes.h"
+#include "JavaScriptEvaluationResult.h"
 #include "WebInspectorUIExtensionControllerProxy.h"
 #include <WebCore/ExceptionDetails.h>
 #include <wtf/UniqueRef.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm
@@ -99,6 +99,11 @@ private:
     MonotonicTime m_lastUseTime;
 };
 
+JSRetainPtr<JSGlobalContextRef> SerializedScriptValue::deserializationContext()
+{
+    return [SharedJSContext::singleton().ensureContext() JSGlobalContextRef];
+}
+
 id SerializedScriptValue::deserialize(WebCore::SerializedScriptValue& serializedScriptValue)
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -558,7 +558,7 @@ struct PerWebProcessState {
 
 @end
 
-RetainPtr<NSError> nsErrorFromExceptionDetails(const WebCore::ExceptionDetails&);
+RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::ExceptionDetails>&);
 
 #if ENABLE(FULLSCREEN_API) && PLATFORM(IOS_FAMILY)
 @interface WKWebView (FullScreenAPI_Internal)

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
@@ -31,6 +31,7 @@
 #import "APISerializedScriptValue.h"
 #import "InspectorExtensionDelegate.h"
 #import "InspectorExtensionTypes.h"
+#import "JavaScriptEvaluationResult.h"
 #import "WKError.h"
 #import "WKWebViewInternal.h"
 #import <WebCore/ExceptionDetails.h>
@@ -92,14 +93,13 @@
             return;
         }
         
-        auto valueOrException = result.value();
+        auto& valueOrException = result.value();
         if (!valueOrException) {
             capturedBlock(nsErrorFromExceptionDetails(valueOrException.error()).get(), nil);
             return;
         }
 
-        id body = API::SerializedScriptValue::deserialize(valueOrException.value()->internalRepresentation());
-        capturedBlock(nil, body);
+        capturedBlock(nil, valueOrException->toID().get());
     });
 }
 
@@ -111,14 +111,13 @@
             return;
         }
         
-        auto valueOrException = result.value();
+        auto& valueOrException = result.value();
         if (!valueOrException) {
             capturedBlock(nsErrorFromExceptionDetails(valueOrException.error()).get(), nil);
             return;
         }
 
-        id body = API::SerializedScriptValue::deserialize(valueOrException.value()->internalRepresentation());
-        capturedBlock(nil, body);
+        capturedBlock(nil, valueOrException->toID().get());
     });
 }
 

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/API/WebExtensionContextAPIDevToolsInspectedWindow.mm
@@ -34,13 +34,14 @@
 
 #import "APIInspectorExtension.h"
 #import "APISerializedScriptValue.h"
+#import "JavaScriptEvaluationResult.h"
 #import "WebExtensionContextProxyMessages.h"
 #import "WebExtensionUtilities.h"
 #import <WebCore/ExceptionDetails.h>
 
 namespace WebKit {
 
-void WebExtensionContext::devToolsInspectedWindowEval(WebPageProxyIdentifier webPageProxyIdentifier, const String& scriptSource, const std::optional<URL>& frameURL, CompletionHandler<void(Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebExtensionError>&&)>&& completionHandler)
+void WebExtensionContext::devToolsInspectedWindowEval(WebPageProxyIdentifier webPageProxyIdentifier, const String& scriptSource, const std::optional<URL>& frameURL, CompletionHandler<void(Expected<Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, WebExtensionError>&&)>&& completionHandler)
 {
     static NSString * const apiName = @"devtools.inspectedWindow.eval()";
 
@@ -72,13 +73,7 @@ void WebExtensionContext::devToolsInspectedWindowEval(WebPageProxyIdentifier web
                 return;
             }
 
-            if (!result.value()) {
-                Expected<std::span<const uint8_t>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(result.value().error());
-                completionHandler({ WTFMove(returnedValue) });
-                return;
-            }
-
-            completionHandler({ result.value()->get().dataReference() });
+            completionHandler({ WTFMove(*result) });
         });
     });
 }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -803,7 +803,7 @@ private:
     // DevTools APIs
     bool isDevToolsMessageAllowed();
     void devToolsPanelsCreate(WebPageProxyIdentifier, const String& title, const String& iconPath, const String& pagePath, CompletionHandler<void(Expected<Inspector::ExtensionTabID, WebExtensionError>&&)>&&);
-    void devToolsInspectedWindowEval(WebPageProxyIdentifier, const String& scriptSource, const std::optional<URL>& frameURL, CompletionHandler<void(Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebExtensionError>&&)>&&);
+    void devToolsInspectedWindowEval(WebPageProxyIdentifier, const String& scriptSource, const std::optional<URL>& frameURL, CompletionHandler<void(Expected<Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, WebExtensionError>&&)>&&);
     void devToolsInspectedWindowReload(WebPageProxyIdentifier, const std::optional<bool>& ignoreCache);
 #endif
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.messages.in
@@ -74,7 +74,7 @@ messages -> WebExtensionContext {
 #if ENABLE(INSPECTOR_EXTENSIONS)
     // DevTools APIs
     [Validator=isDevToolsMessageAllowed] DevToolsPanelsCreate(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String title, String iconPath, String pagePath) -> (Expected<Inspector::ExtensionTabID, WebKit::WebExtensionError> result)
-    [Validator=isDevToolsMessageAllowed] DevToolsInspectedWindowEval(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String scriptSource, std::optional<URL> frameURL) -> (Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebKit::WebExtensionError> result)
+    [Validator=isDevToolsMessageAllowed] DevToolsInspectedWindowEval(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, String scriptSource, std::optional<URL> frameURL) -> (Expected<Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, WebKit::WebExtensionError> result)
     [Validator=isDevToolsMessageAllowed] DevToolsInspectedWindowReload(WebKit::WebPageProxyIdentifier webPageProxyIdentifier, std::optional<bool> ignoreCache)
 #endif
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -175,19 +175,11 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptForExtension(const In
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> dataReference, const std::optional<WebCore::ExceptionDetails>& details, const std::optional<Inspector::ExtensionError> error) mutable {
-            if (error) {
-                completionHandler(makeUnexpected(error.value()));
-                return;
-            }
+        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension { extensionID, scriptSource, frameURL, contextSecurityOrigin, useContentScriptContext }, [completionHandler = WTFMove(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError> error) mutable {
+            if (error)
+                return completionHandler(makeUnexpected(error.value()));
 
-            if (details) {
-                Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(details.value());
-                completionHandler({ returnedValue });
-                return;
-            }
-
-            completionHandler({ API::SerializedScriptValue::createFromWireBytes(dataReference) });
+            completionHandler(WTFMove(result));
         }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }
@@ -245,19 +237,10 @@ void WebInspectorUIExtensionControllerProxy::evaluateScriptInExtensionTab(const 
             return;
         }
 
-        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTFMove(completionHandler)](std::span<const uint8_t> dataReference, const std::optional<WebCore::ExceptionDetails>& details, const std::optional<Inspector::ExtensionError>& error) mutable {
-            if (error) {
-                completionHandler(makeUnexpected(error.value()));
-                return;
-            }
-
-            if (details) {
-                Expected<Ref<API::SerializedScriptValue>, WebCore::ExceptionDetails> returnedValue = makeUnexpected(details.value());
-                completionHandler({ returnedValue });
-                return;
-            }
-
-            completionHandler({ API::SerializedScriptValue::createFromWireBytes(dataReference) });
+        weakThis->protectedInspectorPage()->protectedLegacyMainFrameProcess()->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::EvaluateScriptInExtensionTab { extensionTabID, scriptSource }, [completionHandler = WTFMove(completionHandler)](Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&& result, const std::optional<Inspector::ExtensionError>& error) mutable {
+            if (error)
+                return completionHandler(makeUnexpected(error.value()));
+            completionHandler(WTFMove(result));
         }, weakThis->m_inspectorPage->webPageIDInMainFrameProcess());
     });
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2557,6 +2557,7 @@
 		FABBBC852D35B59A00820017 /* UnifiedSource138.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC812D35B59A00820017 /* UnifiedSource138.cpp */; };
 		FABBBC862D35B59A00820017 /* UnifiedSource139.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FABBBC822D35B59A00820017 /* UnifiedSource139.cpp */; };
 		FABBDEA12B85557500EFAFC4 /* CoreIPCNSURLCredential.mm in Sources */ = {isa = PBXBuildFile; fileRef = FABBDE9E2B85550100EFAFC4 /* CoreIPCNSURLCredential.mm */; };
+		FAC7C0C22D712E2900E7297E /* CoreIPCNumber.mm in Sources */ = {isa = PBXBuildFile; fileRef = FAC7C0C12D712AAF00E7297E /* CoreIPCNumber.mm */; };
 		FAD2A1EE2BF6D51000953297 /* CoroutineUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = FAD2A1ED2BF6D4FD00953297 /* CoroutineUtilities.h */; };
 		FAE61CE62D0A5608000D238D /* UnifiedSource132.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CDF2D0A5606000D238D /* UnifiedSource132.cpp */; };
 		FAE61CE72D0A5608000D238D /* UnifiedSource134.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FAE61CE02D0A5606000D238D /* UnifiedSource134.cpp */; };
@@ -8474,6 +8475,7 @@
 		FAC7C0B02D70228200E7297E /* JavaScriptEvaluationResult.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JavaScriptEvaluationResult.serialization.in; sourceTree = "<group>"; };
 		FAC7C0B12D70229C00E7297E /* JavaScriptEvaluationResult.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JavaScriptEvaluationResult.cpp; sourceTree = "<group>"; };
 		FAC7C0B22D7022AF00E7297E /* JavaScriptEvaluationResult.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JavaScriptEvaluationResult.mm; sourceTree = "<group>"; };
+		FAC7C0C12D712AAF00E7297E /* CoreIPCNumber.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoreIPCNumber.mm; sourceTree = "<group>"; };
 		FAC849872A9E92B600D407EF /* NetworkTransportSession.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkTransportSession.cpp; sourceTree = "<group>"; };
 		FAC849882A9E92B600D407EF /* NetworkTransportSession.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = NetworkTransportSession.messages.in; sourceTree = "<group>"; };
 		FAC849892A9E92B600D407EF /* NetworkTransportSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTransportSession.h; sourceTree = "<group>"; };
@@ -9689,6 +9691,7 @@
 				52FB15422B646156000933CC /* CoreIPCCGColorSpace.h */,
 				52FB15432B64680B000933CC /* CoreIPCCGColorSpace.serialization.in */,
 				F4EFF36B2AF0267200479AB8 /* CoreIPCNumber.h */,
+				FAC7C0C12D712AAF00E7297E /* CoreIPCNumber.mm */,
 				F4EFF36A2AF0267200479AB8 /* CoreIPCNumber.serialization.in */,
 				560F03DB2B6C47F900F53EE7 /* CoreIPCSecAccessControl.h */,
 				561A54522B61E49E00073A72 /* CoreIPCSecAccessControl.serialization.in */,
@@ -20020,6 +20023,7 @@
 				F4F12C932C41CED500BC1254 /* CoreIPCNSURLRequest.mm in Sources */,
 				51ACFFE02B048829001331A2 /* CoreIPCNSValue.mm in Sources */,
 				FA4FE2662B75EB290016E671 /* CoreIPCNull.mm in Sources */,
+				FAC7C0C22D712E2900E7297E /* CoreIPCNumber.mm in Sources */,
 				5157AE0B2B23E97400C0E095 /* CoreIPCPassKit.mm in Sources */,
 				51AD56902B1C46FE001A0ECB /* CoreIPCPersonNameComponents.mm in Sources */,
 				FAF27D302D2851EB00F1F0BB /* CoreIPCPKSecureElementPass.mm in Sources */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -72,7 +72,7 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
         }
     }
 
-    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(webPageProxyIdentifier, expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<std::span<const uint8_t>, WebCore::ExceptionDetails>, WebExtensionError>&& result) mutable {
+    WebProcess::singleton().sendWithAsyncReply(Messages::WebExtensionContext::DevToolsInspectedWindowEval(webPageProxyIdentifier, expression, frameURL), [protectedThis = Ref { *this }, callback = WTFMove(callback)](Expected<Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>, WebExtensionError>&& result) mutable {
         if (!result) {
             callback->reportError(result.error());
             return;
@@ -82,15 +82,14 @@ void WebExtensionAPIDevToolsInspectedWindow::eval(WebPageProxyIdentifier webPage
 
         if (!result.value()) {
             // If an error occurred, element 0 will be undefined, and element 1 will contain an object giving details about the error.
-            callback->call(@[ undefinedValue, @{ isExceptionKey: @YES, valueKey: result.value().error().message } ]);
+            callback->call(@[ undefinedValue, @{ isExceptionKey: @YES, valueKey: result.value().error() ? (NSString *)result.value().error()->message : @"" } ]);
             return;
         }
 
-        Ref serializedValue = API::SerializedScriptValue::createFromWireBytes(result.value().value());
-        id scriptResult = API::SerializedScriptValue::deserialize(serializedValue->internalRepresentation());
+        RetainPtr scriptResult = result.value()->toID();
 
         // If no error occurred, element 0 will contain the result of evaluating the expression, and element 1 will be undefined.
-        callback->call(@[ scriptResult ?: undefinedValue, undefinedValue ]);
+        callback->call(@[ scriptResult ? scriptResult.get() : undefinedValue, undefinedValue ]);
     }, extensionContext().identifier());
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.h
@@ -76,13 +76,13 @@ public:
     void registerExtension(const Inspector::ExtensionID&, const String& extensionBundleIdentifier, const String& displayName, CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&&);
     void unregisterExtension(const Inspector::ExtensionID&, CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&&);
     void createTabForExtension(const Inspector::ExtensionID&, const String& tabName, const URL& tabIconURL, const URL& sourceURL, CompletionHandler<void(Expected<Inspector::ExtensionTabID, Inspector::ExtensionError>)>&&);
-    void evaluateScriptForExtension(const Inspector::ExtensionID&, const String& scriptSource, const std::optional<URL>& frameURL, const std::optional<URL>& contextSecurityOrigin, const std::optional<bool>& useContentScriptContext, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&, const std::optional<Inspector::ExtensionError>&)>&&);
+    void evaluateScriptForExtension(const Inspector::ExtensionID&, const String& scriptSource, const std::optional<URL>& frameURL, const std::optional<URL>& contextSecurityOrigin, const std::optional<bool>& useContentScriptContext, CompletionHandler<void(Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&&, const std::optional<Inspector::ExtensionError>&)>&&);
     void reloadForExtension(const Inspector::ExtensionID&, const std::optional<bool>& ignoreCache, const std::optional<String>& userAgent, const std::optional<String>& injectedScript, CompletionHandler<void(const std::optional<Inspector::ExtensionError>&)>&&);
     void showExtensionTab(const Inspector::ExtensionTabID&, CompletionHandler<void(Expected<void, Inspector::ExtensionError>)>&&);
     void navigateTabForExtension(const Inspector::ExtensionTabID&, const URL& sourceURL, CompletionHandler<void(const std::optional<Inspector::ExtensionError>&)>&&);
 
     // WebInspectorUIExtensionController IPC messages for testing.
-    void evaluateScriptInExtensionTab(const Inspector::ExtensionTabID&, const String& scriptSource, CompletionHandler<void(std::span<const uint8_t>, const std::optional<WebCore::ExceptionDetails>&, const std::optional<Inspector::ExtensionError>&)>&&);
+    void evaluateScriptInExtensionTab(const Inspector::ExtensionTabID&, const String& scriptSource, CompletionHandler<void(Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>>&&, const std::optional<Inspector::ExtensionError>&)>&&);
 
     // Callbacks from the frontend.
     void didShowExtensionTab(const Inspector::ExtensionID&, const Inspector::ExtensionTabID&, WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUIExtensionController.messages.in
@@ -31,13 +31,13 @@ messages -> WebInspectorUIExtensionController {
     UnregisterExtension(String extensionID) -> (Expected<void, Inspector::ExtensionError> result)
 
     CreateTabForExtension(String extensionID, String tabName, URL tabIconURL, URL sourceURL) -> (Expected<String, Inspector::ExtensionError> result)
-    EvaluateScriptForExtension(String extensionID, String scriptSource, std::optional<URL> frameURL, std::optional<URL> contextSecurityOrigin, std::optional<bool> useContentScriptContext) -> (std::span<const uint8_t> resultData, std::optional<WebCore::ExceptionDetails> details, std::optional<Inspector::ExtensionError> error)
+    EvaluateScriptForExtension(String extensionID, String scriptSource, std::optional<URL> frameURL, std::optional<URL> contextSecurityOrigin, std::optional<bool> useContentScriptContext) -> (Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> result, std::optional<Inspector::ExtensionError> error)
     ReloadForExtension(String extensionID, std::optional<bool> ignoreCache, std::optional<String> userAgent, std::optional<String> injectedScript) -> (std::optional<Inspector::ExtensionError> error)
     ShowExtensionTab(String extensionTabIdentifier) -> (Expected<void, Inspector::ExtensionError> result)
     NavigateTabForExtension(String extensionTabIdentifier, URL sourceURL) -> (std::optional<Inspector::ExtensionError> error)
     
     // For testing.
-    EvaluateScriptInExtensionTab(String extensionTabID, String scriptSource) -> (std::span<const uint8_t> resultData, std::optional<WebCore::ExceptionDetails> details, std::optional<Inspector::ExtensionError> error)
+    EvaluateScriptInExtensionTab(String extensionTabID, String scriptSource) -> (Expected<WebKit::JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> result, std::optional<Inspector::ExtensionError> error)
 }
 
 #endif // ENABLE(INSPECTOR_EXTENSIONS)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -899,3 +899,204 @@ TEST(EvaluateJavaScript, WindowPersistency)
     TestWebKitAPI::Util::run(&done);
     done = false;
 }
+
+TEST(EvaluateJavaScript, ReturnTypes)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    __block bool didEvaluateJavaScript = false;
+    NSString *jsTopLevelReplacedByDict = @"(function(){return /hello/})()";
+    // Behaves the same as if sending "(function(){ return {} })()" because of JSValue's containerValueToObject filtering
+    [webView evaluateJavaScript:jsTopLevelReplacedByDict completionHandler:^(id value, NSError *error) {
+        NSDictionary *dict = (NSDictionary *)value;
+        EXPECT_TRUE([dict isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([dict count], 0u);
+    }];
+    NSString *jsWithTopLevelDict = @"(function(){return { } })()";
+    [webView evaluateJavaScript:jsWithTopLevelDict completionHandler:^(id value, NSError *error) {
+        NSDictionary *dict = (NSDictionary *)value;
+        EXPECT_TRUE([dict isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([dict count], 0u);
+    }];
+    NSString *jsWithBlob = @""
+    "(function(){return {"
+    "    blob: new Blob(['Hello']),\n"
+    "}})()";
+    [webView evaluateJavaScript:jsWithBlob completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(error);
+        NSDictionary *dict = (NSDictionary *)value;
+        EXPECT_EQ([dict objectForKey:@"blob"], [NSNull null]);
+    }];
+
+    NSString *jsWithNestedObjects = @""
+    "(function(){"
+    "    let aBool = true;\n"
+    "    let someObject = {};\n"
+    "    const theKey = 'key';\n"
+    "    someObject[theKey] = null;\n"
+    "return {"
+    "    obj1: someObject,\n"
+    "    obj2: 41,\n"
+    "    obj3: someObject,\n"
+    "    obj4: aBool,\n"
+    "    obj5: aBool,\n"
+    "    [theKey]: false,\n"
+    "    theValueToo: theKey,\n"
+    "}})()";
+    [webView evaluateJavaScript:jsWithNestedObjects completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(error);
+        NSDictionary *dict = (NSDictionary *)value;
+        EXPECT_TRUE([dict isKindOfClass:[NSDictionary class]]);
+        id obj1 = [dict objectForKey:@"obj1"];
+        id obj2 = [dict objectForKey:@"obj2"];
+        id obj3 = [dict objectForKey:@"obj3"];
+        id obj4 = [dict objectForKey:@"obj4"];
+        id obj5 = [dict objectForKey:@"obj5"];
+        EXPECT_TRUE(obj1 == obj3);
+        EXPECT_FALSE(obj1 == obj2);
+        EXPECT_TRUE([obj2 isKindOfClass:[NSNumber class]]);
+        EXPECT_TRUE([obj1 isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([obj1 objectForKey:@"key"], [NSNull null]);
+        EXPECT_TRUE([obj4 isKindOfClass:[NSNumber class]]);
+        EXPECT_EQ(obj4, @YES);
+        EXPECT_TRUE(obj4 == obj5);
+        // The key string objects can be shared too
+        id theValueToo = [dict objectForKey:@"theValueToo"];
+        NSEnumerator *keyEnumerator = [dict keyEnumerator];
+        id key;
+        while ((key = [keyEnumerator nextObject])) {
+            NSNumber *v = [dict objectForKey:key];
+            if ([v isEqual:@NO])
+                EXPECT_EQ(key, theValueToo);
+        }
+    }];
+    NSString *jsWithRegexType = @""
+    "(function(){return {"
+    "    text:\"Hello\",\n"
+    "    number: 41,\n"
+    "    undef: undefined,\n"
+    "    bool: true,\n"
+    "    null: null,\n"
+    "    array: [ new Date(8.64e15)],\n"
+    "    regex: /hello/,\n"
+    "    blob: new Blob(['Hello']),\n"
+    "buffer: new ArrayBuffer(8),\n"
+    "int32View: new Int32Array(this.buffer),\n"
+    "objMap: new Map([\n"
+    "    ['key1', 'value1'],\n"
+    "    ['key2', 'value2']\n"
+    "]),\n"
+    "aSet: new Set([1, 2, 3]),\n"
+    "zero: 0,\n"
+    "one: 1,\n"
+    "boolFalse: false,\n"
+    "aDouble: 3.14,\n"
+    "file: new File(['content'], 'file.txt', { type: 'text/plain' }),\n"
+    "fileList: new DataTransfer().files,\n"
+    "imageData: new ImageData(100, 100),\n"
+    "emptyString: '',\n"
+    "arrayBuffer: new ArrayBuffer(8),\n"
+    "arrayBufferView: new Uint8Array(this.arrayBuffer),\n"
+    "bigInt: BigInt(9007199254740991),\n"
+    "Error: new Error('An error occurred'),\n"
+    "}})()";
+
+    [webView evaluateJavaScript:jsWithRegexType completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(error);
+        NSDictionary *dict = (NSDictionary *)value;
+        EXPECT_TRUE([dict isKindOfClass:[NSDictionary class]]);
+        NSString *text = [dict objectForKey:@"text"];
+        EXPECT_TRUE([text isKindOfClass:[NSString class]]);
+        if ([text isKindOfClass:[NSString class]])
+            EXPECT_TRUE([text isEqual:@"Hello"]);
+        NSNumber* number = [dict objectForKey:@"number"];
+        EXPECT_TRUE([number isKindOfClass:[NSNumber class]]);
+        if ([number isKindOfClass:[NSNumber class]])
+            EXPECT_TRUE([number isEqual:@41]);
+        EXPECT_EQ([dict objectForKey:@"undef"], nil);
+        EXPECT_TRUE([[dict objectForKey:@"bool"] isKindOfClass:[NSNumber class]]);
+        if ([[dict objectForKey:@"bool"] isKindOfClass:[NSNumber class]]) {
+            BOOL b = [[dict objectForKey:@"bool"] boolValue];
+            EXPECT_TRUE(b);
+        }
+
+        EXPECT_TRUE([[dict objectForKey:@"boolFalse"] isKindOfClass:[NSNumber class]]);
+        if ([[dict objectForKey:@"boolFalse"] isKindOfClass:[NSNumber class]]) {
+            BOOL b = [[dict objectForKey:@"boolFalse"] boolValue];
+            EXPECT_FALSE(b);
+        }
+        EXPECT_EQ([dict objectForKey:@"null"], [NSNull null]);
+        NSArray* arr = [dict objectForKey:@"array"];
+        EXPECT_TRUE([arr isKindOfClass:[NSArray class]]);
+        EXPECT_NE(arr, nil);
+        EXPECT_EQ([arr count], 1u);
+        if ([arr count] == 1u)
+            EXPECT_TRUE([arr.firstObject isKindOfClass:[NSDate class]]);
+        NSDictionary* regex = [dict objectForKey:@"regex"];
+        EXPECT_TRUE([regex isKindOfClass:[NSDictionary class]]); // Converted to empty dictionary
+        EXPECT_EQ([regex count], 0u);
+
+        EXPECT_EQ([dict objectForKey:@"blob"], [NSNull null]); // Converted to null
+        EXPECT_TRUE([[dict objectForKey:@"aDouble"] isKindOfClass:[NSNumber class]]);
+        EXPECT_TRUE([[dict objectForKey:@"zero"] isKindOfClass:[NSNumber class]]);
+        EXPECT_EQ([dict objectForKey:@"imageData"], [NSNull null]); // Converted to null
+        EXPECT_EQ([dict objectForKey:@"file"], [NSNull null]); // Converted to null
+        NSDictionary* arrayBufferView = [dict objectForKey:@"arrayBufferView"];
+        EXPECT_TRUE([arrayBufferView isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([arrayBufferView count], 0u);
+
+        EXPECT_EQ([dict objectForKey:@"int32view"], nil);
+
+        NSDictionary* objMap = [dict objectForKey:@"objMap"];
+        EXPECT_TRUE([objMap isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([objMap count], 0u);
+
+        NSDictionary* buffer = [dict objectForKey:@"buffer"];
+        EXPECT_TRUE([buffer isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([buffer count], 0u);
+        NSDictionary* arrayBuffer = [dict objectForKey:@"arrayBuffer"];
+        EXPECT_TRUE([arrayBuffer isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([arrayBuffer count], 0u);
+
+        EXPECT_EQ([dict objectForKey:@"error"], nil);
+
+        EXPECT_TRUE([[dict objectForKey:@"one"] isKindOfClass:[NSNumber class]]);
+        NSDictionary* aSet = [dict objectForKey:@"aSet"];
+        EXPECT_TRUE([aSet isKindOfClass:[NSDictionary class]]);
+        EXPECT_EQ([aSet count], 0u);
+
+        EXPECT_EQ([dict objectForKey:@"fileList"], [NSNull null]); // Converted to null
+        NSString *emptyString = [dict objectForKey:@"emptyString"];
+        EXPECT_TRUE([emptyString isKindOfClass:[NSString class]]);
+        if ([emptyString isKindOfClass:[NSString class]])
+            EXPECT_TRUE([emptyString isEqual:@""]);
+    }];
+    [webView evaluateJavaScript:@"(function(){return null)()" completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(value); // top level object must be a dictionary
+    }];
+    [webView evaluateJavaScript:@"(function(){return \"hello\")()" completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(value); // top level object must be a dictionary
+    }];
+
+    constexpr NSUInteger depth { 100000 };
+    NSString *deeplyNestedArray = [[@"" stringByPaddingToLength:depth withString: @"[" startingAtIndex:0] stringByAppendingString:[@"" stringByPaddingToLength:depth withString: @"[" startingAtIndex:0]];
+    [webView evaluateJavaScript:deeplyNestedArray completionHandler:^(id value, NSError *error) {
+        EXPECT_WK_STREQ(error.domain, WKErrorDomain);
+        EXPECT_EQ(error.code, WKErrorJavaScriptExceptionOccurred);
+    }];
+
+    [webView evaluateJavaScript:@"(function(){ var array = []; array.push(array); return array })()" completionHandler:^(id value, NSError *error) {
+        EXPECT_NULL(error);
+        NSArray *array = (NSArray *)value;
+        EXPECT_TRUE([array isKindOfClass:NSArray.class]);
+        EXPECT_EQ(array.count, 1u);
+        EXPECT_TRUE(array[0] == array);
+    }];
+
+    [webView evaluateJavaScript:@"(function(){return [\"Array\"])()" completionHandler:^(id value, NSError *error) {
+        EXPECT_FALSE(value); // top level object must be a dictionary
+        didEvaluateJavaScript = true;
+    }];
+
+    TestWebKitAPI::Util::run(&didEvaluateJavaScript);
+}


### PR DESCRIPTION
#### 83c2523fa0c911e3459629da626ea6d3e6c6d5fc
<pre>
Replace JavaScriptEvaluationResult&apos;s IPC format with a structured map
<a href="https://bugs.webkit.org/show_bug.cgi?id=288788">https://bugs.webkit.org/show_bug.cgi?id=288788</a>
<a href="https://rdar.apple.com/145804771">rdar://145804771</a>

Reviewed by Sihui Liu.

In order to maintain maximum compatibility, we continue to do a roundtrip
through SerializedScriptValue, but we do so now entirely inside the web content
process.  This preserves some strange behavior related to things like blob
serialization which we may want to revisit later, but for now we don&apos;t change
any observable behavior.  This is verified by some excellent tests that
I got from Simon Lewis and included in this PR from his work on a slightly
different approach in <a href="https://github.com/WebKit/WebKit/pull/40911">https://github.com/WebKit/WebKit/pull/40911</a>
Simon&apos;s tests are more extensive than anything we&apos;ve tested before, which is
why they hit several assertions I needed to remove.

The serialization format is a map of identifiers to values of different types
with a root identifier of where to start.  This allows us to preserve pointer
equality of dictionaries that contain each other and keys that are reused as
values and other interesting things.

I also adopt JavaScriptEvaluationResult for the places where the extensions
code deserializes a JavaScript evaluation result, such as
Messages::WebInspectorUIExtensionController::EvaluateScriptForExtension.

* Source/WebKit/Shared/API/APISerializedScriptValue.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::toWK const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.h:
(WebKit::JavaScriptEvaluationResult::root const):
(WebKit::JavaScriptEvaluationResult::map const):
(WebKit::JavaScriptEvaluationResult::wireBytes const):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::JavaScriptEvaluationResult):
(WebKit::JavaScriptEvaluationResult::toID const):
(WebKit::JavaScriptEvaluationResult::toVariant):
(WebKit::JavaScriptEvaluationResult::addObjectToMap):
(WebKit::roundTripThroughSerializedScriptValue):
(WebKit::convertToObjC):
(WebKit::JavaScriptEvaluationResult::extract):
* Source/WebKit/Shared/JavaScriptEvaluationResult.serialization.in:
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/Shared/cf/CoreIPCNumber.h:
(WebKit::CoreIPCNumber::numberHolderForNumber): Deleted.
(WebKit::CoreIPCNumber::CoreIPCNumber): Deleted.
(WebKit::CoreIPCNumber::createCFNumber const): Deleted.
(WebKit::CoreIPCNumber::get const): Deleted.
(WebKit::CoreIPCNumber::toID const): Deleted.
* Source/WebKit/Shared/cf/CoreIPCNumber.mm: Added.
(WebKit::CoreIPCNumber::numberHolderForNumber):
(WebKit::CoreIPCNumber::CoreIPCNumber):
(WebKit::CoreIPCNumber::createCFNumber const):
(WebKit::CoreIPCNumber::get const):
(WebKit::CoreIPCNumber::toID const):
* Source/WebKit/UIProcess/API/Cocoa/APISerializedScriptValueCocoa.mm:
(API::SerializedScriptValue::deserializationContext):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(ReturnTypes)):

Canonical link: <a href="https://commits.webkit.org/291332@main">https://commits.webkit.org/291332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/711b738860ce140f9d40a72a36aab0fbf369d1a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1860 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20691 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28410 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95690 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9477 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83909 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9167 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1540 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42527 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85398 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99703 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91354 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19740 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19990 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79283 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23807 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14774 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19724 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114002 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19411 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32937 "Found 8 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-slow-memory, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21152 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->