### PR TITLE
Address a lot of Safer CPP failures in webpushd

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -105,12 +105,12 @@ public:
     // Remove and return the first element for which the callback returns true. Returns a null version of
     // T if it the callback always returns false.
     template<typename Func>
-    T takeFirst(const Func&);
+    T takeFirst(NOESCAPE const Func&);
 
     // Remove and return the last element for which the callback returns true. Returns a null version of
     // T if it the callback always returns false.
     template<typename Func>
-    T takeLast(const Func&);
+    T takeLast(NOESCAPE const Func&);
 
     void clear();
 
@@ -616,7 +616,7 @@ inline void Deque<T, inlineCapacity>::appendAndBubble(U&& value, const Func& fun
 
 template<typename T, size_t inlineCapacity>
 template<typename Func>
-inline T Deque<T, inlineCapacity>::takeFirst(const Func& func)
+inline T Deque<T, inlineCapacity>::takeFirst(NOESCAPE const Func& func)
 {
     unsigned count = 0;
     unsigned size = this->size();
@@ -635,7 +635,7 @@ inline T Deque<T, inlineCapacity>::takeFirst(const Func& func)
 
 template<typename T, size_t inlineCapacity>
 template<typename Func>
-inline T Deque<T, inlineCapacity>::takeLast(const Func& func)
+inline T Deque<T, inlineCapacity>::takeLast(NOESCAPE const Func& func)
 {
     unsigned count = 0;
     unsigned size = this->size();

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -365,6 +365,3 @@ WebProcess/cocoa/TextTrackRepresentationCocoa.mm
 WebProcess/cocoa/UserMediaCaptureManager.cpp
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
-webpushd/ApplePushServiceConnection.mm
-webpushd/PushService.h
-webpushd/WebPushDaemon.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -37,7 +37,3 @@ WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebStorage/StorageAreaMap.cpp
 WebProcess/cocoa/VideoPresentationManager.mm
 WebProcess/cocoa/WebProcessCocoa.mm
-webpushd/ApplePushServiceConnection.mm
-webpushd/PushService.mm
-webpushd/PushServiceConnection.mm
-webpushd/WebPushDaemon.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -102,4 +102,3 @@ WebProcess/WebSleepDisablerClient.cpp
 WebProcess/WebStorage/StorageAreaMap.cpp
 WebProcess/cocoa/TextTrackRepresentationCocoa.mm
 WebProcess/cocoa/WebProcessCocoa.mm
-webpushd/PushService.mm

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -65,8 +65,8 @@ public:
     WebCore::PushDatabase& database() { return m_database; }
     Ref<WebCore::PushDatabase> protectedDatabase() { return m_database; }
 
-    Vector<String> enabledTopics() { return m_connection->enabledTopics(); }
-    Vector<String> ignoredTopics() { return m_connection->ignoredTopics(); }
+    Vector<String> enabledTopics() { return protectedConnection()->enabledTopics(); }
+    Vector<String> ignoredTopics() { return protectedConnection()->ignoredTopics(); }
 
     void getSubscription(const WebCore::PushSubscriptionSetIdentifier&, const String& scope, CompletionHandler<void(const Expected<std::optional<WebCore::PushSubscriptionData>, WebCore::ExceptionData>&)>&&);
     void subscribe(const WebCore::PushSubscriptionSetIdentifier&, const String& scope, const Vector<uint8_t>& vapidPublicKey, CompletionHandler<void(const Expected<WebCore::PushSubscriptionData, WebCore::ExceptionData>&)>&&);

--- a/Source/WebKit/webpushd/PushServiceConnection.mm
+++ b/Source/WebKit/webpushd/PushServiceConnection.mm
@@ -70,7 +70,7 @@ void PushServiceConnection::startListeningForPushMessages(IncomingPushMessageHan
     if (!m_pendingPushes.size())
         return;
 
-    WorkQueue::protectedMain()->dispatch([this]() mutable {
+    WorkQueue::protectedMain()->dispatch([this, protectdThis = Ref { *this }]() mutable {
         while (m_pendingPushes.size()) {
             @autoreleasepool {
                 auto message = m_pendingPushes.takeFirst();

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -145,7 +145,7 @@ private:
     HashSet<xpc_connection_t> m_pendingConnectionSet;
     HashMap<xpc_connection_t, Ref<PushClientConnection>> m_connectionMap;
 
-    RefPtr<PushService> m_pushService;
+    const RefPtr<PushService> m_pushService;
     bool m_usingMockPushService { false };
     bool m_pushServiceStarted { false };
     Deque<Function<void()>> m_pendingPushServiceFunctions;


### PR DESCRIPTION
#### 770d25a8375298cb04767662418738016bca5ec7
<pre>
Address a lot of Safer CPP failures in webpushd
<a href="https://bugs.webkit.org/show_bug.cgi?id=288789">https://bugs.webkit.org/show_bug.cgi?id=288789</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/webpushd/ApplePushServiceConnection.mm:
(-[_WKAPSConnectionDelegate connection:didReceivePublicToken:]):
(-[_WKAPSConnectionDelegate connection:didReceiveIncomingMessage:]):
(WebPushD::ApplePushServiceConnection::subscribe):
(WebPushD::ApplePushServiceConnection::unsubscribe):
* Source/WebKit/webpushd/PushService.h:
(WebPushD::PushService::enabledTopics):
(WebPushD::PushService::ignoredTopics):
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::create):
(WebPushD::SubscribeRequest::attemptToRecoverFromTopicAlreadyInFilterError):
* Source/WebKit/webpushd/PushServiceConnection.mm:
(WebPushD::PushServiceConnection::startListeningForPushMessages):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::startMockPushService):
(WebPushD::WebPushDaemon::startPushService):
(WebPushD::WebPushDaemon::setPushService):
(WebPushD::WebPushDaemon::updateSubscriptionSetState):
(WebPushD::WebPushDaemon::setPushAndNotificationsEnabledForOrigin):
(WebPushD::WebPushDaemon::injectEncryptedPushMessageForTesting):
(WebPushD::WebPushDaemon::handleIncomingPush):
(WebPushD::WebPushDaemon::getPushTopicsForTesting):
(WebPushD::WebPushDaemon::subscribeToPushService):
(WebPushD::WebPushDaemon::unsubscribeFromPushService):
(WebPushD::WebPushDaemon::getPushSubscription):
(WebPushD::WebPushDaemon::incrementSilentPushCount):
(WebPushD::WebPushDaemon::removeAllPushSubscriptions):
(WebPushD::WebPushDaemon::removePushSubscriptionsForOrigin):
(WebPushD::WebPushDaemon::setPublicTokenForTesting):
(WebPushD::WebPushDaemon::showNotification):

Canonical link: <a href="https://commits.webkit.org/291336@main">https://commits.webkit.org/291336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3296434d5def88ed7be43a28d9d2721ccb1bff2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20696 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83915 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/51309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1546 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42532 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85403 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1517 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99708 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91359 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19745 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79809 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79286 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23810 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19729 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114007 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19416 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32939 "Found 16 new JSC stress test failures: stress/sampling-profiler-display-name.js.dfg-eager-no-cjit-validate, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.wasm-slow-memory, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager-jettison, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22876 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->