### PR TITLE
Address Safer CPP failures in API::Array

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -1,6 +1,5 @@
 AutomationProtocolObjects.h
 Platform/cocoa/CocoaHelpers.mm
-Shared/API/APIArray.h
 Shared/API/APIDictionary.h
 Shared/API/c/WKSharedAPICast.h
 Shared/API/c/cf/WKStringCF.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -2,7 +2,6 @@ AutomationBackendDispatchers.cpp
 AutomationFrontendDispatchers.cpp
 AutomationProtocolObjects.h
 Platform/IPC/ArgumentCoders.h
-Shared/API/APIArray.h
 Shared/API/c/WKArray.cpp
 Shared/API/c/WKContextMenuItem.cpp
 Shared/API/c/WKData.cpp

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -42,7 +42,7 @@ private:
 
     template <class T>
     struct GetObjectTransform {
-        const T* operator()(const RefPtr<Object>& object) const { return static_cast<const T*>(object.get()); }
+        const T* operator()(const RefPtr<Object>& object) const { return downcast<T>(object.get()); }
     };
 
     template <typename T>
@@ -60,10 +60,7 @@ public:
     template<typename T>
     T* at(size_t i) const
     {
-        if (!m_elements[i] || m_elements[i]->type() != T::APIType)
-            return nullptr;
-
-        return static_cast<T*>(m_elements[i].get());
+        return dynamicDowncast<T>(m_elements[i].get());
     }
 
     Object* at(size_t i) const { return m_elements[i].get(); }

--- a/Source/WebKit/Shared/API/APISecurityOrigin.h
+++ b/Source/WebKit/Shared/API/APISecurityOrigin.h
@@ -65,3 +65,5 @@ private:
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(SecurityOrigin);

--- a/Source/WebKit/Shared/APIWebArchive.h
+++ b/Source/WebKit/Shared/APIWebArchive.h
@@ -74,4 +74,6 @@ private:
 
 } // namespace API
 
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(WebArchive);
+
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/APIWebArchiveResource.h
+++ b/Source/WebKit/Shared/APIWebArchiveResource.h
@@ -66,6 +66,8 @@ private:
 
 } // namespace API
 
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(WebArchiveResource);
+
 #endif // PLATFORM(COCOA)
 
 #endif // WebArchiveResource_h

--- a/Source/WebKit/Shared/WebContextMenuItem.h
+++ b/Source/WebKit/Shared/WebContextMenuItem.h
@@ -66,5 +66,9 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebContextMenuItem) \
+static bool isType(const API::Object& object) { return object.type() == API::Object::Type::ContextMenuItem; } \
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // ENABLE(CONTEXT_MENUS)
 #endif // WebContextMenuItem_h

--- a/Source/WebKit/UIProcess/API/APIUserScript.h
+++ b/Source/WebKit/UIProcess/API/APIUserScript.h
@@ -54,3 +54,5 @@ private:
 };
 
 } // namespace API
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(UserScript);

--- a/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
+++ b/Source/WebKit/UIProcess/API/APIUserStyleSheet.h
@@ -53,3 +53,5 @@ private:
 };
 
 } // namespace API
+
+SPECIALIZE_TYPE_TRAITS_API_OBJECT(UserStyleSheet);

--- a/Source/WebKit/UIProcess/WebGrammarDetail.h
+++ b/Source/WebKit/UIProcess/WebGrammarDetail.h
@@ -58,4 +58,8 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebGrammarDetail) \
+static bool isType(const API::Object& object) { return object.type() == API::Object::Type::GrammarDetail; } \
+SPECIALIZE_TYPE_TRAITS_END()
+
 #endif // WebGrammarDetail_h


### PR DESCRIPTION
#### e7c8f62491cb9f9e4c24ea3f220f0db5c5e77ce4
<pre>
Address Safer CPP failures in API::Array
<a href="https://bugs.webkit.org/show_bug.cgi?id=288800">https://bugs.webkit.org/show_bug.cgi?id=288800</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/Shared/API/APIArray.h:
* Source/WebKit/Shared/API/APISecurityOrigin.h:
* Source/WebKit/Shared/APIWebArchive.h:
* Source/WebKit/Shared/APIWebArchiveResource.h:
* Source/WebKit/Shared/WebContextMenuItem.h:
(isType):
* Source/WebKit/UIProcess/API/APIUserScript.h:
* Source/WebKit/UIProcess/API/APIUserStyleSheet.h:

Canonical link: <a href="https://commits.webkit.org/291373@main">https://commits.webkit.org/291373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ddebc11c55b51decaeffbcd662bd3276e48d5e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43098 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20594 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70940 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28359 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9413 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51272 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9107 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg (failure)") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42429 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99603 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79922 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79207 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23738 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24798 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19313 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->