### PR TITLE
Address Safer CPP failures in ContextMenuContextData.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -35,7 +35,6 @@ Shared/Cocoa/APIObject.mm
 Shared/Cocoa/WKNSData.mm
 Shared/Cocoa/WKNSString.mm
 Shared/Cocoa/WKNSURL.mm
-Shared/ContextMenuContextData.cpp
 Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
 Shared/SharedStringHashStore.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -4,7 +4,6 @@ Shared/API/APIObject.h
 Shared/API/c/cg/WKImageCG.cpp
 Shared/APIWebArchive.mm
 Shared/Cocoa/APIObject.mm
-Shared/ContextMenuContextData.cpp
 Shared/WebContextMenuItem.cpp
 Shared/WebHitTestResultData.cpp
 UIProcess/API/C/WKContext.cpp

--- a/Source/WebKit/Shared/ContextMenuContextData.cpp
+++ b/Source/WebKit/Shared/ContextMenuContextData.cpp
@@ -58,14 +58,14 @@ ContextMenuContextData::ContextMenuContextData(const IntPoint& menuLocation, con
 #endif
 {
 #if ENABLE(SERVICE_CONTROLS)
-    if (auto* image = context.controlledImage())
+    if (RefPtr image = context.controlledImage())
         setImage(*image);
 #endif
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
-    if (auto* image = context.potentialQRCodeNodeSnapshotImage())
+    if (RefPtr image = context.potentialQRCodeNodeSnapshotImage())
         setPotentialQRCodeNodeSnapshotImage(*image);
 
-    if (auto* image = context.potentialQRCodeViewportSnapshotImage())
+    if (RefPtr image = context.potentialQRCodeViewportSnapshotImage())
         setPotentialQRCodeViewportSnapshotImage(*image);
 #endif
 }
@@ -86,16 +86,18 @@ ContextMenuContextData::ContextMenuContextData(const WebCore::IntPoint& menuLoca
 void ContextMenuContextData::setImage(WebCore::Image& image)
 {
     // FIXME: figure out the rounding strategy for ShareableBitmap.
-    m_controlledImage = ShareableBitmap::create({ IntSize(image.size()) });
-    if (auto graphicsContext = m_controlledImage->createGraphicsContext())
+
+    RefPtr controlledImage = ShareableBitmap::create({ IntSize(image.size()) });
+    m_controlledImage = controlledImage;
+    if (auto graphicsContext = controlledImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }
 
 std::optional<ShareableBitmap::Handle> ContextMenuContextData::createControlledImageReadOnlyHandle() const
 {
-    if (!m_controlledImage)
-        return std::nullopt;
-    return m_controlledImage->createHandle(SharedMemory::Protection::ReadOnly);
+    if (RefPtr controlledImage = m_controlledImage)
+        return controlledImage->createHandle(SharedMemory::Protection::ReadOnly);
+    return std::nullopt;
 }
 #endif
 
@@ -103,30 +105,32 @@ std::optional<ShareableBitmap::Handle> ContextMenuContextData::createControlledI
 
 void ContextMenuContextData::setPotentialQRCodeNodeSnapshotImage(WebCore::Image& image)
 {
-    m_potentialQRCodeNodeSnapshotImage = ShareableBitmap::create({ IntSize(image.size()) });
-    if (auto graphicsContext = m_potentialQRCodeNodeSnapshotImage->createGraphicsContext())
+    RefPtr potentialQRCodeNodeSnapshotImage = ShareableBitmap::create({ IntSize(image.size()) });
+    m_potentialQRCodeNodeSnapshotImage = potentialQRCodeNodeSnapshotImage;
+    if (auto graphicsContext = potentialQRCodeNodeSnapshotImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }
 
 void ContextMenuContextData::setPotentialQRCodeViewportSnapshotImage(WebCore::Image& image)
 {
-    m_potentialQRCodeViewportSnapshotImage = ShareableBitmap::create({ IntSize(image.size()) });
-    if (auto graphicsContext = m_potentialQRCodeViewportSnapshotImage->createGraphicsContext())
+    RefPtr potentialQRCodeViewportSnapshotImage = ShareableBitmap::create({ IntSize(image.size()) });
+    m_potentialQRCodeViewportSnapshotImage = potentialQRCodeViewportSnapshotImage;
+    if (auto graphicsContext = potentialQRCodeViewportSnapshotImage->createGraphicsContext())
         graphicsContext->drawImage(image, IntPoint());
 }
 
 std::optional<ShareableBitmap::Handle> ContextMenuContextData::createPotentialQRCodeNodeSnapshotImageReadOnlyHandle() const
 {
-    if (!m_potentialQRCodeNodeSnapshotImage)
-        return std::nullopt;
-    return m_potentialQRCodeNodeSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly);
+    if (RefPtr image = m_potentialQRCodeNodeSnapshotImage)
+        return image->createHandle(SharedMemory::Protection::ReadOnly);
+    return std::nullopt;
 }
 
 std::optional<ShareableBitmap::Handle> ContextMenuContextData::createPotentialQRCodeViewportSnapshotImageReadOnlyHandle() const
 {
-    if (!m_potentialQRCodeViewportSnapshotImage)
-        return std::nullopt;
-    return m_potentialQRCodeViewportSnapshotImage->createHandle(SharedMemory::Protection::ReadOnly);
+    if (RefPtr image = m_potentialQRCodeViewportSnapshotImage)
+        return image->createHandle(SharedMemory::Protection::ReadOnly);
+    return std::nullopt;
 }
 
 #endif // ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)


### PR DESCRIPTION
#### be236ce96965df77d448673080a04d67b50cca72
<pre>
Address Safer CPP failures in ContextMenuContextData.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288802">https://bugs.webkit.org/show_bug.cgi?id=288802</a>

Reviewed by Brady Eidson.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/Shared/ContextMenuContextData.cpp:
(WebKit::m_selectionIsEditable):
(WebKit::ContextMenuContextData::setImage):
(WebKit::ContextMenuContextData::createControlledImageReadOnlyHandle const):
(WebKit::ContextMenuContextData::setPotentialQRCodeNodeSnapshotImage):
(WebKit::ContextMenuContextData::setPotentialQRCodeViewportSnapshotImage):
(WebKit::ContextMenuContextData::createPotentialQRCodeNodeSnapshotImageReadOnlyHandle const):
(WebKit::ContextMenuContextData::createPotentialQRCodeViewportSnapshotImageReadOnlyHandle const):

Canonical link: <a href="https://commits.webkit.org/291361@main">https://commits.webkit.org/291361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b6077d04808c09823cba1b282109e200d4d5074

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43094 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70912 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28358 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9410 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83826 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51242 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9104 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79420 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19638 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14477 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79921 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19888 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79205 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12650 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14797 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19622 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24794 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19309 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->