### PR TITLE
Address Safer CPP failures in SharedStringHashStore.cpp

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -37,7 +37,6 @@ Shared/Cocoa/WKNSString.mm
 Shared/Cocoa/WKNSURL.mm
 Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
-Shared/SharedStringHashStore.cpp
 Shared/WebCompiledContentRuleListData.cpp
 Shared/WebHitTestResultData.cpp
 Shared/WebImage.cpp

--- a/Source/WebKit/Shared/SharedStringHashStore.cpp
+++ b/Source/WebKit/Shared/SharedStringHashStore.cpp
@@ -73,7 +73,7 @@ SharedStringHashStore::SharedStringHashStore(Client& client)
 
 std::optional<SharedMemory::Handle> SharedStringHashStore::createSharedMemoryHandle()
 {
-    return m_table.sharedMemory()->createHandle(SharedMemory::Protection::ReadOnly);
+    return m_table.protectedSharedMemory()->createHandle(SharedMemory::Protection::ReadOnly);
 }
 
 void SharedStringHashStore::scheduleAddition(SharedStringHash sharedStringHash)

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp
@@ -104,4 +104,9 @@ SharedStringHash* SharedStringHashTableReadOnly::findSlot(SharedStringHash share
     }
 }
 
+RefPtr<WebCore::SharedMemory> SharedStringHashTableReadOnly::protectedSharedMemory() const
+{
+    return sharedMemory();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
+++ b/Source/WebKit/Shared/SharedStringHashTableReadOnly.h
@@ -42,6 +42,7 @@ public:
     bool contains(WebCore::SharedStringHash) const;
 
     WebCore::SharedMemory* sharedMemory() const { return m_sharedMemory.get(); }
+    RefPtr<WebCore::SharedMemory> protectedSharedMemory() const;
     void setSharedMemory(RefPtr<WebCore::SharedMemory>&&);
 
 protected:


### PR DESCRIPTION
#### 531a0847bba3b96dfaae729de1d8097ec26c9c49
<pre>
Address Safer CPP failures in SharedStringHashStore.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288807">https://bugs.webkit.org/show_bug.cgi?id=288807</a>

Reviewed by Brady Eidson.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/Shared/SharedStringHashStore.cpp:
(WebKit::SharedStringHashStore::createSharedMemoryHandle):
* Source/WebKit/Shared/SharedStringHashTableReadOnly.cpp:
(WebKit::SharedStringHashTableReadOnly::protectedSharedMemory const):
* Source/WebKit/Shared/SharedStringHashTableReadOnly.h:

Canonical link: <a href="https://commits.webkit.org/291363@main">https://commits.webkit.org/291363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91db0c1e0a88c1c44d2753393f8d49ebfd31ac5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43100 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70917 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28360 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9169 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19644 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79925 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79719 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79212 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12656 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14799 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21056 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->