### PR TITLE
Support alignment properties (align-self/justify-self) in absolute positioned layout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-htb-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-vlr-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-vrl-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-htb-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-vlr-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-vrl-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-htb-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-vlr-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-vrl-expected.txt
@@ -1,76 +1,36 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
 FAIL .item 12 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
 FAIL .item 13 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-htb-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-vlr-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-vrl-expected.txt
@@ -1,76 +1,36 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
 FAIL .item 12 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
 FAIL .item 13 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-htb-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-vlr-expected.txt
@@ -1,76 +1,36 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
 FAIL .item 12 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
 FAIL .item 13 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-vrl-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-htb-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-vlr-expected.txt
@@ -1,76 +1,36 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
 FAIL .item 12 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
 FAIL .item 13 assert_equals:
 <div class="container">
   <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-vrl-expected.txt
@@ -1,76 +1,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
 PASS .item 8
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="align-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
 PASS .item 16
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-htb-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-vlr-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-vrl-expected.txt
@@ -1,96 +1,40 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
 FAIL .item 14 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
 FAIL .item 15 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-htb-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-vlr-expected.txt
@@ -1,96 +1,40 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
 FAIL .item 14 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
 </div>
-width expected 20 but got 40
+offsetLeft expected 20 but got 0
 FAIL .item 15 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
 </div>
-width expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+offsetLeft expected 0 but got 20
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-vrl-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-width="20" data-offset-x="10"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-width="20" data-offset-x="0"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-width="20" data-offset-x="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-htb-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-vlr-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-vrl-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-htb-expected.txt
@@ -1,96 +1,40 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
 </div>
-height expected 20 but got 40
+offsetTop expected 20 but got 0
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
 </div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+offsetTop expected 0 but got 20
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
 FAIL .item 14 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
 </div>
-height expected 20 but got 40
+offsetTop expected 20 but got 0
 FAIL .item 15 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
 </div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+offsetTop expected 0 but got 20
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-vlr-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-vrl-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-htb-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-vlr-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-vrl-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-htb-expected.txt
@@ -1,96 +1,40 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
 FAIL .item 4 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
 </div>
-height expected 20 but got 40
+offsetTop expected 20 but got 0
 FAIL .item 5 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
 </div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+offsetTop expected 0 but got 20
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
 FAIL .item 14 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
 </div>
-height expected 20 but got 40
+offsetTop expected 20 but got 0
 FAIL .item 15 assert_equals:
 <div class="container">
   <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
 </div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+offsetTop expected 0 but got 20
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-vlr-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-vrl-expected.txt
@@ -1,96 +1,24 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 4 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 6 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-start;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: self-end;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 1
+PASS .item 2
+PASS .item 3
+PASS .item 4
+PASS .item 5
+PASS .item 6
+PASS .item 7
+PASS .item 8
+PASS .item 9
 PASS .item 10
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: center;" data-expected-height="20" data-offset-y="10"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 13 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 14 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: baseline;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 15 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: last baseline;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 16 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-start;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 17 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: self-end;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 18 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: left;" data-expected-height="20" data-offset-y="0"></div>
-</div>
-height expected 20 but got 40
-FAIL .item 19 assert_equals:
-<div class="container">
-  <div class="item rtl" style="justify-self: right;" data-expected-height="20" data-offset-y="20"></div>
-</div>
-height expected 20 but got 40
+PASS .item 11
+PASS .item 12
+PASS .item 13
+PASS .item 14
+PASS .item 15
+PASS .item 16
+PASS .item 17
+PASS .item 18
+PASS .item 19
 PASS .item 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-htb-expected.txt
@@ -9,58 +9,22 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 PASS .item 13
 PASS .item 14
 PASS .item 15
 PASS .item 16
 PASS .item 17
 PASS .item 18
-FAIL .item 19 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-y="-5"></div>
-offsetTop expected -5 but got 15
-FAIL .item 20 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-y="-5"></div>
-offsetTop expected -5 but got 15
-FAIL .item 21 assert_equals:
-<div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-y="-5"></div>
-offsetTop expected -5 but got 15
-FAIL .item 22 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-y="-5"></div>
-offsetTop expected -5 but got 15
-FAIL .item 23 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-y="-5"></div>
-offsetTop expected -5 but got 15
-FAIL .item 24 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-y="-5"></div>
-offsetTop expected -5 but got 15
+PASS .item 19
+PASS .item 20
+PASS .item 21
+PASS .item 22
+PASS .item 23
+PASS .item 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-vlr-expected.txt
@@ -9,58 +9,22 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 PASS .item 13
 PASS .item 14
 PASS .item 15
 PASS .item 16
 PASS .item 17
 PASS .item 18
-FAIL .item 19 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-x="-5"></div>
-offsetLeft expected -5 but got 15
-FAIL .item 20 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-x="-5"></div>
-offsetLeft expected -5 but got 15
-FAIL .item 21 assert_equals:
-<div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-x="-5"></div>
-offsetLeft expected -5 but got 15
-FAIL .item 22 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-x="-5"></div>
-offsetLeft expected -5 but got 15
-FAIL .item 23 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-x="-5"></div>
-offsetLeft expected -5 but got 15
-FAIL .item 24 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-x="-5"></div>
-offsetLeft expected -5 but got 15
+PASS .item 19
+PASS .item 20
+PASS .item 21
+PASS .item 22
+PASS .item 23
+PASS .item 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-vrl-expected.txt
@@ -9,58 +9,22 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got -5
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got -5
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got -5
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got -5
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got -5
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-x="15"></div>
-</div>
-offsetLeft expected 15 but got -5
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 PASS .item 13
 PASS .item 14
 PASS .item 15
 PASS .item 16
 PASS .item 17
 PASS .item 18
-FAIL .item 19 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 20 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 21 assert_equals:
-<div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 22 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 23 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 24 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
+PASS .item 19
+PASS .item 20
+PASS .item 21
+PASS .item 22
+PASS .item 23
+PASS .item 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-htb-expected.txt
@@ -9,58 +9,22 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-x="-5"></div>
-</div>
-offsetLeft expected -5 but got 15
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 PASS .item 13
 PASS .item 14
 PASS .item 15
 PASS .item 16
 PASS .item 17
 PASS .item 18
-FAIL .item 19 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 20 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 21 assert_equals:
-<div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 22 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 23 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
-FAIL .item 24 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-x="15"></div>
-offsetLeft expected 15 but got -5
+PASS .item 19
+PASS .item 20
+PASS .item 21
+PASS .item 22
+PASS .item 23
+PASS .item 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-vlr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-vlr-expected.txt
@@ -9,58 +9,22 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 PASS .item 13
 PASS .item 14
 PASS .item 15
 PASS .item 16
 PASS .item 17
 PASS .item 18
-FAIL .item 19 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 20 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 21 assert_equals:
-<div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 22 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 23 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 24 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
+PASS .item 19
+PASS .item 20
+PASS .item 21
+PASS .item 22
+PASS .item 23
+PASS .item 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-vrl-expected.txt
@@ -9,58 +9,22 @@ PASS .item 3
 PASS .item 4
 PASS .item 5
 PASS .item 6
-FAIL .item 7 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 8 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 9 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 10 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 11 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
-FAIL .item 12 assert_equals:
-<div class="container">
-  <div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-y="-5"></div>
-</div>
-offsetTop expected -5 but got 15
+PASS .item 7
+PASS .item 8
+PASS .item 9
+PASS .item 10
+PASS .item 11
+PASS .item 12
 PASS .item 13
 PASS .item 14
 PASS .item 15
 PASS .item 16
 PASS .item 17
 PASS .item 18
-FAIL .item 19 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: ltr;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 20 assert_equals:
-<div class="item unsafe" style="writing-mode: horizontal-tb; direction: rtl;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 21 assert_equals:
-<div class="item unsafe" style="writing-mode: veritcal-rl; direction: ltr;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 22 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-rl; direction: rtl;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 23 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: ltr;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
-FAIL .item 24 assert_equals:
-<div class="item unsafe" style="writing-mode: vertical-lr; direction: rtl;" data-offset-y="15"></div>
-offsetTop expected 15 but got -5
+PASS .item 19
+PASS .item 20
+PASS .item 21
+PASS .item 22
+PASS .item 23
+PASS .item 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb-expected.txt
@@ -2,33 +2,21 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item child" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
 FAIL .item 2 assert_equals:
 <div class="container">
   <div class="item child" style="justify-self: stretch; align-self: start;" data-expected-width="40" data-expected-height="40"></div>
 </div>
-height expected 40 but got 50
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item child" style="justify-self: start; align-self: stretch;" data-expected-width="50" data-expected-height="50"></div>
-</div>
-width expected 50 but got 40
+height expected 40 but got 20
+PASS .item 3
 PASS .item 4
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item ar" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 5
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div class="container">
   <div class="item ar" style="justify-self: start; align-self: stretch;" data-expected-width="50" data-expected-height="50"></div>
 </div>
-width expected 50 but got 40
+width expected 50 but got 20
 FAIL .item 8 assert_equals:
 <div class="container">
   <div class="item ar" style="justify-self: stretch; align-self: stretch;" data-expected-width="40" data-expected-height="50"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl-expected.txt
@@ -2,32 +2,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: stretch; align-self: start;" data-expected-width="40" data-expected-height="40"></div>
-</div>
-height expected 40 but got 50
+PASS .item 1
+PASS .item 2
 FAIL .item 3 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: start; align-self: stretch;" data-expected-width="50" data-expected-height="50"></div>
 </div>
-width expected 50 but got 40
+width expected 50 but got 20
 PASS .item 4
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item ar" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 50
+PASS .item 5
 FAIL .item 6 assert_equals:
 <div class="container">
   <div class="item ar" style="justify-self: stretch; align-self: start;" data-expected-width="40" data-expected-height="40"></div>
 </div>
-width expected 40 but got 50
+width expected 40 but got 20
 PASS .item 7
 FAIL .item 8 assert_equals:
 <div class="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb-expected.txt
@@ -2,32 +2,20 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 40
-FAIL .item 2 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: stretch; align-self: start;" data-expected-width="50" data-expected-height="50"></div>
-</div>
-width expected 50 but got 40
+PASS .item 1
+PASS .item 2
 FAIL .item 3 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: start; align-self: stretch;" data-expected-width="40" data-expected-height="40"></div>
 </div>
-height expected 40 but got 50
+height expected 40 but got 20
 PASS .item 4
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item ar" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 5
 FAIL .item 6 assert_equals:
 <div class="container">
   <div class="item ar" style="justify-self: stretch; align-self: start;" data-expected-width="50" data-expected-height="50"></div>
 </div>
-width expected 50 but got 40
+width expected 50 but got 20
 PASS .item 7
 FAIL .item 8 assert_equals:
 <div class="container">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl-expected.txt
@@ -2,33 +2,21 @@
 
 
 
-FAIL .item 1 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 40
+PASS .item 1
 FAIL .item 2 assert_equals:
 <div class="container">
   <div class="item" style="justify-self: stretch; align-self: start;" data-expected-width="50" data-expected-height="50"></div>
 </div>
-width expected 50 but got 40
-FAIL .item 3 assert_equals:
-<div class="container">
-  <div class="item" style="justify-self: start; align-self: stretch;" data-expected-width="40" data-expected-height="40"></div>
-</div>
-height expected 40 but got 50
+width expected 50 but got 20
+PASS .item 3
 PASS .item 4
-FAIL .item 5 assert_equals:
-<div class="container">
-  <div class="item ar" style="justify-self: start; align-self: start;" data-expected-width="20" data-expected-height="20"></div>
-</div>
-width expected 20 but got 50
+PASS .item 5
 PASS .item 6
 FAIL .item 7 assert_equals:
 <div class="container">
   <div class="item ar" style="justify-self: start; align-self: stretch;" data-expected-width="40" data-expected-height="40"></div>
 </div>
-width expected 40 but got 50
+width expected 40 but got 20
 FAIL .item 8 assert_equals:
 <div class="container">
   <div class="item ar" style="justify-self: stretch; align-self: stretch;" data-expected-width="40" data-expected-height="50"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-basic-expected.txt
@@ -21,9 +21,9 @@ FAIL most-block-size --bottom, --top, --left, --right | --left assert_equals: of
 PASS most-inline-size --left-sweep, --bottom-sweep | --left-sweep
 PASS most-inline-size --bottom-sweep, --left-sweep | --bottom-sweep
 PASS most-block-size --left-sweep, --bottom-sweep | --left-sweep
-FAIL most-block-size --bottom-sweep, --left-sweep | --left-sweep assert_equals: offsetLeft expected 110 but got 150
+FAIL most-block-size --bottom-sweep, --left-sweep | --left-sweep assert_equals: offsetLeft expected 110 but got 205
 FAIL most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep assert_equals: offsetLeft expected 110 but got 300
-FAIL most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep assert_equals: offsetLeft expected 150 but got 300
+FAIL most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep assert_equals: offsetLeft expected 205 but got 300
 FAIL most-inline-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
@@ -31,5 +31,5 @@ FAIL most-inline-size
 FAIL most-block-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --right assert_equals: offsetTop expected 0 but got 200
+   | --right assert_equals: offsetTop expected 0 but got 255
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment-expected.txt
@@ -1,15 +1,15 @@
 
 PASS , justify-self:start;align-self:start, justify-self:start;align-self:start, ltr, horizontal-tb
-PASS flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb
-PASS flip-block, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb
-PASS flip-block flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb
-PASS flip-start, justify-self:start;align-self:end, justify-self:end;align-self:start, ltr, horizontal-tb
-PASS flip-block flip-start, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb
-PASS flip-inline flip-start, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb
-PASS flip-block flip-inline flip-start, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb
-PASS flip-inline, justify-self:left;align-self:start, justify-self:right;align-self:start, ltr, horizontal-tb
-PASS flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, horizontal-tb
-PASS flip-start, justify-self:right;align-self:start, justify-self:start;align-self:self-end, ltr, horizontal-tb
+FAIL flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-block, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb assert_equals: offsetTop expected 360 but got 0
+FAIL flip-block flip-inline, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-start, justify-self:start;align-self:end, justify-self:end;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-block flip-start, justify-self:start;align-self:start, justify-self:end;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-inline flip-start, justify-self:start;align-self:start, justify-self:start;align-self:end, ltr, horizontal-tb assert_equals: offsetTop expected 360 but got 0
+FAIL flip-block flip-inline flip-start, justify-self:start;align-self:start, justify-self:end;align-self:end, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-inline, justify-self:left;align-self:start, justify-self:right;align-self:start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-start, justify-self:right;align-self:start, justify-self:start;align-self:self-end, ltr, horizontal-tb assert_equals: offsetLeft expected 0 but got 360
 PASS , justify-self:start
 PASS , justify-self:end
 PASS , justify-self:self-start
@@ -36,6 +36,6 @@ FAIL flip-block, align-self:self-start assert_equals: expected "self-end" but go
 FAIL flip-block, align-self:self-end assert_equals: expected "self-start" but got "self-end"
 FAIL flip-block, align-self:flex-start assert_equals: expected "flex-end" but got "flex-start"
 FAIL flip-block, align-self:flex-end assert_equals: expected "flex-start" but got "flex-end"
-PASS flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, vertical-rl
-PASS flip-start, justify-self:left;align-self:start, justify-self:start;align-self:self-end, rtl, horizontal-tb
+FAIL flip-start, justify-self:left;align-self:end, justify-self:end;align-self:self-start, ltr, vertical-rl assert_equals: offsetLeft expected 360 but got 0
+FAIL flip-start, justify-self:left;align-self:start, justify-self:start;align-self:self-end, rtl, horizontal-tb assert_equals: offsetLeft expected 360 but got 0
 

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp
@@ -30,6 +30,72 @@
 
 namespace WebCore {
 
+LayoutUnit StyleSelfAlignmentData::adjustmentFromStartEdge(LayoutUnit extraSpace, ItemPosition alignmentPosition, LogicalBoxAxis containerAxis, WritingMode containerWritingMode, WritingMode selfWritingMode)
+{
+    ASSERT(ItemPosition::Auto != alignmentPosition);
+
+    switch (alignmentPosition) {
+    case ItemPosition::Normal:
+    case ItemPosition::Stretch:
+    case ItemPosition::Start:
+    case ItemPosition::FlexStart:
+        return 0_lu;
+
+    case ItemPosition::Center:
+    case ItemPosition::AnchorCenter:
+        return extraSpace / 2;
+
+    case ItemPosition::End:
+    case ItemPosition::FlexEnd:
+        return extraSpace;
+
+    case ItemPosition::SelfStart:
+        if (LogicalBoxAxis::Inline == containerAxis)
+            return containerWritingMode.isInlineMatchingAny(selfWritingMode) ? 0_lu : extraSpace;
+        return containerWritingMode.isBlockMatchingAny(selfWritingMode) ? 0_lu : extraSpace;
+    case ItemPosition::SelfEnd:
+        if (LogicalBoxAxis::Inline == containerAxis)
+            return containerWritingMode.isInlineMatchingAny(selfWritingMode) ? extraSpace : 0_lu;
+        return containerWritingMode.isBlockMatchingAny(selfWritingMode) ? extraSpace : 0_lu;
+
+    case ItemPosition::Left:
+        if (LogicalBoxAxis::Inline == containerAxis)
+            return containerWritingMode.isBidiLTR() ? 0_lu : extraSpace;
+        return containerWritingMode.isBlockLeftToRight() ? 0_lu : extraSpace;
+
+    case ItemPosition::Right:
+        if (LogicalBoxAxis::Inline == containerAxis)
+            return containerWritingMode.isBidiLTR() ? extraSpace : 0_lu;
+        return containerWritingMode.isBlockLeftToRight() ? extraSpace : 0_lu;
+
+    case ItemPosition::Baseline:
+        // Self-start if self block axis; else fall back to start.
+        if (!selfWritingMode.isOrthogonal(containerWritingMode)) {
+            if (LogicalBoxAxis::Inline == containerAxis)
+                return 0_lu;
+            return containerWritingMode.isBlockOpposing(selfWritingMode) ? extraSpace : 0_lu;
+        }
+        if (LogicalBoxAxis::Inline == containerAxis) // Self block axis.
+            return containerWritingMode.isInlineMatchingAny(selfWritingMode) ? 0_lu : extraSpace;
+        return 0_lu;
+
+    case ItemPosition::LastBaseline:
+        // Self-end if self block axis; else fall back to end.
+        if (!selfWritingMode.isOrthogonal(containerWritingMode)) {
+            if (LogicalBoxAxis::Inline == containerAxis)
+                return extraSpace;
+            return containerWritingMode.isBlockOpposing(selfWritingMode) ? 0_lu : extraSpace;
+        }
+        if (LogicalBoxAxis::Inline == containerAxis) // Self block axis.
+            return containerWritingMode.isInlineMatchingAny(selfWritingMode) ? extraSpace : 0_lu;
+        return extraSpace;
+
+    default:
+        ASSERT_NOT_REACHED();
+        return 0_lu;
+    }
+}
+
 TextStream& operator<<(TextStream& ts, const StyleSelfAlignmentData& o)
 {
     return ts << o.position() << " " << o.positionType() << " " << o.overflow();

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -55,6 +55,10 @@ public:
     ItemPositionType positionType() const { return static_cast<ItemPositionType>(m_positionType); }
     OverflowAlignment overflow() const { return static_cast<OverflowAlignment>(m_overflow); }
 
+    // Must resolve Auto before calling. Normal treated as Start.
+    // Returns position adjustment from container's start edge.
+    static LayoutUnit adjustmentFromStartEdge(LayoutUnit extraSpace, ItemPosition alignmentPosition, LogicalBoxAxis containerAxis, WritingMode containerWritingMode, WritingMode selfWritingMode);
+
     friend bool operator==(const StyleSelfAlignmentData&, const StyleSelfAlignmentData&) = default;
 
 private:


### PR DESCRIPTION
#### 88b4bea020234d7fd33e88acbb82d580a46130c0
<pre>
Support alignment properties (align-self/justify-self) in absolute positioned layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=288531">https://bugs.webkit.org/show_bug.cgi?id=288531</a>
<a href="https://rdar.apple.com/145689547">rdar://145689547</a>

Reviewed by Alan Baradlay.

Add basic support for align-self/justify-self in absolutely positioned layout.
Also fix some orthogonal flow coordinate stuff covered by those tests.

* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-htb-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vlr-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/align-self-vrl-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-htb-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vlr-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-ltr-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/justify-self-vrl-rtl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-align-self-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-vlr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/safe-justify-self-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-htb-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-htb-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-align/abspos/stretch-intrinsic-size-vrl-vrl-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/try-tactic-alignment-expected.txt:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::PositionedLayoutConstraints::containingCoordsAreFlipped const):
(WebCore::RenderBox::PositionedLayoutConstraints::captureInsets):
(WebCore::RenderBox::PositionedLayoutConstraints::resolvePosition const):
(WebCore::RenderBox::PositionedLayoutConstraints::resolveAlignmentAdjustment const):
(WebCore::RenderBox::computePositionedLogicalWidth const):
(WebCore::RenderBox::PositionedLayoutConstraints::convertLogicalLeftValue const):
(WebCore::RenderBox::computePositionedLogicalWidthUsing const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::computePositionedLogicalWidthReplaced const):
(WebCore::RenderBox::computeAnchorCenteredPosition const):
* Source/WebCore/rendering/style/StyleSelfAlignmentData.cpp:
(WebCore::StyleSelfAlignmentData::adjustmentFromStartEdge):
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:

Canonical link: <a href="https://commits.webkit.org/291417@main">https://commits.webkit.org/291417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9cf31a75472f96247575fc98b0a741d73943705

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12280 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97724 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43240 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20732 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70999 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28427 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83938 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51325 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1570 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79505 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99746 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80001 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20032 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79303 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12795 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19765 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24941 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19452 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->