### PR TITLE
[Cocoa] Adopt CASpatialAudioExperience for WebAudio

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5980,6 +5980,7 @@ PreferSpatialAudioExperience:
     WebCore:
       default: false
   defaultsOverridable: true
+  sharedPreferenceForWebProcess: true
 
 PrivateClickMeasurementDebugModeEnabled:
   type: bool

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -633,8 +633,14 @@ void AudioContext::pageMutedStateDidChange()
 #if PLATFORM(IOS_FAMILY)
 void AudioContext::sceneIdentifierDidChange()
 {
-    if (document() && document()->page())
-        destination().setSceneIdentifier(document()->page()->sceneIdentifier());
+    RefPtr document = this->document();
+    if (!document)
+        return;
+
+    if (RefPtr page = document->page()) {
+        ALWAYS_LOG(LOGIDENTIFIER, page->sceneIdentifier());
+        destination().setSceneIdentifier(page->sceneIdentifier());
+    }
 }
 
 const String& AudioContext::sceneIdentifier() const

--- a/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
+++ b/Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp
@@ -34,6 +34,7 @@
 #include "AudioNodeInput.h"
 #include "AudioWorklet.h"
 #include "AudioWorkletMessagingProxy.h"
+#include "Document.h"
 #include "Logging.h"
 #include "MediaStrategy.h"
 #include "PlatformStrategies.h"
@@ -116,12 +117,11 @@ void DefaultAudioDestinationNode::createDestination()
 {
     ALWAYS_LOG(LOGIDENTIFIER, "contextSampleRate = ", sampleRate(), ", hardwareSampleRate = ", AudioDestination::hardwareSampleRate());
     ASSERT(!m_destination);
-    m_destination = platformStrategies()->mediaStrategy().createAudioDestination(*this, m_inputDeviceId, m_numberOfInputChannels, channelCount(), sampleRate());
-
+    m_destination = platformStrategies()->mediaStrategy().createAudioDestination({ *this, m_inputDeviceId, m_numberOfInputChannels, channelCount(), sampleRate()
 #if PLATFORM(IOS_FAMILY)
-    if (m_destination)
-        m_destination->setSceneIdentifier(String { context().sceneIdentifier() });
+        , context().sceneIdentifier()
 #endif
+        });
 }
 
 void DefaultAudioDestinationNode::recreateDestination()

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9312,6 +9312,7 @@ void HTMLMediaElement::visibilityAdjustmentStateDidChange()
 void HTMLMediaElement::sceneIdentifierDidChange()
 {
     if (RefPtr page = document().page()) {
+        ALWAYS_LOG(LOGIDENTIFIER, page->sceneIdentifier());
         if (RefPtr player = m_player)
             player->setSceneIdentifier(page->sceneIdentifier());
     }

--- a/Source/WebCore/platform/MediaStrategy.h
+++ b/Source/WebCore/platform/MediaStrategy.h
@@ -37,11 +37,12 @@ class MediaRecorderPrivateWriter;
 class MediaRecorderPrivateWriterListener;
 class NowPlayingManager;
 
+struct AudioDestinationCreationOptions;
+
 class WEBCORE_EXPORT MediaStrategy {
 public:
 #if ENABLE(WEB_AUDIO)
-    virtual Ref<AudioDestination> createAudioDestination(
-        AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) = 0;
+    virtual Ref<AudioDestination> createAudioDestination(const AudioDestinationCreationOptions&) = 0;
 #endif
     virtual std::unique_ptr<NowPlayingManager> createNowPlayingManager() const;
     void resetMediaEngines();

--- a/Source/WebCore/platform/audio/AudioDestination.h
+++ b/Source/WebCore/platform/audio/AudioDestination.h
@@ -45,11 +45,23 @@ namespace WebCore {
 // The audio hardware periodically calls the AudioIOCallback render() method asking it to render/output the next render quantum of audio.
 // It optionally will pass in local/live audio input when it calls render().
 
+struct AudioDestinationCreationOptions {
+    AudioIOCallback& callback;
+    const String& inputDeviceId;
+    unsigned numberOfInputChannels;
+    unsigned numberOfOutputChannels;
+    float sampleRate;
+#if PLATFORM(IOS_FAMILY)
+    const String& sceneIdentifier;
+#endif
+};
+
 class AudioDestination : public AbstractRefCounted {
 public:
     // Pass in (numberOfInputChannels > 0) if live/local audio input is desired.
     // Port-specific device identification information for live/local input streams can be passed in the inputDeviceId.
-    WEBCORE_EXPORT static Ref<AudioDestination> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
+    using CreationOptions = AudioDestinationCreationOptions;
+    WEBCORE_EXPORT static Ref<AudioDestination> create(const CreationOptions&);
 
     virtual ~AudioDestination() = default;
 
@@ -76,25 +88,42 @@ public:
 
     void callRenderCallback(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition);
 
+    const String& inputDeviceId() const { return m_inputDeviceId; }
+    unsigned numberOfInputChannels() const { return m_numberOfInputChannels; }
+    unsigned numberOfOutputChannels() const { return m_numberOfOutputChannels; }
+
 #if PLATFORM(IOS_FAMILY)
-    void setSceneIdentifier(const String&) { }
+    const String& sceneIdentifier() const { return m_sceneIdentifier; }
+    virtual void setSceneIdentifier(const String& identifier) { m_sceneIdentifier = identifier; }
 #endif
 
 protected:
-    explicit AudioDestination(AudioIOCallback&, float sampleRate);
+    explicit AudioDestination(const CreationOptions&);
 
     Lock m_callbackLock;
     AudioIOCallback* m_callback WTF_GUARDED_BY_LOCK(m_callbackLock) { nullptr };
 
 private:
-    const float m_sampleRate;
+    String m_inputDeviceId;
+    unsigned m_numberOfInputChannels;
+    unsigned m_numberOfOutputChannels;
+    float m_sampleRate;
+#if PLATFORM(IOS_FAMILY)
+    String m_sceneIdentifier;
+#endif
 };
 
-inline AudioDestination::AudioDestination(AudioIOCallback& callback, float sampleRate)
-    : m_sampleRate(sampleRate)
+inline AudioDestination::AudioDestination(const CreationOptions& options)
+    : m_inputDeviceId { options.inputDeviceId }
+    , m_numberOfInputChannels { options.numberOfInputChannels }
+    , m_numberOfOutputChannels { options.numberOfOutputChannels }
+    , m_sampleRate { options.sampleRate }
+#if PLATFORM(IOS_FAMILY)
+    , m_sceneIdentifier { options.sceneIdentifier }
+#endif
 {
     Locker locker { m_callbackLock };
-    m_callback = &callback;
+    m_callback = &options.callback;
 }
 
 inline void AudioDestination::clearCallback()

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.cpp
@@ -38,15 +38,15 @@ namespace WebCore {
 
 constexpr size_t fifoSize = 96 * AudioUtilities::renderQuantumSize;
 
-AudioDestinationResampler::AudioDestinationResampler(AudioIOCallback& callback, unsigned numberOfOutputChannels, float inputSampleRate, float outputSampleRate)
-    : AudioDestination(callback, inputSampleRate)
-    , m_outputBus(AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize, false).releaseNonNull())
-    , m_renderBus(AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull())
-    , m_fifo(numberOfOutputChannels, fifoSize)
+AudioDestinationResampler::AudioDestinationResampler(const CreationOptions& options, float outputSampleRate)
+    : AudioDestination(options)
+    , m_outputBus(AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, false).releaseNonNull())
+    , m_renderBus(AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull())
+    , m_fifo(options.numberOfOutputChannels, fifoSize)
 {
-    if (inputSampleRate != outputSampleRate) {
-        double scaleFactor = static_cast<double>(inputSampleRate) / outputSampleRate;
-        m_resampler = makeUnique<MultiChannelResampler>(scaleFactor, numberOfOutputChannels, AudioUtilities::renderQuantumSize, [this](AudioBus* bus, size_t framesToProcess) {
+    if (options.sampleRate != outputSampleRate) {
+        double scaleFactor = static_cast<double>(options.sampleRate) / outputSampleRate;
+        m_resampler = makeUnique<MultiChannelResampler>(scaleFactor, options.numberOfOutputChannels, AudioUtilities::renderQuantumSize, [this](AudioBus* bus, size_t framesToProcess) {
             ASSERT_UNUSED(framesToProcess, framesToProcess == AudioUtilities::renderQuantumSize);
             callRenderCallback(nullptr, bus, AudioUtilities::renderQuantumSize, m_outputTimestamp);
         });

--- a/Source/WebCore/platform/audio/AudioDestinationResampler.h
+++ b/Source/WebCore/platform/audio/AudioDestinationResampler.h
@@ -41,7 +41,7 @@ class MultiChannelResampler;
 // The subclass should use m_outputBus to access the rendering.
 class AudioDestinationResampler : public AudioDestination {
 public:
-    WEBCORE_EXPORT AudioDestinationResampler(AudioIOCallback&, unsigned numberOfOutputChannels, float inputSampleRate, float outputSampleRate);
+    WEBCORE_EXPORT AudioDestinationResampler(const CreationOptions&, float outputSampleRate);
     WEBCORE_EXPORT virtual ~AudioDestinationResampler();
 
     WEBCORE_EXPORT void start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&&) final;

--- a/Source/WebCore/platform/audio/SharedAudioDestination.cpp
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.cpp
@@ -40,8 +40,9 @@ namespace WebCore {
 
 class SharedAudioDestinationAdapter : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<SharedAudioDestinationAdapter>, public AudioIOCallback {
 public:
+    using CreationOptions = AudioDestinationCreationOptions;
     using AudioDestinationCreationFunction = SharedAudioDestination::AudioDestinationCreationFunction;
-    static Ref<SharedAudioDestinationAdapter> ensureAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction);
+    static Ref<SharedAudioDestinationAdapter> ensureAdapter(const CreationOptions&, AudioDestinationCreationFunction&& ensureFunction);
     ~SharedAudioDestinationAdapter();
 
     void addRenderer(SharedAudioDestination&, CompletionHandler<void(bool)>&&);
@@ -57,12 +58,22 @@ public:
         return protectedDestination()->outputLatency();
     }
 
+#if PLATFORM(IOS_FAMILY)
+    const String& sceneIdentifier() const { return m_sceneIdentifier; }
+#endif
+
+    AudioDestinationCreationFunction takeEnsureFunction() { return WTFMove(m_ensureFunction); }
+
 private:
+#if PLATFORM(IOS_FAMILY)
+    using AdapterKey = std::tuple<unsigned, float, String>;
+#else
     using AdapterKey = std::tuple<unsigned, float>;
-    using AdapterMap = UncheckedKeyHashMap<AdapterKey, ThreadSafeWeakPtr<SharedAudioDestinationAdapter>>;
+#endif
+    using AdapterMap = HashMap<AdapterKey, ThreadSafeWeakPtr<SharedAudioDestinationAdapter>>;
     static AdapterMap& sharedMap();
 
-    SharedAudioDestinationAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&&);
+    SharedAudioDestinationAdapter(const CreationOptions&, AudioDestinationCreationFunction&&);
 
     void render(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition& outputPosition) final;
     void isPlayingDidChange() final { }
@@ -75,8 +86,13 @@ private:
     unsigned m_numberOfOutputChannels;
     float m_sampleRate;
 
+#if PLATFORM(IOS_FAMILY)
+    String m_sceneIdentifier { emptyString() };
+#endif
+
     Ref<AudioDestination> m_destination;
     Ref<AudioBus> m_workBus;
+    AudioDestinationCreationFunction m_ensureFunction;
 
     bool m_started { false };
 
@@ -98,32 +114,45 @@ auto SharedAudioDestinationAdapter::sharedMap() -> AdapterMap&
     return map;
 }
 
-Ref<SharedAudioDestinationAdapter> SharedAudioDestinationAdapter::ensureAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
+Ref<SharedAudioDestinationAdapter> SharedAudioDestinationAdapter::ensureAdapter(const CreationOptions& options, AudioDestinationCreationFunction&& ensureFunction)
 {
-    std::tuple key { numberOfOutputChannels, sampleRate };
+    std::tuple key { options.numberOfOutputChannels, options.sampleRate
+#if PLATFORM(IOS_FAMILY)
+        , options.sceneIdentifier.isNull() ? emptyString() : options.sceneIdentifier
+#endif
+    };
     auto results = sharedMap().find(key);
     if (results != sharedMap().end()) {
         if (RefPtr existingAdapter = results->value.get())
             return existingAdapter.releaseNonNull();
     }
 
-    Ref newAdapter = adoptRef(*new SharedAudioDestinationAdapter(numberOfOutputChannels, sampleRate, WTFMove(ensureFunction)));
+    Ref newAdapter = adoptRef(*new SharedAudioDestinationAdapter(options, WTFMove(ensureFunction)));
     auto weakAdapter = ThreadSafeWeakPtr<SharedAudioDestinationAdapter> { newAdapter.get() };
     sharedMap().set(key, WTFMove(weakAdapter));
     return newAdapter;
 }
 
-SharedAudioDestinationAdapter::SharedAudioDestinationAdapter(unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
-    : m_numberOfOutputChannels { numberOfOutputChannels }
-    , m_sampleRate { sampleRate }
-    , m_destination { ensureFunction(*this) }
-    , m_workBus { AudioBus::create(numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull() }
+SharedAudioDestinationAdapter::SharedAudioDestinationAdapter(const CreationOptions& options, AudioDestinationCreationFunction&& ensureFunction)
+    : m_numberOfOutputChannels { options.numberOfOutputChannels }
+    , m_sampleRate { options.sampleRate }
+    , m_destination { ensureFunction({ *this, options.inputDeviceId, options.numberOfInputChannels, options.numberOfOutputChannels, options.sampleRate
+#if PLATFORM(IOS_FAMILY)
+        , options.sceneIdentifier.isNull() ? emptyString() : options.sceneIdentifier
+#endif
+        }) }
+    , m_workBus { AudioBus::create(options.numberOfOutputChannels, AudioUtilities::renderQuantumSize).releaseNonNull() }
+    , m_ensureFunction { WTFMove(ensureFunction) }
 {
 }
 
 SharedAudioDestinationAdapter::~SharedAudioDestinationAdapter()
 {
-    auto key = std::make_tuple(m_numberOfOutputChannels, m_sampleRate);
+    auto key = std::make_tuple(m_numberOfOutputChannels, m_sampleRate
+#if PLATFORM(IOS_FAMILY)
+        , m_sceneIdentifier
+#endif
+        );
     sharedMap().remove(key);
     protectedDestination()->clearCallback();
 }
@@ -221,14 +250,14 @@ void SharedAudioDestinationAdapter::render(AudioBus* sourceBus, AudioBus* destin
         destinationBus->sumFrom(protectedWorkBus);
     }
 }
-Ref<SharedAudioDestination> SharedAudioDestination::create(AudioIOCallback& callback, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
+Ref<SharedAudioDestination> SharedAudioDestination::create(const CreationOptions& options, AudioDestinationCreationFunction&& ensureFunction)
 {
-    return adoptRef(*new SharedAudioDestination(callback, numberOfOutputChannels, sampleRate, WTFMove(ensureFunction)));
+    return adoptRef(*new SharedAudioDestination(options, WTFMove(ensureFunction)));
 }
 
-SharedAudioDestination::SharedAudioDestination(AudioIOCallback& callback, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&& ensureFunction)
-    : AudioDestination(callback, sampleRate)
-    , m_outputAdapter(SharedAudioDestinationAdapter::ensureAdapter(numberOfOutputChannels, sampleRate, WTFMove(ensureFunction)))
+SharedAudioDestination::SharedAudioDestination(const CreationOptions& options, AudioDestinationCreationFunction&& ensureFunction)
+    : AudioDestination(options)
+    , m_outputAdapter(SharedAudioDestinationAdapter::ensureAdapter(options, WTFMove(ensureFunction)))
 {
 }
 
@@ -305,6 +334,49 @@ void SharedAudioDestination::sharedRender(AudioBus* sourceBus, AudioBus* destina
         semaphore.wait();
     }
 }
+
+#if PLATFORM(IOS_FAMILY)
+class NullAudioIOCallback final : public AudioIOCallback {
+public:
+    static NullAudioIOCallback& singleton()
+    {
+        static NeverDestroyed<NullAudioIOCallback> callback;
+        return callback.get();
+    }
+private:
+    void render(AudioBus*, AudioBus*, size_t, const AudioIOPosition&) final { }
+    void isPlayingDidChange() final { }
+};
+
+void SharedAudioDestination::setSceneIdentifier(const String& identifier)
+{
+    if (protectedOutputAdapter()->sceneIdentifier() == identifier)
+        return;
+
+    // We need to re-create the outputAdapter when the sceneIdentifier
+    // changes, as the adapter may be shared with other destinations
+    // whose sceneIdentifier is _not_ changing.
+    auto ensureFunction = protectedOutputAdapter()->takeEnsureFunction();
+    bool wasPlaying = isPlaying();
+
+    if (wasPlaying)
+        protectedOutputAdapter()->removeRenderer(*this, [] (bool) { });
+
+    m_outputAdapter = SharedAudioDestinationAdapter::ensureAdapter({
+        NullAudioIOCallback::singleton(),
+        inputDeviceId(),
+        numberOfInputChannels(),
+        numberOfOutputChannels(),
+        sampleRate(),
+#if PLATFORM(IOS_FAMILY)
+        identifier,
+#endif
+    }, WTFMove(ensureFunction));
+
+    if (wasPlaying)
+        protectedOutputAdapter()->addRenderer(*this, [] (bool) { });
+}
+#endif
 
 Ref<SharedAudioDestinationAdapter> SharedAudioDestination::protectedOutputAdapter() const
 {

--- a/Source/WebCore/platform/audio/SharedAudioDestination.h
+++ b/Source/WebCore/platform/audio/SharedAudioDestination.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUDIO)
 
 #include "AudioDestination.h"
+#include "PageIdentifier.h"
 
 namespace WebCore {
 
@@ -35,8 +36,8 @@ class SharedAudioDestinationAdapter;
 
 class SharedAudioDestination final : public AudioDestination, public ThreadSafeRefCounted<SharedAudioDestination, WTF::DestructionThread::Main> {
 public:
-    using AudioDestinationCreationFunction = Function<Ref<AudioDestination>(AudioIOCallback&)>;
-    WEBCORE_EXPORT static Ref<SharedAudioDestination> create(AudioIOCallback&, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&&);
+    using AudioDestinationCreationFunction = Function<Ref<AudioDestination>(const CreationOptions&)>;
+    WEBCORE_EXPORT static Ref<SharedAudioDestination> create(const CreationOptions&, AudioDestinationCreationFunction&&);
     WEBCORE_EXPORT virtual ~SharedAudioDestination();
 
     void ref() const final { return ThreadSafeRefCounted::ref(); }
@@ -45,7 +46,7 @@ public:
     void sharedRender(AudioBus* sourceBus, AudioBus* destinationBus, size_t framesToProcess, const AudioIOPosition&);
 
 private:
-    SharedAudioDestination(AudioIOCallback&, unsigned numberOfOutputChannels, float sampleRate, AudioDestinationCreationFunction&&);
+    SharedAudioDestination(const CreationOptions&, AudioDestinationCreationFunction&&);
 
     // AudioDestination
     void start(Function<void(Function<void()>&&)>&& dispatchToRenderThread, CompletionHandler<void(bool)>&&) final;
@@ -53,6 +54,9 @@ private:
     bool isPlaying() final { return m_isPlaying; }
     unsigned framesPerBuffer() const final;
     MediaTime outputLatency() const final;
+#if PLATFORM(IOS_FAMILY)
+    void setSceneIdentifier(const String&) final;
+#endif
 
     void setIsPlaying(bool);
 

--- a/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h
@@ -40,12 +40,12 @@ class AudioBus;
 class MultiChannelResampler;
 class PushPullFIFO;
 
-using CreateAudioDestinationCocoaOverride = Ref<AudioDestination>(*)(AudioIOCallback&, float sampleRate);
+using CreateAudioDestinationCocoaOverride = Ref<AudioDestination>(*)(const AudioDestinationCreationOptions&);
 
 // An AudioDestination using CoreAudio's default output AudioUnit
 class AudioDestinationCocoa : public AudioDestinationResampler, public AudioUnitRenderer, public ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main> {
 public:
-    WEBCORE_EXPORT AudioDestinationCocoa(AudioIOCallback&, unsigned numberOfOutputChannels, float sampleRate);
+    WEBCORE_EXPORT AudioDestinationCocoa(const CreationOptions&);
     WEBCORE_EXPORT virtual ~AudioDestinationCocoa();
     void ref() const final { return ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main>::ref(); }
     void deref() const final { return ThreadSafeRefCounted<AudioDestinationCocoa, WTF::DestructionThread::Main>::deref(); }
@@ -56,7 +56,11 @@ protected:
     WEBCORE_EXPORT OSStatus render(double sampleTime, uint64_t hostTime, UInt32 numberOfFrames, AudioBufferList* ioData) final;
 
 private:
-    friend Ref<AudioDestination> AudioDestination::create(AudioIOCallback&, const String&, unsigned, unsigned, float);
+    friend Ref<AudioDestination> AudioDestination::create(const CreationOptions&);
+
+#if PLATFORM(IOS_FAMILY)
+    void setSceneIdentifier(const String&) override;
+#endif
 
     void startRendering(CompletionHandler<void(bool)>&&) override;
     void stopRendering(CompletionHandler<void(bool)>&&) override;
@@ -64,6 +68,9 @@ private:
 
     AudioOutputUnitAdaptor m_audioOutputUnitAdaptor;
 
+#if PLATFORM(IOS_FAMILY)
+    String m_sceneIdentifier;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp
@@ -80,6 +80,17 @@ size_t AudioOutputUnitAdaptor::outputLatency() const
     return 0;
 }
 
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+void AudioOutputUnitAdaptor::setSpatialAudioExperience(CASpatialAudioExperience *experience)
+{
+    UInt32 size = sizeof(experience);
+    OSStatus result = PAL::AudioUnitSetProperty(m_outputUnit, kAudioOutputUnitProperty_IntendedSpatialExperience, kAudioUnitScope_Global, 0, (void *)experience, size);
+    if (result != noErr)
+        RELEASE_LOG(Media, "ERROR: Failed to set kAudioOutputUnitProperty_IntendedSpatialExperience with error: %ld", static_cast<long>(result));
+}
+#endif
+
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUDIO)

--- a/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.h
@@ -29,6 +29,8 @@
 
 #include <AudioUnit/AudioUnit.h>
 
+OBJC_CLASS CASpatialAudioExperience;
+
 namespace WebCore {
 
 class AudioUnitRenderer {
@@ -47,6 +49,10 @@ public:
     WEBCORE_EXPORT OSStatus stop();
 
     WEBCORE_EXPORT size_t outputLatency() const;
+
+#if HAVE(SPATIAL_AUDIO_EXPERIENCE)
+    WEBCORE_EXPORT void setSpatialAudioExperience(CASpatialAudioExperience *);
+#endif
 
 private:
     static OSStatus inputProc(void* userData, AudioUnitRenderActionFlags*, const AudioTimeStamp*, UInt32 busNumber, UInt32 numberOfFrames, AudioBufferList* ioData);

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm
@@ -62,6 +62,9 @@ RetainPtr<CASpatialAudioExperience> createSpatialAudioExperienceWithOptions(cons
     }
 
     // Either not visible, or with no layer or target:
+    if (options.sceneIdentifier.isEmpty())
+        return nil;
+
     RetainPtr anchoring = adoptNS([[CASceneAnchoringStrategy alloc] initWithSceneIdentifier:options.sceneIdentifier]);
     return adoptNS([[CAHeadTrackedSpatialAudio alloc] initWithSoundStageSize:toCASoundStageSize(options.soundStageSize) anchoringStrategy:anchoring.get()]);
 }

--- a/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
+++ b/Source/WebCore/platform/audio/gstreamer/AudioDestinationGStreamer.h
@@ -28,7 +28,7 @@ namespace WebCore {
 
 class AudioDestinationGStreamer : public AudioDestination, public RefCounted<AudioDestinationGStreamer> {
 public:
-    AudioDestinationGStreamer(AudioIOCallback&, unsigned long numberOfOutputChannels, float sampleRate);
+    AudioDestinationGStreamer(const CreationOptions&);
     virtual ~AudioDestinationGStreamer();
 
     void ref() const final { return RefCounted<AudioDestinationGStreamer>::ref(); }

--- a/Source/WebCore/platform/mock/MockAudioDestinationCocoa.cpp
+++ b/Source/WebCore/platform/mock/MockAudioDestinationCocoa.cpp
@@ -39,8 +39,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MockAudioDestinationCocoa);
 
 const int kRenderBufferSize = 128;
 
-MockAudioDestinationCocoa::MockAudioDestinationCocoa(AudioIOCallback& callback, float sampleRate)
-    : AudioDestinationCocoa(callback, 2, sampleRate)
+MockAudioDestinationCocoa::MockAudioDestinationCocoa(const CreationOptions& options)
+    : AudioDestinationCocoa(options)
     , m_workQueue(WorkQueue::create("MockAudioDestinationCocoa Render Queue"_s))
     , m_timer(RunLoop::current(), this, &MockAudioDestinationCocoa::tick)
 {

--- a/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
+++ b/Source/WebCore/platform/mock/MockAudioDestinationCocoa.h
@@ -39,12 +39,12 @@ class AudioIOCallback;
 class MockAudioDestinationCocoa final : public AudioDestinationCocoa {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(MockAudioDestinationCocoa, WEBCORE_EXPORT);
 public:
-    static Ref<AudioDestination> create(AudioIOCallback& callback, float sampleRate)
+    static Ref<AudioDestination> create(const CreationOptions& options)
     {
-        return adoptRef(*new MockAudioDestinationCocoa(callback, sampleRate));
+        return adoptRef(*new MockAudioDestinationCocoa(options));
     }
 
-    WEBCORE_EXPORT MockAudioDestinationCocoa(AudioIOCallback&, float sampleRate);
+    WEBCORE_EXPORT MockAudioDestinationCocoa(const CreationOptions&);
     WEBCORE_EXPORT virtual ~MockAudioDestinationCocoa();
 
 private:

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -39,6 +39,7 @@
 #include <wtf/WeakRef.h>
 
 #if PLATFORM(COCOA)
+#include <WebCore/AudioOutputUnitAdaptor.h>
 #include "SharedCARingBuffer.h"
 #endif
 
@@ -79,6 +80,9 @@ private:
     void stopAudioDestination(RemoteAudioDestinationIdentifier, CompletionHandler<void(bool)>&&);
 #if PLATFORM(COCOA)
     void audioSamplesStorageChanged(RemoteAudioDestinationIdentifier, ConsumerSharedCARingBuffer::Handle&&);
+#endif
+#if PLATFORM(IOS_FAMILY)
+    void setSceneIdentifier(RemoteAudioDestinationIdentifier, String&&);
 #endif
 
     HashMap<RemoteAudioDestinationIdentifier, UniqueRef<RemoteAudioDestination>> m_audioDestinations;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in
@@ -37,6 +37,9 @@ messages -> RemoteAudioDestinationManager {
 #if PLATFORM(COCOA)
     AudioSamplesStorageChanged(WebKit::RemoteAudioDestinationIdentifier identifier, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle)
 #endif
+#if PLATFORM(IOS_FAMILY)
+    SetSceneIdentifier(WebKit::RemoteAudioDestinationIdentifier identifier, String sceneIdentifier);
+#endif
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -44,6 +44,7 @@
 #if PLATFORM(COCOA)
 namespace WebCore {
 class WebAudioBufferList;
+struct AudioDestinationCreationOptions;
 }
 #endif
 
@@ -54,9 +55,10 @@ class RemoteAudioDestinationProxy : public WebCore::AudioDestinationResampler, p
 public:
     using AudioIOCallback = WebCore::AudioIOCallback;
 
-    static Ref<RemoteAudioDestinationProxy> create(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
+    using CreationOptions = WebCore::AudioDestinationCreationOptions;
+    static Ref<RemoteAudioDestinationProxy> create(const CreationOptions&);
 
-    RemoteAudioDestinationProxy(AudioIOCallback&, const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate);
+    RemoteAudioDestinationProxy(const CreationOptions&);
     ~RemoteAudioDestinationProxy();
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
@@ -78,6 +80,10 @@ private:
 
     uint32_t totalFrameCount() const;
 
+#if PLATFORM(IOS_FAMILY)
+    void setSceneIdentifier(const String&) final;
+#endif
+
     Markable<RemoteAudioDestinationIdentifier> m_destinationID; // Call destinationID() getter to make sure the destinationID is valid.
 
     static uint8_t s_realtimeThreadCount;
@@ -95,6 +101,9 @@ private:
     unsigned m_numberOfInputChannels;
     float m_remoteSampleRate;
     size_t m_audioUnitLatency;
+#if PLATFORM(IOS_FAMILY)
+    String m_sceneIdentifier;
+#endif
 
     RefPtr<Thread> m_renderThread;
     RefPtr<WebCore::SharedMemory> m_frameCount;

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp
@@ -53,17 +53,16 @@ using namespace WebCore;
 WebMediaStrategy::~WebMediaStrategy() = default;
 
 #if ENABLE(WEB_AUDIO)
-Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(WebCore::AudioIOCallback& callback, const String& inputDeviceId,
-    unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate)
+Ref<WebCore::AudioDestination> WebMediaStrategy::createAudioDestination(const WebCore::AudioDestinationCreationOptions& options)
 {
     ASSERT(isMainRunLoop());
 #if ENABLE(GPU_PROCESS)
     if (m_useGPUProcess)
-        return WebCore::SharedAudioDestination::create(callback, numberOfOutputChannels, sampleRate, [inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate] (WebCore::AudioIOCallback& callback) {
-            return RemoteAudioDestinationProxy::create(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate);
+        return WebCore::SharedAudioDestination::create(options, [] (auto& options) {
+            return RemoteAudioDestinationProxy::create(options);
         });
 #endif
-    return WebCore::AudioDestination::create(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate);
+    return WebCore::AudioDestination::create(options);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
+++ b/Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h
@@ -42,8 +42,7 @@ private:
     bool isWebMediaStrategy() const final { return true; }
 
 #if ENABLE(WEB_AUDIO)
-    Ref<WebCore::AudioDestination> createAudioDestination(WebCore::AudioIOCallback&,
-        const String& inputDeviceId, unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) override;
+    Ref<WebCore::AudioDestination> createAudioDestination(const WebCore::AudioDestinationCreationOptions&) override;
 #endif
     std::unique_ptr<WebCore::NowPlayingManager> createNowPlayingManager() const final;
     bool hasThreadSafeMediaSourceSupport() const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm
@@ -69,10 +69,9 @@ PasteboardStrategy* WebPlatformStrategies::createPasteboardStrategy()
 class WebMediaStrategy final : public MediaStrategy {
 private:
 #if ENABLE(WEB_AUDIO)
-    Ref<AudioDestination> createAudioDestination(AudioIOCallback& callback, const String& inputDeviceId,
-        unsigned numberOfInputChannels, unsigned numberOfOutputChannels, float sampleRate) override
+    Ref<AudioDestination> createAudioDestination(const AudioDestinationCreationOptions& options) override
     {
-        return AudioDestination::create(callback, inputDeviceId, numberOfInputChannels, numberOfOutputChannels, sampleRate);
+        return AudioDestination::create(options);
     }
 #endif
 };


### PR DESCRIPTION
#### e69c00275149ab466509f9d5cb8a8634bc80e7a5
<pre>
[Cocoa] Adopt CASpatialAudioExperience for WebAudio
<a href="https://bugs.webkit.org/show_bug.cgi?id=288249">https://bugs.webkit.org/show_bug.cgi?id=288249</a>
<a href="https://rdar.apple.com/145326961">rdar://145326961</a>

Reviewed by Andy Estes.

Add support for creating a CASpatialAudioExperience and attaching that
experience to the CoreAudio AudioOutputUnit used by WebAudio.

The number of parameters taken by various AudioDestination subclasses
and strategies has become burdensome, so rather than add an additional
parameter needed for creating a CASpatialAudioExperience, add a new
AudioDestinationCreationOptions struct and use that struct for the
same purposes.

This new AudioDestinationCreationOptions struct will also contain a
sceneIdentifier used to anchor audio generation to a particular screen
location.

However, most audio on Cocoa ports flows through SharedAudioDestination,
which muxes that audio together into a single AudioUnit. Add the
spatialIdentifier as a key in the SharedAudioDestination&apos;s internal hash
map, and re-create the destinations adaptor when that destination&apos;s
sceneIdentifier changes.

The sceneIdentifier and preference must be passed through to the GPU
process so that it can be accessed by RemoteAudioDestinationManager.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::sceneIdentifierDidChange):
* Source/WebCore/Modules/webaudio/DefaultAudioDestinationNode.cpp:
(WebCore::DefaultAudioDestinationNode::createDestination):
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::sceneIdentifierDidChange):
* Source/WebCore/platform/MediaStrategy.h:
* Source/WebCore/platform/audio/AudioDestination.h:
(WebCore::AudioDestination::inputDeviceId const):
(WebCore::AudioDestination::numberOfInputChannels const):
(WebCore::AudioDestination::numberOfOutputChannels const):
(WebCore::AudioDestination::sceneIdentifier const):
(WebCore::AudioDestination::setSceneIdentifier):
(WebCore::AudioDestination::AudioDestination):
* Source/WebCore/platform/audio/AudioDestinationResampler.cpp:
(WebCore::AudioDestinationResampler::AudioDestinationResampler):
* Source/WebCore/platform/audio/AudioDestinationResampler.h:
* Source/WebCore/platform/audio/SharedAudioDestination.cpp:
(WebCore::SharedAudioDestinationAdapter::sceneIdentifier const):
(WebCore::SharedAudioDestinationAdapter::takeEnsureFunction):
(WebCore::SharedAudioDestinationAdapter::ensureAdapter):
(WebCore::SharedAudioDestinationAdapter::SharedAudioDestinationAdapter):
(WebCore::SharedAudioDestinationAdapter::~SharedAudioDestinationAdapter):
(WebCore::SharedAudioDestination::create):
(WebCore::SharedAudioDestination::SharedAudioDestination):
(WebCore::SharedAudioDestination::setSceneIdentifier):
* Source/WebCore/platform/audio/SharedAudioDestination.h:
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.cpp:
(WebCore::AudioDestination::create):
(WebCore::AudioDestinationCocoa::AudioDestinationCocoa):
(WebCore::AudioDestinationCocoa::setSceneIdentifier):
* Source/WebCore/platform/audio/cocoa/AudioDestinationCocoa.h:
* Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.cpp:
(WebCore::AudioOutputUnitAdaptor::setSpatialAudioExperience):
* Source/WebCore/platform/audio/cocoa/AudioOutputUnitAdaptor.h:
* Source/WebCore/platform/audio/cocoa/SpatialAudioExperienceHelper.mm:
(WebCore::createSpatialAudioExperienceWithOptions):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::sceneIdentifierDidChange):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateSpatialTrackingLabel):
* Source/WebCore/platform/mediastream/AudioMediaStreamTrackRenderer.h:
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.cpp:
(WebCore::AudioTrackPrivateMediaStream::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp:
(WebCore::AudioMediaStreamTrackRendererCocoa::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.h:
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.cpp:
(WebCore::LocalAudioMediaStreamTrackRendererInternalUnit::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererInternalUnit.h:
(WebCore::AudioMediaStreamTrackRendererInternalUnit::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp:
(WebCore::AudioMediaStreamTrackRendererUnit::setSpatialAudioExperience):
(WebCore::AudioMediaStreamTrackRendererUnit::Unit::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mediastream/cocoa/BaseAudioMediaStreamTrackRendererUnit.h:
(WebCore::BaseAudioMediaStreamTrackRendererUnit::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp:
(WebCore::IncomingAudioMediaStreamTrackRendererUnit::setSpatialAudioExperience):
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/mock/MockAudioDestinationCocoa.cpp:
(WebCore::MockAudioDestinationCocoa::MockAudioDestinationCocoa):
* Source/WebCore/platform/mock/MockAudioDestinationCocoa.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.cpp:
(WebKit::RemoteAudioDestinationManager::createAudioDestination):
(WebKit::RemoteAudioDestinationManager::setSceneIdentifier):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.cpp:
(WebKit::RemoteAudioDestinationProxy::create):
(WebKit::RemoteAudioDestinationProxy::RemoteAudioDestinationProxy):
(WebKit::RemoteAudioDestinationProxy::connection):
(WebKit::RemoteAudioDestinationProxy::setSceneIdentifier):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.cpp:
(WebKit::WebMediaStrategy::createAudioDestination):
* Source/WebKit/WebProcess/GPU/media/WebMediaStrategy.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebPlatformStrategies.mm:

Canonical link: <a href="https://commits.webkit.org/291404@main">https://commits.webkit.org/291404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/435bcbd0eef3e661c403931811757cd4f74bf7e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92695 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97686 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43206 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70979 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28416 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9484 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51310 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9176 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42534 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79489 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1594 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99710 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91361 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14538 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79987 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79289 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19671 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-001.html (failure)") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23811 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12761 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14827 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24907 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114009 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19418 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32940 "Found 10 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.default, wasm.yaml/wasm/spec-tests/float_exprs.wast.js.wasm-collect-continuously, wasm.yaml/wasm/stress/ipint-bbq-osr-with-try5.js.wasm-eager, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.default-wasm, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-collect-continuously, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate.js.wasm-slow-memory, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-slow-memory (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->