### PR TITLE
[webkitcorepy.string_utils] Add a function that rounds seconds and minutes.

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py
@@ -92,23 +92,31 @@ def out_of(number, base):
     return '[{}{}/{}]'.format(' ' * (len(base) - len(number)), number, base)
 
 
-def elapsed(seconds):
-    if seconds <= 0:
-        return 'no time'
-    elif seconds < 1:
-        return 'less than a second'
+def elapsed(seconds: float, precision: int = None, shorthand: bool = False):
+    rounded_seconds = round(seconds, ndigits=precision)
+    if seconds < 60:
+        if shorthand:
+            return f'{rounded_seconds}s' if not (rounded_seconds == 0 and seconds > 0) else '<1s'
+        elif precision is None:
+            if seconds <= 0:
+                return 'no time'
+            elif seconds < 1:
+                return 'less than a second'
+        return pluralize(rounded_seconds, 'second')
 
-    seconds = int(round(seconds))
+    seconds = int(seconds)
     minutes = seconds // 60
     hours = minutes // 60
     days = hours // 24
 
+    precise_seconds = (seconds % 60) + round(rounded_seconds - seconds, ndigits=precision)
+
     force = False
     result = ''
-    for value, description in [(days, 'day'), (hours % 24, 'hour'), (minutes % 60, 'minute')]:
+    for value, description, letter in [(days, 'day', 'd'), (hours % 24, 'hour', 'h'), (minutes % 60, 'minute', 'm')]:
         if force or value:
             force = True
-            result += ' ' + pluralize(value, description)
+            result += f'{str(value)}{letter} ' if shorthand else f' {pluralize(value, description)}'
     if force:
-        return result[1:] + ' and ' + pluralize(seconds % 60, 'second')
-    return pluralize(seconds % 60, 'second')
+        return result + f'{precise_seconds}s' if shorthand else f"{result[1:]} and {pluralize(precise_seconds, 'second')}"
+    return pluralize(precise_seconds, 'second')

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py
@@ -83,9 +83,46 @@ class StringUtils(unittest.TestCase):
 
     def test_elapsed(self):
         self.assertEqual(string_utils.elapsed(0), 'no time')
+        self.assertEqual(string_utils.elapsed(0, 2), '0 seconds')
+        self.assertEqual(string_utils.elapsed(0, None, True), '0s')
+        self.assertEqual(string_utils.elapsed(0, 2, True), '0s')
+
         self.assertEqual(string_utils.elapsed(.5), 'less than a second')
+        self.assertEqual(string_utils.elapsed(.5, 1), '0.5 seconds')
+        self.assertEqual(string_utils.elapsed(.5, None, True), '<1s')
+        self.assertEqual(string_utils.elapsed(.5, 1, True), '0.5s')
+
         self.assertEqual(string_utils.elapsed(1), '1 second')
+        self.assertEqual(string_utils.elapsed(1, 2), '1 second')
+        self.assertEqual(string_utils.elapsed(1, None, True), '1s')
+        self.assertEqual(string_utils.elapsed(1, 2, True), '1s')
+
         self.assertEqual(string_utils.elapsed(4), '4 seconds')
+        self.assertEqual(string_utils.elapsed(4, 2), '4 seconds')
+        self.assertEqual(string_utils.elapsed(4, None, True), '4s')
+        self.assertEqual(string_utils.elapsed(4, 2, True), '4s')
+
         self.assertEqual(string_utils.elapsed(74), '1 minute and 14 seconds')
-        self.assertEqual(string_utils.elapsed(3 * 60 * 60), '3 hours 0 minutes and 0 seconds')
-        self.assertEqual(string_utils.elapsed(24 * 60 * 60 + 60 * 60 + 4 * 60 + 5), '1 day 1 hour 4 minutes and 5 seconds')
+        self.assertEqual(string_utils.elapsed(74, 2), '1 minute and 14 seconds')
+        self.assertEqual(string_utils.elapsed(74, None, True), '1m 14s')
+        self.assertEqual(string_utils.elapsed(74, 2, True), '1m 14s')
+
+        self.assertEqual(string_utils.elapsed(3.14159265), '3 seconds')
+        self.assertEqual(string_utils.elapsed(3.14159265, 2), '3.14 seconds')
+        self.assertEqual(string_utils.elapsed(3.14159265, None, True), '3s')
+        self.assertEqual(string_utils.elapsed(3.14159265, 2, True), '3.14s')
+
+        self.assertEqual(string_utils.elapsed(97.8459703), '1 minute and 38 seconds')
+        self.assertEqual(string_utils.elapsed(97.8459703, 2), '1 minute and 37.85 seconds')
+        self.assertEqual(string_utils.elapsed(97.8459703, None, True), '1m 38s')
+        self.assertEqual(string_utils.elapsed(97.8459703, 2, True), '1m 37.85s')
+
+        self.assertEqual(string_utils.elapsed(3 * 60 * 60 + 5.66), '3 hours 0 minutes and 6 seconds')
+        self.assertEqual(string_utils.elapsed(3 * 60 * 60 + 5.66, 1), '3 hours 0 minutes and 5.7 seconds')
+        self.assertEqual(string_utils.elapsed(3 * 60 * 60 + 5.66, None, True), '3h 0m 6s')
+        self.assertEqual(string_utils.elapsed(3 * 60 * 60 + 5.66, 1, True), '3h 0m 5.7s')
+
+        self.assertEqual(string_utils.elapsed(24 * 60 * 60 + 60 * 60 + 4 * 60 + 5.65), '1 day 1 hour 4 minutes and 6 seconds')
+        self.assertEqual(string_utils.elapsed(24 * 60 * 60 + 60 * 60 + 4 * 60 + 5.65, 1), '1 day 1 hour 4 minutes and 5.6 seconds')
+        self.assertEqual(string_utils.elapsed(24 * 60 * 60 + 60 * 60 + 4 * 60 + 5.65, None, True), '1d 1h 4m 6s')
+        self.assertEqual(string_utils.elapsed(24 * 60 * 60 + 60 * 60 + 4 * 60 + 5.65, 1, True), '1d 1h 4m 5.6s')


### PR DESCRIPTION
#### 6617ffedc1ede4e9ff869ff483ec876475b2d071
<pre>
[webkitcorepy.string_utils] Add a function that rounds seconds and minutes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=288808">https://bugs.webkit.org/show_bug.cgi?id=288808</a>
<a href="https://rdar.apple.com/145818734">rdar://145818734</a>

Reviewed by NOBODY (OOPS!).

Adds more customizability to the elapsed function in string_utils.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/string_utils.py:
    (elapsed): Adds options for precision (rounding digits) and shorthand.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/string_utils_unittest.py:
    (StringUtils):
    -&gt; (test_elapsed): Add more test cases.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6617ffedc1ede4e9ff869ff483ec876475b2d071

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20734 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70993 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28430 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51324 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/92226 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1630 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42570 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99748 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79998 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/92312 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20034 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79300 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23832 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1142 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12797 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19454 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->