### PR TITLE
[SwiftUI] Provide ability for clients to scroll a WebView using a ScrollPosition

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2461,6 +2461,28 @@ void LocalFrameView::setScrollOffsetWithOptions(const ScrollOffset& scrollOffset
     setCurrentScrollType(oldScrollType);
 }
 
+void LocalFrameView::scrollToEdgeWithOptions(RectEdges<bool> edges, const ScrollPositionChangeOptions& options)
+{
+    LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView::scrollToEdgeWithOptions " << edges << " animated " << (options.animated == ScrollIsAnimated::Yes) << ", clearing anchor");
+
+    ASSERT(std::ranges::count_if(WebCore::allBoxSides, [edges](auto side) { return edges[side]; }) == 1);
+
+    auto currentOffset = scrollOffsetFromPosition(scrollPosition());
+    auto minimumScrollOffset = scrollOffsetFromPosition(minimumScrollPosition());
+    auto maximumScrollOffset = scrollOffsetFromPosition(maximumScrollPosition());
+
+    if (edges.top())
+        currentOffset.setY(minimumScrollOffset.y());
+    else if (edges.left())
+        currentOffset.setX(minimumScrollOffset.x());
+    else if (edges.bottom())
+        currentOffset.setY(maximumScrollOffset.y());
+    else if (edges.right())
+        currentOffset.setX(maximumScrollOffset.x());
+
+    setScrollOffsetWithOptions(currentOffset, options);
+}
+
 void LocalFrameView::setScrollPosition(const ScrollPosition& scrollPosition, const ScrollPositionChangeOptions& options)
 {
     LOG_WITH_STREAM(Scrolling, stream << "LocalFrameView::setScrollPosition " << scrollPosition << " animated " << (options.animated == ScrollIsAnimated::Yes) << ", clearing anchor");

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -268,6 +268,7 @@ public:
     IntRect windowClipRect() const final;
     WEBCORE_EXPORT IntRect windowClipRectForFrameOwner(const HTMLFrameOwnerElement*, bool clipToLayerContents) const;
 
+    WEBCORE_EXPORT void scrollToEdgeWithOptions(WebCore::RectEdges<bool>, const ScrollPositionChangeOptions&);
     WEBCORE_EXPORT void setScrollOffsetWithOptions(const ScrollOffset&, const ScrollPositionChangeOptions&);
     WEBCORE_EXPORT void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions& = ScrollPositionChangeOptions::createProgrammatic()) final;
     void restoreScrollbar();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -364,6 +364,16 @@ static bool shouldRestrictBaseURLSchemes()
     return shouldRestrictBaseURLSchemes;
 }
 
+static WebCore::RectEdges<bool> toRectEdges(_WKRectEdge edges)
+{
+    return {
+        static_cast<bool>(edges & _WKRectEdgeTop),
+        static_cast<bool>(edges & _WKRectEdgeRight),
+        static_cast<bool>(edges & _WKRectEdgeBottom),
+        static_cast<bool>(edges & _WKRectEdgeLeft),
+    };
+}
+
 #if PLATFORM(MAC)
 static uint32_t convertUserInterfaceDirectionPolicy(WKUserInterfaceDirectionPolicy policy)
 {
@@ -5812,6 +5822,11 @@ struct WKWebViewData {
 - (void)_setUseSystemAppearance:(BOOL)useSystemAppearance
 {
     [[_configuration preferences] _setUseSystemAppearance:useSystemAppearance];
+}
+
+- (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated
+{
+    self._protectedPage->scrollToEdge(toRectEdges(edge), animated ? WebCore::ScrollIsAnimated::Yes : WebCore::ScrollIsAnimated::No);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -595,4 +595,6 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 @property (nonatomic, setter=_setAllowsMagnification:) BOOL _allowsMagnification;
 #endif
 
+- (void)_scrollToEdge:(_WKRectEdge)edge animated:(BOOL)animated;
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift
@@ -21,29 +21,28 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-public import SwiftUI
-@_spi(CrossImportOverlay) public import WebKit
+#if ENABLE_SWIFTUI && compiler(>=6.0)
 
-extension EdgeInsets {
-#if canImport(UIKit)
-    init(_ edgeInsets: UIEdgeInsets) {
-        self = EdgeInsets(top: edgeInsets.top, leading: edgeInsets.left, bottom: edgeInsets.bottom, trailing: edgeInsets.right)
+import Foundation
+internal import WebKit_Internal
+
+extension _WKRectEdge {
+    init(_ cocoaEdge: NSDirectionalRectEdge) {
+        var result: _WKRectEdge = []
+        if cocoaEdge.contains(.top) {
+            result.insert(.top)
+        }
+        if cocoaEdge.contains(.leading) {
+            result.insert(.left)
+        }
+        if cocoaEdge.contains(.bottom) {
+            result.insert(.bottom)
+        }
+        if cocoaEdge.contains(.trailing) {
+            result.insert(.right)
+        }
+        self = result
     }
-#else
-    init(_ edgeInsets: NSEdgeInsets) {
-        self = EdgeInsets(top: edgeInsets.top, leading: edgeInsets.left, bottom: edgeInsets.bottom, trailing: edgeInsets.right)
-    }
+}
+
 #endif
-}
-
-extension ScrollGeometry {
-    init(_ geometry: WKScrollGeometryAdapter) {
-        self = ScrollGeometry(contentOffset: geometry.contentOffset, contentSize: geometry.contentSize, contentInsets: EdgeInsets(geometry.contentInsets), containerSize: geometry.containerSize)
-    }
-}
-
-extension Transaction {
-    var isAnimated: Bool {
-        animation != nil && !disablesAnimations
-    }
-}

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -108,6 +108,16 @@ extension WebPageWebView {
         get { self._allowsMagnification }
         set { self._allowsMagnification = newValue }
     }
+
+    @_spi(CrossImportOverlay)
+    public func setContentOffset(_ offset: CGPoint, animated: Bool) {
+        scrollView.setContentOffset(offset, animated: animated)
+    }
+
+    @_spi(CrossImportOverlay)
+    public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
+        self._scroll(to: _WKRectEdge(edge), animated: animated)
+    }
 #else
     @_spi(CrossImportOverlay)
     public var alwaysBounceVertical: Bool {
@@ -131,6 +141,16 @@ extension WebPageWebView {
     public var bouncesHorizontally: Bool {
         get { self._rubberBandingEnabled.contains(.left) && self._rubberBandingEnabled.contains(.right) }
         set { self._rubberBandingEnabled.formUnion([.left, .right]) }
+    }
+
+    @_spi(CrossImportOverlay)
+    public func setContentOffset(_ offset: CGPoint, animated: Bool) {
+        self._setContentOffset(offset, animated: animated)
+    }
+
+    @_spi(CrossImportOverlay)
+    public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
+        self._scroll(to: _WKRectEdge(edge), animated: animated)
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -15317,6 +15317,11 @@ void WebPageProxy::setContentOffset(WebCore::ScrollOffset offset, WebCore::Scrol
     send(Messages::WebPage::SetContentOffset(offset, animated));
 }
 
+void WebPageProxy::scrollToEdge(WebCore::RectEdges<bool> edges, WebCore::ScrollIsAnimated animated)
+{
+    send(Messages::WebPage::ScrollToEdge(edges, animated));
+}
+
 bool WebPageProxy::shouldEnableLockdownMode() const
 {
     return m_configuration->lockdownModeEnabled();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1213,6 +1213,7 @@ public:
     void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
     void scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
     void setContentOffset(WebCore::ScrollPosition, WebCore::ScrollIsAnimated);
+    void scrollToEdge(WebCore::RectEdges<bool>, WebCore::ScrollIsAnimated);
 
 #if PLATFORM(COCOA)
     void windowAndViewFramesChanged(const WebCore::FloatRect& viewFrameInWindowCoordinates, const WebCore::FloatPoint& accessibilityViewCoordinates);

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		07E4BDC72A3A7089000D5509 /* _WKWebViewTextInputNotifications.h in Headers */ = {isa = PBXBuildFile; fileRef = 07E4BDC52A3A7089000D5509 /* _WKWebViewTextInputNotifications.h */; };
 		07E4BDC82A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07E4BDC62A3A7089000D5509 /* _WKWebViewTextInputNotifications.mm */; };
 		07F327F22CB09B74006D9918 /* _WKTextPreview.h in Headers */ = {isa = PBXBuildFile; fileRef = 07F327F02CB085A4006D9918 /* _WKTextPreview.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		07F6B5592D719323009F206D /* _WKRectEdge+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */; };
 		07FAA74B2CE947AA00128360 /* WebPage+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */; };
 		0D4599052C86B00F00435F48 /* WKDigitalCredentialsPicker.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D9D28E72C81473B002CB4C7 /* WKDigitalCredentialsPicker.h */; };
 		0DD656D42C8F0A4400278C3B /* DigitalCredentialsCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D20EA1C2C59E2F900CA61BD /* DigitalCredentialsCoordinator.h */; };
@@ -3253,6 +3254,7 @@
 		07EF07592745A8160066EA04 /* DisplayCaptureSessionManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayCaptureSessionManager.h; sourceTree = "<group>"; };
 		07F327F02CB085A4006D9918 /* _WKTextPreview.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKTextPreview.h; sourceTree = "<group>"; };
 		07F327F12CB085A4006D9918 /* _WKTextPreview.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = _WKTextPreview.mm; sourceTree = "<group>"; };
+		07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "_WKRectEdge+Extras.swift"; sourceTree = "<group>"; };
 		07FAA74A2CE947AA00128360 /* WebPage+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebPage+Navigation.swift"; sourceTree = "<group>"; };
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		089C1667FE841158C02AAC07 /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -11788,6 +11790,7 @@
 				5790A6772567A0CD0077C5A7 /* _WKPublicKeyCredentialRequestOptions.mm */,
 				5790A65C25679C110077C5A7 /* _WKPublicKeyCredentialUserEntity.h */,
 				5790A65D25679C110077C5A7 /* _WKPublicKeyCredentialUserEntity.mm */,
+				07F6B5582D719323009F206D /* _WKRectEdge+Extras.swift */,
 				F4DADD102BABB619008B398F /* _WKRectEdge.h */,
 				A55BA80C1BA12BE1007CD33D /* _WKRemoteWebInspectorViewController.h */,
 				A55BA80D1BA12BE1007CD33D /* _WKRemoteWebInspectorViewController.mm */,
@@ -20068,6 +20071,7 @@
 				5790A65B25679B260077C5A7 /* _WKPublicKeyCredentialRelyingPartyEntity.mm in Sources */,
 				5790A6792567A0CD0077C5A7 /* _WKPublicKeyCredentialRequestOptions.mm in Sources */,
 				5790A65F25679C110077C5A7 /* _WKPublicKeyCredentialUserEntity.mm in Sources */,
+				07F6B5592D719323009F206D /* _WKRectEdge+Extras.swift in Sources */,
 				49FBEFFD239B011D00BD032F /* _WKResourceLoadStatisticsFirstParty.mm in Sources */,
 				49FBEFFF239B012F00BD032F /* _WKResourceLoadStatisticsThirdParty.mm in Sources */,
 				5CA26D83217AD1B800F97A35 /* _WKWarningView.mm in Sources */,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9537,6 +9537,18 @@ void WebPage::setContentOffset(WebCore::ScrollOffset offset, WebCore::ScrollIsAn
     frameView->setScrollOffsetWithOptions(offset, options);
 }
 
+void WebPage::scrollToEdge(WebCore::RectEdges<bool> edges, WebCore::ScrollIsAnimated animated)
+{
+    RefPtr frameView = localMainFrameView();
+    if (!frameView)
+        return;
+
+    auto options = WebCore::ScrollPositionChangeOptions::createProgrammatic();
+    options.animated = animated;
+
+    frameView->scrollToEdgeWithOptions(edges, options);
+}
+
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(VIDEO)
 void WebPage::beginTextRecognitionForVideoInElementFullScreen(const HTMLVideoElement& element)
 {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1443,6 +1443,7 @@ public:
 
     void scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
     void setContentOffset(WebCore::ScrollOffset, WebCore::ScrollIsAnimated);
+    void scrollToEdge(WebCore::RectEdges<bool>, WebCore::ScrollIsAnimated);
 
     void setMinimumSizeForAutoLayout(const WebCore::IntSize&);
     WebCore::IntSize minimumSizeForAutoLayout() const { return m_minimumSizeForAutoLayout; }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -742,6 +742,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
 
     ScrollToRect(WebCore::FloatRect targetRect, WebCore::FloatPoint origin)
     SetContentOffset(WebCore::IntPoint position, enum:bool WebCore::ScrollIsAnimated animated)
+    ScrollToEdge(WebCore::RectEdges<bool> edges, enum:bool WebCore::ScrollIsAnimated animated)
 
     NavigateServiceWorkerClient(WebCore::ScriptExecutionContextIdentifier documentIdentifier, URL url) -> (enum:uint8_t WebCore::ScheduleLocationChangeResult result)
 

--- a/Source/WebKit/_WebKit_SwiftUI/CocoaWebViewAdapter.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/CocoaWebViewAdapter.swift
@@ -92,6 +92,8 @@ class CocoaWebViewAdapter: PlatformView, PlatformTextSearching {
 
     var findContext: FindContext?
 
+    var scrollPosition: ScrollPositionContext?
+
 #if os(macOS)
     // This is called by the Find menu items in the Menu Bar
     @objc(performFindPanelAction:)

--- a/Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift
@@ -24,12 +24,24 @@
 #if ENABLE_SWIFTUI && compiler(>=6.0)
 
 import Foundation
+import SwiftUI
 
 @MainActor
 func onNextMainRunLoop(do body: @escaping @MainActor () -> Void) {
     RunLoop.main.perform(inModes: [.common]) {
         MainActor.assumeIsolated {
             body()
+        }
+    }
+}
+
+extension NSDirectionalRectEdge {
+    init(_ edge: Edge) {
+        self = switch edge {
+        case .top: .top
+        case .leading: .leading
+        case .bottom: .bottom
+        case .trailing: .trailing
         }
     }
 }

--- a/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift
@@ -52,6 +52,9 @@ extension EnvironmentValues {
 
     @Entry
     var webViewOnScrollGeometryChange = OnScrollGeometryChangeContext()
+
+    @Entry
+    var webViewScrollPositionContext = ScrollPositionContext()
 }
 
 extension View {
@@ -127,6 +130,11 @@ extension View {
         action: @escaping (T, T) -> Void
     ) -> some View where T : Hashable {
         modifier(OnScrollGeometryChangeModifier(transform: transform, action: action))
+    }
+
+    @_spi(Private)
+    public func webViewScrollPosition(_ position: Binding<ScrollPosition>) -> some View {
+        environment(\.webViewScrollPositionContext, .init(position: position))
     }
 }
 

--- a/Source/WebKit/_WebKit_SwiftUI/ViewModifierContexts.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/ViewModifierContexts.swift
@@ -77,3 +77,7 @@ struct FindContext {
     var canFind = true
     var canReplace = true
 }
+
+struct ScrollPositionContext {
+    var position: Binding<ScrollPosition>?
+}


### PR DESCRIPTION
#### 618b1ef1bc467c98376d75b330ec744db9572c70
<pre>
[SwiftUI] Provide ability for clients to scroll a WebView using a ScrollPosition
<a href="https://bugs.webkit.org/show_bug.cgi?id=288813">https://bugs.webkit.org/show_bug.cgi?id=288813</a>
<a href="https://rdar.apple.com/145824125">rdar://145824125</a>

Reviewed by Aditya Keerthi.

The existing `ScrollPosition` SwiftUI type in conjunction with the `.scrollPosition` view modifier allow clients to programatically
scroll in the following ways:

1. To a particular point
2. To a particular x or y value
3. To a particular edge
4. To a particular identifiable view

This implements support for (1) and (3) by adding a `.webViewScrollPosition` view modifier. (2) is not currently possible because
the SwiftUI API does not expose these properties. (4) is potentially possible, but out of scope for this PR.

To facilitate this, new functionality is internally added to WebKit to allow scrolling to a particular edge.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToEdgeWithOptions):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKRectEdge+Extras.swift: Copied from Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift.
(_WKRectEdge.result):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
(WebPageWebView.setContentOffset(_:animated:)):
(WebPageWebView.scrollTo(_:animated:)):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _scrollToEdge:animated:]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::scrollToEdge):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::scrollToEdge):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::scrollToEdge):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/_WebKit_SwiftUI/CocoaWebViewAdapter.swift:
(CocoaWebViewAdapter.scrollPosition):
* Source/WebKit/_WebKit_SwiftUI/Foundation+Extras.swift:
* Source/WebKit/_WebKit_SwiftUI/SwiftUI+Extras.swift:
(Transaction.isAnimated):
* Source/WebKit/_WebKit_SwiftUI/View+WebViewModifiers.swift:
(View.webViewScrollPosition(_:)):
* Source/WebKit/_WebKit_SwiftUI/ViewModifierContexts.swift:
(ScrollPositionContext.position):
* Source/WebKit/_WebKit_SwiftUI/WebViewRepresentable.swift:
(WebViewRepresentable.updatePlatformView(_:context:)):
(WebViewCoordinator.update(_:configuration:context:)):
(WebViewCoordinator.updateScrollPosition(_:context:)):
(WebViewCoordinator.updateFindInteraction(_:context:)):
(WebViewCoordinator.update(_:configuration:environment:)): Deleted.
(WebViewCoordinator.updateFindInteraction(_:environment:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/291379@main">https://commits.webkit.org/291379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d36c2cc4bfa114eacf1803c35cd8a3a64b7a931d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92786 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1978 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94836 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20789 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95788 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9225 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19838 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79867 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19664 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/23856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19822 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/22969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->