### PR TITLE
[CoordinatedGraphics] Simplify contents scale handling

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp
@@ -40,7 +40,7 @@ void CoordinatedBackingStore::removeTile(uint32_t id)
     m_tiles.remove(id);
 }
 
-void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect, const IntRect& tileRect, RefPtr<CoordinatedTileBuffer>&& buffer, const IntPoint& offset)
+void CoordinatedBackingStore::updateTile(uint32_t id, const IntRect& sourceRect, const IntRect& tileRect, Ref<CoordinatedTileBuffer>&& buffer, const IntPoint& offset)
 {
     auto it = m_tiles.find(id);
     ASSERT(it != m_tiles.end());
@@ -65,57 +65,29 @@ void CoordinatedBackingStore::paintToTextureMapper(TextureMapper& textureMapper,
         return;
 
     ASSERT(!m_size.isZero());
-    Vector<CoordinatedBackingStoreTile*, 16> tilesToPaint;
-    Vector<CoordinatedBackingStoreTile*, 16> previousTilesToPaint;
-
-    // We have to do this every time we paint, in case the opacity has changed.
-    FloatRect coveredRect;
-    for (auto& tile : m_tiles.values()) {
-        if (!tile.canBePainted())
-            continue;
-
-        if (tile.scale() == m_scale) {
-            tilesToPaint.append(&tile);
-            coveredRect.unite(tile.rect());
-            continue;
-        }
-
-        // Only show the previous tile if the opacity is high, otherwise effect looks like a bug.
-        // We show the previous-scale tile anyway if it doesn't intersect with any current-scale tile.
-        if (opacity < 0.95 && coveredRect.intersects(tile.rect()))
-            continue;
-
-        previousTilesToPaint.append(&tile);
-    }
-
-    // targetRect is on the contents coordinate system, so we must compare two rects on the contents coordinate system.
-    // See CoodinatedBackingStoreProxy.
     FloatRect layerRect = { { }, m_size };
     TransformationMatrix adjustedTransform = transform * TransformationMatrix::rectToRect(layerRect, targetRect);
-
-    auto paintTile = [&](CoordinatedBackingStoreTile& tile) {
+    for (const auto& tile : m_tiles.values()) {
+        ASSERT(tile.scale() == m_scale);
         textureMapper.drawTexture(tile.texture(), tile.rect(), adjustedTransform, opacity, allTileEdgesExposed(layerRect, tile.rect()) ? TextureMapper::AllEdgesExposed::Yes : TextureMapper::AllEdgesExposed::No);
-    };
-
-    for (auto* tile : previousTilesToPaint)
-        paintTile(*tile);
-    for (auto* tile : tilesToPaint)
-        paintTile(*tile);
+    }
 }
 
 void CoordinatedBackingStore::drawBorder(TextureMapper& textureMapper, const Color& borderColor, float borderWidth, const FloatRect& targetRect, const TransformationMatrix& transform)
 {
+    ASSERT(!m_size.isZero());
     FloatRect layerRect = { { }, m_size };
     TransformationMatrix adjustedTransform = transform * TransformationMatrix::rectToRect(layerRect, targetRect);
-    for (auto& tile : m_tiles.values())
+    for (const auto& tile : m_tiles.values())
         textureMapper.drawBorder(borderColor, borderWidth, tile.rect(), adjustedTransform);
 }
 
 void CoordinatedBackingStore::drawRepaintCounter(TextureMapper& textureMapper, int repaintCount, const Color& borderColor, const FloatRect& targetRect, const TransformationMatrix& transform)
 {
+    ASSERT(!m_size.isZero());
     FloatRect layerRect = { { }, m_size };
     TransformationMatrix adjustedTransform = transform * TransformationMatrix::rectToRect(layerRect, targetRect);
-    for (auto& tile : m_tiles.values())
+    for (const auto& tile : m_tiles.values())
         textureMapper.drawNumber(repaintCount, borderColor, tile.rect().location(), adjustedTransform);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h
@@ -41,7 +41,7 @@ public:
 
     void createTile(uint32_t tileID);
     void removeTile(uint32_t tileID);
-    void updateTile(uint32_t tileID, const IntRect&, const IntRect&, RefPtr<CoordinatedTileBuffer>&&, const IntPoint&);
+    void updateTile(uint32_t tileID, const IntRect&, const IntRect&, Ref<CoordinatedTileBuffer>&&, const IntPoint&);
 
     void processPendingUpdates(TextureMapper&);
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -45,10 +45,8 @@ static uint32_t generateTileID()
 
 CoordinatedBackingStoreProxy::Update::~Update() = default;
 
-void CoordinatedBackingStoreProxy::Update::appendUpdate(float scale, Vector<uint32_t>&& tilesToCreate, Vector<TileUpdate>&& tilesToUpdate, Vector<uint32_t>&& tilesToRemove)
+void CoordinatedBackingStoreProxy::Update::appendUpdate(Vector<uint32_t>&& tilesToCreate, Vector<TileUpdate>&& tilesToUpdate, Vector<uint32_t>&& tilesToRemove)
 {
-    m_scale = scale;
-
     // Remove any creations or updates previously registered for tiles that are going to be removed now.
     if (!m_tilesToCreate.isEmpty() || !m_tilesToUpdate.isEmpty()) {
         Vector<uint32_t, 8> createdTilesRemoved;
@@ -100,25 +98,35 @@ CoordinatedBackingStoreProxy::CoordinatedBackingStoreProxy(float contentsScale, 
 
 CoordinatedBackingStoreProxy::~CoordinatedBackingStoreProxy() = default;
 
-bool CoordinatedBackingStoreProxy::setContentsScale(float contentsScale)
+void CoordinatedBackingStoreProxy::reset()
 {
-    if (m_contentsScale == contentsScale)
-        return false;
-
-    m_contentsScale = contentsScale;
     m_coverAreaMultiplier = 2;
     m_pendingTileCreation = false;
     m_contentsRect = { };
     m_visibleRect = { };
     m_coverRect = { };
     m_keepRect = { };
+
+    Vector<uint32_t> tilesToRemove;
+    for (const auto& tile : m_tiles.values())
+        tilesToRemove.append(tile.id);
     m_tiles.clear();
 
     {
         Locker locker { m_update.lock };
         m_update.pending = Update();
+        if (!tilesToRemove.isEmpty())
+            m_update.pending.appendUpdate({ }, { }, WTFMove(tilesToRemove));
     }
+}
 
+bool CoordinatedBackingStoreProxy::setContentsScale(float contentsScale)
+{
+    if (m_contentsScale == contentsScale)
+        return false;
+
+    m_contentsScale = contentsScale;
+    reset();
     return true;
 }
 
@@ -180,7 +188,7 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
     result.add(UpdateResult::TilesChanged);
     {
         Locker locker { m_update.lock };
-        m_update.pending.appendUpdate(m_contentsScale, WTFMove(tilesToCreate), WTFMove(tilesToUpdate), WTFMove(tilesToRemove));
+        m_update.pending.appendUpdate(WTFMove(tilesToCreate), WTFMove(tilesToUpdate), WTFMove(tilesToRemove));
     }
     return result;
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h
@@ -59,16 +59,14 @@ public:
             Ref<CoordinatedTileBuffer> buffer;
         };
 
-        float scale() const { return m_scale; }
         const Vector<uint32_t>& tilesToCreate() const { return m_tilesToCreate; }
         const Vector<TileUpdate>& tilesToUpdate() const { return m_tilesToUpdate; }
         const Vector<uint32_t>& tilesToRemove() const { return m_tilesToRemove; }
 
-        void appendUpdate(float, Vector<uint32_t>&&, Vector<TileUpdate>&&, Vector<uint32_t>&&);
+        void appendUpdate(Vector<uint32_t>&&, Vector<TileUpdate>&&, Vector<uint32_t>&&);
         void waitUntilPaintingComplete();
 
     private:
-        float m_scale { 1 };
         Vector<uint32_t> m_tilesToCreate;
         Vector<TileUpdate> m_tilesToUpdate;
         Vector<uint32_t> m_tilesToRemove;
@@ -129,6 +127,7 @@ private:
 
     CoordinatedBackingStoreProxy(float contentsScale, const IntSize& tileSize);
 
+    void reset();
     void invalidateRegion(const Vector<IntRect, 1>&);
     void createOrDestroyTiles(const IntRect& visibleRect, const IntRect& scaledContentsRect, float coverAreaMultiplier, Vector<uint32_t>& tilesToCreate, Vector<uint32_t>& tilesToRemove);
     std::pair<IntRect, IntRect> computeCoverAndKeepRect() const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h
@@ -35,12 +35,12 @@ public:
     explicit CoordinatedBackingStoreTile(float scale = 1);
     ~CoordinatedBackingStoreTile();
 
-    BitmapTexture& texture() { ASSERT(canBePainted()); return *m_texture; }
+    BitmapTexture& texture() const { ASSERT(canBePainted()); return *m_texture; }
     float scale() const { return m_scale; }
-    const FloatRect& rect() { return m_rect; }
+    const FloatRect& rect() const { return m_rect; }
 
     struct Update {
-        RefPtr<CoordinatedTileBuffer> buffer;
+        Ref<CoordinatedTileBuffer> buffer;
         IntRect sourceRect;
         IntRect tileRect;
         IntPoint bufferOffset;


### PR DESCRIPTION
#### 07ffb1d30ef7746374d77a03a884e5abeb026707
<pre>
[CoordinatedGraphics] Simplify contents scale handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=288820">https://bugs.webkit.org/show_bug.cgi?id=288820</a>

Reviewed by Miguel Gomez.

We currently set the contents scale in the backing store proxy that is
propagated to the tile updates as part of the updates. We don&apos;t need to
keep the scale for every update, since it&apos;s always the same as the
backing store proxy, so we can use the current layer value to resize the
backing store during the composition. Also with the current code we
always create new tiles when the scale changes, so we don&apos;t need the old
code to handle the case of painting tiles with different scales.

* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.cpp:
(WebCore::CoordinatedBackingStore::updateTile):
(WebCore::CoordinatedBackingStore::paintToTextureMapper):
(WebCore::CoordinatedBackingStore::drawBorder):
(WebCore::CoordinatedBackingStore::drawRepaintCounter):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::Update::appendUpdate):
(WebCore::CoordinatedBackingStoreProxy::reset):
(WebCore::CoordinatedBackingStoreProxy::setContentsScale):
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.h:
(WebCore::CoordinatedBackingStoreTile::texture const):
(WebCore::CoordinatedBackingStoreTile::rect const):
(WebCore::CoordinatedBackingStoreTile::texture): Deleted.
(WebCore::CoordinatedBackingStoreTile::rect): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::updateBackingStore):
(WebCore::CoordinatedPlatformLayer::updateContents):
(WebCore::CoordinatedPlatformLayer::flushCompositingState):

Canonical link: <a href="https://commits.webkit.org/291485@main">https://commits.webkit.org/291485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/969ed58638e55ae9078414d622c39f8dbe7c0d31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92660 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43175 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70950 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28395 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51286 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1513 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42498 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99673 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/79965 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79262 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1064 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12726 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14875 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24872 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->