### PR TITLE
Non-unified build fixes, end of February 2025 edition

### DIFF
--- a/Source/WebCore/loader/ResourceMonitorThrottlerHolder.cpp
+++ b/Source/WebCore/loader/ResourceMonitorThrottlerHolder.cpp
@@ -27,6 +27,8 @@
 #include "ResourceMonitorThrottlerHolder.h"
 
 #include "ResourceMonitorThrottler.h"
+#include "SQLiteDatabase.h"
+#include <wtf/CrossThreadCopier.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Seconds.h>

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -36,6 +36,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "LocalFrameViewLayoutContext.h"
+#include "RenderBlockInlines.h"
 #include "RenderButton.h"
 #include "RenderCounter.h"
 #include "RenderDescendantIterator.h"

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -27,6 +27,8 @@
 #include "RenderTreeBuilderInline.h"
 
 #include "RenderBlockFlow.h"
+#include "RenderBlockInlines.h"
+#include "RenderBoxInlines.h"
 #include "RenderChildIterator.h"
 #include "RenderInline.h"
 #include "RenderTable.h"


### PR DESCRIPTION
#### 9c95e83accf041decea600f4442efd6e393163db
<pre>
Non-unified build fixes, end of February 2025 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=288766">https://bugs.webkit.org/show_bug.cgi?id=288766</a>

Unreviewed non-unified build fixes.

* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp: Add missing
  SQLiteDatabase.h and wtf/CrossThreadCopier.h header inclusions.
* Source/WebCore/loader/ResourceMonitorThrottlerHolder.cpp: Add missing
  RenderBlockInlines.h header inclusion.
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp: Add missing
  RenderBlockInlines.h header inclusion.
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp: Add
  missing RenderBlockInlines.h and RenderBoxInlines.h header inclusions.

Canonical link: <a href="https://commits.webkit.org/291319@main">https://commits.webkit.org/291319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5845c4edd8b3c25c5727bc254ef784744087b745

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1842 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97659 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20674 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/70964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9467 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51296 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9157 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42509 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1498 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99684 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19722 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/79972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/19972 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79271 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23791 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14763 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19706 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24883 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19393 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22853 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->