### PR TITLE
[MSE][GStreamer] Fix crash in seek when video is torn down

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -734,6 +734,8 @@ MediaTime MediaPlayerPrivateGStreamer::currentTime() const
 
 void MediaPlayerPrivateGStreamer::setRate(float rate)
 {
+    if (!m_pipeline)
+        return;
     RefPtr player = m_player.get();
 
     float rateClamped = clampTo(rate, -20.0, 20.0);

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -229,6 +229,8 @@ MediaTime MediaPlayerPrivateGStreamerMSE::duration() const
 
 void MediaPlayerPrivateGStreamerMSE::seekToTarget(const SeekTarget& target)
 {
+    if (!m_pipeline)
+        return;
     GST_DEBUG_OBJECT(pipeline(), "Requested seek to %s", target.time.toString().utf8().data());
     doSeek(target, m_playbackRate);
 }


### PR DESCRIPTION
#### 6b895b68961a0128baba0961a788c44db71d535c
<pre>
[MSE][GStreamer] Fix crash in seek when video is torn down
<a href="https://bugs.webkit.org/show_bug.cgi?id=260455">https://bugs.webkit.org/show_bug.cgi?id=260455</a>

Reviewed by Philippe Normand.

This patch fixes a crash in webKitMediaSrcFlushStream() after the
pipeline has been torn down as consequence of the render proxy of the
player becoming inactive.

 # Background

The root cause of the crash is this performance fix:
<a href="https://github.com/WebKit/WebKit/pull/30549">https://github.com/WebKit/WebKit/pull/30549</a> [GStreamer] Paused pipelines
accumulate when scrolling on Reddit pages with many videos

Since that patch, the player is torn down every time its associated
render proxy becomes inactive.

That is particularly helpful in pages with lots of videos the user
scrolls past, but it&apos;s a flawed solution, as tearDown() is
irrecoverable, but the render proxy can become inactive only
temporarily.

 # How the crash happens

This can be observed in the nbcnews.com pages linked in the bug report,
where as you scroll, the video is transplanted from the big widget at
the top to a smaller floating miniplayer.

With the pipeline torn down, WebKitMediaSrc was set to NULL state,
cleared its streams list, and therefore failed to find the stream for
which the flush (consequence of a seek) was requested. WebKit is not
supposed to ever request WebKitMediaSrc to operate on a stream it
doesn&apos;t have, so this causes a crash.

 # Remaining problems

Note however that, even if this patch prevents the crash, the video
still becomes blank afterwards as the pipeline is still (wrongly) torn
down.

Reverting the tearing down logic of the player would unfortunately
regress performance in affected websites such as Reddit, so I&apos;m limiting
the scope of this patch to just preventing the crash.

Going forward, a better mechanism for keeping only a reasonable number
of GStreamer threads (and by extension pipelines) in a page is needed.

Such a mechanism should avoid false positives like the one observed in
nbcnews.com and be able to handle resuming playback after suspension
(the current one is irrecoverable).

 # Other bugs in the same Bugzilla entry

Some of the crashes in the bug report are unrelated to this fix. In
general, flushing and seeking has many moving parts, so most multimedia
bugs involve them in some way, and it can be non-obvious to tell two
bugs apart involving flushing.

Here is a summary of the different bugs I&apos;m aware of from reading and
testing the pages in that Bugzilla entry:

* (Fixed, this patch, appears in the report)
  Crash in webKitMediaSrcFlushStream() after the render proxy is inactive.

* (Not fixed, already mentioned, does not appear in the report)
  Need better logic for player suspension.

* (Already fixed, appears in the report)
  The crashes related to scrolling on the Apple MacBook Air pages were
  fixed by aa09557dfddc2a32fe6c10f9c5e756b9cea48f61.
  In this case the bug related to a different suspension logic that is
  not meant to tear down the pipeline, but due to a bug, it accidentally
  set the pipeline to READY, which causes the WebKitMediaSrc element to
  be torn down -- hence the very similar traceback.

* (Not fixed, does not appear in the report)
  Sometimes video is blank in the Mac Book Air page.
  This is caused by an upstream bug in basetransform, of which vp9parse
  is derived from:
  <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4193">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4193</a>
  baseparse: loses (doesn&apos;t propagate) sticky events after a flush

* (Not fixed, appears in one of the backtraces: gdb.txt 2024-08-09 by Kdwk)
  gst_alpha_combine_unlock_stop: assertion failed: (self-&gt;flushing)
  This crash is reproduced sometimes in the Mac Book Air page.
  It&apos;s caused by an upstream bug in alphacombine:
  <a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4174">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/4174</a>
  alphacombine expects FLUSH_START count to equal FLUSH_STOP count

* (Not reproduced at my end) gst_caps_remove_structure: assertion
  &apos;IS_WRITABLE (caps)&apos; failed.
  <a href="https://bugs.webkit.org/show_bug.cgi?id=260455#c17">https://bugs.webkit.org/show_bug.cgi?id=260455#c17</a>
  Reported by Philippe, happens in vp9parse. Could be related to another
  bug or be its own.

At this point I think it makes sense to close this Bugzilla entry. New
entries can be created for each of the remaining bugs that at this point
we know are different if needed, and for any other ones found thereafter.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::setRate):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::seekToTarget):

Canonical link: <a href="https://commits.webkit.org/291490@main">https://commits.webkit.org/291490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bad50554be4df3a77ddd4c9f549bf24eb509128b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71160 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28579 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9722 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51488 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9416 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42903 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100089 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20116 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14756 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20368 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79486 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13199 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25276 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19787 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23247 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21528 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->