### PR TITLE
Annotate endpoints with ServiceWorkersEnabled

### DIFF
--- a/LayoutTests/http/tests/workers/service/Client-properties-auxiliary.html
+++ b/LayoutTests/http/tests/workers/service/Client-properties-auxiliary.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/Client-properties-subframe.html
+++ b/LayoutTests/http/tests/workers/service/Client-properties-subframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/Client-properties.html
+++ b/LayoutTests/http/tests/workers/service/Client-properties.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope-properties.html
+++ b/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope-properties.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_clients_SameObject.html
+++ b/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_clients_SameObject.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_getRegistration.html
+++ b/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_getRegistration.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_register.html
+++ b/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_register.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_registration_SameObject.html
+++ b/LayoutTests/http/tests/workers/service/ServiceWorkerGlobalScope_registration_SameObject.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/WorkerNavigator_serviceWorker.html
+++ b/LayoutTests/http/tests/workers/service/WorkerNavigator_serviceWorker.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/basic-ServiceWorker-postMessage.https.html
+++ b/LayoutTests/http/tests/workers/service/basic-ServiceWorker-postMessage.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-activate-event.html
+++ b/LayoutTests/http/tests/workers/service/basic-activate-event.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-fetch.https.html
+++ b/LayoutTests/http/tests/workers/service/basic-fetch.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-install-event-waitUntil-multiple-promises.html
+++ b/LayoutTests/http/tests/workers/service/basic-install-event-waitUntil-multiple-promises.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-install-event-waitUntil-reject.html
+++ b/LayoutTests/http/tests/workers/service/basic-install-event-waitUntil-reject.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-install-event-waitUntil-resolve.html
+++ b/LayoutTests/http/tests/workers/service/basic-install-event-waitUntil-resolve.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-install-event.html
+++ b/LayoutTests/http/tests/workers/service/basic-install-event.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-messageport.html
+++ b/LayoutTests/http/tests/workers/service/basic-messageport.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-register-exceptions.html
+++ b/LayoutTests/http/tests/workers/service/basic-register-exceptions.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-register-private.html
+++ b/LayoutTests/http/tests/workers/service/basic-register-private.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useEphemeralSession=true ] -->
+<!-- webkit-test-runner [ useEphemeralSession=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/basic-register.html
+++ b/LayoutTests/http/tests/workers/service/basic-register.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-timeout.https.html
+++ b/LayoutTests/http/tests/workers/service/basic-timeout.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/workers/service/basic-unregister-then-register-again-no-reuse.html
+++ b/LayoutTests/http/tests/workers/service/basic-unregister-then-register-again-no-reuse.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-unregister-then-register-again-reuse.html
+++ b/LayoutTests/http/tests/workers/service/basic-unregister-then-register-again-reuse.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/basic-unregister.https.html
+++ b/LayoutTests/http/tests/workers/service/basic-unregister.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/client-added-to-clients-when-restored-from-page-cache.html
+++ b/LayoutTests/http/tests/workers/service/client-added-to-clients-when-restored-from-page-cache.html
@@ -1,5 +1,5 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
-<!DOCTYPE html>
+<!-- webkit-test-runner [ UsesBackForwardCache=true  ServiceWorkersEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/client-removed-from-clients-while-in-page-cache.html
+++ b/LayoutTests/http/tests/workers/service/client-removed-from-clients-while-in-page-cache.html
@@ -1,5 +1,5 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
-<!DOCTYPE html>
+<!-- webkit-test-runner [ UsesBackForwardCache=true ServiceWorkersEnabled=true ] -->
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/controller-change.html
+++ b/LayoutTests/http/tests/workers/service/controller-change.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/cors-image-fetch.html
+++ b/LayoutTests/http/tests/workers/service/cors-image-fetch.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/getnotifications-stop.html
+++ b/LayoutTests/http/tests/workers/service/getnotifications-stop.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/js-test-pre.js"></script>
 <script src="/resources/gc.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/getnotifications.html
+++ b/LayoutTests/http/tests/workers/service/getnotifications.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/js-test-pre.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>
 <script>

--- a/LayoutTests/http/tests/workers/service/image-fetch.html
+++ b/LayoutTests/http/tests/workers/service/image-fetch.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/indexeddb-cryptokey-put-get.https.html
+++ b/LayoutTests/http/tests/workers/service/indexeddb-cryptokey-put-get.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/install-fails.html
+++ b/LayoutTests/http/tests/workers/service/install-fails.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/interception-from-dedicated-worker-on-reload.html
+++ b/LayoutTests/http/tests/workers/service/interception-from-dedicated-worker-on-reload.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/navigator-serviceWorker-same-object.html
+++ b/LayoutTests/http/tests/workers/service/navigator-serviceWorker-same-object.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="/js-test-resources/js-test.js"></script>

--- a/LayoutTests/http/tests/workers/service/openwindow-from-notification-click.html
+++ b/LayoutTests/http/tests/workers/service/openwindow-from-notification-click.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/js-test-pre.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>
 <script>

--- a/LayoutTests/http/tests/workers/service/other_resources/test.html
+++ b/LayoutTests/http/tests/workers/service/other_resources/test.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/page-cache-service-worker-pending-promise.https.html
+++ b/LayoutTests/http/tests/workers/service/page-cache-service-worker-pending-promise.https.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!-- webkit-test-runner [ UsesBackForwardCache=true ServiceWorkersEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <body>

--- a/LayoutTests/http/tests/workers/service/page-caching.html
+++ b/LayoutTests/http/tests/workers/service/page-caching.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!-- webkit-test-runner [ UsesBackForwardCache=true ServiceWorkersEnabled=true ] -->
 <!DOCTYPE html>
 <html>
 <head>

--- a/LayoutTests/http/tests/workers/service/postmessage-after-sw-process-crash.https.html
+++ b/LayoutTests/http/tests/workers/service/postmessage-after-sw-process-crash.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/postmessage-after-terminate.https.html
+++ b/LayoutTests/http/tests/workers/service/postmessage-after-terminate.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/postmessage-after-terminating-hung-worker.html
+++ b/LayoutTests/http/tests/workers/service/postmessage-after-terminating-hung-worker.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html
+++ b/LayoutTests/http/tests/workers/service/registerServiceWorkerClient-after-network-process-crash.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-clear-redundant-worker.html
+++ b/LayoutTests/http/tests/workers/service/registration-clear-redundant-worker.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-task-queue-scheduling-1.html
+++ b/LayoutTests/http/tests/workers/service/registration-task-queue-scheduling-1.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-updateViaCache-all-importScripts.html
+++ b/LayoutTests/http/tests/workers/service/registration-updateViaCache-all-importScripts.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-updateViaCache-all.html
+++ b/LayoutTests/http/tests/workers/service/registration-updateViaCache-all.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-updateViaCache-imports-importScripts.html
+++ b/LayoutTests/http/tests/workers/service/registration-updateViaCache-imports-importScripts.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-updateViaCache-none-importScripts.html
+++ b/LayoutTests/http/tests/workers/service/registration-updateViaCache-none-importScripts.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/registration-updateViaCache-none.html
+++ b/LayoutTests/http/tests/workers/service/registration-updateViaCache-none.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/resources/cors-image-fetch-iframe.html
+++ b/LayoutTests/http/tests/workers/service/resources/cors-image-fetch-iframe.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <body>
     <img id="image" onload="loadedImage()" onerror="erroredImage()"></img>
     <script>

--- a/LayoutTests/http/tests/workers/service/resources/interception-from-dedicated-worker-on-reload-iframe.html
+++ b/LayoutTests/http/tests/workers/service/resources/interception-from-dedicated-worker-on-reload-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script>

--- a/LayoutTests/http/tests/workers/service/self_registration.html
+++ b/LayoutTests/http/tests/workers/service/self_registration.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/self_registration_update.html
+++ b/LayoutTests/http/tests/workers/service/self_registration_update.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/service-worker-cache-api.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-cache-api.https.html
@@ -1,4 +1,3 @@
-<html>
 <head>
 <script src="resources/sw-test-pre.js"></script>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/tests/workers/service/service-worker-clear.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-clear.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-crossorigin-fetch.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-crossorigin-fetch.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/tests/workers/service/service-worker-download-async-delegates.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-async-delegates.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-download-body.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-body.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-octet-stream-nosniff.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-download-stream.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download-stream.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-download.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-download.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-fetch.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-fetch.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-gc-event.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-gc-event.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-getRegistration.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-getRegistration.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-importScript.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-importScript.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/service-worker-registration-gc-event.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-registration-gc-event.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="resources/sw-test-pre.js"></script>

--- a/LayoutTests/http/tests/workers/service/service-worker-request-with-body.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-request-with-body.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/service-worker-resource-timing.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-resource-timing.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/service-worker-user-timing.https.html
+++ b/LayoutTests/http/tests/workers/service/service-worker-user-timing.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/serviceworker-idb.https.html
+++ b/LayoutTests/http/tests/workers/service/serviceworker-idb.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/serviceworker-websocket.https.html
+++ b/LayoutTests/http/tests/workers/service/serviceworker-websocket.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/serviceworkerclients-claim.https.html
+++ b/LayoutTests/http/tests/workers/service/serviceworkerclients-claim.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/serviceworkerclients-get.https.html
+++ b/LayoutTests/http/tests/workers/service/serviceworkerclients-get.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/serviceworkerclients-matchAll.https.html
+++ b/LayoutTests/http/tests/workers/service/serviceworkerclients-matchAll.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/tests/workers/service/shift-reload-navigation.html
+++ b/LayoutTests/http/tests/workers/service/shift-reload-navigation.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/shownotification-allowed-document.html
+++ b/LayoutTests/http/tests/workers/service/shownotification-allowed-document.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/js-test-pre.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>
 <script>

--- a/LayoutTests/http/tests/workers/service/shownotification-allowed.html
+++ b/LayoutTests/http/tests/workers/service/shownotification-allowed.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/js-test-pre.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>
 <script>

--- a/LayoutTests/http/tests/workers/service/shownotification-denied.html
+++ b/LayoutTests/http/tests/workers/service/shownotification-denied.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/resources/js-test-pre.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>
 <script>

--- a/LayoutTests/http/tests/workers/service/shownotification-invalid-data.html
+++ b/LayoutTests/http/tests/workers/service/shownotification-invalid-data.html
@@ -1,4 +1,4 @@
-<head>
+<head><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <script src="/js-test-resources/js-test.js"></script>
 <script src="/resources/notifications-test-pre.js"></script>
 <script>

--- a/LayoutTests/http/tests/workers/service/tainted-image-fetch.html
+++ b/LayoutTests/http/tests/workers/service/tainted-image-fetch.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/tests/workers/service/worker-fails-to-start.html
+++ b/LayoutTests/http/tests/workers/service/worker-fails-to-start.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/sw-test-pre.js"></script>
 </head>

--- a/LayoutTests/http/wpt/service-workers/about-blank-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/about-blank-iframe.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Event</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html
+++ b/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter.https.html
+++ b/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/cache-control-request.html
+++ b/LayoutTests/http/wpt/service-workers/cache-control-request.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker and Cache Control requests</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
+++ b/LayoutTests/http/wpt/service-workers/cache-mode-hard-reload-serviceworker.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 </head>
 <body>

--- a/LayoutTests/http/wpt/service-workers/check-service-worker-header.https.html
+++ b/LayoutTests/http/wpt/service-workers/check-service-worker-header.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <title>Service Worker Fetch Event</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html
+++ b/LayoutTests/http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <meta charset=utf-8>
 <title></title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/client-properties.https.html
+++ b/LayoutTests/http/wpt/service-workers/client-properties.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/clone-opaque-being-loaded-response.html
+++ b/LayoutTests/http/wpt/service-workers/clone-opaque-being-loaded-response.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker returning an opaque cloned response</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https.html
+++ b/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker-memory-cache.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker.https.html
+++ b/LayoutTests/http/wpt/service-workers/controlled-dedicatedworker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https.html
+++ b/LayoutTests/http/wpt/service-workers/controlled-module-dedicatedworker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/controlled-sharedworker.https.html
+++ b/LayoutTests/http/wpt/service-workers/controlled-sharedworker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/cors-preflight-star.any-serviceworker.html
+++ b/LayoutTests/http/wpt/service-workers/cors-preflight-star.any-serviceworker.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <title>Service Worker: Fetch API CORS preflight tests</title>

--- a/LayoutTests/http/wpt/service-workers/cross-site-navigation-same-cookie-lax.https.html
+++ b/LayoutTests/http/wpt/service-workers/cross-site-navigation-same-cookie-lax.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 </head>
 <body>

--- a/LayoutTests/http/wpt/service-workers/extendableEvent.https.html
+++ b/LayoutTests/http/wpt/service-workers/extendableEvent.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Extendable Event</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-metrics-via-service-worker.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-metrics-via-service-worker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-navigation-preload.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-navigation-preload.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-changing-request.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download-through-direct-preload.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/common/utils.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-download.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/common/utils.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download-and-clone.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/common/utils.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload-use-download.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/common/utils.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-service-worker-preload.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-timeout.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-timeout.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetch-worker-terminate.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetch-worker-terminate.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/fetchEvent.https.html
+++ b/LayoutTests/http/wpt/service-workers/fetchEvent.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Event</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/file-upload.html
+++ b/LayoutTests/http/wpt/service-workers/file-upload.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/form-data-upload.html
+++ b/LayoutTests/http/wpt/service-workers/form-data-upload.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/header-filtering.https.html
+++ b/LayoutTests/http/wpt/service-workers/header-filtering.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <title>Service Worker Header Filtering</title>

--- a/LayoutTests/http/wpt/service-workers/mac/throttleable.https.html
+++ b/LayoutTests/http/wpt/service-workers/mac/throttleable.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ PageVisibilityBasedProcessSuppressionEnabled=true ] -->
+<!doctype html><!-- webkit-test-runner [ PageVisibilityBasedProcessSuppressionEnabled=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/media-range-request.html
+++ b/LayoutTests/http/wpt/service-workers/media-range-request.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/module-meta-url-fragment.https.html
+++ b/LayoutTests/http/wpt/service-workers/module-meta-url-fragment.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Modules Fragment of import.meta.url</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigate-iframes-window-client.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigate-iframes-window-client.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-fetch-worker-terminate.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-iframe-cancel.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Event</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-iframe-site.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-iframe-site.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Event</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-optimization.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-optimization.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-preload-without-worker-connection.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/common/utils.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-redirect-main-frame.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-redirect-main-frame.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker redirections and callbacks</title>
 </head>

--- a/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-redirect-with-hash.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <title>Navigation redirect with hash</title>
 <meta name=timeout content=long>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-redirect.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-redirect.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Event</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/navigation-timing.https.html
+++ b/LayoutTests/http/wpt/service-workers/navigation-timing.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker navigation timing request and response time</title>
 </head>

--- a/LayoutTests/http/wpt/service-workers/no-cors-css-with-subresources.https.html
+++ b/LayoutTests/http/wpt/service-workers/no-cors-css-with-subresources.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/online.https.html
+++ b/LayoutTests/http/wpt/service-workers/online.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/persistent-importScripts.html
+++ b/LayoutTests/http/wpt/service-workers/persistent-importScripts.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/routines.js"></script>
 </head>

--- a/LayoutTests/http/wpt/service-workers/persistent-modules.html
+++ b/LayoutTests/http/wpt/service-workers/persistent-modules.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="resources/routines.js"></script>
 </head>

--- a/LayoutTests/http/wpt/service-workers/postMessage-fetch-order.https.html
+++ b/LayoutTests/http/wpt/service-workers/postMessage-fetch-order.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>message and fetch events order</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<!-- webkit-test-runner [ NotificationEventEnabled=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-async.https.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<!-- webkit-test-runner [ NotificationEventEnabled=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<!-- webkit-test-runner [ NotificationEventEnabled=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https.html
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-sync.https.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ NotificationEventEnabled=true ] -->
+<!-- webkit-test-runner [ NotificationEventEnabled=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/resources/clone-opaque-being-loaded-response-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/resources/clone-opaque-being-loaded-response-iframe.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <body>
 FAIL: body should be replaced when executing the script.
 <script src="/WebKit/resources/lengthy-pass.py"></script>

--- a/LayoutTests/http/wpt/service-workers/resources/create-temp-file-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/resources/create-temp-file-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <body>
 <script src="temp-file-utils.js"></script>

--- a/LayoutTests/http/wpt/service-workers/resources/empty.html
+++ b/LayoutTests/http/wpt/service-workers/resources/empty.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <body>
 </body>
 </html>

--- a/LayoutTests/http/wpt/service-workers/resources/header-filtering-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/resources/header-filtering-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script>

--- a/LayoutTests/http/wpt/service-workers/resources/module-meta-url-fragment.html
+++ b/LayoutTests/http/wpt/service-workers/resources/module-meta-url-fragment.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script>
 globalThis.metaURLs = [];

--- a/LayoutTests/http/wpt/service-workers/resources/navigation-timing-part-2.html
+++ b/LayoutTests/http/wpt/service-workers/resources/navigation-timing-part-2.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker navigation timing request and response time</title>
 </head>

--- a/LayoutTests/http/wpt/service-workers/resources/serviceworker-and-preloads-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/resources/serviceworker-and-preloads-iframe.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 </head>

--- a/LayoutTests/http/wpt/service-workers/resources/third-party-cookie-iframe.html
+++ b/LayoutTests/http/wpt/service-workers/resources/third-party-cookie-iframe.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>

--- a/LayoutTests/http/wpt/service-workers/resources/third-party-registration-frame.html
+++ b/LayoutTests/http/wpt/service-workers/resources/third-party-registration-frame.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
 </head>

--- a/LayoutTests/http/wpt/service-workers/same-cookie-lax.https.html
+++ b/LayoutTests/http/wpt/service-workers/same-cookie-lax.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/server-trust-evaluation.https.html
+++ b/LayoutTests/http/wpt/service-workers/server-trust-evaluation.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker triggering server trust evaluation</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-crashing-while-fetching.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-crashing-while-fetching.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-different-process.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-different-process.https.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-iframe-preload-after-response.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-iframe-preload-after-response.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-iframe-preload.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-iframe-preload.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-match-during-fetch.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-networkprocess-crash.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-networkprocess-crash.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <title>Cache Storage: network process crash</title>

--- a/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-pending-job-cancel.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker cancel pending job</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-preload-when-not-activated.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-preload-when-not-activated.https.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-spinning-activate.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-spinning-activate.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ] -->
+<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-spinning-fetch.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-spinning-fetch.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true dumpJSConsoleLogInStdErr=true ] -->
+<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true dumpJSConsoleLogInStdErr=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-spinning-install.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-spinning-install.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ] -->
+<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-spinning-message.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-spinning-message.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ] -->
+<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-spinning-push.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-spinning-push.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ] -->
+<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html
@@ -1,4 +1,4 @@
-<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ] -->
+<!doctype html><!-- webkit-test-runner [ ShouldUseServiceWorkerShortTimeout=true ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/serviceworker-and-preloads.html
+++ b/LayoutTests/http/wpt/service-workers/serviceworker-and-preloads.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <title>Service Worker Fetch Event</title>

--- a/LayoutTests/http/wpt/service-workers/serviceworker-in-dedicatedworker.https.html
+++ b/LayoutTests/http/wpt/service-workers/serviceworker-in-dedicatedworker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/serviceworker-in-sharedworker.https.html
+++ b/LayoutTests/http/wpt/service-workers/serviceworker-in-sharedworker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/skipFetchEvent.https.html
+++ b/LayoutTests/http/wpt/service-workers/skipFetchEvent.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/http/wpt/service-workers/third-party-cookie.html
+++ b/LayoutTests/http/wpt/service-workers/third-party-cookie.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <title>Service Worker third party cookie setting</title>

--- a/LayoutTests/http/wpt/service-workers/third-party-registration.html
+++ b/LayoutTests/http/wpt/service-workers/third-party-registration.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker third party registration</title>
 <script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>

--- a/LayoutTests/http/wpt/service-workers/update-service-worker.https.html
+++ b/LayoutTests/http/wpt/service-workers/update-service-worker.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker update and interception</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/update-with-importScripts.html
+++ b/LayoutTests/http/wpt/service-workers/update-with-importScripts.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <html>
 <head>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/use-element.https.html
+++ b/LayoutTests/http/wpt/service-workers/use-element.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <title>Service Worker Fetch Event for use element</title>
 <script src="/resources/testharness.js"></script>

--- a/LayoutTests/http/wpt/service-workers/useragent.https.html
+++ b/LayoutTests/http/wpt/service-workers/useragent.https.html
@@ -1,4 +1,4 @@
-<html>
+<html><!-- webkit-test-runner [ ServiceWorkersEnabled=true ] -->
 <head>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp
@@ -278,4 +278,10 @@ void ServiceWorkerDownloadTask::didFailDownload(std::optional<ResourceError>&& e
     });
 }
 
+std::optional<SharedPreferencesForWebProcess> ServiceWorkerDownloadTask::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
+{
+    Ref networkProcess = m_networkProcess;
+    return networkProcess->webProcessConnection(connection)->sharedPreferencesForWebProcess();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h
@@ -65,6 +65,7 @@ public:
     void start();
     void stop() { cancel(); }
 
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const;
 private:
     ServiceWorkerDownloadTask(NetworkSession&, NetworkDataTaskClient&, WebSWServerToContextConnection&, WebCore::ServiceWorkerIdentifier, WebCore::SWServerConnectionIdentifier, WebCore::FetchIdentifier, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& response, DownloadID);
     void startListeningForIPC();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in
@@ -21,9 +21,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    ExceptionForEnabledBy,
     DispatchedFrom=WebContent,
-    DispatchedTo=Networking
+    DispatchedTo=Networking,
+    SharedPreferencesNeedsConnection,
+    EnabledBy=ServiceWorkersEnabled
 ]
 messages -> ServiceWorkerDownloadTask {
     DidFail(WebCore::ResourceError error)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp
@@ -610,6 +610,14 @@ RefPtr<NetworkResourceLoader> ServiceWorkerFetchTask::protectedLoader() const
     return m_loader.get();
 }
 
+std::optional<SharedPreferencesForWebProcess> ServiceWorkerFetchTask::sharedPreferencesForWebProcess() const
+{
+    if (RefPtr swServerConnection = m_swServerConnection.get())
+        return swServerConnection->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
+}
+
 } // namespace WebKit
 
 #undef SWFETCH_RELEASE_LOG

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -60,6 +60,7 @@ class NetworkSession;
 class ServiceWorkerNavigationPreloader;
 class WebSWServerConnection;
 class WebSWServerToContextConnection;
+struct SharedPreferencesForWebProcess;
 
 class ServiceWorkerFetchTask : public RefCountedAndCanMakeWeakPtr<ServiceWorkerFetchTask> {
     WTF_MAKE_TZONE_ALLOCATED(ServiceWorkerFetchTask);
@@ -89,6 +90,8 @@ public:
     bool convertToDownload(DownloadManager&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
 
     MonotonicTime startTime() const;
+
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:
     ServiceWorkerFetchTask(WebSWServerConnection&, NetworkResourceLoader&, WebCore::ResourceRequest&&, WebCore::SWServerConnectionIdentifier, WebCore::ServiceWorkerIdentifier, WebCore::SWServerRegistration&, NetworkSession*, bool isWorkerReady);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=ServiceWorkersEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=ServiceWorkersEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp
@@ -485,5 +485,12 @@ void WebSWServerToContextConnection::reportNetworkUsageToWorkerClient(const WebC
 }
 #endif
 
+std::optional<SharedPreferencesForWebProcess> WebSWServerToContextConnection::sharedPreferencesForWebProcess() const
+{
+    if (auto connectionToWebProcess = m_connection.get())
+        return connectionToWebProcess->sharedPreferencesForWebProcess();
+
+    return std::nullopt;
+}
 #undef MESSAGE_CHECK
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -98,6 +98,7 @@ public:
     void didFinishActivation(WebCore::ServiceWorkerIdentifier);
 
     void terminateIdleServiceWorkers();
+    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void reportNetworkUsageToWorkerClient(const WebCore::ScriptExecutionContextIdentifier, size_t bytesTransferredOverNetworkDelta) final;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 [
-    ExceptionForEnabledBy,
+    EnabledBy=ServiceWorkersEnabled,
     DispatchedFrom=WebContent,
     DispatchedTo=Networking
 ]


### PR DESCRIPTION
#### dba3e8ae31d56f6409fdbdad57fde78a116d7af4
<pre>
Annotate endpoints with ServiceWorkersEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=288829">https://bugs.webkit.org/show_bug.cgi?id=288829</a>
<a href="https://rdar.apple.com/145850966">rdar://145850966</a>

Reviewed by NOBODY (OOPS!).

Annotate endpoints with ServiceWorkersEnabled

* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.cpp:
(WebKit::ServiceWorkerDownloadTask::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerDownloadTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerConnection.messages.in:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dba3e8ae31d56f6409fdbdad57fde78a116d7af4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43378 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20834 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71019 "Found 4 new test failures: http/tests/workers/service/service-worker-download-async-delegates.https.html http/tests/workers/service/service-worker-download-body.https.html http/tests/workers/service/service-worker-download-stream.https.html http/tests/workers/service/service-worker-download.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28453 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1666 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42670 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79549 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99849 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19883 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14594 "Found 2 new test failures: http/tests/workers/service/service-worker-download-stream.https.html http/tests/workers/service/service-worker-download.https.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80040 "Found 3 new test failures: http/tests/workers/service/service-worker-download-body.https.html http/tests/workers/service/service-worker-download-stream.https.html http/tests/workers/service/service-worker-download.https.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79929 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79340 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12909 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25043 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->