### PR TITLE
Implement WebAuthn Signal API

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -775,6 +775,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webaudio/WaveShaperNode.idl
     Modules/webaudio/WaveShaperOptions.idl
 
+    Modules/webauthn/AllAcceptedCredentialsOptions.idl
     Modules/webauthn/AttestationConveyancePreference.idl
     Modules/webauthn/AuthenticationExtensionsClientInputs.idl
     Modules/webauthn/AuthenticationExtensionsClientInputsJSON.idl
@@ -788,6 +789,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webauthn/AuthenticatorSelectionCriteria.idl
     Modules/webauthn/AuthenticatorTransport.idl
     Modules/webauthn/CredentialPropertiesOutput.idl
+    Modules/webauthn/CurrentUserDetailsOptions.idl
     Modules/webauthn/PublicKeyCredential.idl
     Modules/webauthn/PublicKeyCredentialCreationOptions.idl
     Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.idl
@@ -798,12 +800,12 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/webauthn/PublicKeyCredentialRequestOptions.idl
     Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.idl
     Modules/webauthn/PublicKeyCredentialRpEntity.idl
+    Modules/webauthn/PublicKeyCredentialType.idl
     Modules/webauthn/PublicKeyCredentialUserEntity.idl
     Modules/webauthn/PublicKeyCredentialUserEntityJSON.idl
-
-    Modules/webauthn/PublicKeyCredentialType.idl
     Modules/webauthn/RegistrationResponseJSON.idl
     Modules/webauthn/ResidentKeyRequirement.idl
+    Modules/webauthn/UnknownCredentialOptions.idl
     Modules/webauthn/UserVerificationRequirement.idl
 
     Modules/webcodecs/AacEncoderConfig.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -993,6 +993,7 @@ $(PROJECT_DIR)/Modules/webaudio/WebKitAudioPannerNode.idl
 $(PROJECT_DIR)/Modules/webaudio/WebKitDynamicsCompressorNode.idl
 $(PROJECT_DIR)/Modules/webaudio/WebKitOfflineAudioContext.idl
 $(PROJECT_DIR)/Modules/webaudio/WebKitOscillatorNode.idl
+$(PROJECT_DIR)/Modules/webauthn/AllAcceptedCredentialsOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/AttestationConveyancePreference.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticationExtensionsClientInputs.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticationExtensionsClientInputsJSON.idl
@@ -1005,6 +1006,7 @@ $(PROJECT_DIR)/Modules/webauthn/AuthenticatorAttestationResponse.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticatorResponse.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticatorSelectionCriteria.idl
 $(PROJECT_DIR)/Modules/webauthn/AuthenticatorTransport.idl
+$(PROJECT_DIR)/Modules/webauthn/CurrentUserDetailsOptions.idl
 $(PROJECT_DIR)/Modules/webauthn/CredentialPropertiesOutput.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredential.idl
 $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -1022,6 +1024,7 @@ $(PROJECT_DIR)/Modules/webauthn/PublicKeyCredentialUserEntityJSON.idl
 $(PROJECT_DIR)/Modules/webauthn/RegistrationResponseJSON.idl
 $(PROJECT_DIR)/Modules/webauthn/ResidentKeyRequirement.idl
 $(PROJECT_DIR)/Modules/webauthn/UserVerificationRequirement.idl
+$(PROJECT_DIR)/Modules/webauthn/UnknownCredentialOptions.idl
 $(PROJECT_DIR)/Modules/webcodecs/AacEncoderConfig.idl
 $(PROJECT_DIR)/Modules/webcodecs/AudioSampleFormat.idl
 $(PROJECT_DIR)/Modules/webcodecs/AvcEncoderConfig.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -84,6 +84,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAesGcmParams.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAesGcmParams.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAesKeyParams.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAesKeyParams.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAllAcceptedCredentialsOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAllAcceptedCredentialsOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAnalyserNode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAnalyserNode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSAnalyserOptions.cpp
@@ -708,6 +710,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCryptoRsaHashedKeyAlgorithm.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCryptoRsaHashedKeyAlgorithm.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCryptoRsaKeyAlgorithm.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCryptoRsaKeyAlgorithm.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCurrentUserDetailsOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCurrentUserDetailsOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomAnimationOptions.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomAnimationOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCustomEffect.cpp
@@ -3082,6 +3086,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUndoItem.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUndoItem.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUndoManager.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUndoManager.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUnknownCredentialOptions.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUnknownCredentialOptions.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserActivation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserActivation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSUserMessageHandler.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -763,6 +763,9 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webauthn/PublicKeyCredentialType.idl \
     $(WebCore)/Modules/webauthn/ResidentKeyRequirement.idl \
     $(WebCore)/Modules/webauthn/UserVerificationRequirement.idl \
+    $(WebCore)/Modules/webauthn/UnknownCredentialOptions.idl \
+    $(WebCore)/Modules/webauthn/AllAcceptedCredentialsOptions.idl \
+    $(WebCore)/Modules/webauthn/CurrentUserDetailsOptions.idl \
     $(WebCore)/Modules/webcodecs/AacEncoderConfig.idl \
     $(WebCore)/Modules/webcodecs/AudioSampleFormat.idl \
     $(WebCore)/Modules/webcodecs/AvcEncoderConfig.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -624,6 +624,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/web-locks/WebLockMode.h
     Modules/web-locks/WebLockRegistry.h
 
+    Modules/webauthn/AllAcceptedCredentialsOptions.h
     Modules/webauthn/AttestationConveyancePreference.h
     Modules/webauthn/AuthenticationExtensionsClientInputs.h
     Modules/webauthn/AuthenticationExtensionsClientInputsJSON.h
@@ -633,6 +634,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webauthn/AuthenticatorCoordinatorClient.h
     Modules/webauthn/AuthenticatorResponseData.h
     Modules/webauthn/AuthenticatorTransport.h
+    Modules/webauthn/CurrentUserDetailsOptions.h
     Modules/webauthn/PublicKeyCredentialCreationOptions.h
     Modules/webauthn/PublicKeyCredentialCreationOptionsJSON.h
     Modules/webauthn/PublicKeyCredentialDescriptor.h
@@ -641,6 +643,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webauthn/PublicKeyCredentialRequestOptions.h
     Modules/webauthn/PublicKeyCredentialRequestOptionsJSON.h
     Modules/webauthn/PublicKeyCredentialType.h
+    Modules/webauthn/UnknownCredentialOptions.h
     Modules/webauthn/UserVerificationRequirement.h
     Modules/webauthn/WebAuthenticationConstants.h
     Modules/webauthn/WebAuthenticationUtils.h

--- a/Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.h
+++ b/Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+struct AllAcceptedCredentialsOptions {
+    String rpId;
+    String userId;
+    Vector<String> allAcceptedCredentialIds;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.idl
+++ b/Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.idl
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_AUTHN,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary AllAcceptedCredentialsOptions {
+    required DOMString                     rpId;
+    required Base64URLString               userId;
+    required sequence<Base64URLString>     allAcceptedCredentialIds;
+};

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -29,10 +29,12 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "AbortSignal.h"
+#include "AllAcceptedCredentialsOptions.h"
 #include "AuthenticatorAssertionResponse.h"
 #include "AuthenticatorAttestationResponse.h"
 #include "AuthenticatorCoordinatorClient.h"
 #include "AuthenticatorResponseData.h"
+#include "CurrentUserDetailsOptions.h"
 #include "DocumentInlines.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSBasicCredential.h"
@@ -47,6 +49,7 @@
 #include "PublicKeyCredentialRequestOptions.h"
 #include "RegistrableDomain.h"
 #include "LegacySchemeRegistry.h"
+#include "UnknownCredentialOptions.h"
 #include "WebAuthenticationConstants.h"
 #include "WebAuthenticationUtils.h"
 #include <pal/crypto/CryptoDigest.h>
@@ -422,6 +425,67 @@ void AuthenticatorCoordinator::getClientCapabilities(const Document& document, D
     };
 
     m_client->getClientCapabilities(document.securityOrigin(), WTFMove(completionHandler));
+}
+
+void AuthenticatorCoordinator::signalUnknownCredential(const Document& document, UnknownCredentialOptions&& options, DOMPromiseDeferred<void>&& promise)
+{
+    if (!m_client) {
+        promise.reject(Exception { ExceptionCode::UnknownError, "Web Authentication client not present."_s });
+        return;
+    }
+    if (RegistrableDomain::uncheckedCreateFromHost(options.rpId) != RegistrableDomain { document.securityOrigin().data() }) {
+        promise.reject(Exception { ExceptionCode::SecurityError, "The origin of the document is not authorized for the provided RP ID."_s });
+        return;
+    }
+
+    auto completionHandler = [promise = WTFMove(promise)] (std::optional<WebCore::ExceptionData> error) mutable {
+        if (error) {
+            promise.reject(error->toException());
+            return;
+        }
+    };
+    m_client->signalUnknownCredential(document.securityOrigin(), WTFMove(options), WTFMove(completionHandler));
+}
+
+void AuthenticatorCoordinator::signalAllAcceptedCredentials(const Document& document, AllAcceptedCredentialsOptions&& options, DOMPromiseDeferred<void>&& promise)
+{
+    if (!m_client)  {
+        promise.reject(Exception { ExceptionCode::UnknownError, "Web Authentication client not present."_s });
+        return;
+    }
+    if (RegistrableDomain::uncheckedCreateFromHost(options.rpId) != RegistrableDomain { document.securityOrigin().data() }) {
+        promise.reject(Exception { ExceptionCode::SecurityError, "The origin of the document is not authorized for the provided RP ID."_s });
+        return;
+    }
+
+    auto completionHandler = [promise = WTFMove(promise)] (std::optional<WebCore::ExceptionData> error) mutable {
+        if (error) {
+            promise.reject(error->toException());
+            return;
+        }
+    };
+    m_client->signalAllAcceptedCredentials(document.securityOrigin(), WTFMove(options), WTFMove(completionHandler));
+}
+
+void AuthenticatorCoordinator::signalCurrentUserDetails(const Document& document, CurrentUserDetailsOptions&& options, DOMPromiseDeferred<void>&& promise)
+{
+    if (!m_client)  {
+        promise.reject(Exception { ExceptionCode::UnknownError, "Web Authentication client not present."_s });
+        return;
+    }
+    if (RegistrableDomain::uncheckedCreateFromHost(options.rpId) != RegistrableDomain { document.securityOrigin().data() }) {
+        promise.reject(Exception { ExceptionCode::SecurityError, "The origin of the document is not authorized for the provided RP ID."_s });
+        return;
+    }
+
+    auto completionHandler = [promise = WTFMove(promise)] (std::optional<WebCore::ExceptionData> error) mutable {
+        if (error) {
+            promise.reject(error->toException());
+            return;
+        }
+        promise.resolve();
+    };
+    m_client->signalCurrentUserDetails(document.securityOrigin(), WTFMove(options), WTFMove(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEB_AUTHN)
 
 #include "IDLTypes.h"
+#include "PublicKeyCredential.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
@@ -80,6 +81,10 @@ public:
     void isConditionalMediationAvailable(const Document&, DOMPromiseDeferred<IDLBoolean>&&) const;
 
     void getClientCapabilities(const Document&, DOMPromiseDeferred<PublicKeyCredentialClientCapabilities>&&) const;
+
+    void signalUnknownCredential(const Document&, UnknownCredentialOptions&&, DOMPromiseDeferred<void>&&);
+    void signalAllAcceptedCredentials(const Document&, AllAcceptedCredentialsOptions&&, DOMPromiseDeferred<void>&&);
+    void signalCurrentUserDetails(const Document&, CurrentUserDetailsOptions&&, DOMPromiseDeferred<void>&&);
 
 private:
     AuthenticatorCoordinator() = default;

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h
@@ -29,6 +29,7 @@
 
 #include "AuthenticatorCoordinator.h"
 #include "ExceptionData.h"
+#include "PublicKeyCredential.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/WeakPtr.h>
 
@@ -75,6 +76,9 @@ public:
     virtual void isConditionalMediationAvailable(const SecurityOrigin&, QueryCompletionHandler&&) = 0;
     virtual void isUserVerifyingPlatformAuthenticatorAvailable(const SecurityOrigin&, QueryCompletionHandler&&) = 0;
     virtual void getClientCapabilities(const SecurityOrigin&, CapabilitiesCompletionHandler&&) = 0;
+    virtual void signalUnknownCredential(const SecurityOrigin&, UnknownCredentialOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) = 0;
+    virtual void signalAllAcceptedCredentials(const SecurityOrigin&, AllAcceptedCredentialsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) = 0;
+    virtual void signalCurrentUserDetails(const SecurityOrigin&, CurrentUserDetailsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) = 0;
     virtual void cancel(CompletionHandler<void()>&&) = 0;
 };
 

--- a/Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.h
+++ b/Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+struct CurrentUserDetailsOptions {
+    String rpId;
+    String userId;
+    String name;
+    String displayName;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.idl
+++ b/Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.idl
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_AUTHN,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary CurrentUserDetailsOptions {
+    required DOMString                     rpId;
+    required Base64URLString               userId;
+    required DOMString                     name;
+    required DOMString                     displayName;
+};

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp
@@ -28,11 +28,13 @@
 
 #if ENABLE(WEB_AUTHN)
 
+#include "AllAcceptedCredentialsOptions.h"
 #include "AuthenticatorAssertionResponse.h"
 #include "AuthenticatorAttestationResponse.h"
 #include "AuthenticatorCoordinator.h"
 #include "AuthenticatorResponse.h"
 #include "BufferSource.h"
+#include "CurrentUserDetailsOptions.h"
 #include "Document.h"
 #include "JSAuthenticatorAttachment.h"
 #include "JSDOMPromiseDeferred.h"
@@ -44,6 +46,7 @@
 #include "PublicKeyCredentialDescriptorJSON.h"
 #include "PublicKeyCredentialRequestOptionsJSON.h"
 #include "Settings.h"
+#include "UnknownCredentialOptions.h"
 #include "WebAuthenticationUtils.h"
 #include <wtf/text/Base64.h>
 
@@ -292,6 +295,24 @@ ExceptionOr<PublicKeyCredentialRequestOptions> PublicKeyCredential::parseRequest
         options.extensions = extensions.releaseReturnValue();
     }
     return options;
+}
+
+void PublicKeyCredential::signalUnknownCredential(Document& document, UnknownCredentialOptions&& options, DOMPromiseDeferred<void>&& promise)
+{
+    if (auto* page = document.page())
+        page->authenticatorCoordinator().signalUnknownCredential(document, WTFMove(options), WTFMove(promise));
+}
+
+void PublicKeyCredential::signalAllAcceptedCredentials(Document& document, AllAcceptedCredentialsOptions&& options, DOMPromiseDeferred<void>&& promise)
+{
+    if (auto* page = document.page())
+        page->authenticatorCoordinator().signalAllAcceptedCredentials(document, WTFMove(options), WTFMove(promise));
+}
+
+void PublicKeyCredential::signalCurrentUserDetails(Document& document, CurrentUserDetailsOptions&& options, DOMPromiseDeferred<void>&& promise)
+{
+    if (auto* page = document.page())
+        page->authenticatorCoordinator().signalCurrentUserDetails(document, WTFMove(options), WTFMove(promise));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.h
@@ -31,7 +31,6 @@
 #include "BasicCredential.h"
 #include "ExceptionOr.h"
 #include "IDLTypes.h"
-#include "JSPublicKeyCredentialRequestOptions.h"
 #include "RegistrationResponseJSON.h"
 #include <wtf/Forward.h>
 
@@ -48,6 +47,9 @@ struct PublicKeyCredentialCreationOptionsJSON;
 struct PublicKeyCredentialRequestOptions;
 struct PublicKeyCredentialRequestOptionsJSON;
 struct AuthenticationExtensionsClientOutputs;
+struct UnknownCredentialOptions;
+struct AllAcceptedCredentialsOptions;
+struct CurrentUserDetailsOptions;
 
 template<typename IDLType> class DOMPromiseDeferred;
 
@@ -68,6 +70,10 @@ public:
     static ExceptionOr<PublicKeyCredentialCreationOptions> parseCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON&&);
 
     static ExceptionOr<PublicKeyCredentialRequestOptions> parseRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON&&);
+
+    static void signalUnknownCredential(Document&, UnknownCredentialOptions&&, DOMPromiseDeferred<void>&&);
+    static void signalAllAcceptedCredentials(Document&, AllAcceptedCredentialsOptions&&, DOMPromiseDeferred<void>&&);
+    static void signalCurrentUserDetails(Document&, CurrentUserDetailsOptions&&, DOMPromiseDeferred<void>&&);
 
 private:
     PublicKeyCredential(Ref<AuthenticatorResponse>&&);

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredential.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredential.idl
@@ -42,4 +42,8 @@ typedef (RegistrationResponseJSON or AuthenticationResponseJSON) PublicKeyCreden
     [CallWith=CurrentDocument] static Promise<PublicKeyCredentialClientCapabilities> getClientCapabilities();
     static PublicKeyCredentialCreationOptions parseCreationOptionsFromJSON(PublicKeyCredentialCreationOptionsJSON options);
     static PublicKeyCredentialRequestOptions parseRequestOptionsFromJSON(PublicKeyCredentialRequestOptionsJSON options);
+
+    [CallWith=CurrentDocument] static Promise<undefined> signalUnknownCredential(UnknownCredentialOptions options);
+    [CallWith=CurrentDocument] static Promise<undefined> signalAllAcceptedCredentials(AllAcceptedCredentialsOptions options);
+    [CallWith=CurrentDocument] static Promise<undefined> signalCurrentUserDetails(CurrentUserDetailsOptions options);
 };

--- a/Source/WebCore/Modules/webauthn/UnknownCredentialOptions.h
+++ b/Source/WebCore/Modules/webauthn/UnknownCredentialOptions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+struct UnknownCredentialOptions {
+    String rpId;
+    String credentialId;
+};
+
+} // namespace WebCore
+
+#endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/UnknownCredentialOptions.idl
+++ b/Source/WebCore/Modules/webauthn/UnknownCredentialOptions.idl
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=WEB_AUTHN,
+    JSGenerateToJSObject,
+    JSGenerateToNativeObject,
+] dictionary UnknownCredentialOptions {
+    required DOMString                     rpId;
+    required Base64URLString               credentialId;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3497,6 +3497,7 @@ JSAnimationFrameRatePreset.cpp
 JSAnimationPlaybackEvent.cpp
 JSAnimationPlaybackEventInit.cpp
 JSAnimationTimeline.cpp
+JSAllAcceptedCredentialsOptions.cpp
 JSAttestationConveyancePreference.cpp
 JSAttr.cpp
 JSAudioBuffer.cpp
@@ -3708,6 +3709,7 @@ JSCustomEffectCallback.cpp
 JSCustomElementRegistry.cpp
 JSCustomEvent.cpp
 JSCustomStateSet.cpp
+JSCurrentUserDetailsOptions.cpp
 JSDOMApplicationCache.cpp
 JSDOMAudioSession.cpp
 JSDOMCSSCustomPropertyDescriptor.cpp
@@ -4778,6 +4780,7 @@ JSURLSearchParams.cpp
 JSUserActivation.cpp
 JSUndoItem.cpp
 JSUndoManager.cpp
+JSUnknownCredentialOptions.cpp
 JSUserMessageHandler.cpp
 JSUserMessageHandlersNamespace.cpp
 JSUserVerificationRequirement.cpp

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1678,6 +1678,24 @@ struct WebCore::AuthenticationExtensionsClientOutputs {
     int64_t alg;
 };
 
+struct WebCore::UnknownCredentialOptions {
+    String rpId;
+    String credentialId;
+};
+
+struct WebCore::AllAcceptedCredentialsOptions {
+    String rpId;
+    String userId;
+    Vector<String> allAcceptedCredentialIds;
+};
+
+struct WebCore::CurrentUserDetailsOptions {
+    String rpId;
+    String userId;
+    String name;
+    String displayName;
+};
+
 struct WebCore::AuthenticatorSelectionCriteria {
     std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
     std::optional<WebCore::ResidentKeyRequirement> residentKey;

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h
@@ -46,4 +46,4 @@ SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionScrollableItem)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKTextExtractionImageItem)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKSLinearMediaSpatialVideoMetadata)
 SOFT_LINK_CLASS_FOR_HEADER(WebKit, WKStageModeInteractionDriver)
-
+SOFT_LINK_CLASS_FOR_HEADER(WebKit, CredentialUpdaterShim)

--- a/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm
@@ -77,3 +77,4 @@ SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionScrolla
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKTextExtractionImageItem)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKSLinearMediaSpatialVideoMetadata)
 SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, WKStageModeInteractionDriver)
+SOFT_LINK_CLASS_FOR_SOURCE_OPTIONAL(WebKit, WebKitSwift, CredentialUpdaterShim)

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -31,6 +31,7 @@
 #include <WebCore/CredentialRequestOptions.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/MediationRequirement.h>
+#include <WebCore/PublicKeyCredential.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Forward.h>
 #include <wtf/MonotonicTime.h>
@@ -113,6 +114,11 @@ private:
     void isUserVerifyingPlatformAuthenticatorAvailable(const WebCore::SecurityOriginData&, QueryCompletionHandler&&);
     void isConditionalMediationAvailable(const WebCore::SecurityOriginData&, QueryCompletionHandler&&);
     void getClientCapabilities(const WebCore::SecurityOriginData&, CapabilitiesCompletionHandler&&);
+
+    void signalUnknownCredential(const WebCore::SecurityOriginData&, WebCore::UnknownCredentialOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&);
+    void signalAllAcceptedCredentials(const WebCore::SecurityOriginData&, WebCore::AllAcceptedCredentialsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&);
+    void signalCurrentUserDetails(const WebCore::SecurityOriginData&, WebCore::CurrentUserDetailsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&);
+
     void cancel(CompletionHandler<void()>&&);
 
     void handleRequest(WebAuthenticationRequestData&&, RequestCompletionHandler&&);

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in
@@ -36,6 +36,9 @@ messages -> WebAuthenticatorCoordinatorProxy {
     isConditionalMediationAvailable(WebCore::SecurityOriginData origin) -> (bool result)
     IsUserVerifyingPlatformAuthenticatorAvailable(WebCore::SecurityOriginData origin) -> (bool result)
     GetClientCapabilities(WebCore::SecurityOriginData origin) -> (Vector<KeyValuePair<String, bool>> result)
+    SignalUnknownCredential(WebCore::SecurityOriginData origin, struct WebCore::UnknownCredentialOptions options) -> (std::optional<WebCore::ExceptionData> error)
+    SignalAllAcceptedCredentials(WebCore::SecurityOriginData origin, struct WebCore::AllAcceptedCredentialsOptions options) -> (std::optional<WebCore::ExceptionData> error)
+    SignalCurrentUserDetails(WebCore::SecurityOriginData origin, struct WebCore::CurrentUserDetailsOptions options) -> (std::optional<WebCore::ExceptionData> error)
     Cancel() -> ()
 }
 

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
@@ -113,6 +113,22 @@ void WebAuthenticatorCoordinator::getClientCapabilities(const SecurityOrigin& or
     protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetClientCapabilities(origin.data()), WTFMove(handler));
 }
 
+void WebAuthenticatorCoordinator::signalUnknownCredential(const SecurityOrigin& origin, UnknownCredentialOptions&& options, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&& handler)
+{
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalUnknownCredential(origin.data(), WTFMove(options)), WTFMove(handler));
+}
+
+void WebAuthenticatorCoordinator::signalAllAcceptedCredentials(const SecurityOrigin& origin, AllAcceptedCredentialsOptions&& options, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&& handler)
+{
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalAllAcceptedCredentials(origin.data(), WTFMove(options)), WTFMove(handler));
+}
+
+void WebAuthenticatorCoordinator::signalCurrentUserDetails(const SecurityOrigin& origin, CurrentUserDetailsOptions&& options, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&& handler)
+{
+    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalCurrentUserDetails(origin.data(), WTFMove(options)), WTFMove(handler));
+}
+
+
 } // namespace WebKit
 
 #undef WEBAUTHN_RELEASE_LOG_ERROR_NO_FRAME

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
@@ -48,6 +48,9 @@ private:
     void isConditionalMediationAvailable(const WebCore::SecurityOrigin&, WebCore::QueryCompletionHandler&&) final;
     void isUserVerifyingPlatformAuthenticatorAvailable(const WebCore::SecurityOrigin&, WebCore::QueryCompletionHandler&&) final;
     void getClientCapabilities(const WebCore::SecurityOrigin&, WebCore::CapabilitiesCompletionHandler&&) final;
+    void signalUnknownCredential(const WebCore::SecurityOrigin&, WebCore::UnknownCredentialOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) final;
+    void signalAllAcceptedCredentials(const WebCore::SecurityOrigin&, WebCore::AllAcceptedCredentialsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) final;
+    void signalCurrentUserDetails(const WebCore::SecurityOrigin&, WebCore::CurrentUserDetailsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) final;
     void cancel(CompletionHandler<void()>&&) final;
 
     Ref<WebPage> protectedPage() const;


### PR DESCRIPTION
#### 445bbfd2a3de74ce9b57ebbd2ed0d0271c473e5c
<pre>
Implement WebAuthn Signal API
<a href="https://bugs.webkit.org/show_bug.cgi?id=278339">https://bugs.webkit.org/show_bug.cgi?id=278339</a>
<a href="https://rdar.apple.com/problem/134285651">rdar://problem/134285651</a>

Reviewed by Nitin Mahendru.

This patch implements the new WebAuthn signal API. This allows RPs to
tell authenticators what credentials it will accept and also to update
credential information.

We don&apos;t currently mock the information nessesary to write tests for these
methods in LayoutTests.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.h: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebCore/Modules/webauthn/AllAcceptedCredentialsOptions.idl: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinator::signalUnknownCredential):
(WebCore::AuthenticatorCoordinator::signalAllAcceptedCredentials):
(WebCore::AuthenticatorCoordinator::signalCurrentUserDetails):
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.h:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinatorClient.h:
* Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.h: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebCore/Modules/webauthn/CurrentUserDetailsOptions.idl: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebCore/Modules/webauthn/PublicKeyCredential.cpp:
(WebCore::PublicKeyCredential::signalUnknownCredential):
(WebCore::PublicKeyCredential::signalAllAcceptedCredentials):
(WebCore::PublicKeyCredential::signalCurrentUserDetails):
* Source/WebCore/Modules/webauthn/PublicKeyCredential.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredential.idl:
* Source/WebCore/Modules/webauthn/UnknownCredentialOptions.h: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebCore/Modules/webauthn/UnknownCredentialOptions.idl: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.h:
* Source/WebKit/UIProcess/Cocoa/WebKitSwiftSoftLink.mm:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebKitSwift/AuthenticationServices/CredentialUpdaterShim.h: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredential.idl.
* Source/WebKit/WebKitSwift/AuthenticationServices/CredentialUpdaterShim.swift: Added.
(CredentialUpdaterShim.signalUnknownCredential(_:credentialID:)):
(CredentialUpdaterShim.signalAllAcceptedCredentials(_:userHandle:acceptedCredentialIDs:)):
(CredentialUpdaterShim.signalCurrentUserDetails(_:userHandle:newName:)):
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp:
(WebKit::WebAuthenticatorCoordinator::signalUnknownCredential):
(WebKit::WebAuthenticatorCoordinator::signalAllAcceptedCredentials):
(WebKit::WebAuthenticatorCoordinator::signalCurrentUserDetails):
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h:

Canonical link: <a href="https://commits.webkit.org/291458@main">https://commits.webkit.org/291458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7201075b68efd974d18ff4af2ae9e382d2d3284

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43488 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71077 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28494 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84090 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51405 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1726 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42801 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99983 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20014 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80100 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79401 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19718 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23947 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1220 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13046 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25174 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19685 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21426 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->