### PR TITLE
[JSC] `RegExp#[Symbol.search]` should throw `TypeError` when `lastIndex` isn't writable

### DIFF
--- a/JSTests/microbenchmarks/regexp-search-basic.js
+++ b/JSTests/microbenchmarks/regexp-search-basic.js
@@ -1,0 +1,9 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+const re = /foo/;
+for (let i = 0; i < 1e5; i++) {
+    shouldBe(re[Symbol.search]("abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoo"), 78);
+}

--- a/JSTests/stress/regexp-search-lastIndex-writable.js
+++ b/JSTests/stress/regexp-search-lastIndex-writable.js
@@ -1,0 +1,40 @@
+function shouldThrow(run, errorType) {
+    let actual;
+    var hadError = false;
+
+    try {
+        actual = run();
+    } catch (e) {
+        hadError = true;
+        actual = e;
+    }
+
+    if (!hadError)
+        throw new Error("Expected " + run + "() to throw " + errorType.name + ", but did not throw.");
+    if (!(actual instanceof errorType))
+        throw new Error("Expeced " + run + "() to throw " + errorType.name + " , but threw '" + actual + "'");
+}
+
+{
+    const re = /abc/;
+    Object.defineProperty(re, "lastIndex", { value: -1, writable: false });
+    shouldThrow(() => {
+        re[Symbol.search]("a")
+    }, TypeError);
+}
+
+{
+    const re = /abc/g;
+    Object.defineProperty(re, "lastIndex", { value: 0, writable: false });
+    shouldThrow(() => {
+        re[Symbol.search]("a")
+    }, TypeError);
+}
+
+{
+    const re = /abc/y;
+    Object.defineProperty(re, "lastIndex", { value: 0, writable: false });
+    shouldThrow(() => {
+        re[Symbol.search]("a")
+    }, TypeError);
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1346,8 +1346,6 @@ test/staging/sm/Math/cbrt-approx.js:
   default: 'Error: got 1.39561242508609, expected a number near 1.3956124250860895 (relative error: 2)'
 test/staging/sm/Proxy/revoked-get-function-realm-typeerror.js:
   default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
-test/staging/sm/RegExp/lastIndex-search.js:
-  default: 'Error: Assertion failed: expected exception TypeError, no exception thrown'
 test/staging/sm/RegExp/match-local-tolength-recompilation.js:
   default: 'Test262Error: Expected SameValue(«false», «true») to be true'
 test/staging/sm/RegExp/replace-local-tolength-recompilation.js:

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -177,6 +177,7 @@ namespace JSC {
     macro(regExpSearchFast) \
     macro(regExpSplitFast) \
     macro(regExpTestFast) \
+    macro(regExpLastIndexIsWritable) \
     macro(stringIncludesInternal) \
     macro(stringIndexOfInternal) \
     macro(stringSplitFast) \

--- a/Source/JavaScriptCore/builtins/RegExpPrototype.js
+++ b/Source/JavaScriptCore/builtins/RegExpPrototype.js
@@ -404,7 +404,8 @@ function search(strArg)
     // Check for observable side effects and call the fast path if there aren't any.
     if (@isRegExpObject(regexp)
         && @tryGetById(regexp, "exec") === @regExpBuiltinExec
-        && typeof regexp.lastIndex === "number")
+        && (typeof regexp.lastIndex === "number")
+        && @regExpLastIndexIsWritable.@call(regexp))
         return @regExpSearchFast.@call(regexp, strArg);
 
     // 1. Let rx be the this value.

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -111,6 +111,7 @@ class JSGlobalObject;
     v(regExpPrototypeSymbolMatch, nullptr) \
     v(regExpPrototypeSymbolReplace, nullptr) \
     v(regExpTestFast, nullptr) \
+    v(regExpLastIndexIsWritable, nullptr) \
     v(stringIncludesInternal, nullptr) \
     v(stringIndexOfInternal, nullptr) \
     v(stringSplitFast, nullptr) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1756,6 +1756,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpTestFast)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "regExpTestFast"_s, regExpProtoFuncTestFast, ImplementationVisibility::Private, RegExpTestFastIntrinsic));
         });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpLastIndexIsWritable)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 0, "regExpLastIndexIsWritable"_s, regExpProtoFuncLastIndexIsWritable, ImplementationVisibility::Private));
+    });
 
     // String.prototype helpers.
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::stringIncludesInternal)].initLater([] (const Initializer<JSCell>& init) {

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -131,6 +131,11 @@ public:
 
     bool areLegacyFeaturesEnabled() const { return !(m_regExpAndFlags & legacyFeaturesDisabledFlag); }
 
+    bool lastIndexIsWritable() const
+    {
+        return !(m_regExpAndFlags & lastIndexIsNotWritableFlag);
+    }
+
 private:
     JS_EXPORT_PRIVATE RegExpObject(VM&, Structure*, RegExp*, bool areLegacyFeaturesEnabled);
 #if ASSERT_ENABLED
@@ -138,11 +143,6 @@ private:
 #endif
 
     DECLARE_VISIT_CHILDREN;
-
-    bool lastIndexIsWritable() const
-    {
-        return !(m_regExpAndFlags & lastIndexIsNotWritableFlag);
-    }
 
     void setLastIndexIsNotWritable()
     {

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -657,6 +657,14 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSplitFast, (JSGlobalObject* globalObject
     return JSValue::encode(result);
 }
 
+JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncLastIndexIsWritable, (JSGlobalObject*, CallFrame* callFrame))
+{
+    JSValue thisValue = callFrame->thisValue();
+    RegExpObject* regexp = jsCast<RegExpObject*>(thisValue);
+
+    return JSValue::encode(jsBoolean(regexp->lastIndexIsWritable()));
+}
+
 } // namespace JSC
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.h
@@ -57,5 +57,6 @@ JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncMatchFast);
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSearchFast);
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncSplitFast);
 JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncTestFast);
+JSC_DECLARE_HOST_FUNCTION(regExpProtoFuncLastIndexIsWritable);
 
 } // namespace JSC


### PR DESCRIPTION
#### 2dfad00e508f228026f20fdb9022df16058b35c3
<pre>
[JSC] `RegExp#[Symbol.search]` should throw `TypeError` when `lastIndex` isn&apos;t writable
<a href="https://bugs.webkit.org/show_bug.cgi?id=288832">https://bugs.webkit.org/show_bug.cgi?id=288832</a>

Reviewed by NOBODY (OOPS!).

According to the spec[1], `RegExp#[Symbol.search]` writes to the `lastIndex`
property of `this` in the following cases:

- `lastIndex` is not 0
- The value of `lastIndex` changes before and after calling `RegExpExec`
  (which occurs when the `g` or `y` flag is enabled)

So, if `lastIndex` is not writable and the above conditions are met, a
`TypeError` should be thrown.

However, in the current JSC implementation, no error is thrown. This
patch changes to execute the slow path when `lastIndex` is not writable,
ensuring that an error is thrown.

                             TipOfTree                  Patched

regexp-search-basic        4.4263+-0.5470            4.3608+-0.2899          might be 1.0150x faster

[1]: <a href="https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.search%">https://tc39.es/ecma262/#sec-regexp.prototype-%symbol.search%</a>

* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/builtins/RegExpPrototype.js:
(overriddenName.string_appeared_here.search):
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototype.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dfad00e508f228026f20fdb9022df16058b35c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92716 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97710 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43227 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12542 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/70983 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28420 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9495 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51314 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9187 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1572 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42555 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85426 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79498 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1543 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99905 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91382 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80060 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20018 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79360 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23822 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12782 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24928 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114030 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19439 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32944 "Found 7 new JSC stress test failures: wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.default-wasm, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/stress/b3-signed-extend-16-to-64.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/top-most-enclosing-stack.js.wasm-eager-jettison (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22899 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21180 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->