### PR TITLE
AX: Immediately queue changes to AXProperty::TextRuns as part of the next tree snapshot so we have the right tree state in response to text markers generated from typing in an editable field

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -28,6 +28,9 @@ accessibility/menuitem-is-selected.html [ Failure ]
 
 accessibility/element-reflection-ariaactivedescendant.html [ Failure ]
 
+# This test only passes with ITM due to a workaround in the test that we should fix.
+# accessibility/mac/text-marker-from-typing-notification.html
+
 # Used to be a timeout until https://github.com/WebKit/WebKit/commit/c69e4c0caaf5368db791652eee3a057ed2751144, now is a text failure.
 accessibility/frame-disconnect-textmarker-cache-crash.html [ Failure ]
 

--- a/LayoutTests/accessibility/mac/input-type-change-crash-expected.txt
+++ b/LayoutTests/accessibility/mac/input-type-change-crash-expected.txt
@@ -1,10 +1,10 @@
 This tests setting the value to a readonly or disabled text field which was previously editable
 
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextEditType":3}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"b","AXTextEditType":3}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextEditType":1},{"AXTextChangeValue":"hellob","AXTextEditType":2}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"hellob","AXTextEditType":1},{"AXTextChangeValue":"world","AXTextEditType":2}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"c","AXTextEditType":3}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"worldc","AXTextEditType":1},{"AXTextChangeValue":"WebKit","AXTextEditType":2}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"d","AXTextEditType":3}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextChangeValueStartMarker":{},"AXTextEditType":3}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"b","AXTextChangeValueStartMarker":{},"AXTextEditType":3}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextChangeValueStartMarker":{},"AXTextEditType":1},{"AXTextChangeValue":"hellob","AXTextChangeValueStartMarker":{},"AXTextEditType":2}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"hellob","AXTextChangeValueStartMarker":{},"AXTextEditType":1},{"AXTextChangeValue":"world","AXTextChangeValueStartMarker":{},"AXTextEditType":2}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"c","AXTextChangeValueStartMarker":{},"AXTextEditType":3}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"worldc","AXTextChangeValueStartMarker":{},"AXTextEditType":1},{"AXTextChangeValue":"WebKit","AXTextChangeValueStartMarker":{},"AXTextEditType":2}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"d","AXTextChangeValueStartMarker":{},"AXTextEditType":3}]
 

--- a/LayoutTests/accessibility/mac/text-marker-from-typing-notification-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-from-typing-notification-expected.txt
@@ -1,0 +1,10 @@
+This test ensures we behave correctly when immediately using an AXTextChangeValueStartMarker from a notification.
+
+PASS: addedNotificationListener === true
+PASS: webarea.indexForTextMarker(textChangeMarker) === 1
+PASS: webarea.indexForTextMarker(textChangeMarker) === 2
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/text-marker-from-typing-notification.html
+++ b/LayoutTests/accessibility/mac/text-marker-from-typing-notification.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<textarea id="textarea"></textarea>
+    
+<script>
+var output = "This test ensures we behave correctly when immediately using an AXTextChangeValueStartMarker from a notification.\n\n";
+
+var notificationCount = 0;
+var webarea;
+var textChangeMarker;
+var textarea = document.getElementById("textarea");
+function notificationCallback(notification, userInfo) {
+    if (notification !== "AXValueChanged")
+        return;
+
+    notificationCount++;
+    textChangeMarker = userInfo["AXTextChangeValues"][0]["AXTextChangeValueStartMarker"];
+
+    // This "dummy" indexForTextMarker call is necessary for the test to pass in ITM because of this sequence:
+    //   1. eventSender.keyDown("a") happens, which causes an AXValueChanged notification, bringing us here
+    //   2. The keydown causes a new RenderText to be created, and |textChangeMarker| points to offset 1 of the
+    //      associated object's text runs (which is just "a"). This is correct and valid.
+    //   3. However, by the time we get here, we still have not created the isolated object for the AX object associated
+    //      with the RenderText, meaning `indexForTextMarker` exits early because it is "not valid" (it can't get an object
+    //      for the ID associated with the marker).
+    //   4. Doing a "dummy" indexForTextMarker before actually doing so in the `expect` lets the isolated tree update
+    //      before the expectation. But this just masks the bug. When we send out a text marker, we _must_ guarantee
+    //      that the object, and the tree in general is valid. i.e., it's not enough to guarantee the object has been
+    //      created, as ATs may want to use `indexForTextMarker`, which won't work if the object is created but not
+    //      connected to its ancestors.
+    webarea.indexForTextMarker(textChangeMarker)
+
+    output += expect("webarea.indexForTextMarker(textChangeMarker)", `${notificationCount}`);
+
+    if (notificationCount == 1)
+        eventSender.keyDown("b")
+    else if (notificationCount == 2) {
+        webarea.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    webarea = accessibilityController.rootElement.childAtIndex(0);
+    var addedNotificationListener = webarea.addNotificationListener(notificationCallback);
+    output += expect("addedNotificationListener", "true");
+
+    textarea.focus();
+    eventSender.keyDown("a")
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -908,6 +908,8 @@ accessibility/mac/dynamic-drag.html [ Skip ]
 
 accessibility/display-contents/role-row-headers.html [ Skip ]
 
+accessibility/mac/text-marker-from-typing-notification.html [ Skip ]
+
 # Missing AccessibilityUIElement::dateTimeValue() implementation.
 accessibility/dynamic-datetime-attribute.html [ Skip ]
 
@@ -925,6 +927,8 @@ accessibility/select-whitespace-collapsed-text.html [ Skip ]
 # Missing AccessibilityUIElement::isIndeterminate() implementation.
 accessibility/indeterminate-progressbar-custom-element.html [ Skip ]
 accessibility/progress-indeterminate-value.html [ Skip ]
+
+accessibility/mac/input-type-change-crash.html [ Skip ]
 
 # Missing AccessibilityUIElement::isInTable() implementation.
 accessibility/table-ancestry.html [ Skip ]

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -1483,7 +1483,7 @@ void AXObjectCache::handleRowspanChanged(AccessibilityTableCell& axCell)
 #if ENABLE(AX_THREAD_TEXT_APIS)
 void AXObjectCache::onTextRunsChanged(const RenderObject& renderer)
 {
-    postNotification(const_cast<RenderObject*>(&renderer), AXNotification::TextRunsChanged);
+    updateIsolatedTree(get(const_cast<RenderObject&>(renderer)), AXNotification::TextRunsChanged);
 }
 #endif
 

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -746,6 +746,11 @@ static BOOL accessibilityShouldRepostNotifications;
 
 static bool isValueTypeSupported(id value)
 {
+#if PLATFORM(MAC)
+    if (value && CFGetTypeID((__bridge CFTypeRef)value) == AXTextMarkerGetTypeID())
+        return true;
+#endif // PLATFORM(MAC)
+
     return [value isKindOfClass:[NSString class]] || [value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[WebAccessibilityObjectWrapperBase class]];
 }
 

--- a/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm
@@ -32,6 +32,7 @@
 #import "config.h"
 #import "AccessibilityCommonCocoa.h"
 
+#import "AccessibilityTextMarker.h"
 #import "JSWrapper.h"
 #import "StringFunctions.h"
 #import <JavaScriptCore/JSStringRefCF.h>
@@ -100,6 +101,12 @@ JSValueRef makeValueRefForValue(JSContextRef context, id value)
         return makeJSObject(context, value);
     if ([value isKindOfClass:[NSArray class]])
         return makeJSArray(context, value);
+#if PLATFORM(MAC)
+    if (value && CFGetTypeID((__bridge CFTypeRef)value) == AXTextMarkerGetTypeID()) {
+        Ref marker = AccessibilityTextMarker::create(value);
+        return JSObjectMake(context, marker->wrapperClass(), marker.ptr());
+    }
+#endif // PLATFORM(MAC)
     return nullptr;
 }
 


### PR DESCRIPTION
#### 3809a67b854d775397ce4b455fdb8c622843db3c
<pre>
AX: Immediately queue changes to AXProperty::TextRuns as part of the next tree snapshot so we have the right tree state in response to text markers generated from typing in an editable field
<a href="https://bugs.webkit.org/show_bug.cgi?id=288845">https://bugs.webkit.org/show_bug.cgi?id=288845</a>
<a href="https://rdar.apple.com/145865930">rdar://145865930</a>

Reviewed by Chris Fleizach.

When a user types, this happens:

 1. AXObjectCache::onTextRunsChanged gets called.

 2. We send out a AXValueChanged notification that includes a text marker with an offset pointing to
    the end of the changed text. Before sending the notification, we processQueuedNodeUpdates() to
    ensure we queue up isolated tree updates representing the new state of the page, so that if an AT
    responds immediately with the text marker we gave it, we are working off the latest information.

The problem is that, prior to this commit, AXObjectCache::onTextRunsChanged used AXObjectCache::postNotification to
queue the text runs update, which critically is not covered by processQueuedNodeUpdates. This means that if an AT
immediately responded with the text marker, we would not yet have updated the text runs, and thus behave incorrectly.

To fix this, this commit changes AXObjectCache::onTextRunsChanged to use AXObjectCache::updateIsolatedTree, which
immediately queues up a property update for use by processQueuedNodeUpdates().

Long term, we should switch everything over to being processed by processQueuedNodeUpdates(), guaranteeing we are
always pushing consistent snapshots of the tree.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
Note the ITM workaround made in the new test.
* LayoutTests/accessibility/mac/text-marker-from-typing-notification-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-from-typing-notification.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onTextRunsChanged):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::toTextRunMarker const):

* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(isValueTypeSupported):
* Tools/WebKitTestRunner/InjectedBundle/cocoa/AccessibilityCommonCocoa.mm:
(WTR::makeValueRefForValue):
Enable support for passing text markers in `userInfo` notifications sent
to layout tests.

Canonical link: <a href="https://commits.webkit.org/291454@main">https://commits.webkit.org/291454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa190c65100999adb787dc3f45333ecdb82fff95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12466 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71043 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95917 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9600 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51371 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1678 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99936 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80064 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79364 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12993 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25127 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19638 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21379 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->