### PR TITLE
Update test and expectations for iOS for http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html

### DIFF
--- a/LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html
+++ b/LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html
@@ -18,5 +18,6 @@ Select some code that doesn't have a space before it.
 <span id="test">This is the text without a space
 <code>fakecode.h</code>
 and the end of the selecton.</span>
+Additional text after the selection.
 </html>
 

--- a/LayoutTests/platform/ios/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt
+++ b/LayoutTests/platform/ios/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt
@@ -1,0 +1,1 @@
+:~:text=it.-,This%20is%20the%20text%20without%20a%20space%20fakecode.h%20and%20the%20end%20of%20the%20selecton.,-Additional


### PR DESCRIPTION
#### 6ad61266bb23cd5374a8cd318d6d0be89e246437
<pre>
Update test and expectations for iOS for http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=288848">https://bugs.webkit.org/show_bug.cgi?id=288848</a>
<a href="https://rdar.apple.com/145868474">rdar://145868474</a>

Unreviewed bug fix.

There is a bug in the spec where if we are looking for a range based on a directive that
has no prefix or suffix and the range ends in a period that is also the end of the document
then we fail to find the range. This cannot be fixed by adding a suffix or prefix to the
directive because there is nothing after the end to add context. This bug is also present in
Blink&apos;s implementation, and does seem to be a fallout from how the spec is written, so I do
believe it is an issue with the spec. But since it only affects situations in which the
document is very small, and you are attempting to select to the end of document, and the document
end&apos;s with a period, I am changing the test instead of investing more time in figuring out
the right way to fix the spec and/or our searching functionality.

The reason that iOS and macOS have different implementations is because of the age old decision
to use AppKit for our word boundary logic on mac and unicode on iOS, and this works for AppKit,
but the unicode implementation needs to add additional context to the directive to correctly find it.

* LayoutTests/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html:
* LayoutTests/platform/ios/http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/291599@main">https://commits.webkit.org/291599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2631955e9b8068b4968461e830fa3bee592bc2e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97750 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43265 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71003 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28436 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1581 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42593 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79525 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99771 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80012 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79314 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19806 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23840 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12820 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19790 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19477 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21218 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->