### PR TITLE
[JSC] Fix a bug not calling didAllocate for PreciseAllocation (from 290699@main)

### DIFF
--- a/Source/JavaScriptCore/heap/CompleteSubspace.cpp
+++ b/Source/JavaScriptCore/heap/CompleteSubspace.cpp
@@ -139,7 +139,8 @@ void* CompleteSubspace::tryAllocateSlow(VM& vm, size_t size, GCDeferralContext* 
     if (!allocation)
         return nullptr;
     
-    m_space.registerPreciseAllocation(allocation);
+    m_preciseAllocations.append(allocation);
+    m_space.registerPreciseAllocation(allocation, /* isNewAllocation */ true);
     return allocation->cell();
 }
 

--- a/Source/JavaScriptCore/heap/IsoSubspace.cpp
+++ b/Source/JavaScriptCore/heap/IsoSubspace.cpp
@@ -82,10 +82,13 @@ void IsoSubspace::didBeginSweepingToFreeList(MarkedBlock::Handle* block)
 
 void* IsoSubspace::tryAllocateLowerTierPrecise(size_t size)
 {
-    auto revive = [&] (PreciseAllocation* allocation, bool isNewAllocation) {
-        m_space.registerPreciseAllocation(allocation, isNewAllocation);
-        ASSERT(allocation->indexInSpace() == m_space.m_preciseAllocations.size() - 1);
+    auto revive = [&] (PreciseAllocation* allocation) {
+        // Lower-tier cells never report capacity. This is intentional since it will not be freed until VM dies.
+        // Whether we will do GC or not does not affect on the used memory by lower-tier cells. So we should not
+        // count them in capacity since it is not interesting to decide whether we should do GC.
         m_preciseAllocations.append(allocation);
+        m_space.registerPreciseAllocation(allocation, /* isNewAllocation */ false);
+        ASSERT(allocation->indexInSpace() == m_space.m_preciseAllocations.size() - 1);
         return allocation->cell();
     };
 
@@ -93,14 +96,12 @@ void* IsoSubspace::tryAllocateLowerTierPrecise(size_t size)
     if (!m_lowerTierPreciseFreeList.isEmpty()) {
         PreciseAllocation* allocation = &*m_lowerTierPreciseFreeList.begin();
         allocation->remove();
-        return revive(allocation, false);
+        return revive(allocation);
     }
     if (m_remainingLowerTierPreciseCount) {
         PreciseAllocation* allocation = PreciseAllocation::tryCreateForLowerTierPrecise(m_space.heap(), size, this, --m_remainingLowerTierPreciseCount);
-        if (allocation) {
-            // FIXME: This is new allocation but reporting it as new causes a bunch of regressions...
-            return revive(allocation, false);
-        }
+        if (allocation)
+            return revive(allocation);
     }
     return nullptr;
 }

--- a/Source/JavaScriptCore/heap/MarkedSpace.cpp
+++ b/Source/JavaScriptCore/heap/MarkedSpace.cpp
@@ -235,10 +235,14 @@ void MarkedSpace::registerPreciseAllocation(PreciseAllocation* allocation, bool 
     ASSERT(allocation->isNewlyAllocated());
     ASSERT(!allocation->isMarked());
     m_preciseAllocations.append(allocation);
-    if (isNewAllocation)
-        m_capacity += allocation->cellSize();
     if (auto* set = preciseAllocationSet())
         set->add(allocation->cell());
+    if (isNewAllocation) {
+        // Existing code's ordering is calling `didAllocate` and increasing capacity.
+        size_t size = allocation->cellSize();
+        heap().didAllocate(size);
+        m_capacity += size;
+    }
 }
 
 void MarkedSpace::sweepPreciseAllocations()

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -159,7 +159,7 @@ public:
     HeapVersion newlyAllocatedVersion() const { return m_newlyAllocatedVersion; }
     HeapVersion edenVersion() const { return m_edenVersion; }
 
-    void registerPreciseAllocation(PreciseAllocation*, bool isNewAllocation = true);
+    void registerPreciseAllocation(PreciseAllocation*, bool isNewAllocation);
     const Vector<PreciseAllocation*>& preciseAllocations() const { return m_preciseAllocations; }
     unsigned preciseAllocationsNurseryOffset() const { return m_preciseAllocationsNurseryOffset; }
     unsigned preciseAllocationsOffsetForThisCollection() const { return m_preciseAllocationsOffsetForThisCollection; }

--- a/Source/JavaScriptCore/heap/PreciseSubspace.cpp
+++ b/Source/JavaScriptCore/heap/PreciseSubspace.cpp
@@ -66,7 +66,8 @@ void* PreciseSubspace::tryAllocate(size_t size)
     if (!allocation)
         return nullptr;
 
-    m_space.registerPreciseAllocation(allocation);
+    m_preciseAllocations.append(allocation);
+    m_space.registerPreciseAllocation(allocation, /* isNewAllocation */ true);
     return allocation->cell();
 }
 


### PR DESCRIPTION
#### a6bd280ee5349f360af50fbe3601c110b381ca82
<pre>
[JSC] Fix a bug not calling didAllocate for PreciseAllocation (from 290699@main)
<a href="https://bugs.webkit.org/show_bug.cgi?id=288854">https://bugs.webkit.org/show_bug.cgi?id=288854</a>
<a href="https://rdar.apple.com/145872082">rdar://145872082</a>

Reviewed by Yijia Huang.

290699@main accidentally removed didAllocate call for PreciseAllocation.
This patch fixes it. Also we use non default parameter to make
isNewAllocation parameter more explicit from the caller side.

* Source/JavaScriptCore/heap/CompleteSubspace.cpp:
(JSC::CompleteSubspace::tryAllocateSlow):
* Source/JavaScriptCore/heap/IsoSubspace.cpp:
(JSC::IsoSubspace::tryAllocateLowerTierPrecise):
* Source/JavaScriptCore/heap/MarkedSpace.cpp:
(JSC::MarkedSpace::registerPreciseAllocation):
* Source/JavaScriptCore/heap/MarkedSpace.h:
* Source/JavaScriptCore/heap/PreciseSubspace.cpp:
(JSC::PreciseSubspace::tryAllocate):

Canonical link: <a href="https://commits.webkit.org/291381@main">https://commits.webkit.org/291381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b867510467b003d74025625712df43c6eff2fdb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92779 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1971 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20782 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95781 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9527 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9217 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/1600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85489 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99797 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91445 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19831 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79862 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23851 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14814 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19815 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/24991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114093 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/32959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22962 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->