### PR TITLE
Add support for generating a consumer for CSS property 'background-clip'

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2080,9 +2080,7 @@
                 "fill-layer-property": true,
                 "separator": " ",
                 "disables-native-appearance": true,
-                "parser-function": "consumeBackgroundClip",
-                "parser-grammar-unused": "<single-background-clip>#",
-                "parser-grammar-unused-reason": "Needs support for settings-enabled keywords in the grammaer."
+                "parser-grammar": "<single-background-clip>#"
             },
             "specification": {
                 "category": "css-backgrounds",
@@ -13358,7 +13356,7 @@
             }
         },
         "<single-background-clip>": {
-            "grammar": "<box> | text | -webkit-text",
+            "grammar": "<box> | border-area@(settings-flag=cssBackgroundClipBorderAreaEnabled) | text | -webkit-text",
             "exported": true,
             "specification": {
                 "category": "css-backgrounds",

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -1984,7 +1984,7 @@ static RefPtr<CSSValue> consumeBackgroundComponent(CSSPropertyID property, CSSPa
     switch (property) {
     // background-*
     case CSSPropertyBackgroundClip:
-        return consumeSingleBackgroundClip(range, context);
+        return CSSPropertyParsing::consumeSingleBackgroundClip(range, context);
     case CSSPropertyBackgroundBlendMode:
         return CSSPropertyParsing::consumeSingleBackgroundBlendMode(range);
     case CSSPropertyBackgroundAttachment:

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -342,43 +342,6 @@ RefPtr<CSSValue> consumeBorderColor(CSSParserTokenRange& range, const CSSParserC
     return consumeColor(range, context, { .acceptQuirkyColors = acceptQuirkyColors });
 }
 
-// MARK: - Background Clip
-
-RefPtr<CSSValue> consumeSingleBackgroundClip(CSSParserTokenRange& range, const CSSParserContext& context)
-{
-    // <single-background-clip> = <visual-box>
-    // https://drafts.csswg.org/css-backgrounds/#propdef-background-clip
-
-    switch (auto keyword = range.peek().id(); keyword) {
-    case CSSValueID::CSSValueBorderBox:
-    case CSSValueID::CSSValuePaddingBox:
-    case CSSValueID::CSSValueContentBox:
-    case CSSValueID::CSSValueText:
-    case CSSValueID::CSSValueWebkitText:
-        range.consumeIncludingWhitespace();
-        return CSSPrimitiveValue::create(keyword);
-    case CSSValueID::CSSValueBorderArea:
-        if (!context.cssBackgroundClipBorderAreaEnabled)
-            return nullptr;
-        range.consumeIncludingWhitespace();
-        return CSSPrimitiveValue::create(keyword);
-
-    default:
-        return nullptr;
-    }
-}
-
-RefPtr<CSSValue> consumeBackgroundClip(CSSParserTokenRange& range, const CSSParserContext& context)
-{
-    // <'background-clip'> = <visual-box>#
-    // https://drafts.csswg.org/css-backgrounds/#propdef-background-clip
-
-    auto lambda = [&](CSSParserTokenRange& range) -> RefPtr<CSSValue> {
-        return consumeSingleBackgroundClip(range, context);
-    };
-    return consumeListSeparatedBy<',', OneOrMore, ListOptimization::SingleValue>(range, lambda);
-}
-
 // MARK: - Background Size
 
 template<CSSPropertyID property> static RefPtr<CSSValue> consumeBackgroundSize(CSSParserTokenRange& range, const CSSParserContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.h
@@ -85,16 +85,6 @@ RefPtr<CSSValue> consumeBorderWidth(CSSParserTokenRange&, const CSSParserContext
 // https://drafts.csswg.org/css-backgrounds/#propdef-border-top-width
 RefPtr<CSSValue> consumeBorderColor(CSSParserTokenRange&, const CSSParserContext&, CSSPropertyID currentShorthand);
 
-// MARK: - Background Clip
-
-// <single-background-clip> = <visual-box>
-// https://drafts.csswg.org/css-backgrounds/#propdef-background-clip
-RefPtr<CSSValue> consumeSingleBackgroundClip(CSSParserTokenRange&, const CSSParserContext&);
-
-// <'background-clip'> = <visual-box>#
-// https://drafts.csswg.org/css-backgrounds/#propdef-background-clip
-RefPtr<CSSValue> consumeBackgroundClip(CSSParserTokenRange&, const CSSParserContext&);
-
 // MARK: - Background Size
 
 // <bg-size> = [ <length-percentage [0,∞]> | auto ]{1,2} | cover | contain


### PR DESCRIPTION
#### 1d8267518d1a78ce5ba1966a2e56b4fb7e07ed4e
<pre>
Add support for generating a consumer for CSS property &apos;background-clip&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=288855">https://bugs.webkit.org/show_bug.cgi?id=288855</a>

Reviewed by Antti Koivisto.

Supporting &apos;background-clip&apos; required adding support for annotating terms
in the grammar with a settings flag. The syntax uses an @-annotation:

     `[ foo bar@(settings-flag=cssBarEnabled) baz]`

To make this work, support for setting annotations on keywords was needed.
This proved a bit challenging with the parser, so a bit of refactoring to
explicitly track the nodes multipliers and annotations will be attached to
was added.

There were also a number of spelling issues in process-css-properties.py
that were corrected.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.h:
* Source/WebCore/css/process-css-properties.py:

Canonical link: <a href="https://commits.webkit.org/291625@main">https://commits.webkit.org/291625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/093cbebd743af44b7fc4a8f1d8d7b746bde0ba53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92769 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43280 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71009 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28440 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51338 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9218 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1595 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42608 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79528 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1566 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99787 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14575 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80016 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79318 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19830 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23848 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12835 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/24981 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21233 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->