### PR TITLE
[scroll-animations] WPT test scroll-animations/scroll-timelines/effect-updateTiming.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt
@@ -28,12 +28,9 @@ PASS Allows setting the iterations of an animation in progress
 PASS Allows setting the iterations of an animation in progress with duration "auto"
 PASS Allows setting the duration to 123.45
 PASS Allows setting the duration to auto
+PASS Allows setting the duration to Infinity
 PASS Throws when setting invalid duration: -1
 PASS Throws when setting invalid duration: NaN
-FAIL Throws when setting invalid duration: Infinity assert_throws_js: function "() => {
-      const anim = createScrollLinkedAnimationWithTiming(t,  { duration: invalid })
-      anim.play();
-    }" did not throw
 PASS Throws when setting invalid duration: -Infinity
 PASS Throws when setting invalid duration: "abc"
 PASS Throws when setting invalid duration: "100"

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.html
@@ -347,6 +347,7 @@ const gGoodDurationValuesForProgressBased = [
   // will be represented as 100
   { specified: 123.45, computed: 100 },
   { specified: 'auto', computed: 100 },
+  { specified: Infinity, computed: 100 },
 ];
 
 for (const duration of gGoodDurationValuesForProgressBased) {
@@ -370,7 +371,7 @@ for (const duration of gGoodDurationValuesForProgressBased) {
 
 // adapted for progress based animations
 const gBadDurationValuesForProgressBased = [
-  -1, NaN, Infinity, -Infinity, 'abc', '100'
+  -1, NaN, -Infinity, 'abc', '100'
 ];
 
 for (const invalid of gBadDurationValuesForProgressBased) {


### PR DESCRIPTION
#### d4aa6cc2230023b38e8dcce9c01b26c05dc75b8d
<pre>
[scroll-animations] WPT test scroll-animations/scroll-timelines/effect-updateTiming.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=284542">https://bugs.webkit.org/show_bug.cgi?id=284542</a>
<a href="https://rdar.apple.com/141356805">rdar://141356805</a>

Reviewed by Dean Jackson.

The Web Animations Level 1 specification indicates the following for the `duration` property
of the `OptionalEffectTiming` interface [0]:

    &gt; The iteration duration, which is a real number greater than or equal to zero
    &gt; (including positive infinity) representing the time taken to complete a single
    &gt; iteration of the animation effect.

Looking through the Web Animations Level 2 and Scroll-driven Animations Level 1 specifications,
there is no text anywhere that indicates that an infinite duration for a progress-based animation
would yield an exception. As such, the test expecting `Infinity` for `duration` to throw is in
error. So we&apos;re modifying the relevant test to expect this to be a valid value instead.

Assuming there may have been an intent to restrict the `duration` for progress-based animations,
the following issue [1] was filed on the Scroll-driven Animations specification.

[0] <a href="https://drafts.csswg.org/web-animations-1/#dom-effecttiming-duration">https://drafts.csswg.org/web-animations-1/#dom-effecttiming-duration</a>
[1] <a href="https://github.com/w3c/csswg-drafts/issues/11804">https://github.com/w3c/csswg-drafts/issues/11804</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/effect-updateTiming.html:

Canonical link: <a href="https://commits.webkit.org/291435@main">https://commits.webkit.org/291435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/32e0ff704285ae3af13fbabda0e9f8d22022cd36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/1981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43300 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71012 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28441 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51341 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1604 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42628 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99807 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14581 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80024 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79326 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1124 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12855 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14846 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19512 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/22972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21253 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->