### PR TITLE
Address more Safer CPP failures in Proxy classes in the WebKit/ folder

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -3,7 +3,6 @@ UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKBrowsingContextController.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-UIProcess/Inspector/InspectorTargetProxy.cpp
 UIProcess/WebURLSchemeTask.cpp
 UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -155,13 +155,10 @@ UIProcess/Extensions/WebExtensionCommand.cpp
 UIProcess/FrameProcess.cpp
 UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
-UIProcess/Inspector/InspectorTargetProxy.cpp
 UIProcess/Inspector/WebPageInspectorController.cpp
 UIProcess/Inspector/mac/WKInspectorViewController.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
-UIProcess/RemotePageProxy.cpp
 UIProcess/SpeechRecognitionPermissionManager.cpp
-UIProcess/WebOpenPanelResultListenerProxy.cpp
 UIProcess/WebPreferences.h
 UIProcess/WebProcessActivityState.cpp
 UIProcess/WebURLSchemeHandler.cpp
@@ -202,10 +199,7 @@ WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsEventCocoa.mm
 WebProcess/Extensions/Cocoa/WebExtensionControllerProxyCocoa.mm
 WebProcess/Extensions/Bindings/Cocoa/JSWebExtensionWrapperCocoa.mm
-WebProcess/FileAPI/BlobRegistryProxy.cpp
 WebProcess/FullScreen/WebFullScreenManager.cpp
-WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.cpp
-WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
 WebProcess/GPU/media/MediaSourcePrivateRemote.cpp
 WebProcess/GPU/media/RemoteAudioHardwareListener.cpp
 WebProcess/GPU/media/RemoteImageDecoderAVFManager.cpp
@@ -313,8 +307,6 @@ WebProcess/WebPage/WebFoundTextRangeController.cpp
 WebProcess/WebPage/WebFrame.cpp
 WebProcess/WebPage/WebOpenPanelResultListener.cpp
 WebProcess/WebPage/WebPageOverlay.cpp
-WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
-WebProcess/WebPage/WebURLSchemeTaskProxy.cpp
 WebProcess/WebPage/mac/PageBannerMac.mm
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/TiledCoreAnimationScrollingCoordinator.mm
@@ -327,7 +319,6 @@ WebProcess/cocoa/PlaybackSessionManager.mm
 WebProcess/cocoa/RemoteCaptureSampleManager.cpp
 WebProcess/cocoa/RemoteRealtimeAudioSource.cpp
 WebProcess/cocoa/RemoteRealtimeMediaSource.cpp
-WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
 WebProcess/cocoa/RemoteRealtimeVideoSource.cpp
 WebProcess/cocoa/TextTrackRepresentationCocoa.mm
 WebProcess/cocoa/UserMediaCaptureManager.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -89,8 +89,6 @@ WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
 WebProcess/WebPage/ViewGestureGeometryCollector.cpp
 WebProcess/WebPage/ViewUpdateDispatcher.cpp
 WebProcess/WebPage/WebFrame.cpp
-WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp
-WebProcess/WebPage/WebURLSchemeTaskProxy.cpp
 WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectBase.mm
 WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm

--- a/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp
@@ -71,8 +71,9 @@ void InspectorTargetProxy::connect(Inspector::FrontendChannel::ConnectionType co
         return;
     }
 
-    if (m_page->hasRunningProcess())
-        m_page->legacyMainFrameProcess().send(Messages::WebPage::ConnectInspector(identifier(), connectionType), m_page->webPageIDInMainFrameProcess());
+    Ref page = m_page.get();
+    if (page->hasRunningProcess())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::ConnectInspector(identifier(), connectionType), page->webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::disconnect()
@@ -85,8 +86,9 @@ void InspectorTargetProxy::disconnect()
         return;
     }
 
-    if (m_page->hasRunningProcess())
-        m_page->legacyMainFrameProcess().send(Messages::WebPage::DisconnectInspector(identifier()), m_page->webPageIDInMainFrameProcess());
+    Ref page = m_page.get();
+    if (page->hasRunningProcess())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::DisconnectInspector(identifier()), page->webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::sendMessageToTargetBackend(const String& message)
@@ -96,8 +98,9 @@ void InspectorTargetProxy::sendMessageToTargetBackend(const String& message)
         return;
     }
 
-    if (m_page->hasRunningProcess())
-        m_page->legacyMainFrameProcess().send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message), m_page->webPageIDInMainFrameProcess());
+    Ref page = m_page.get();
+    if (page->hasRunningProcess())
+        page->protectedLegacyMainFrameProcess()->send(Messages::WebPage::SendMessageToTargetBackend(identifier(), message), page->webPageIDInMainFrameProcess());
 }
 
 void InspectorTargetProxy::didCommitProvisionalTarget()

--- a/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.cpp
@@ -42,34 +42,26 @@ WebOpenPanelResultListenerProxy::WebOpenPanelResultListenerProxy(WebPageProxy* p
 {
 }
 
-WebOpenPanelResultListenerProxy::~WebOpenPanelResultListenerProxy()
-{
-}
+WebOpenPanelResultListenerProxy::~WebOpenPanelResultListenerProxy() = default;
 
 #if PLATFORM(IOS_FAMILY)
 void WebOpenPanelResultListenerProxy::chooseFiles(const Vector<WTF::String>& filenames, const String& displayString, const API::Data* iconImageData)
 {
-    if (!m_page)
-        return;
-
-    m_page->didChooseFilesForOpenPanelWithDisplayStringAndIcon(filenames, displayString, iconImageData);
+    if (RefPtr page = m_page)
+        page->didChooseFilesForOpenPanelWithDisplayStringAndIcon(filenames, displayString, iconImageData);
 }
 #endif
 
 void WebOpenPanelResultListenerProxy::chooseFiles(const Vector<String>& filenames, const Vector<String>& allowedMIMETypes)
 {
-    if (!m_page)
-        return;
-
-    m_page->didChooseFilesForOpenPanel(filenames, allowedMIMETypes);
+    if (RefPtr page = m_page)
+        page->didChooseFilesForOpenPanel(filenames, allowedMIMETypes);
 }
 
 void WebOpenPanelResultListenerProxy::cancel()
 {
-    if (!m_page)
-        return;
-
-    m_page->didCancelForOpenPanel();
+    if (RefPtr page = m_page)
+        page->didCancelForOpenPanel();
 }
 
 void WebOpenPanelResultListenerProxy::invalidate()

--- a/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
+++ b/Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp
@@ -47,62 +47,62 @@ void BlobRegistryProxy::registerInternalFileBlobURL(const URL& url, Ref<BlobData
     }
 
     String replacementPath = path == file->path() ? nullString() : file->path();
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalFileBlobURL(url, path, replacementPath, WTFMove(extensionHandle), contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::RegisterInternalFileBlobURL(url, path, replacementPath, WTFMove(extensionHandle), contentType), 0);
 }
 
 void BlobRegistryProxy::registerInternalBlobURL(const URL& url, Vector<BlobPart>&& blobParts, const String& contentType)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURL(url, blobParts, contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURL(url, blobParts, contentType), 0);
 }
 
 void BlobRegistryProxy::registerBlobURL(const URL& url, const URL& srcURL, const PolicyContainer& policyContainer, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURL { url, srcURL, policyContainer, topOrigin }, 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::RegisterBlobURL { url, srcURL, policyContainer, topOrigin }, 0);
 }
 
 void BlobRegistryProxy::registerInternalBlobURLOptionallyFileBacked(const URL& url, const URL& srcURL, RefPtr<WebCore::BlobDataFileReference>&& file, const String& contentType)
 {
     ASSERT(file);
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLOptionallyFileBacked(url, srcURL, file->path(), contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLOptionallyFileBacked(url, srcURL, file->path(), contentType), 0);
 }
 
 void BlobRegistryProxy::unregisterBlobURL(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURL(url, topOrigin), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURL(url, topOrigin), 0);
 }
 
 void BlobRegistryProxy::registerInternalBlobURLForSlice(const URL& url, const URL& srcURL, long long start, long long end, const String& contentType)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLForSlice(url, srcURL, start, end, contentType), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::RegisterInternalBlobURLForSlice(url, srcURL, start, end, contentType), 0);
 }
 
 void BlobRegistryProxy::registerBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLHandle(url, topOrigin), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::RegisterBlobURLHandle(url, topOrigin), 0);
 }
 
 void BlobRegistryProxy::unregisterBlobURLHandle(const URL& url, const std::optional<SecurityOriginData>& topOrigin)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().connection().send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURLHandle(url, topOrigin), 0);
+    WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->send(Messages::NetworkConnectionToWebProcess::UnregisterBlobURLHandle(url, topOrigin), 0);
 }
 
 String BlobRegistryProxy::blobType(const URL& url)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobType(url), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendSync(Messages::NetworkConnectionToWebProcess::BlobType(url), 0);
     auto [result] = sendResult.takeReplyOr(emptyString());
     return result;
 }
 
 unsigned long long BlobRegistryProxy::blobSize(const URL& url)
 {
-    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().connection().sendSync(Messages::NetworkConnectionToWebProcess::BlobSize(url), 0);
+    auto sendResult = WebProcess::singleton().ensureNetworkProcessConnection().protectedConnection()->sendSync(Messages::NetworkConnectionToWebProcess::BlobSize(url), 0);
     auto [resultSize] = sendResult.takeReplyOr(0);
     return resultSize;
 }
 
 void BlobRegistryProxy::writeBlobsToTemporaryFilesForIndexedDB(const Vector<String>& blobURLs, CompletionHandler<void(Vector<String>&& filePaths)>&& completionHandler)
 {
-    WebProcess::singleton().ensureNetworkProcessConnection().writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler));
+    WebProcess::singleton().ensureProtectedNetworkProcessConnection()->writeBlobsToTemporaryFilesForIndexedDB(blobURLs, WTFMove(completionHandler));
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h
@@ -49,7 +49,7 @@ public:
 private:
     RemoteNativeImageBackendProxy(Ref<WebCore::ShareableBitmap>, WebCore::PlatformImagePtr);
 
-    Ref<WebCore::ShareableBitmap> m_bitmap;
+    const Ref<WebCore::ShareableBitmap> m_bitmap;
     WebCore::PlatformImageNativeImageBackend m_platformBackend;
 };
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -163,8 +163,8 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
 
 void RemoteResourceCacheProxy::recordFontUse(Font& font)
 {
-    if (font.platformData().customPlatformData())
-        recordFontCustomPlatformDataUse(*font.platformData().customPlatformData());
+    if (RefPtr platformData = font.platformData().customPlatformData())
+        recordFontCustomPlatformDataUse(*platformData);
 
     auto result = m_fonts.add(font.renderingResourceIdentifier(), m_renderingUpdateID);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -99,7 +99,7 @@ private:
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
     unsigned m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate { 0 };
 
-    CheckedRef<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
+    const CheckedRef<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
     uint64_t m_renderingUpdateID;
 };
 

--- a/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h
@@ -63,7 +63,7 @@ public:
 
 private:
     WebURLSchemeTaskProxy(WebURLSchemeHandlerProxy&, WebCore::ResourceLoader&, WebFrame&);
-    bool hasLoader();
+    WebCore::ResourceLoader* coreLoader();
 
     void queueTask(Function<void()>&& task) { m_queuedTasks.append(WTFMove(task)); }
     void processNextPendingTask();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1404,6 +1404,11 @@ WebLoaderStrategy& WebProcess::webLoaderStrategy()
     return m_webLoaderStrategy;
 }
 
+Ref<WebLoaderStrategy> WebProcess::protectedWebLoaderStrategy()
+{
+    return m_webLoaderStrategy.get();
+}
+
 #if ENABLE(GPU_PROCESS)
 
 GPUProcessConnection& WebProcess::ensureGPUProcessConnection()

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -271,6 +271,7 @@ public:
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
     RefPtr<NetworkProcessConnection> protectedNetworkProcessConnection();
     WebLoaderStrategy& webLoaderStrategy();
+    Ref<WebLoaderStrategy> protectedWebLoaderStrategy();
     WebFileSystemStorageConnection& fileSystemStorageConnection();
 
     RefPtr<WebTransportSession> webTransportSession(WebTransportSessionIdentifier);

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp
@@ -68,6 +68,11 @@ RemoteRealtimeMediaSourceProxy::~RemoteRealtimeMediaSourceProxy()
     failApplyConstraintCallbacks("Source terminated"_s);
 }
 
+Ref<IPC::Connection> RemoteRealtimeMediaSourceProxy::protectedConnection() const
+{
+    return m_connection;
+}
+
 void RemoteRealtimeMediaSourceProxy::updateConnection()
 {
     m_connection = getSourceConnection(m_shouldCaptureInGPUProcess);
@@ -76,23 +81,23 @@ void RemoteRealtimeMediaSourceProxy::updateConnection()
 void RemoteRealtimeMediaSourceProxy::startProducingData(WebCore::PageIdentifier pageIdentifier)
 {
     m_interrupted = false;
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::StartProducingData { m_identifier, pageIdentifier }, 0);
+    protectedConnection()->send(Messages::UserMediaCaptureManagerProxy::StartProducingData { m_identifier, pageIdentifier }, 0);
 }
 
 void RemoteRealtimeMediaSourceProxy::stopProducingData()
 {
     m_interrupted = false;
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::StopProducingData { m_identifier }, 0);
+    protectedConnection()->send(Messages::UserMediaCaptureManagerProxy::StopProducingData { m_identifier }, 0);
 }
 
 void RemoteRealtimeMediaSourceProxy::endProducingData()
 {
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::EndProducingData { m_identifier }, 0);
+    protectedConnection()->send(Messages::UserMediaCaptureManagerProxy::EndProducingData { m_identifier }, 0);
 }
 
 void RemoteRealtimeMediaSourceProxy::createRemoteMediaSource(const MediaDeviceHashSalts& deviceIDHashSalts, WebCore::PageIdentifier pageIdentifier, CreateCallback&& callback, bool shouldUseRemoteFrame)
 {
-    m_connection->sendWithAsyncReply(Messages::UserMediaCaptureManagerProxy::CreateMediaSourceForCaptureDeviceWithConstraints(identifier(), m_device, deviceIDHashSalts, m_constraints, shouldUseRemoteFrame, pageIdentifier), WTFMove(callback));
+    protectedConnection()->sendWithAsyncReply(Messages::UserMediaCaptureManagerProxy::CreateMediaSourceForCaptureDeviceWithConstraints(identifier(), m_device, deviceIDHashSalts, m_constraints, shouldUseRemoteFrame, pageIdentifier), WTFMove(callback));
 }
 
 RemoteRealtimeMediaSourceProxy RemoteRealtimeMediaSourceProxy::clone()
@@ -107,14 +112,14 @@ RemoteRealtimeMediaSourceProxy RemoteRealtimeMediaSourceProxy::clone()
 
 void RemoteRealtimeMediaSourceProxy::createRemoteCloneSource(WebCore::RealtimeMediaSourceIdentifier cloneIdentifier, WebCore::PageIdentifier pageIdentifier)
 {
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::Clone { m_identifier, cloneIdentifier, pageIdentifier }, 0);
+    protectedConnection()->send(Messages::UserMediaCaptureManagerProxy::Clone { m_identifier, cloneIdentifier, pageIdentifier }, 0);
 }
 
 void RemoteRealtimeMediaSourceProxy::applyConstraints(const MediaConstraints& constraints, RealtimeMediaSource::ApplyConstraintsHandler&& completionHandler)
 {
     m_pendingApplyConstraintsRequests.append(std::make_pair(WTFMove(completionHandler), constraints));
     // FIXME: Use sendAsyncWithReply.
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::ApplyConstraints { m_identifier, constraints }, 0);
+    protectedConnection()->send(Messages::UserMediaCaptureManagerProxy::ApplyConstraints { m_identifier, constraints }, 0);
 }
 
 struct RemoteRealtimeMediaSourceProxy::PromiseConverter {
@@ -126,17 +131,17 @@ struct RemoteRealtimeMediaSourceProxy::PromiseConverter {
 
 Ref<WebCore::RealtimeMediaSource::TakePhotoNativePromise> RemoteRealtimeMediaSourceProxy::takePhoto(PhotoSettings&& settings)
 {
-    return m_connection->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::TakePhoto { identifier(), WTFMove(settings) });
+    return protectedConnection()->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::TakePhoto { identifier(), WTFMove(settings) });
 }
 
 Ref<WebCore::RealtimeMediaSource::PhotoCapabilitiesNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoCapabilities()
 {
-    return m_connection->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities { identifier() });
+    return protectedConnection()->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::GetPhotoCapabilities { identifier() });
 }
 
 Ref<WebCore::RealtimeMediaSource::PhotoSettingsNativePromise> RemoteRealtimeMediaSourceProxy::getPhotoSettings()
 {
-    return m_connection->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::GetPhotoSettings { identifier() });
+    return protectedConnection()->sendWithPromisedReply<PromiseConverter>(Messages::UserMediaCaptureManagerProxy::GetPhotoSettings { identifier() });
 }
 
 void RemoteRealtimeMediaSourceProxy::applyConstraintsSucceeded()
@@ -163,7 +168,7 @@ void RemoteRealtimeMediaSourceProxy::end()
 {
     ASSERT(!m_isEnded);
     m_isEnded = true;
-    m_connection->send(Messages::UserMediaCaptureManagerProxy::RemoveSource { m_identifier }, 0);
+    protectedConnection()->send(Messages::UserMediaCaptureManagerProxy::RemoveSource { m_identifier }, 0);
 }
 
 void RemoteRealtimeMediaSourceProxy::whenReady(CompletionHandler<void(WebCore::CaptureSourceError&&)>&& callback)
@@ -199,7 +204,7 @@ void RemoteRealtimeMediaSourceProxy::didFail(CaptureSourceError&& reason)
 
 bool RemoteRealtimeMediaSourceProxy::isPowerEfficient() const
 {
-    auto syncResult = m_connection->sendSync(Messages::UserMediaCaptureManagerProxy::IsPowerEfficient { identifier() }, 0, GPUProcessConnection::defaultTimeout);
+    auto syncResult = protectedConnection()->sendSync(Messages::UserMediaCaptureManagerProxy::IsPowerEfficient { identifier() }, 0, GPUProcessConnection::defaultTimeout);
     auto [isPowerEfficient] = syncResult.takeReplyOr(false);
     return isPowerEfficient;
 }

--- a/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
+++ b/Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h
@@ -94,6 +94,7 @@ public:
 
 private:
     struct PromiseConverter;
+    Ref<IPC::Connection> protectedConnection() const;
 
     WebCore::RealtimeMediaSourceIdentifier m_identifier;
     Ref<IPC::Connection> m_connection;


### PR DESCRIPTION
#### 1713c1db7e43d3b9fa41ab63921acea23b60d490
<pre>
Address more Safer CPP failures in Proxy classes in the WebKit/ folder
<a href="https://bugs.webkit.org/show_bug.cgi?id=288864">https://bugs.webkit.org/show_bug.cgi?id=288864</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/Inspector/InspectorTargetProxy.cpp:
(WebKit::InspectorTargetProxy::connect):
(WebKit::InspectorTargetProxy::disconnect):
(WebKit::InspectorTargetProxy::sendMessageToTargetBackend):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::injectPageIntoNewProcess):
(WebKit::RemotePageProxy::processDidTerminate):
(WebKit::RemotePageProxy::~RemotePageProxy):
(WebKit::RemotePageProxy::didReceiveMessage):
(WebKit::RemotePageProxy::handleMessage):
(WebKit::RemotePageProxy::decidePolicyForResponse):
(WebKit::RemotePageProxy::didCommitLoadForFrame):
(WebKit::RemotePageProxy::decidePolicyForNavigationActionAsync):
(WebKit::RemotePageProxy::decidePolicyForNavigationActionSync):
(WebKit::RemotePageProxy::didFailProvisionalLoadForFrame):
(WebKit::RemotePageProxy::didStartProvisionalLoadForFrame):
(WebKit::RemotePageProxy::didChangeProvisionalURLForFrame):
(WebKit::RemotePageProxy::didReceiveSyncMessage):
* Source/WebKit/UIProcess/WebOpenPanelResultListenerProxy.cpp:
(WebKit::WebOpenPanelResultListenerProxy::chooseFiles):
(WebKit::WebOpenPanelResultListenerProxy::cancel):
(WebKit::WebOpenPanelResultListenerProxy::~WebOpenPanelResultListenerProxy): Deleted.
* Source/WebKit/WebProcess/FileAPI/BlobRegistryProxy.cpp:
(WebKit::BlobRegistryProxy::registerInternalFileBlobURL):
(WebKit::BlobRegistryProxy::registerInternalBlobURL):
(WebKit::BlobRegistryProxy::registerBlobURL):
(WebKit::BlobRegistryProxy::registerInternalBlobURLOptionallyFileBacked):
(WebKit::BlobRegistryProxy::unregisterBlobURL):
(WebKit::BlobRegistryProxy::registerInternalBlobURLForSlice):
(WebKit::BlobRegistryProxy::registerBlobURLHandle):
(WebKit::BlobRegistryProxy::unregisterBlobURLHandle):
(WebKit::BlobRegistryProxy::blobType):
(WebKit::BlobRegistryProxy::blobSize):
(WebKit::BlobRegistryProxy::writeBlobsToTemporaryFilesForIndexedDB):
* Source/WebKit/WebProcess/GPU/graphics/RemoteNativeImageBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordFontUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/WebPage/WebURLSchemeHandlerProxy.cpp:
(WebKit::WebURLSchemeHandlerProxy::startNewTask):
(WebKit::WebURLSchemeHandlerProxy::stopAllTasks):
(WebKit::WebURLSchemeHandlerProxy::taskDidPerformRedirection):
(WebKit::WebURLSchemeHandlerProxy::taskDidReceiveResponse):
(WebKit::WebURLSchemeHandlerProxy::taskDidReceiveData):
(WebKit::WebURLSchemeHandlerProxy::taskDidComplete):
(WebKit::WebURLSchemeHandlerProxy::removeTask):
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.cpp:
(WebKit::pageIDFromWebFrame):
(WebKit::WebURLSchemeTaskProxy::startLoading):
(WebKit::WebURLSchemeTaskProxy::didPerformRedirection):
(WebKit::WebURLSchemeTaskProxy::didReceiveResponse):
(WebKit::WebURLSchemeTaskProxy::didReceiveData):
(WebKit::WebURLSchemeTaskProxy::didComplete):
(WebKit::WebURLSchemeTaskProxy::coreLoader):
(WebKit::WebURLSchemeTaskProxy::hasLoader): Deleted.
* Source/WebKit/WebProcess/WebPage/WebURLSchemeTaskProxy.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::protectedWebLoaderStrategy):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.cpp:
(WebKit::RemoteRealtimeMediaSourceProxy::protectedConnection const):
(WebKit::RemoteRealtimeMediaSourceProxy::startProducingData):
(WebKit::RemoteRealtimeMediaSourceProxy::stopProducingData):
(WebKit::RemoteRealtimeMediaSourceProxy::endProducingData):
(WebKit::RemoteRealtimeMediaSourceProxy::createRemoteMediaSource):
(WebKit::RemoteRealtimeMediaSourceProxy::createRemoteCloneSource):
(WebKit::RemoteRealtimeMediaSourceProxy::applyConstraints):
(WebKit::RemoteRealtimeMediaSourceProxy::takePhoto):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoCapabilities):
(WebKit::RemoteRealtimeMediaSourceProxy::getPhotoSettings):
(WebKit::RemoteRealtimeMediaSourceProxy::end):
(WebKit::RemoteRealtimeMediaSourceProxy::isPowerEfficient const):
* Source/WebKit/WebProcess/cocoa/RemoteRealtimeMediaSourceProxy.h:

Canonical link: <a href="https://commits.webkit.org/291459@main">https://commits.webkit.org/291459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5e25689b39f7325e358bbda9d9539d6786c6cbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92972 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97971 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43498 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12804 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9642 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51409 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9335 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42811 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79627 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99994 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20024 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20275 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19719 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23952 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25184 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23155 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->