### PR TITLE
[iOS] [UnifiedPDF] PDF documents sometimes flicker during rotation (reenable dynamic viewport size updates)

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -4314,7 +4314,7 @@ static bool isLockdownModeWarningNeeded()
     WebCore::FloatRect oldUnobscuredContentRect = _page->unobscuredContentRect();
 
     auto isOldBoundsValid = !CGRectIsEmpty(oldBounds) || !CGRectIsEmpty(_perProcessState.animatedResizeOldBounds);
-    if (![self usesStandardContentView] || !_perProcessState.hasCommittedLoadForMainFrame || !isOldBoundsValid || oldUnobscuredContentRect.isEmpty() || _perProcessState.liveResizeParameters || [self _isDisplayingPDF]) {
+    if (![self usesStandardContentView] || !_perProcessState.hasCommittedLoadForMainFrame || !isOldBoundsValid || oldUnobscuredContentRect.isEmpty() || _perProcessState.liveResizeParameters) {
         if ([_customContentView respondsToSelector:@selector(web_beginAnimatedResizeWithUpdates:)])
             [_customContentView web_beginAnimatedResizeWithUpdates:updateBlock];
         else
@@ -4405,7 +4405,7 @@ static bool isLockdownModeWarningNeeded()
     CGFloat oldWebViewWidthInContentViewCoordinates = oldUnobscuredContentRect.width();
     _perProcessState.animatedResizeOriginalContentWidth = [&] {
 #if HAVE(UIKIT_RESIZABLE_WINDOWS)
-        if (self._isWindowResizingEnabled)
+        if (self._isWindowResizingEnabled && !self._isDisplayingPDF)
             return contentSizeInContentViewCoordinates.width;
 #endif
         return std::min(contentSizeInContentViewCoordinates.width, oldWebViewWidthInContentViewCoordinates);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -83,6 +83,7 @@ class PDFIncrementalLoader;
 class PDFPluginAnnotation;
 class PluginView;
 class WebFrame;
+class WebPage;
 class WebKeyboardEvent;
 class WebMouseEvent;
 class WebWheelEvent;
@@ -253,7 +254,6 @@ public:
     virtual void willAttachScrollingNode() { }
     virtual void didAttachScrollingNode() { }
     virtual void didChangeSettings() { }
-    virtual void finalizeRenderingUpdate() { }
 
     // HUD Actions.
 #if ENABLE(PDF_HUD)
@@ -366,6 +366,7 @@ private:
 protected:
     explicit PDFPluginBase(WebCore::HTMLPlugInElement&);
 
+    WebPage* webPage() const;
     WebCore::Page* page() const;
 
     virtual void teardown();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -185,6 +185,12 @@ void PDFPluginBase::teardown()
         m_element->pluginDestroyedWithPendingPDFTestCallback(WTFMove(m_pdfTestCallback));
 }
 
+WebPage* PDFPluginBase::webPage() const
+{
+    RefPtr frame = m_frame.get();
+    return frame ? frame->page() : nullptr;
+}
+
 Page* PDFPluginBase::page() const
 {
     if (RefPtr coreFrame = m_frame ? m_frame->coreLocalFrame() : nullptr)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -263,26 +263,10 @@ auto PDFPresentationController::pdfPositionForCurrentView(AnchorPoint anchorPoin
     if (!maybePageIndex)
         return { };
 
-    enum class PagePosition : bool { TopLeft, TopCenter };
-    auto pagePosition = PagePosition::TopCenter;
-    FloatPoint topLeftInPluginSpace;
-    if (checkedPlugin->shouldSizeToFitContent()) {
-        RefPtr view = checkedPlugin->frameView();
-        if (!view)
-            return { };
-
-        auto topLeftInRootView = view->contentsToRootView(view->unobscuredContentRect().location());
-        topLeftInPluginSpace = checkedPlugin->convertFromRootViewToPlugin(topLeftInRootView);
-        pagePosition = PagePosition::TopLeft;
-    }
-
     auto pageIndex = *maybePageIndex;
     auto pageBounds = documentLayout.layoutBoundsForPageAtIndex(pageIndex);
-    auto topLeftInDocumentSpace = checkedPlugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Plugin, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, topLeftInPluginSpace);
-    auto pagePoint = documentLayout.documentToPDFPage(FloatPoint {
-        pagePosition == PagePosition::TopLeft ? topLeftInDocumentSpace.x() : pageBounds.center().x(),
-        topLeftInDocumentSpace.y()
-    }, pageIndex);
+    auto topLeftInDocumentSpace = checkedPlugin->convertDown(UnifiedPDFPlugin::CoordinateSpace::Plugin, UnifiedPDFPlugin::CoordinateSpace::PDFDocumentLayout, FloatPoint::zero());
+    auto pagePoint = documentLayout.documentToPDFPage(FloatPoint { pageBounds.center().x(), topLeftInDocumentSpace.y() }, pageIndex);
 
     LOG_WITH_STREAM(PDF, stream << "PDFPresentationController::pdfPositionForCurrentView - point " << pagePoint << " in page " << pageIndex << " with anchor point " << std::to_underlying(anchorPoint));
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -230,8 +230,6 @@ public:
 
     static WebCore::ViewportConfiguration::Parameters viewportParameters();
 
-    void finalizeRenderingUpdate() final;
-
 private:
     explicit UnifiedPDFPlugin(WebCore::HTMLPlugInElement&);
     bool isUnifiedPDFPlugin() const override { return true; }
@@ -706,9 +704,6 @@ private:
 #endif
 
     RefPtr<WebCore::ShadowRoot> m_shadowRoot;
-
-    std::optional<VisiblePDFPosition> m_pendingAnchoringInfo;
-    bool m_willSetPendingAnchoringInfo { false };
 
     // FIXME: We should rationalize these with the values in ViewGestureController.
     // For now, we'll leave them differing as they do in PDFPlugin.

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1225,14 +1225,6 @@ bool PluginView::pluginHandlesPageScaleFactor() const
     return protectedPlugin()->handlesPageScaleFactor();
 }
 
-void PluginView::finalizeRenderingUpdate()
-{
-    if (!m_isInitialized)
-        return;
-
-    return protectedPlugin()->finalizeRenderingUpdate();
-}
-
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -164,7 +164,6 @@ public:
     WebCore::FloatRect absoluteBoundingRectForSmartMagnificationAtPoint(WebCore::FloatPoint) const;
 
     void frameViewLayoutOrVisualViewportChanged(const WebCore::IntRect& unobscuredContentRect);
-    void finalizeRenderingUpdate();
 
 private:
     PluginView(WebCore::HTMLPlugInElement&, const URL&, const String& contentType, bool shouldUseManualLoader, WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5121,11 +5121,6 @@ void WebPage::finalizeRenderingUpdate(OptionSet<FinalizeRenderingUpdateFlags> fl
     WTFBeginSignpost(this, FinalizeRenderingUpdate);
 #endif
 
-#if ENABLE(PDF_PLUGIN)
-    if (RefPtr pluginView = mainFramePlugIn())
-        pluginView->finalizeRenderingUpdate();
-#endif
-
     protectedCorePage()->finalizeRenderingUpdate(flags);
 #if ENABLE(GPU_PROCESS)
     if (RefPtr proxy = m_remoteRenderingBackendProxy)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2023,6 +2023,7 @@ private:
     void scheduleLayoutViewportHeightExpansionUpdate();
     void scheduleEditorStateUpdateAfterAnimationIfNeeded(const WebCore::Element&);
     void computeEnclosingLayerID(EditorState&, const WebCore::VisibleSelection&) const;
+    bool mainFramePlugInDefersScalingToViewport() const;
 
     void addTextInteractionSources(OptionSet<TextInteractionSource>);
     void removeTextInteractionSources(OptionSet<TextInteractionSource>);


### PR DESCRIPTION
#### 815f89b9a45b74461caa2e42ffcda9c8a49c93e9
<pre>
[iOS] [UnifiedPDF] PDF documents sometimes flicker during rotation (reenable dynamic viewport size updates)
<a href="https://bugs.webkit.org/show_bug.cgi?id=288868">https://bugs.webkit.org/show_bug.cgi?id=288868</a>
<a href="https://rdar.apple.com/145881576">rdar://145881576</a>

Reviewed by Abrar Rahman Protyasha.

Reenable dynamic viewport size updates for unified PDF — see below for more details.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _beginAnimatedResizeWithUpdates:]):

Remove the `-_isDisplayingPDF` check when deciding whether or not to bail immediately from animated
resize. Instead, only avoid maintaining the current content width when Stage Manager is enabled,
when computing `animatedResizeOriginalContentWidth` (this prevents us from intentionally allowing
horizontal scrolling when resizing the window to a width narrower than the minimum content width).

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::didChangeSettings):

Remove all the plumbing added to hook Unified PDF into `finalizeRenderingUpdate`, now that we no
longer rely on `UnifiedPDFPlugin` to restore scroll positions.

(WebKit::PDFPluginBase::finalizeRenderingUpdate): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::webPage const):

Add a helper method to grab the `WebPage`.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::pdfPositionForCurrentView const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::geometryDidChange):

Add a call to `scheduleFullEditorStateUpdate` (i.e. update selection geometry), in the case where
there&apos;s a selection and the size is changing. This ensures that the selection never shows up out of
place after resize, now that we no longer scroll as a result of restoring the anchor (which
previously updated the selection highlight as a byproduct).

(WebKit::UnifiedPDFPlugin::updateLayout):

Revert some now-unnecessary logic for restoring the anchor, in the `shouldSizeToFitContent` case.
Rather than using `PDFPresentationController::restorePDFPosition`, we now just use the same dynamic
viewport resize codepath that we use for normal webpages, which guarantees a smooth transition
(covered by an animated snapshot view) during rotation while keeping the center of the viewport
stable before and after the animated resize.

(WebKit::UnifiedPDFPlugin::finalizeRenderingUpdate): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::finalizeRenderingUpdate): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::finalizeRenderingUpdate):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setViewportConfigurationViewLayoutSize):

Pull this check for `plugin &amp;&amp; !plugin-&gt;pluginHandlesPageScaleFactor()` out into a separate helper
method, which case can also use below.

(WebKit::WebPage::mainFramePlugInDefersScalingToViewport const):
(WebKit::WebPage::shouldEnableViewportBehaviorsForResizableWindows const):

Opt out of the normal &quot;resizable windows&quot; codepath for unified PDF, when Stage Manager is enabled.
This ensures that the width of the embed element always fits the viewport width, regardless of
window size (as opposed to falling back to horizontal scrolling).

Canonical link: <a href="https://commits.webkit.org/291407@main">https://commits.webkit.org/291407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/691fe78c9d160231b298f5929da975cae0bb78fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2018 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20828 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9547 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9237 "Passed tests") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99843 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19877 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20128 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79336 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19688 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23868 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19861 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23008 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->