### PR TITLE
Change the initial value of dynamic-range-limit to constrained-high and add a UA style rule to continue rendering videos in full HDR

### DIFF
--- a/LayoutTests/fast/css/dynamic-range-limit-default-expected.txt
+++ b/LayoutTests/fast/css/dynamic-range-limit-default-expected.txt
@@ -1,0 +1,5 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/css/dynamic-range-limit-default.html
+++ b/LayoutTests/fast/css/dynamic-range-limit-default.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SupportHDRDisplayEnabled=true ] -->
+<html id="html">
+<body>
+<script src='../../resources/js-test-pre.js'></script>
+<div id="div"></div>
+<video id="video"></video>
+<div id="div-standard" style="dynamic-range-limit: standard">
+    <div id="div-under-standard"></div>
+    <video id="video-under-standard"></video>
+    <video id="video-constrained-high" style="dynamic-range-limit: constrained-high"></video>
+</div>
+<script>
+if (CSS.supports("dynamic-range-limit", "standard") && CSS.supports("dynamic-range-limit", "constrained-high") && CSS.supports("dynamic-range-limit", "no-limit")) {
+    const quiet = true; // So that the non-failure output is the same if dynamic-range-limit is not supported.
+    shouldBe('document.documentElement.style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.documentElement)["dynamic-range-limit"]', '"constrained-high"', quiet);
+    shouldBe('document.getElementById("html").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("html"))["dynamic-range-limit"]', '"constrained-high"', quiet);
+    shouldBe('document.getElementById("div").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("div"))["dynamic-range-limit"]', '"constrained-high"', quiet);
+    shouldBe('document.getElementById("video").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video"))["dynamic-range-limit"]', '"no-limit"', quiet);
+    shouldBe('document.getElementById("div-standard").style["dynamic-range-limit"]', '"standard"', quiet);
+    shouldBe('getComputedStyle(document.getElementById("div-standard"))["dynamic-range-limit"]', '"standard"', quiet);
+    shouldBe('document.getElementById("div-under-standard").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("div-under-standard"))["dynamic-range-limit"]', '"standard"', quiet);
+    shouldBe('document.getElementById("video-under-standard").style["dynamic-range-limit"]', '""', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video-under-standard"))["dynamic-range-limit"]', '"no-limit"', quiet);
+    shouldBe('document.getElementById("video-constrained-high").style["dynamic-range-limit"]', '"constrained-high"', quiet);
+    shouldBe('getComputedStyle(document.getElementById("video-constrained-high"))["dynamic-range-limit"]', '"constrained-high"', quiet);
+}
+</script>
+<script src='../../resources/js-test-post.js'></script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-hdr/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-hdr/inheritance-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Property dynamic-range-limit has initial value no-limit
+FAIL Property dynamic-range-limit has initial value no-limit assert_equals: expected "no-limit" but got "constrained-high"
 PASS Property dynamic-range-limit inherits
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4310,7 +4310,7 @@
         "dynamic-range-limit": {
             "animation-type": "see prose",
             "inherited": true,
-            "initial": "no-limit",
+            "initial": "constrained-high",
             "values": [
                 "standard",
                 "constrained-high",

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -167,6 +167,7 @@ video {
     -webkit-tap-highlight-color: transparent;
 #endif
     content: normal !important;
+    dynamic-range-limit: no-limit;
 }
 
 audio {

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -58,6 +58,7 @@ static void applyUASheetBehaviorsToContext(CSSParserContext& context)
     context.popoverAttributeEnabled = true;
     context.propertySettings.cssInputSecurityEnabled = true;
     context.propertySettings.cssCounterStyleAtRulesEnabled = true;
+    context.propertySettings.supportHDRDisplayEnabled = true;
     context.propertySettings.viewTransitionsEnabled = true;
 #if HAVE(CORE_MATERIAL)
     context.propertySettings.useSystemAppearance = true;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1347,7 +1347,7 @@ private:
     WeakPtr<const MediaResourceLoader> m_lastMediaResourceLoaderForTesting;
 
     std::optional<DynamicRangeMode> m_overrideDynamicRangeMode;
-    PlatformDynamicRangeLimit m_platformDynamicRangeLimit;
+    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::constrainedHigh() };
 
     friend class TrackDisplayUpdateScope;
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -845,7 +845,7 @@ private:
     bool m_shouldPrepareToRender { false };
     bool m_initializingMediaEngine { false };
     DynamicRangeMode m_preferredDynamicRangeMode;
-    PlatformDynamicRangeLimit m_platformDynamicRangeLimit;
+    PlatformDynamicRangeLimit m_platformDynamicRangeLimit { PlatformDynamicRangeLimit::constrainedHigh() };
     PitchCorrectionAlgorithm m_pitchCorrectionAlgorithm { PitchCorrectionAlgorithm::BestAllAround };
     RefPtr<PlatformMediaResourceLoader> m_mediaResourceLoader;
 

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -68,7 +68,7 @@ private:
     static constexpr float constrainedHighValue = 0.5;
     static constexpr float noLimitValue = 1;
 
-    float m_value { noLimitValue };
+    float m_value { constrainedHighValue };
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, PlatformDynamicRangeLimit);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -870,7 +870,7 @@ inline bool RenderStyle::hasExplicitlySetDirection() const { return m_nonInherit
 inline bool RenderStyle::hasExplicitlySetWritingMode() const { return m_nonInheritedData->miscData->hasExplicitlySetWritingMode; }
 
 inline const Style::DynamicRangeLimit& RenderStyle::dynamicRangeLimit() const { return m_rareInheritedData->dynamicRangeLimit; }
-inline Style::DynamicRangeLimit RenderStyle::initialDynamicRangeLimit() { return CSS::Keyword::NoLimit { }; }
+inline Style::DynamicRangeLimit RenderStyle::initialDynamicRangeLimit() { return CSS::Keyword::ConstrainedHigh { }; }
 
 #if PLATFORM(IOS_FAMILY)
 inline bool RenderStyle::touchCalloutEnabled() const { return m_rareInheritedData->touchCalloutEnabled; }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -2804,12 +2804,12 @@ inline Style::DynamicRangeLimit BuilderConverter::convertDynamicRangeLimit(Build
         }
 
         builderState.setCurrentPropertyInvalidAtComputedValueTime();
-        return Style::DynamicRangeLimit { CSS::Keyword::NoLimit { } };
+        return Style::DynamicRangeLimit { CSS::Keyword::ConstrainedHigh { } };
     }
 
     RefPtr dynamicRangeLimit = requiredDowncast<CSSDynamicRangeLimitValue>(builderState, value);
     if (!dynamicRangeLimit)
-        return Style::DynamicRangeLimit { CSS::Keyword::NoLimit { } };
+        return Style::DynamicRangeLimit { CSS::Keyword::ConstrainedHigh { } };
 
     return toStyle(dynamicRangeLimit->dynamicRangeLimit(), builderState);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp
@@ -39,9 +39,9 @@ static_assert(WebCore::PlatformDynamicRangeLimit::noLimit().value() == 1.0f);
 TEST(PlatformDynamicRangeLimit, DefaultConstruction)
 {
     auto def = WebCore::PlatformDynamicRangeLimit();
-    EXPECT_EQ(def.value(), 1.0f);
+    EXPECT_EQ(def.value(), 0.5f);
 
-    static_assert(WebCore::PlatformDynamicRangeLimit().value() == 1);
+    static_assert(WebCore::PlatformDynamicRangeLimit().value() == 0.5);
 }
 
 static WebCore::PlatformDynamicRangeLimit mix(float standard, float constrainedHigh, float noLimit)


### PR DESCRIPTION
#### b3a724ce17d018d1b8c34d73c6c0b3ac17e9dbac
<pre>
Change the initial value of dynamic-range-limit to constrained-high and add a UA style rule to continue rendering videos in full HDR
<a href="https://bugs.webkit.org/show_bug.cgi?id=288748">https://bugs.webkit.org/show_bug.cgi?id=288748</a>
<a href="https://rdar.apple.com/145784202">rdar://145784202</a>

Reviewed by Cameron McCormack.

To start gently along the path to HDR websites, this
patch sets the initial (aka default) value of
dynamic-range-limit to constrained-high.

For historical reasons, videos have already been
presented in full HDR, so a UA rule was added to make
videos no-limit by default.

* LayoutTests/fast/css/dynamic-range-limit-default-expected.txt: Added.
* LayoutTests/fast/css/dynamic-range-limit-default.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-hdr/inheritance-expected.txt:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/html.css:
(video):
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::applyUASheetBehaviorsToContext):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialDynamicRangeLimit):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertDynamicRangeLimit):
* Tools/TestWebKitAPI/Tests/WebCore/PlatformDynamicRangeLimitTests.cpp:
(TestWebKitAPI::TEST(PlatformDynamicRangeLimit, DefaultConstruction)):

Canonical link: <a href="https://commits.webkit.org/291421@main">https://commits.webkit.org/291421@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c3a1172b9f9d758edf8c8e276dfb13e2591916c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97824 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94878 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95830 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9551 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/83987 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/51352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1619 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79546 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99846 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19880 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14593 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20131 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79337 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23871 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25040 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19551 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23011 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21292 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->