### PR TITLE
[SwiftUI] Remove unnecessary `@_spi(CrossImportOverlay)` uses

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WKScrollGeometryAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKScrollGeometryAdapter.swift
@@ -28,21 +28,16 @@ internal import WebKit_Internal
 
 @_spi(CrossImportOverlay)
 public struct WKScrollGeometryAdapter {
-    @_spi(CrossImportOverlay)
     public let containerSize: CGSize
 
 #if canImport(UIKit)
-    @_spi(CrossImportOverlay)
     public let contentInsets: UIEdgeInsets
 #else
-    @_spi(CrossImportOverlay)
     public let contentInsets: NSEdgeInsets
 #endif
 
-    @_spi(CrossImportOverlay)
     public let contentOffset: CGPoint
 
-    @_spi(CrossImportOverlay)
     public let contentSize: CGSize
 
     init(_ geometry: WKScrollGeometry) {

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -31,7 +31,6 @@ internal import WebKit_Internal
 @MainActor
 @_spi(CrossImportOverlay)
 public final class WebPageWebView: WKWebView {
-    @_spi(CrossImportOverlay)
     public weak var delegate: (any Delegate)? = nil
 
 #if os(iOS)
@@ -61,7 +60,6 @@ public final class WebPageWebView: WKWebView {
 
 extension WebPageWebView {
     @MainActor
-    @_spi(CrossImportOverlay)
     public protocol Delegate: AnyObject {
 #if os(iOS)
         func findInteraction(_ interaction: UIFindInteraction, didBegin session: UIFindSession)
@@ -79,76 +77,63 @@ extension WebPageWebView {
     // MARK: Platform-agnostic scrolling capabilities
 
 #if canImport(UIKit)
-    @_spi(CrossImportOverlay)
     public var alwaysBounceVertical: Bool {
         get { scrollView.alwaysBounceVertical }
         set { scrollView.alwaysBounceVertical = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public var alwaysBounceHorizontal: Bool {
         get { scrollView.alwaysBounceHorizontal }
         set { scrollView.alwaysBounceHorizontal = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public var bouncesVertically: Bool {
         get { scrollView.bouncesVertically }
         set { scrollView.bouncesVertically = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public var bouncesHorizontally: Bool {
         get { scrollView.bouncesHorizontally }
         set { scrollView.bouncesHorizontally = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public var allowsMagnification: Bool {
         get { self._allowsMagnification }
         set { self._allowsMagnification = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public func setContentOffset(_ offset: CGPoint, animated: Bool) {
         scrollView.setContentOffset(offset, animated: animated)
     }
 
-    @_spi(CrossImportOverlay)
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
         self._scroll(to: _WKRectEdge(edge), animated: animated)
     }
 #else
-    @_spi(CrossImportOverlay)
     public var alwaysBounceVertical: Bool {
         get { self._alwaysBounceVertical }
         set { self._alwaysBounceVertical = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public var alwaysBounceHorizontal: Bool {
         get { self._alwaysBounceHorizontal }
         set { self._alwaysBounceHorizontal = newValue }
     }
 
-    @_spi(CrossImportOverlay)
     public var bouncesVertically: Bool {
         get { self._rubberBandingEnabled.contains(.top) && self._rubberBandingEnabled.contains(.bottom) }
         set { self._rubberBandingEnabled.formUnion([.top, .bottom]) }
     }
 
-    @_spi(CrossImportOverlay)
     public var bouncesHorizontally: Bool {
         get { self._rubberBandingEnabled.contains(.left) && self._rubberBandingEnabled.contains(.right) }
         set { self._rubberBandingEnabled.formUnion([.left, .right]) }
     }
 
-    @_spi(CrossImportOverlay)
     public func setContentOffset(_ offset: CGPoint, animated: Bool) {
         self._setContentOffset(offset, animated: animated)
     }
 
-    @_spi(CrossImportOverlay)
     public func scrollTo(edge: NSDirectionalRectEdge, animated: Bool) {
         self._scroll(to: _WKRectEdge(edge), animated: animated)
     }


### PR DESCRIPTION
#### 65345fe73a70ea55b59eaa53f0308eff59733c40
<pre>
[SwiftUI] Remove unnecessary `@_spi(CrossImportOverlay)` uses
<a href="https://bugs.webkit.org/show_bug.cgi?id=288866">https://bugs.webkit.org/show_bug.cgi?id=288866</a>
<a href="https://rdar.apple.com/145878679">rdar://145878679</a>

Reviewed by Aditya Keerthi.

Remove the uses of `@_spi(CrossImportOverlay)` which are not needed; specifically, those applied to symbols
inside types that are themselves annotated as `@_spi(CrossImportOverlay)`.

* Source/WebKit/UIProcess/API/Swift/WKScrollGeometryAdapter.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:

Canonical link: <a href="https://commits.webkit.org/291389@main">https://commits.webkit.org/291389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2a6b0c51b5e9333ce9216d5ad34fde0e9d11fa93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92833 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2027 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/43344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/97829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/43344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95835 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9555 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/83991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/97829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/42672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/19885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/99851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/20136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/79886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/99851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/12911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14819 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/19869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/23016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->