### PR TITLE
Address safer cpp failures in WebKit/UIProcess/WebAuthentication

### DIFF
--- a/Source/WebCore/Modules/webauthn/fido/Pin.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.cpp
@@ -282,23 +282,12 @@ TokenRequest::TokenRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORVal
 {
 }
 
-const CryptoKeyAES& TokenRequest::sharedKey() const
-{
-    return m_sharedKey;
-}
-
-
 SetPinRequest::SetPinRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& newPinEnc, Vector<uint8_t>&& pinUvAuthParam)
     : m_sharedKey(WTFMove(sharedKey))
     , m_coseKey(WTFMove(coseKey))
     , m_newPinEnc(WTFMove(newPinEnc))
     , m_pinUvAuthParam(WTFMove(pinUvAuthParam))
 {
-}
-
-const WebCore::CryptoKeyAES& SetPinRequest::sharedKey() const
-{
-    return m_sharedKey;
 }
 
 const Vector<uint8_t>& SetPinRequest::pinAuth() const

--- a/Source/WebCore/Modules/webauthn/fido/Pin.h
+++ b/Source/WebCore/Modules/webauthn/fido/Pin.h
@@ -135,14 +135,14 @@ private:
 
 struct SetPinRequest {
 public:
-    WEBCORE_EXPORT const WebCore::CryptoKeyAES& sharedKey() const;
+    const WebCore::CryptoKeyAES& sharedKey() const { return m_sharedKey.get(); }
     WEBCORE_EXPORT static std::optional<SetPinRequest> tryCreate(const String& newPin, const WebCore::CryptoKeyEC&);
     WEBCORE_EXPORT const Vector<uint8_t>& pinAuth() const;
 
     friend Vector<uint8_t> encodeAsCBOR(const SetPinRequest&);
 
 private:
-    Ref<WebCore::CryptoKeyAES> m_sharedKey;
+    const Ref<WebCore::CryptoKeyAES> m_sharedKey;
     mutable cbor::CBORValue::MapValue m_coseKey;
     Vector<uint8_t> m_newPinEnc;
     Vector<uint8_t> m_pinUvAuthParam;
@@ -161,14 +161,14 @@ public:
 
     // sharedKey returns the shared ECDH key that was used to encrypt the PIN.
     // This is needed to decrypt the response.
-    WEBCORE_EXPORT const WebCore::CryptoKeyAES& sharedKey() const;
+    const WebCore::CryptoKeyAES& sharedKey() const { return m_sharedKey.get(); }
 
     friend Vector<uint8_t> encodeAsCBOR(const TokenRequest&);
 
 private:
     TokenRequest(Ref<WebCore::CryptoKeyAES>&& sharedKey, cbor::CBORValue::MapValue&& coseKey, Vector<uint8_t>&& pinHash);
 
-    Ref<WebCore::CryptoKeyAES> m_sharedKey;
+    const Ref<WebCore::CryptoKeyAES> m_sharedKey;
     mutable cbor::CBORValue::MapValue m_coseKey;
     Vector<uint8_t> m_pinHash; // Only the left 16 bytes are kept.
 };

--- a/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -13,7 +13,6 @@ UIProcess/API/Cocoa/WKNSURLAuthenticationChallenge.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
-UIProcess/WebAuthentication/Virtual/VirtualService.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/GPU/graphics/WebGPU/WebGPUDowncastConvertToBackingContext.cpp
 WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -161,17 +161,6 @@ UIProcess/Inspector/mac/WKInspectorViewController.mm
 UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
 UIProcess/RemotePageProxy.cpp
 UIProcess/SpeechRecognitionPermissionManager.cpp
-UIProcess/WebAuthentication/AuthenticatorManager.cpp
-UIProcess/WebAuthentication/Cocoa/LocalService.mm
-UIProcess/WebAuthentication/Cocoa/NfcService.mm
-UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
-UIProcess/WebAuthentication/Mock/MockNfcService.mm
-UIProcess/WebAuthentication/Virtual/VirtualService.mm
-UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
-UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
-UIProcess/WebAuthentication/fido/CtapNfcDriver.cpp
-UIProcess/WebAuthentication/fido/FidoService.cpp
-UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
 UIProcess/WebOpenPanelResultListenerProxy.cpp
 UIProcess/WebPreferences.h
 UIProcess/WebProcessActivityState.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -5,13 +5,6 @@ UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
 UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm
 UIProcess/SpeechRecognitionPermissionManager.cpp
 UIProcess/UserMediaProcessManager.cpp
-UIProcess/WebAuthentication/Authenticator.cpp
-UIProcess/WebAuthentication/AuthenticatorManager.cpp
-UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
-UIProcess/WebAuthentication/Cocoa/CcidService.mm
-UIProcess/WebAuthentication/Cocoa/NfcService.mm
-UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
-UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
 UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -28,8 +28,6 @@ UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
 UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
 UIProcess/Gamepad/UIGamepadProvider.cpp
 UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
-UIProcess/WebAuthentication/AuthenticatorManager.cpp
-UIProcess/WebAuthentication/Cocoa/NfcService.mm
 UIProcess/WebPreferences.cpp
 UIProcess/WebProcessCache.cpp
 UIProcess/mac/DisplayCaptureSessionManager.mm

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -49,7 +49,8 @@ public:
 
     void setLAContext(LAContext *context) { m_response->setLAContext(context); }
 
-    WebCore::AuthenticatorAssertionResponse* response() { return m_response.ptr(); }
+    WebCore::AuthenticatorAssertionResponse& response() { return m_response.get(); }
+    Ref<WebCore::AuthenticatorAssertionResponse> protectedResponse() { return m_response; }
 
 private:
     WebAuthenticationAssertionResponse(Ref<WebCore::AuthenticatorAssertionResponse>&&);

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp
@@ -54,6 +54,11 @@ RefPtr<WebKit::AuthenticatorManager> WebAuthenticationPanel::protectedManager() 
     return m_manager;
 }
 
+Ref<WebAuthenticationPanelClient> WebAuthenticationPanel::protectedClient() const
+{
+    return m_client;
+}
+
 WebAuthenticationPanel::WebAuthenticationPanel(const AuthenticatorManager& manager, const WTF::String& rpId, const TransportSet& transports, ClientDataType type, const WTF::String& userName)
     : m_client(WebAuthenticationPanelClient::create())
     , m_weakManager(manager)

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h
@@ -66,6 +66,7 @@ public:
     void setMockConfiguration(WebCore::MockWebAuthenticationConfiguration&&);
 
     const WebAuthenticationPanelClient& client() const { return m_client.get(); }
+    Ref<WebAuthenticationPanelClient> protectedClient() const;
     void setClient(Ref<WebAuthenticationPanelClient>&&);
 
     // FIXME: <rdar://problem/71509848> Remove the following deprecated methods.

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp
@@ -36,13 +36,14 @@ void Authenticator::handleRequest(const WebAuthenticationRequestData& data)
 {
     m_pendingRequestData = data;
     // Enforce asynchronous execution of makeCredential/getAssertion.
-    RunLoop::protectedMain()->dispatch([weakThis = WeakPtr { *this }, this] {
-        if (!weakThis)
+    RunLoop::protectedMain()->dispatch([weakThis = WeakPtr { *this }] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
-        if (std::holds_alternative<WebCore::PublicKeyCredentialCreationOptions>(m_pendingRequestData.options))
-            makeCredential();
+        if (std::holds_alternative<WebCore::PublicKeyCredentialCreationOptions>(protectedThis->m_pendingRequestData.options))
+            protectedThis->makeCredential();
         else
-            getAssertion();
+            protectedThis->getAssertion();
     });
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Authenticator.h
@@ -52,7 +52,7 @@ class AuthenticatorObserver : public AbstractRefCountedAndCanMakeWeakPtr<Authent
 public:
     virtual ~AuthenticatorObserver() = default;
     virtual void respondReceived(AuthenticatorObserverRespond&&) = 0;
-    virtual void downgrade(Authenticator* id, Ref<Authenticator>&& downgradedAuthenticator) = 0;
+    virtual void downgrade(Authenticator& id, Ref<Authenticator>&& downgradedAuthenticator) = 0;
     virtual void authenticatorStatusUpdated(WebAuthenticationStatus) = 0;
     virtual void requestPin(uint64_t retries, CompletionHandler<void(const WTF::String&)>&&) = 0;
     virtual void requestNewPin(uint64_t minLength, CompletionHandler<void(const WTF::String&)>&&) = 0;
@@ -75,6 +75,7 @@ protected:
     Authenticator() = default;
 
     AuthenticatorObserver* observer() const { return m_observer.get(); }
+    RefPtr<AuthenticatorObserver> protectedObserver() const { return m_observer.get(); }
     const WebAuthenticationRequestData& requestData() const { return m_pendingRequestData; }
 
     void receiveRespond(AuthenticatorObserverRespond&&) const;

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h
@@ -99,10 +99,11 @@ private:
     // AuthenticatorTransportServiceObserver
     void authenticatorAdded(Ref<Authenticator>&&) final;
     void serviceStatusUpdated(WebAuthenticationStatus) final;
+    bool isAuthenticatorManager() const final { return true; }
 
     // AuthenticatorObserver
     void respondReceived(Respond&&) final;
-    void downgrade(Authenticator* id, Ref<Authenticator>&& downgradedAuthenticator) final;
+    void downgrade(Authenticator& id, Ref<Authenticator>&& downgradedAuthenticator) final;
     void authenticatorStatusUpdated(WebAuthenticationStatus) final;
     void requestPin(uint64_t retries, CompletionHandler<void(const WTF::String&)>&&) final;
     void requestNewPin(uint64_t minLength, CompletionHandler<void(const WTF::String&)>&&) final;
@@ -135,5 +136,9 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::AuthenticatorManager)
+static bool isType(const WebKit::AuthenticatorTransportServiceObserver& observer) { return observer.isAuthenticatorManager(); }
+SPECIALIZE_TYPE_TRAITS_END()
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h
@@ -49,6 +49,8 @@ public:
     virtual void authenticatorAdded(Ref<Authenticator>&&) = 0;
     virtual void serviceStatusUpdated(WebAuthenticationStatus) = 0;
 
+    virtual bool isAuthenticatorManager() const { return false; }
+
 protected:
     AuthenticatorTransportServiceObserver() = default;
 };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -101,10 +101,10 @@ void CcidConnection::trySelectFidoApplet()
 
 void CcidConnection::transact(Vector<uint8_t>&& data, DataReceivedCallback&& callback) const
 {
-    [m_smartCard beginSessionWithReply:makeBlockPtr([this, data = WTFMove(data), callback = WTFMove(callback)] (BOOL success, NSError *error) mutable {
+    [m_smartCard beginSessionWithReply:makeBlockPtr([this, protectedThis = Ref { *this }, data = WTFMove(data), callback = WTFMove(callback)] (BOOL success, NSError *error) mutable {
         if (!success)
             return;
-        [m_smartCard transmitRequest:toNSData(data).autorelease() reply:makeBlockPtr([this, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
+        [m_smartCard transmitRequest:toNSData(data).autorelease() reply:makeBlockPtr([this, protectedThis = Ref { *this }, callback = WTFMove(callback)](NSData * _Nullable nsResponse, NSError * _Nullable error) mutable {
             [m_smartCard endSession];
             callOnMainRunLoop([response = makeVector(nsResponse), callback = WTFMove(callback)] () mutable {
                 callback(WTFMove(response));

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm
@@ -118,7 +118,7 @@ void CcidService::updateSlots(NSArray *slots)
         slotsSet.add(name);
         auto it = m_slotObservers.find(name);
         if (it == m_slotObservers.end()) {
-            [[TKSmartCardSlotManager defaultManager] getSlotWithName:nsName reply:makeBlockPtr([this, name](TKSmartCardSlot * _Nullable slot) mutable {
+            [[TKSmartCardSlotManager defaultManager] getSlotWithName:nsName reply:makeBlockPtr([this, protectedThis = Ref { *this }, name](TKSmartCardSlot * _Nullable slot) mutable {
                 auto slotObserver = adoptNS([[_WKSmartCardSlotStateObserver alloc] initWithService:this slot:WTFMove(slot)]);
                 m_slotObservers.add(name, slotObserver);
                 [slot addObserver:slotObserver.get() forKeyPath:@"state" options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial context:nil];

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm
@@ -71,9 +71,11 @@ LOCAL_SERVICE_ADDITIONS
 
 void LocalService::startDiscoveryInternal()
 {
-    if (!platformStartDiscovery() || !observer())
+    if (!platformStartDiscovery())
         return;
-    observer()->authenticatorAdded(LocalAuthenticator::create(createLocalConnection()));
+
+    if (RefPtr observer = this->observer())
+        observer->authenticatorAdded(LocalAuthenticator::create(createLocalConnection()));
 }
 
 bool LocalService::platformStartDiscovery() const

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm
@@ -216,7 +216,7 @@ void WebAuthenticationPanelClient::selectAssertionResponse(Vector<Ref<WebCore::A
             completionHandler(nullptr);
             return;
         }
-        completionHandler(downcast<API::WebAuthenticationAssertionResponse>([response _apiObject]).response());
+        completionHandler(downcast<API::WebAuthenticationAssertionResponse>([response _apiObject]).protectedResponse().ptr());
     }).get()];
 }
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h
@@ -66,6 +66,11 @@ private:
 } // namespace WebKit
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::VirtualAuthenticatorManager)
+static bool isType(const WebKit::AuthenticatorTransportServiceObserver& observer)
+{
+    auto* manager = dynamicDowncast<WebKit::AuthenticatorManager>(observer);
+    return manager && manager->isVirtual();
+}
 static bool isType(const WebKit::AuthenticatorManager& manager) { return manager.isVirtual(); }
 SPECIALIZE_TYPE_TRAITS_END()
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm
@@ -73,7 +73,8 @@ void VirtualService::startDiscoveryInternal()
 {
 
     for (auto& authenticator : m_authenticators) {
-        if (!observer())
+        RefPtr observer = this->observer();
+        if (!observer)
             return;
         auto config = authenticator.second;
         auto authenticatorId = authenticator.first;
@@ -81,10 +82,10 @@ void VirtualService::startDiscoveryInternal()
         case WebCore::AuthenticatorTransport::Nfc:
         case WebCore::AuthenticatorTransport::Ble:
         case WebCore::AuthenticatorTransport::Usb:
-            observer()->authenticatorAdded(CtapAuthenticator::create(CtapHidDriver::create(VirtualHidConnection::create(authenticatorId, config, WeakPtr { static_cast<VirtualAuthenticatorManager *>(observer()) })), authenticatorInfoForConfig(config)));
+            observer->authenticatorAdded(CtapAuthenticator::create(CtapHidDriver::create(VirtualHidConnection::create(authenticatorId, config, WeakPtr { downcast<VirtualAuthenticatorManager>(*observer) })), authenticatorInfoForConfig(config)));
             break;
         case WebCore::AuthenticatorTransport::Internal:
-            observer()->authenticatorAdded(LocalAuthenticator::create(VirtualLocalConnection::create(config)));
+            observer->authenticatorAdded(LocalAuthenticator::create(VirtualLocalConnection::create(config)));
             break;
         default:
             UNIMPLEMENTED();

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -49,6 +49,8 @@
 #include <wtf/text/MakeString.h>
 
 #define CTAP_RELEASE_LOG(fmt, ...) RELEASE_LOG(WebAuthn, "%p [aaguid=%s, transport=%s] - CtapAuthenticator::" fmt, this, aaguidForDebugging().utf8().data(), transportForDebugging().utf8().data(), ##__VA_ARGS__)
+#define CTAP_RELEASE_LOG_WITH_THIS(thisPtr, fmt, ...) RELEASE_LOG(WebAuthn, "%p [aaguid=%s, transport=%s] - CtapAuthenticator::" fmt, thisPtr.get(), thisPtr->aaguidForDebugging().utf8().data(), thisPtr->transportForDebugging().utf8().data(), ##__VA_ARGS__)
+
 
 namespace WebKit {
 using namespace WebCore;
@@ -110,7 +112,7 @@ void CtapAuthenticator::makeCredential()
     Vector<String> authenticatorSupportedExtensions;
     if (m_isKeyStoreFull || (m_info.remainingDiscoverableCredentials() && !m_info.remainingDiscoverableCredentials())) {
         if (options.authenticatorSelection && (options.authenticatorSelection->requireResidentKey || options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required)) {
-            observer()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
+            protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
             return;
         }
         residentKeyAvailability = AuthenticatorSupportedOptions::ResidentKeyAvailability::kNotSupported;
@@ -125,7 +127,7 @@ void CtapAuthenticator::makeCredential()
     CTAP_RELEASE_LOG("makeCredential: Sending %s", base64EncodeToString(cborCmd).utf8().data());
     if (m_info.maxMsgSize() && cborCmd.size() >= *m_info.maxMsgSize())
         CTAP_RELEASE_LOG("CtapAuthenticator::makeCredential cmdSize = %lu maxMsgSize = %u", cborCmd.size(), *m_info.maxMsgSize());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -153,7 +155,7 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
         if (error == CtapDeviceResponseCode::kCtap2ErrKeyStoreFull) {
             auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
             if (options.authenticatorSelection->requireResidentKey || options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required)
-                observer()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
+                protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::KeyStoreFull);
             else if (!m_isKeyStoreFull) {
                 m_isKeyStoreFull = true;
                 makeCredential();
@@ -162,8 +164,10 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
         }
 
         if (isPinError(error)) {
-            if (!m_pinAuth.isEmpty() && observer()) // Skip the very first command that acts like wink.
-                observer()->authenticatorStatusUpdated(toStatus(error));
+            if (!m_pinAuth.isEmpty()) { // Skip the very first command that acts like wink.
+                if (RefPtr observer = this->observer())
+                    observer->authenticatorStatusUpdated(toStatus(error));
+            }
             if (tryRestartPin(error))
                 return;
         }
@@ -201,7 +205,7 @@ void CtapAuthenticator::getAssertion()
     if (m_info.maxMsgSize() && cborCmd.size() >= *m_info.maxMsgSize())
         CTAP_RELEASE_LOG("getAssertion cmdSize = %lu maxMsgSize = %u", cborCmd.size(), *m_info.maxMsgSize());
     CTAP_RELEASE_LOG("getAssertion: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -225,14 +229,18 @@ void CtapAuthenticator::continueGetAssertionAfterResponseReceived(Vector<uint8_t
             return;
 
         if (isPinError(error)) {
-            if (!m_pinAuth.isEmpty() && observer()) // Skip the very first command that acts like wink.
-                observer()->authenticatorStatusUpdated(toStatus(error));
+            if (!m_pinAuth.isEmpty()) { // Skip the very first command that acts like wink.
+                if (RefPtr observer = this->observer())
+                    observer->authenticatorStatusUpdated(toStatus(error));
+            }
             if (tryRestartPin(error))
                 return;
         }
 
-        if (error == CtapDeviceResponseCode::kCtap2ErrNoCredentials && observer())
-            observer()->authenticatorStatusUpdated(WebAuthenticationStatus::NoCredentialsFound);
+        if (error == CtapDeviceResponseCode::kCtap2ErrNoCredentials) {
+            if (RefPtr observer = this->observer())
+                observer->authenticatorStatusUpdated(WebAuthenticationStatus::NoCredentialsFound);
+        }
 
         CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: No credentials found.");
         receiveRespond(ExceptionData { ExceptionCode::UnknownError, makeString("Unknown internal error. Error code: "_s, static_cast<uint8_t>(error)) });
@@ -250,7 +258,7 @@ void CtapAuthenticator::continueGetAssertionAfterResponseReceived(Vector<uint8_t
     m_assertionResponses.append(response.releaseNonNull());
     auto cborCmd = encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetNextAssertion);
     CTAP_RELEASE_LOG("continueGetAssertionAfterResponseReceived: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -274,16 +282,17 @@ void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uin
 
     if (!m_remainingAssertionResponses) {
         if (RefPtr observer = this->observer()) {
-            observer->selectAssertionResponse(Vector { m_assertionResponses }, WebAuthenticationSource::External, [this, weakThis = WeakPtr { *this }] (AuthenticatorAssertionResponse* response) {
+            observer->selectAssertionResponse(Vector { m_assertionResponses }, WebAuthenticationSource::External, [weakThis = WeakPtr { *this }] (AuthenticatorAssertionResponse* response) {
                 RELEASE_ASSERT(RunLoop::isMain());
-                if (!weakThis)
+                RefPtr protectedThis = weakThis.get();
+                if (!protectedThis)
                     return;
-                auto result = m_assertionResponses.findIf([expectedResponse = response] (auto& response) {
+                auto result = protectedThis->m_assertionResponses.findIf([expectedResponse = response] (auto& response) {
                     return response.ptr() == expectedResponse;
                 });
                 if (result == notFound)
                     return;
-                receiveRespond(m_assertionResponses[result].copyRef());
+                protectedThis->receiveRespond(protectedThis->m_assertionResponses[result].copyRef());
             });
         }
         return;
@@ -291,7 +300,7 @@ void CtapAuthenticator::continueGetNextAssertionAfterResponseReceived(Vector<uin
 
     auto cborCmd = encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetNextAssertion);
     CTAP_RELEASE_LOG("continueGetNextAssertionAfterResponseReceived: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;
@@ -303,12 +312,13 @@ void CtapAuthenticator::getRetries()
 {
     auto cborCmd = encodeAsCBOR(pin::RetriesRequest { });
     CTAP_RELEASE_LOG("getRetries: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this](Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
-        if (!weakThis)
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
-        CTAP_RELEASE_LOG("getRetries: Response %s", base64EncodeToString(data).utf8().data());
-        weakThis->continueGetKeyAgreementAfterGetRetries(WTFMove(data));
+        CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "getRetries: Response %s", base64EncodeToString(data).utf8().data());
+        protectedThis->continueGetKeyAgreementAfterGetRetries(WTFMove(data));
     });
 }
 
@@ -324,12 +334,13 @@ void CtapAuthenticator::continueGetKeyAgreementAfterGetRetries(Vector<uint8_t>&&
 
     auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { });
     CTAP_RELEASE_LOG("continueGetKeyAgreementAfterGetRetries: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this, retries = retries->retries] (Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, retries = retries->retries] (Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
-        if (!weakThis)
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
-        CTAP_RELEASE_LOG("continueGetKeyAgreementAfterGetRetries: Response %s", base64EncodeToString(data).utf8().data());
-        weakThis->continueRequestPinAfterGetKeyAgreement(WTFMove(data), retries);
+        CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "continueGetKeyAgreementAfterGetRetries: Response %s", base64EncodeToString(data).utf8().data());
+        protectedThis->continueRequestPinAfterGetKeyAgreement(WTFMove(data), retries);
     });
 }
 
@@ -345,12 +356,13 @@ void CtapAuthenticator::continueRequestPinAfterGetKeyAgreement(Vector<uint8_t>&&
 
     if (RefPtr observer = this->observer()) {
         CTAP_RELEASE_LOG("continueRequestPinAfterGetKeyAgreement: Requesting pin from observer.");
-        observer->requestPin(retries, [weakThis = WeakPtr { *this }, this, keyAgreement = WTFMove(*keyAgreement)] (const String& pin) {
+        observer->requestPin(retries, [weakThis = WeakPtr { *this }, keyAgreement = WTFMove(*keyAgreement)] (const String& pin) {
             RELEASE_ASSERT(RunLoop::isMain());
-            if (!weakThis)
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
-            CTAP_RELEASE_LOG("continueRequestPinAfterGetKeyAgreement: Got pin from observer.");
-            weakThis->continueGetPinTokenAfterRequestPin(pin, keyAgreement.peerKey);
+            CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "continueRequestPinAfterGetKeyAgreement: Got pin from observer.");
+            protectedThis->continueGetPinTokenAfterRequestPin(pin, keyAgreement.peerKey);
         });
     }
 }
@@ -379,12 +391,12 @@ void CtapAuthenticator::continueGetPinTokenAfterRequestPin(const String& pin, co
 
     auto cborCmd = encodeAsCBOR(*tokenRequest);
     CTAP_RELEASE_LOG("continueGetPinTokenAfterRequestPin: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this, tokenRequest = WTFMove(*tokenRequest)] (Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, tokenRequest = WTFMove(*tokenRequest)] (Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        CTAP_RELEASE_LOG("continueGetPinTokenAfterRequestPin: Response %s", base64EncodeToString(data).utf8().data());
+        CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "continueGetPinTokenAfterRequestPin: Response %s", base64EncodeToString(data).utf8().data());
         protectedThis->continueRequestAfterGetPinToken(WTFMove(data), tokenRequest);
     });
 }
@@ -434,7 +446,8 @@ bool CtapAuthenticator::tryDowngrade()
     CTAP_RELEASE_LOG("tryDowngrade");
     if (m_info.versions().find(ProtocolVersion::kU2f) == m_info.versions().end())
         return false;
-    if (!observer())
+    RefPtr observer = this->observer();
+    if (!observer)
         return false;
 
     bool isConvertible = false;
@@ -449,7 +462,7 @@ bool CtapAuthenticator::tryDowngrade()
     CTAP_RELEASE_LOG("tryDowngrade: Downgrading to U2F.");
     m_isDowngraded = true;
     driver().setProtocol(ProtocolVersion::kU2f);
-    observer()->downgrade(this, U2fAuthenticator::create(releaseDriver()));
+    observer->downgrade(*this, U2fAuthenticator::create(releaseDriver()));
     return true;
 }
 
@@ -476,14 +489,14 @@ void CtapAuthenticator::continueSetupPinAfterCommand(Vector<uint8_t>&& data, con
     auto error = getResponseCode(data);
     if (error != fido::CtapDeviceResponseCode::kSuccess) {
         CTAP_RELEASE_LOG("continueSetupPinAfterCommand: Response of setPin was not successful: %s", base64EncodeToString(data).utf8().data());
-        observer()->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
+        protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
         return;
     }
     m_info.mutableOptions().setClientPinAvailability(AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet);
     auto pinUTF8 = pin::validateAndConvertToUTF8(pin);
     if (!pinUTF8) {
         CTAP_RELEASE_LOG("continueSetupPinAfterCommand: Unable to convert PIN, although it was successfully set.");
-        observer()->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
+        protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::PinInvalid);
         return;
     }
     auto tokenRequest = pin::TokenRequest::tryCreate(*pinUTF8, peerKey);
@@ -495,12 +508,12 @@ void CtapAuthenticator::continueSetupPinAfterCommand(Vector<uint8_t>&& data, con
 
     auto cborCmd = encodeAsCBOR(*tokenRequest);
     CTAP_RELEASE_LOG("continueSetupPinAfterCommand: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, this, tokenRequest = WTFMove(*tokenRequest)] (Vector<uint8_t>&& data) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, tokenRequest = WTFMove(*tokenRequest)] (Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        CTAP_RELEASE_LOG("continueGetPinTokenAfterRequestPin: Response %s", base64EncodeToString(data).utf8().data());
+        CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "continueGetPinTokenAfterRequestPin: Response %s", base64EncodeToString(data).utf8().data());
         protectedThis->continueRequestAfterGetPinToken(WTFMove(data), tokenRequest);
     });
 }
@@ -521,7 +534,7 @@ void CtapAuthenticator::continueSetupPinAfterGetKeyAgreement(Vector<uint8_t>&& d
     }
     m_pinAuth = setPinRequest->pinAuth();
     auto cborCmd = encodeAsCBOR(*setPinRequest);
-    driver().transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, pin, peerKey = WTFMove( keyAgreement->peerKey)](Vector<uint8_t>&& response) {
+    protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WeakPtr { *this }, pin, peerKey = WTFMove( keyAgreement->peerKey)](Vector<uint8_t>&& response) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -531,33 +544,34 @@ void CtapAuthenticator::continueSetupPinAfterGetKeyAgreement(Vector<uint8_t>&& d
 
 void CtapAuthenticator::setupPin()
 {
-    if (!observer())
+    RefPtr observer = this->observer();
+    if (!observer)
         return;
     CTAP_RELEASE_LOG("setupPin: Requesting new pin from delegate");
     uint64_t minLength = m_info.minPINLength().value_or(4);
-    observer()->requestNewPin(minLength, [weakThis = WeakPtr { *this }, this] (const String& pin) {
+    observer->requestNewPin(minLength, [weakThis = WeakPtr { *this }] (const String& pin) {
         ASSERT(RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
         if (auto minPINLength = protectedThis->m_info.minPINLength(); pin.length() < (minPINLength ? *minPINLength : 4)) {
-            protectedThis->observer()->authenticatorStatusUpdated(WebAuthenticationStatus::PINTooShort); // PINTooShort
+            protectedThis->protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::PINTooShort); // PINTooShort
             protectedThis->performAuthenticatorSelectionForSetupPin();
             return;
         }
         if (pin.sizeInBytes() > kPINMaxSizeInBytes) {
-            protectedThis->observer()->authenticatorStatusUpdated(WebAuthenticationStatus::PINTooLong); // PINTooLong
+            protectedThis->protectedObserver()->authenticatorStatusUpdated(WebAuthenticationStatus::PINTooLong); // PINTooLong
             protectedThis->performAuthenticatorSelectionForSetupPin();
             return;
         }
         auto cborCmd = encodeAsCBOR(pin::KeyAgreementRequest { });
-        CTAP_RELEASE_LOG("setupPin: Sending %s", base64EncodeToString(cborCmd).utf8().data());
-        driver().transact(WTFMove(cborCmd), [weakThis = WTFMove(weakThis), this, pin] (Vector<uint8_t>&& data) {
+        CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "setupPin: Sending %s", base64EncodeToString(cborCmd).utf8().data());
+        protectedThis->protectedDriver()->transact(WTFMove(cborCmd), [weakThis = WTFMove(weakThis), pin] (Vector<uint8_t>&& data) {
             ASSERT(RunLoop::isMain());
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
-            CTAP_RELEASE_LOG("setupPin: Response %s", base64EncodeToString(data).utf8().data());
+            CTAP_RELEASE_LOG_WITH_THIS(protectedThis, "setupPin: Response %s", base64EncodeToString(data).utf8().data());
             protectedThis->continueSetupPinAfterGetKeyAgreement(WTFMove(data), pin);
         });
     });
@@ -568,7 +582,7 @@ void CtapAuthenticator::performAuthenticatorSelectionForSetupPin()
     CTAP_RELEASE_LOG("performAuthenticatorSelectionForSetupPin: Requesting gesture for authenticator selection");
     if (m_info.versions().contains(ProtocolVersion::kCtap21) || m_info.versions().contains(ProtocolVersion::kCtap21Pre)) {
         // We should perform the authenticatorSelector command
-        driver().transact(encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorAuthenticatorSelection), [weakThis = WeakPtr { *this }, weakDriver = WeakPtr { driver() }] (Vector<uint8_t>&& response) mutable {
+        protectedDriver()->transact(encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorAuthenticatorSelection), [weakThis = WeakPtr { *this }, weakDriver = WeakPtr { driver() }] (Vector<uint8_t>&& response) mutable {
             ASSERT(RunLoop::isMain());
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->setupPin();
@@ -576,7 +590,7 @@ void CtapAuthenticator::performAuthenticatorSelectionForSetupPin()
     } else {
         auto zeroLengthPinAuth = encodeBogusRequestForAuthenticatorSelection();
         // We should send a zeroLength pinAuth
-        driver().transact(WTFMove(zeroLengthPinAuth), [weakThis = WeakPtr { *this }, weakDriver = WeakPtr { driver() }] (Vector<uint8_t>&& response) mutable {
+        protectedDriver()->transact(WTFMove(zeroLengthPinAuth), [weakThis = WeakPtr { *this }, weakDriver = WeakPtr { driver() }] (Vector<uint8_t>&& response) mutable {
             ASSERT(RunLoop::isMain());
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->setupPin();

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp
@@ -60,7 +60,7 @@ void CtapCcidDriver::transact(Vector<uint8_t>&& data, ResponseCallback&& callbac
         command.setIns(kCtapNfcApduIns);
         command.setData(WTFMove(data));
         command.setResponseLength(ApduCommand::kApduMaxResponseLength);
-        auto ncallback = [callback = WTFMove(callback), this](Vector<uint8_t>&& resp) mutable {
+        auto ncallback = [callback = WTFMove(callback), this, protectedThis = Ref { *this }](Vector<uint8_t>&& resp) mutable {
             auto apduResponse = ApduResponse::createFromMessage(WTFMove(resp));
             if (!apduResponse) {
                 respondAsync(WTFMove(callback), { });

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h
@@ -46,7 +46,7 @@ private:
 
     void respondAsync(ResponseCallback&&, Vector<uint8_t>&& response) const;
 
-    Ref<CcidConnection> m_connection;
+    const Ref<CcidConnection> m_connection;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h
@@ -46,7 +46,7 @@ private:
 
     void respondAsync(ResponseCallback&&, Vector<uint8_t>&& response) const;
 
-    Ref<NfcConnection> m_connection;
+    const Ref<NfcConnection> m_connection;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp
@@ -51,6 +51,11 @@ CtapDriver& FidoAuthenticator::driver() const
     return *m_driver;
 }
 
+Ref<CtapDriver> FidoAuthenticator::protectedDriver() const
+{
+    return driver();
+}
+
 Ref<CtapDriver> FidoAuthenticator::releaseDriver()
 {
     ASSERT(m_driver);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
@@ -41,6 +41,7 @@ protected:
     explicit FidoAuthenticator(Ref<CtapDriver>&&);
 
     CtapDriver& driver() const;
+    Ref<CtapDriver> protectedDriver() const;
     Ref<CtapDriver> releaseDriver();
 
     String transportForDebugging() const;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp
@@ -57,21 +57,26 @@ void FidoService::getInfo(Ref<CtapDriver>&& driver)
     // Get authenticator info from the device.
     driver->transact(encodeEmptyAuthenticatorRequest(CtapRequestCommand::kAuthenticatorGetInfo), [weakThis = WeakPtr { *this }, weakDriver = WeakPtr { driver.get() }] (Vector<uint8_t>&& response) mutable {
         ASSERT(RunLoop::isMain());
-        if (!weakThis)
-            return;
-        weakThis->continueAfterGetInfo(WTFMove(weakDriver), WTFMove(response));
+        RefPtr protectedThis = weakThis.get();
+        RefPtr driver = weakDriver.get();
+        if (protectedThis && driver)
+            protectedThis->continueAfterGetInfo(*driver, WTFMove(response));
     });
     auto addResult = m_drivers.add(WTFMove(driver));
     ASSERT_UNUSED(addResult, addResult.isNewEntry);
 }
 
-void FidoService::continueAfterGetInfo(WeakPtr<CtapDriver>&& weakDriver, Vector<uint8_t>&& response)
+void FidoService::continueAfterGetInfo(CtapDriver& inputDriver, Vector<uint8_t>&& response)
 {
-    if (!weakDriver)
+    RefPtr driver = m_drivers.take(&inputDriver);
+    if (!driver)
         return;
 
-    RefPtr driver = m_drivers.take(weakDriver.get());
-    if (!driver || !observer() || response.isEmpty())
+    RefPtr observer = this->observer();
+    if (!observer)
+        return;
+
+    if (response.isEmpty())
         return;
 
     CTAP_RELEASE_LOG("Got response from getInfo: %s", base64EncodeToString(response).utf8().data());
@@ -79,11 +84,11 @@ void FidoService::continueAfterGetInfo(WeakPtr<CtapDriver>&& weakDriver, Vector<
     auto info = readCTAPGetInfoResponse(response);
     if (info && info->versions().find(ProtocolVersion::kCtap2) != info->versions().end()) {
         driver->setMaxMsgSize(info->maxMsgSize());
-        observer()->authenticatorAdded(CtapAuthenticator::create(driver.releaseNonNull(), WTFMove(*info)));
+        observer->authenticatorAdded(CtapAuthenticator::create(driver.releaseNonNull(), WTFMove(*info)));
         return;
     }
     driver->setProtocol(ProtocolVersion::kU2f);
-    observer()->authenticatorAdded(U2fAuthenticator::create(driver.releaseNonNull()));
+    observer->authenticatorAdded(U2fAuthenticator::create(driver.releaseNonNull()));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h
@@ -45,7 +45,7 @@ protected:
     void getInfo(Ref<CtapDriver>&&);
 
 private:
-    void continueAfterGetInfo(WeakPtr<CtapDriver>&&, Vector<uint8_t>&& info);
+    void continueAfterGetInfo(CtapDriver&, Vector<uint8_t>&& info);
 
     // Keeping drivers alive when they are getting info from devices.
     HashSet<Ref<CtapDriver>> m_drivers;

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -132,7 +132,7 @@ void U2fAuthenticator::issueNewCommand(Vector<uint8_t>&& command, CommandType ty
 void U2fAuthenticator::issueCommand(const Vector<uint8_t>& command, CommandType type)
 {
     U2F_RELEASE_LOG("issueCommand: Sending %s", base64EncodeToString(command).utf8().data());
-    driver().transact(Vector<uint8_t>(command), [weakThis = WeakPtr { *this }, type](Vector<uint8_t>&& data) {
+    protectedDriver()->transact(Vector<uint8_t>(command), [weakThis = WeakPtr { *this }, type](Vector<uint8_t>&& data) {
         ASSERT(RunLoop::isMain());
         if (!weakThis)
             return;


### PR DESCRIPTION
#### 4912508a6d26dec6478027222442371154d1a125
<pre>
Address safer cpp failures in WebKit/UIProcess/WebAuthentication
<a href="https://bugs.webkit.org/show_bug.cgi?id=288883">https://bugs.webkit.org/show_bug.cgi?id=288883</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/webauthn/fido/Pin.cpp:
(fido::pin::TokenRequest::sharedKey const): Deleted.
(fido::pin::SetPinRequest::sharedKey const): Deleted.
* Source/WebCore/Modules/webauthn/fido/Pin.h:
(fido::pin::SetPinRequest::sharedKey const):
(fido::pin::TokenRequest::sharedKey const):
* Source/WebKit/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.cpp:
(API::WebAuthenticationPanel::protectedClient const):
* Source/WebKit/UIProcess/API/APIWebAuthenticationPanel.h:
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.cpp:
(WebKit::Authenticator::handleRequest):
* Source/WebKit/UIProcess/WebAuthentication/Authenticator.h:
(WebKit::Authenticator::protectedObserver const):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::AuthenticatorManager::serviceStatusUpdated):
(WebKit::AuthenticatorManager::downgrade):
(WebKit::AuthenticatorManager::authenticatorStatusUpdated):
(WebKit::AuthenticatorManager::requestPin):
(WebKit::AuthenticatorManager::requestNewPin):
(WebKit::AuthenticatorManager::selectAssertionResponse):
(WebKit::AuthenticatorManager::decidePolicyForLocalAuthenticator):
(WebKit::AuthenticatorManager::requestLAContextForUserVerification):
(WebKit::AuthenticatorManager::runPanel):
(WebKit::AuthenticatorManager::invokePendingCompletionHandler):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.h:
(isType):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorTransportService.h:
(WebKit::AuthenticatorTransportServiceObserver::isAuthenticatorManager const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(WebKit::CcidConnection::transact const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(WebKit::CcidService::updateSlots):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalService.mm:
(WebKit::LocalService::startDiscoveryInternal):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/NfcService.mm:
(WebKit::NfcService::didDetectMultipleTags const):
(WebKit::NfcService::restartDiscoveryInternal):
(WebKit::NfcService::platformStartDiscovery):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticationPanelClient.mm:
(WebKit::WebAuthenticationPanelClient::selectAssertionResponse const):
* Source/WebKit/UIProcess/WebAuthentication/Mock/MockNfcService.mm:
(WebKit::MockNfcService::platformStartDiscovery):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualAuthenticatorManager.h:
(isType):
* Source/WebKit/UIProcess/WebAuthentication/Virtual/VirtualService.mm:
(WebKit::VirtualService::startDiscoveryInternal):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::getAssertion):
(WebKit::CtapAuthenticator::continueGetAssertionAfterResponseReceived):
(WebKit::CtapAuthenticator::continueGetNextAssertionAfterResponseReceived):
(WebKit::CtapAuthenticator::getRetries):
(WebKit::CtapAuthenticator::continueGetKeyAgreementAfterGetRetries):
(WebKit::CtapAuthenticator::continueRequestPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::continueGetPinTokenAfterRequestPin):
(WebKit::CtapAuthenticator::tryDowngrade):
(WebKit::CtapAuthenticator::continueSetupPinAfterCommand):
(WebKit::CtapAuthenticator::continueSetupPinAfterGetKeyAgreement):
(WebKit::CtapAuthenticator::setupPin):
(WebKit::CtapAuthenticator::performAuthenticatorSelectionForSetupPin):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.cpp:
(WebKit::CtapCcidDriver::transact):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapCcidDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapNfcDriver.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.cpp:
(WebKit::FidoAuthenticator::protectedDriver const):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.cpp:
(WebKit::FidoService::getInfo):
(WebKit::FidoService::continueAfterGetInfo):
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoService.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::issueCommand):

Canonical link: <a href="https://commits.webkit.org/291449@main">https://commits.webkit.org/291449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92dfdf22d848616acfdfac519c2164285192355f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92956 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97955 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43482 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71074 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28490 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95958 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9633 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84086 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51402 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42795 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80096 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79397 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19711 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23942 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13035 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19992 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19679 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23139 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->