### PR TITLE
[SwiftUI] Update `WebPage.DialogPresenting` to latest interface

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift
@@ -77,7 +77,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
         let result = await dialogPresenter.handleFileInputPrompt(parameters: parameters, initiatedBy: .init(frame))
 
         return switch result {
-        case let .ok(value): value
+        case let .selected(value): value
         case .cancel: nil
         }
     }

--- a/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
@@ -28,59 +28,115 @@ import Foundation
 // MARK: Supporting types
 
 extension WebPage {
-    @_spi(Private)
+    /// The result of handling a JavaScript confirm invocation.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public enum JavaScriptConfirmResult: Hashable, Sendable {
+        /// Signals an affirmative action was produced by the invocation.
         case ok
+
+        /// Signals a negative action was produced by the invocation.
         case cancel
     }
 
-    @_spi(Private)
+    /// The result of handling a JavaScript confirm invocation.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public enum JavaScriptPromptResult: Hashable, Sendable {
+        /// Signals an affirmative action was produced by the invocation with the specified text.
         case ok(String)
+
+        /// Signals a negative action was produced by the invocation.
         case cancel
     }
 
-    @_spi(Private)
+    /// The result of handling a JavaScript open invocation.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
     public enum FileInputPromptResult: Hashable, Sendable {
-        case ok([URL])
+        /// Signals an affirmative action was produced by the invocation with the specified files.
+        case selected([URL])
+
+        /// Signals a negative action was produced by the invocation.
         case cancel
     }
 }
 
 // MARK: DialogPresenting protocol
 
-@_spi(Private)
+/// Allows providing custom behavior to handle JavaScript actions and provide a response.
+///
+/// Typically when handling these, some UI should be presented to the user for them to provide a response,
+/// which will then be communicated back to JavaScript.
+///
+/// When these methods are invoked, JavaScript is blocked until the async method returns.
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 public protocol DialogPresenting {
+    /// A JavaScript `alert()` function has been invoked.
+    ///
+    /// - Parameters:
+    ///   - message: The message provided by JavaScript.
+    ///   - frame: Information about the frame whose JavaScript process initiated this call.
     @MainActor
     func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async
 
+    /// A JavaScript `confirm()` function has been invoked.
+    ///
+    /// - Parameters:
+    ///   - message: The message provided by JavaScript.
+    ///   - frame: Information about the frame whose JavaScript process initiated this call.
+    /// - Returns: The result of handling the invocation.
     @MainActor
     func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult
 
+    /// A JavaScript `prompt()` function has been invoked.
+    ///
+    /// - Parameters:
+    ///   - message: The message provided by JavaScript.
+    ///   - defaultText: The initial text provided by JavaScript, intended to be displayed in some text entry field.
+    ///   - frame: Information about the frame whose JavaScript process initiated this call.
+    /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include some text returned to JavaScript.
     @MainActor
     func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult
 
+    /// Returns the result of handling a JavaScript request to open files.
+    ///
+    /// - Parameter parameters: The options to use for the file dialog.
+    ///   - frame: Information about the frame whose JavaScript process initiated this call.
+    /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include a set of files returned to JavaScript.
     @MainActor
     func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult
 }
 
 // MARK: Default implementation
 
+@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
 public extension DialogPresenting {
+    /// By default, this method immediately returns.
     @MainActor
     func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async {
     }
 
+    /// By default, this method immediately returns with a result of `.cancel`.
     @MainActor
     func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult {
         .cancel
     }
 
+    /// By default, this method immediately returns with a result of `.cancel`.
     @MainActor
     func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult {
         .cancel
     }
 
+    /// By default, this method immediately returns with a result of `.cancel`.
     @MainActor
     func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult {
         .cancel

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -229,7 +229,6 @@ final public class WebPage {
         self.init(_configuration: configuration, _navigationDecider: navigationDecider, _dialogPresenter: dialogPresenter, _downloadCoordinator: downloadCoordinator)
     }
 
-    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding,
@@ -256,7 +255,6 @@ final public class WebPage {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: dialogPresenter, _downloadCoordinator: downloadCoordinator)
     }
 
-    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         dialogPresenter: some DialogPresenting
@@ -264,7 +262,6 @@ final public class WebPage {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: dialogPresenter, _downloadCoordinator: nil)
     }
 
-    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
         navigationDecider: some NavigationDeciding
@@ -280,7 +277,6 @@ final public class WebPage {
         self.init(_configuration: configuration, _navigationDecider: nil, _dialogPresenter: nil, _downloadCoordinator: downloadCoordinator)
     }
 
-    @_spi(Private)
     public convenience init(
         configuration: Configuration = Configuration(),
     ) {

--- a/Tools/SwiftBrowser/Source/SwiftBrowser.swift
+++ b/Tools/SwiftBrowser/Source/SwiftBrowser.swift
@@ -22,7 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import SwiftUI
-@_spi(Private) import WebKit
+import WebKit
 
 @main
 struct SwiftBrowserApp: App {

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -173,7 +173,7 @@ final class BrowserViewModel {
 
         switch result {
         case let .success(urls):
-            currentFilePicker!.completion(.ok(urls))
+            currentFilePicker!.completion(.selected(urls))
 
         case .failure:
             currentFilePicker!.completion(.cancel)

--- a/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
@@ -22,7 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-@_spi(Private) import WebKit
+import WebKit
 
 @MainActor
 final class DialogPresenter: DialogPresenting {

--- a/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/NavigationDecider.swift
@@ -22,7 +22,7 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
-@_spi(Private) import WebKit
+import WebKit
 @_spi(Private) import _WebKit_SwiftUI
 
 @MainActor

--- a/Tools/SwiftBrowser/Source/Views/ContentView.swift
+++ b/Tools/SwiftBrowser/Source/Views/ContentView.swift
@@ -23,7 +23,7 @@
 
 import SwiftUI
 import UniformTypeIdentifiers
-@_spi(Private) import WebKit
+import WebKit
 @_spi(Private) import _WebKit_SwiftUI
 
 private struct ToolbarBackForwardMenuView: View {

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -24,7 +24,7 @@
 #if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.0)
 
 import Testing
-@_spi(Private) import WebKit
+import WebKit
 
 fileprivate struct TestURLSchemeHandler: URLSchemeHandler, Sendable {
     struct Failure: Error {


### PR DESCRIPTION
#### 9eae8b7e72a059d163bd6d363ef1a138e9fb88e7
<pre>
[SwiftUI] Update `WebPage.DialogPresenting` to latest interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=288890">https://bugs.webkit.org/show_bug.cgi?id=288890</a>
<a href="https://rdar.apple.com/145891303">rdar://145891303</a>

Reviewed by Aditya Keerthi.

Update some various definitions/declarations for WebPage.DialogPresenting.

* Source/WebKit/UIProcess/API/Swift/WKUIDelegateAdapter.swift:
(WKUIDelegateAdapter.webView(_:runOpenPanelWith:initiatedByFrame:)):
* Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift:
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.didImportFiles(_:any:)):

Canonical link: <a href="https://commits.webkit.org/291464@main">https://commits.webkit.org/291464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3371c00b4f7cf5af3c6f875773bd91efa27c3c2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97885 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71035 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28461 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1654 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42727 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79576 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99907 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80055 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20191 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79355 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23897 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1161 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12966 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14860 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19924 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25100 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19611 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->