### PR TITLE
AX: AXTextMarker::offsetFromRoot repeatedly calls lineID() on a non-text-run marker, which is very expensive

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1130,8 +1130,8 @@ public:
     virtual String textContentPrefixFromListMarker() const = 0;
 #if ENABLE(AX_THREAD_TEXT_APIS)
     virtual bool hasTextRuns() = 0;
-    virtual TextEmissionBehavior emitTextAfterBehavior() const = 0;
-    bool emitsNewlineAfter() const;
+    virtual TextEmissionBehavior textEmissionBehavior() const = 0;
+    bool emitsNewline() const;
     virtual AXTextRunLineID listMarkerLineID() const = 0;
     virtual String listMarkerText() const = 0;
 #endif
@@ -1586,9 +1586,9 @@ inline Vector<AXID> AXCoreObject::childrenIDs(bool updateChildrenIfNeeded)
 }
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-inline bool AXCoreObject::emitsNewlineAfter() const
+inline bool AXCoreObject::emitsNewline() const
 {
-    auto behavior = emitTextAfterBehavior();
+    auto behavior = textEmissionBehavior();
     return behavior == TextEmissionBehavior::Newline || behavior == TextEmissionBehavior::DoubleNewline;
 }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -745,8 +745,8 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::EmbeddedImageDescription:
         stream << "EmbeddedImageDescription";
         break;
-    case AXProperty::EmitTextAfterBehavior:
-        stream << "EmitTextAfterBehavior";
+    case AXProperty::TextEmissionBehavior:
+        stream << "TextEmissionBehavior";
         break;
     case AXProperty::ExpandedTextValue:
         stream << "ExpandedTextValue";

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -533,6 +533,9 @@ int AXTextMarker::lineIndex() const
         startMarker = tree->firstMarker();
     else
         return -1;
+    // Do this conversion early so we only do it once, rather than in every function that requires
+    // |startMarker| to be a text-run marker.
+    startMarker = startMarker.toTextRunMarker();
 
     auto currentLineID = startMarker.lineID();
     auto targetLineID = lineID();
@@ -693,30 +696,42 @@ unsigned AXTextMarker::offsetFromRoot() const
         AXTextMarker rootMarker { root->treeID(), root->objectID(), 0 };
         unsigned offset = 0;
         auto current = rootMarker;
+
+        bool needsNewlineOffset = false;
+        auto applyNewlineOffset = [&] () {
+            if (needsNewlineOffset && offset) {
+                // Only represent a newline if we have started counting
+                // actual, non-whitespace text (i.e. offset is > 0).
+                offset++;
+            }
+            needsNewlineOffset = false;
+        };
+
         while (current.isValid() && !hasSameObjectAndOffset(current)) {
-            RefPtr currentObject = current.isolatedObject();
+            applyNewlineOffset();
             auto previous = current;
             // If an object has text runs, and we are not at the very last position in those runs, use findMarker to navigate within them.
             // Otherwise, we want to explore all objects.
-            if (currentObject->hasTextRuns() && current.runs() && current.offset() < current.runs()->totalLength()) {
+            RefPtr currentObject = current.isolatedObject();
+            const auto* runs = currentObject->textRuns();
+            if (runs && current.offset() < runs->totalLength()) {
                 current = previous.findMarker(AXDirection::Next, CoalesceObjectBreaks::No, IgnoreBRs::No);
                 // While searching, we want to explore all positions (hence, we don't coalesce newlines or skip line breaks above)
                 // But, don't increment if the previous and current have the same visual position.
                 if (!previous.equivalentTextPosition(current))
                     offset++;
             } else {
-                RefPtr nextObject = currentObject ? currentObject->nextInPreOrder() : nullptr;
+                if (currentObject->emitsNewline()) {
+                    // If the next text we come across is on a new line, we need to increment the offset, since the
+                    // previous + current text marker won't share an equivalent visual text position.
+                    needsNewlineOffset = true;
+                }
+                RefPtr nextObject = currentObject->nextInPreOrder();
                 current = nextObject ? AXTextMarker { *nextObject, 0 } : AXTextMarker();
-                bool nextOrPreviousObjectIsLineBreak = currentObject->roleValue() == AccessibilityRole::LineBreak || (nextObject && nextObject->roleValue() == AccessibilityRole::LineBreak);
-
-                // If we come across an object on a new line, we need to increment the offset, since the previous + current
-                // text marker won't share an equivalent visual text position.
-                // However, if we are moving on or off of a line break, don't compare lineIDs. The line break object has
-                // it's own text runs which will already be considered in the offset count.
-                if (!nextOrPreviousObjectIsLineBreak && previous.lineID() && current.lineID() && previous.lineID() != current.lineID())
-                    offset++;
             }
         }
+        applyNewlineOffset();
+
         // If this assert fails, it means we couldn't navigate from root to `this`, which should never happen.
         TEXT_MARKER_ASSERT_DOBULE(hasSameObjectAndOffset(current), (*this), current);
         return offset;
@@ -900,7 +915,7 @@ String AXTextMarkerRange::toString() const
 
     auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {
         // FIXME: This function should not just be emitting newlines, but instead handling every character type in TextEmissionBehavior.
-        auto behavior = object.emitTextAfterBehavior();
+        auto behavior = object.textEmissionBehavior();
         if (behavior != TextEmissionBehavior::Newline && behavior != TextEmissionBehavior::DoubleNewline)
             return;
 
@@ -1320,6 +1335,8 @@ AXTextMarkerRange AXTextMarker::lineRange(LineRangeType type, IncludeTrailingLin
 {
     if (!isValid())
         return { };
+    if (!isInTextRun())
+        return toTextRunMarker().lineRange(type, includeTrailingLineBreak);
 
     if (type == LineRangeType::Current) {
         auto startMarker = atLineStart() ? *this : previousLineStart();
@@ -1352,6 +1369,9 @@ AXTextMarkerRange AXTextMarker::wordRange(WordRangeType type) const
 {
     if (!isValid())
         return { };
+    if (!isInTextRun())
+        return toTextRunMarker().wordRange(type);
+
     AXTextMarker startMarker, endMarker;
 
     if (type == WordRangeType::Right) {
@@ -1381,6 +1401,8 @@ AXTextMarkerRange AXTextMarker::sentenceRange(SentenceRangeType type) const
 {
     if (!isValid())
         return { };
+    if (!isInTextRun())
+        return toTextRunMarker().sentenceRange(type);
 
     AXTextMarker startMarker, endMarker;
 
@@ -1400,6 +1422,8 @@ AXTextMarkerRange AXTextMarker::paragraphRange() const
 {
     if (!isValid())
         return { };
+    if (!isInTextRun())
+        return toTextRunMarker().paragraphRange();
 
     // paragraphForCharacterOffset on the main thread doesn't directly call nextParagraphEnd and previousParagraphStart.
     // When actually computing the range from the current position, directly call findParagraph.

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.h
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.h
@@ -136,7 +136,7 @@ public:
     LayoutRect elementRect() const override;
 
 #if ENABLE(AX_THREAD_TEXT_APIS)
-    TextEmissionBehavior emitTextAfterBehavior() const final;
+    TextEmissionBehavior textEmissionBehavior() const final;
 #endif
 
 protected:

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -391,7 +391,7 @@ public:
 #if ENABLE(AX_THREAD_TEXT_APIS)
     virtual AXTextRuns textRuns() { return { }; }
     bool hasTextRuns() final { return textRuns().size(); }
-    TextEmissionBehavior emitTextAfterBehavior() const override { return TextEmissionBehavior::None; }
+    TextEmissionBehavior textEmissionBehavior() const override { return TextEmissionBehavior::None; }
     AXTextRunLineID listMarkerLineID() const override { return { }; }
     String listMarkerText() const override { return { }; }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm
@@ -95,7 +95,7 @@ RetainPtr<NSAttributedString> AXTextMarkerRange::toAttributedString(AXCoreObject
     RetainPtr<NSMutableAttributedString> result = start.isolatedObject()->createAttributedString(start.runs()->substring(start.offset()), spellCheck);
     auto emitNewlineOnExit = [&] (AXIsolatedObject& object) {
         // FIXME: This function should not just be emitting newlines, but instead handling every character type in TextEmissionBehavior.
-        auto behavior = object.emitTextAfterBehavior();
+        auto behavior = object.textEmissionBehavior();
         if (behavior != TextEmissionBehavior::Newline && behavior != TextEmissionBehavior::DoubleNewline)
             return;
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -117,7 +117,7 @@ void AXIsolatedObject::initializeProperties(const Ref<AccessibilityObject>& axOb
             setProperty(AXProperty::TagName, TagName::attachment);
 
         setProperty(AXProperty::TextRuns, object.textRuns());
-        setProperty(AXProperty::EmitTextAfterBehavior, object.emitTextAfterBehavior());
+        setProperty(AXProperty::TextEmissionBehavior, object.textEmissionBehavior());
         if (roleValue() == AccessibilityRole::ListMarker) {
             setProperty(AXProperty::ListMarkerText, object.listMarkerText().isolatedCopy());
             setProperty(AXProperty::ListMarkerLineID, object.listMarkerLineID());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -89,7 +89,7 @@ public:
         const auto* runs = textRuns();
         return runs && runs->size();
     }
-    TextEmissionBehavior emitTextAfterBehavior() const final { return propertyValue<TextEmissionBehavior>(AXProperty::EmitTextAfterBehavior); }
+    TextEmissionBehavior textEmissionBehavior() const final { return propertyValue<TextEmissionBehavior>(AXProperty::TextEmissionBehavior); }
     AXTextRunLineID listMarkerLineID() const final { return propertyValue<AXTextRunLineID>(AXProperty::ListMarkerLineID); };
     String listMarkerText() const final { return stringAttributeValue(AXProperty::ListMarkerText); }
 #endif // ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -127,7 +127,6 @@ enum class AXProperty : uint16_t {
     DocumentLinks,
     DocumentURI,
     EmbeddedImageDescription,
-    EmitTextAfterBehavior,
     ExpandedTextValue,
     ExtendedDescription,
 #if PLATFORM(COCOA)
@@ -278,6 +277,7 @@ enum class AXProperty : uint16_t {
     // synthesize it on-the-fly using AXProperty::TextRuns.
     TextContent,
 #endif // !ENABLE(AX_THREAD_TEXT_APIS)
+    TextEmissionBehavior,
     TextInputMarkedTextMarkerRange,
 #if ENABLE(AX_THREAD_TEXT_APIS)
     TextRuns,


### PR DESCRIPTION
#### ce9170834f27d66522b20ec1f423db0ee11f0ca2
<pre>
AX: AXTextMarker::offsetFromRoot repeatedly calls lineID() on a non-text-run marker, which is very expensive
<a href="https://bugs.webkit.org/show_bug.cgi?id=288887">https://bugs.webkit.org/show_bug.cgi?id=288887</a>
<a href="https://rdar.apple.com/145889534">rdar://145889534</a>

Reviewed by Chris Fleizach.

This commit fixes quadratic behavior in AXTextMarker::offsetFromRoot caused by repeatedly calling lineID() on
a non-text-runs marker, which traverses to the first text-runs marker. This commit reimplements offsetFromRoot in a way
that is much more efficient, leaning on our existing knowledge of whether objects emit newlines rather than comparing
lineID()s.

This commit also includes a few other minor performance optimizations based on the learning from this problem — namely,
we should always convert marker to text-runs-markers ASAP to avoid repeatedly doing so in functions that require
text-runs-markers to operate correctly.

* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::emitsNewline const):
(WebCore::AXCoreObject::emitsNewlineAfter const): Deleted.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::lineIndex const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarkerRange::toString const):
(WebCore::AXTextMarker::lineRange const):
(WebCore::AXTextMarker::wordRange const):
(WebCore::AXTextMarker::sentenceRange const):
(WebCore::AXTextMarker::paragraphRange const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::textEmissionBehavior const):
(WebCore::AccessibilityNodeObject::emitTextAfterBehavior const): Deleted.
* Source/WebCore/accessibility/AccessibilityNodeObject.h:
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/cocoa/AXTextMarkerCocoa.mm:
(WebCore::AXTextMarkerRange::toAttributedString const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::initializeProperties):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:

Canonical link: <a href="https://commits.webkit.org/291455@main">https://commits.webkit.org/291455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84b0f7e5a7640a13277d95b40f7a5c6825bfac28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92890 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12441 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2087 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71036 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28467 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95892 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51364 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1655 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42729 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79573 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99909 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19716 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23899 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12968 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25102 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->