### PR TITLE
MutationEvent interface is exposed even when mutation events are disabled

### DIFF
--- a/LayoutTests/fast/dom/mutation-events-disablement-expected.txt
+++ b/LayoutTests/fast/dom/mutation-events-disablement-expected.txt
@@ -5,6 +5,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS mutationEvents is []
 PASS mutationEvents is []
+PASS typeof MutationEvent is "undefined"
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/mutation-events-disablement.html
+++ b/LayoutTests/fast/dom/mutation-events-disablement.html
@@ -23,6 +23,7 @@ const text = document.body.appendChild(document.createTextNode('hello'));
 mutationEvents = [];
 text.replaceData(0, 5, 'world');
 shouldBe('mutationEvents', '[]');
+shouldBeEqualToString('typeof MutationEvent', 'undefined');
 
 </script>
 </body>

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -320,6 +320,7 @@ namespace WebCore {
     macro(MediaStreamTrackProcessor) \
     macro(MerchantValidationEvent) \
     macro(MockRTCRtpTransform) \
+    macro(MutationEvent) \
     macro(NavigateEvent) \
     macro(Navigation) \
     macro(NavigationCurrentEntryChangeEvent) \

--- a/Source/WebCore/dom/MutationEvent.idl
+++ b/Source/WebCore/dom/MutationEvent.idl
@@ -18,7 +18,8 @@
  */
 
 [
-    Exposed=Window
+    Exposed=Window,
+    EnabledBySetting=MutationEventsEnabled
 ] interface MutationEvent : Event {
     // attrChangeType
     const unsigned short MODIFICATION = 1;


### PR DESCRIPTION
#### 6f72ce51bf5d70bd051f0e1bb438e73a8b0e85df
<pre>
MutationEvent interface is exposed even when mutation events are disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=288894">https://bugs.webkit.org/show_bug.cgi?id=288894</a>

Reviewed by Chris Dumez and Anne van Kesteren.

Runtime guard MutationEvent interface.

* LayoutTests/fast/dom/mutation-events-disablement-expected.txt:
* LayoutTests/fast/dom/mutation-events-disablement.html:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/MutationEvent.idl:

Canonical link: <a href="https://commits.webkit.org/291448@main">https://commits.webkit.org/291448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab6c2b4cc2b566e9cc3f341f2962b572f9a305bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71046 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95920 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9601 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84044 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51374 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1680 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42757 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79590 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99938 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19970 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14635 "Found 1 new test failure: imported/w3c/IndexedDB-private-browsing/idbobjectstore_add6.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80067 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79367 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23915 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1180 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/12996 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14853 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19954 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25130 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19641 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23101 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21382 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->