### PR TITLE
Add support for generating a consumer for CSS property @font-palette-values 'font-family'

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -12634,9 +12634,7 @@
         "@font-palette-values": {
             "font-family": {
                 "codegen-properties": {
-                    "parser-function": "consumeFontPaletteValuesFontFamily",
-                    "parser-grammar-unused": "<family-name>#",
-                    "parser-grammar-unused-reason": "Needs support for special 'family-name' processing."
+                    "parser-grammar": "<family-name>#@(no-single-item-opt)"
                 },
                 "specification": {
                     "category": "css-fonts-4",

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -339,9 +339,9 @@ static std::optional<UnresolvedFontFamily> consumeFontFamilyUnresolved(CSSParser
     return list;
 }
 
-static RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range)
+RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range, const CSSParserContext&)
 {
-    // // https://drafts.csswg.org/css-fonts-4/#family-name-syntax
+    // https://drafts.csswg.org/css-fonts-4/#family-name-syntax
 
     auto familyName = consumeFamilyNameUnresolved(range);
     if (familyName.isNull())
@@ -349,15 +349,15 @@ static RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange& range)
     return CSSValuePool::singleton().createFontFamilyValue(familyName);
 }
 
-RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange& range, const CSSParserContext&)
+RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     // <'font-family'> = [ <family-name> | <generic-family> ]#
     // https://drafts.csswg.org/css-fonts-4/#font-family-prop
 
-    return consumeListSeparatedBy<',', OneOrMore>(range, [] (auto& range) -> RefPtr<CSSValue> {
+    return consumeListSeparatedBy<',', OneOrMore>(range, [&](auto& range) -> RefPtr<CSSValue> {
         if (auto parsedValue = consumeGenericFamily(range))
             return parsedValue;
-        return consumeFamilyName(range);
+        return consumeFamilyName(range, context);
     });
 }
 
@@ -760,12 +760,12 @@ RefPtr<CSSValue> consumeFontSizeAdjust(CSSParserTokenRange& range, const CSSPars
 // MARK: - @font-face
 
 // MARK: @font-face 'font-family'
-RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange& range, const CSSParserContext&)
+RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange& range, const CSSParserContext& context)
 {
     // <'font-family'> = <family-name>
     // https://drafts.csswg.org/css-fonts-4/#descdef-font-face-font-family
 
-    auto name = consumeFamilyName(range);
+    auto name = consumeFamilyName(range, context);
     if (!name || !range.atEnd())
         return nullptr;
 
@@ -1429,18 +1429,6 @@ RefPtr<CSSValue> consumeFontFaceFontWeight(CSSParserTokenRange& range, const CSS
 #endif
 
 // MARK: - @font-palette-values
-
-// MARK: @font-palette-values 'font-family'
-
-RefPtr<CSSValue> consumeFontPaletteValuesFontFamily(CSSParserTokenRange& range, const CSSParserContext&)
-{
-    // <'font-family'> = <family-name>#
-    // https://drafts.csswg.org/css-fonts/#descdef-font-palette-values-font-family
-
-    return consumeListSeparatedBy<',', OneOrMore>(range, [](auto& range) {
-        return consumeFamilyName(range);
-    });
-}
 
 // MARK: @font-palette-values 'override-colors'
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -108,6 +108,9 @@ RefPtr<CSSValue> consumeFontStyle(CSSParserTokenRange&, const CSSParserContext&)
 // MARK: 'font-family'
 // https://drafts.csswg.org/css-fonts-4/#font-family-prop
 RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange&, const CSSParserContext&);
+// Sub-production of 'font-family': <family-name>
+// https://drafts.csswg.org/css-fonts-4/#family-name-syntax
+RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange&, const CSSParserContext&);
 // Sub-production of 'font-family': <generic-family>
 // https://drafts.csswg.org/css-fonts-4/#generic-family-name-syntax
 const AtomString& genericFontFamily(CSSValueID);
@@ -194,9 +197,6 @@ RefPtr<CSSValue> parseFontFaceFontWeight(const String&, ScriptExecutionContext&)
 RefPtr<CSSValue> consumeFontFaceFontWeight(CSSParserTokenRange&, const CSSParserContext&);
 
 // MARK: - @font-palette-values descriptor consumers:
-
-// MARK: @font-palette-values 'font-family'
-RefPtr<CSSValue> consumeFontPaletteValuesFontFamily(CSSParserTokenRange&, const CSSParserContext&);
 
 // MARK: @font-palette-values 'override-colors'
 // https://drafts.csswg.org/css-fonts-4/#descdef-font-palette-values-override-colors


### PR DESCRIPTION
#### 4a939d9b1ce06eb5143083d9c19223c71945b675
<pre>
Add support for generating a consumer for CSS property @font-palette-values &apos;font-family&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=288898">https://bugs.webkit.org/show_bug.cgi?id=288898</a>

Reviewed by Antti Koivisto.

@font-palette-values &apos;font-family&apos; can be generated using the existing
generation support. The inner &lt;family-name&gt; is still custom, but the outer
list can be fully generated.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:

Canonical link: <a href="https://commits.webkit.org/291626@main">https://commits.webkit.org/291626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/029ead3c3f983c5c762a4ee601c9f0a22959ddd5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21428 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71361 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28749 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51695 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2108 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43252 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79892 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100444 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20464 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79708 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24245 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25626 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20135 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21876 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->