### PR TITLE
Make `Vector::operator==` work correctly with padded structs

### DIFF
--- a/Source/WTF/wtf/VectorTraits.h
+++ b/Source/WTF/wtf/VectorTraits.h
@@ -55,8 +55,10 @@ namespace WTF {
         static constexpr bool canCompareWithMemcmp = true;
     };
 
+    // Requiring std::has_unique_object_representations_v<T> to make sure the type doesn't have padding and can
+    // be used with memcmp().
     template<typename T>
-    struct VectorTraits : VectorTraitsBase<std::is_standard_layout_v<T> && std::is_trivial_v<T>, T> { };
+    struct VectorTraits : VectorTraitsBase<std::is_standard_layout_v<T> && std::is_trivial_v<T> && std::has_unique_object_representations_v<T>, T> { };
 
     struct SimpleClassVectorTraits : VectorTraitsBase<false, void>
     {

--- a/Source/WebCore/css/CSSKeyframesRule.cpp
+++ b/Source/WebCore/css/CSSKeyframesRule.cpp
@@ -87,19 +87,8 @@ std::optional<size_t> StyleRuleKeyframes::findKeyframeIndex(const String& key) c
         return { pair.first, pair.second };
     });
 
-    // FIXME: using Vector::operator==() here fails on Intel, so we provide our own logic.
-    auto keysAreEqual = [](const Vector<StyleRuleKeyframe::Key>& a, const Vector<StyleRuleKeyframe::Key>& b) {
-        if (a.size() != b.size())
-            return false;
-        for (auto i = a.size(); i--;) {
-            if (!(a[i] == b[i]))
-                return false;
-        }
-        return true;
-    };
-
     for (auto i = m_keyframes.size(); i--; ) {
-        if (keysAreEqual(m_keyframes[i]->keys(), convertedKeys))
+        if (m_keyframes[i]->keys() == convertedKeys)
             return i;
     }
     return std::nullopt;


### PR DESCRIPTION
#### 30eb04f14b597dea982fdc352f4d4c70fca5d22e
<pre>
Make `Vector::operator==` work correctly with padded structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=287554">https://bugs.webkit.org/show_bug.cgi?id=287554</a>
<a href="https://rdar.apple.com/144700872">rdar://144700872</a>

Reviewed by Geoffrey Garen.

VectorTraits::canCompareWithMemcmp is used to determine whether or not Vector can be used
to compare 2 vectors. It was initialized using:
- `std::is_standard_layout_v&lt;T&gt; &amp;&amp; std::is_trivial_v&lt;T&gt;`

However, this led to incorrect results on some platforms when using padded structures.
To detect padded structures, we are now adding `std::has_unique_object_representations_v&lt;T&gt;`
to this check.

This is what is used already for the assertion inside equalSpans(), before calling
`memcmp()`. Per the documentation [1], has_unique_object_representations_v would
return false for padded structs.

[1] <a href="https://en.cppreference.com/w/cpp/types/has_unique_object_representations">https://en.cppreference.com/w/cpp/types/has_unique_object_representations</a>

* Source/WTF/wtf/VectorTraits.h:
* Source/WebCore/css/CSSKeyframesRule.cpp:
(WebCore::StyleRuleKeyframes::findKeyframeIndex const):

Canonical link: <a href="https://commits.webkit.org/291724@main">https://commits.webkit.org/291724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba6c04db8b9f5b638c5881fe5ab7bc6c26a19c91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93811 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/13389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3124 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98817 "Failed to checkout and rebase branch from PR 41696") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21827 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/98817 "Failed to checkout and rebase branch from PR 41696") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96813 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/98817 "Failed to checkout and rebase branch from PR 41696") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2406 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/43652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86521 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80124 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100852 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92477 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20863 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80723 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19899 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/24511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20847 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115127 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/20534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/23994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/22275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->