### PR TITLE
[JSC] Optimize `Array#includes` for Dense Atom String Arrays

### DIFF
--- a/JSTests/microbenchmarks/atom-string-array-includes-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-includes-found.js
@@ -1,0 +1,12 @@
+
+let words = ['break', 'yield', 'break', 'yield', 'break', 'yield', 'super'];
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (!test('super'))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-includes-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-includes-not-found.js
@@ -1,0 +1,12 @@
+
+let words = ['break', 'yield', 'break', 'yield', 'break', 'yield', 'super'];
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('superr'))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-empty-includes-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-empty-includes-found.js
@@ -1,0 +1,12 @@
+
+let words = "greedisgood".split('');
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (!test('s'))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-empty-includes-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-empty-includes-not-found.js
@@ -1,0 +1,12 @@
+
+let words = "greedisgood".split('');
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('ss'))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-includes-non-rope-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-includes-non-rope-found.js
@@ -1,0 +1,12 @@
+
+let words = "break break break break break break break break yield super".split(" ");
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (!test('yield'))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-includes-non-rope-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-includes-non-rope-not-found.js
@@ -1,0 +1,12 @@
+
+let words = "break break break break break break break break yield super".split(" ");
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+for (let i = 0; i < 1e5; i++) {
+    if (test('yieldd'))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-includes-rope-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-includes-rope-found.js
@@ -1,0 +1,13 @@
+
+let words = "break break break break yield super".split(" ");
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+let search = 'y' + 'i' + 'e' + 'l' + 'd';
+for (let i = 0; i < 1e5; i++) {
+    if (!test(search))
+        throw new Error("bad");
+}

--- a/JSTests/microbenchmarks/atom-string-array-split-space-includes-rope-not-found.js
+++ b/JSTests/microbenchmarks/atom-string-array-split-space-includes-rope-not-found.js
@@ -1,0 +1,13 @@
+
+let words = "break break break break yield super".split(" ");
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+let search = 'y' + 'i' + 'e' + 'l' + 'd' + 'd';
+for (let i = 0; i < 1e5; i++) {
+    if (test(search))
+        throw new Error("bad");
+}

--- a/JSTests/stress/atom-string-array-includes.js
+++ b/JSTests/stress/atom-string-array-includes.js
@@ -1,0 +1,15 @@
+
+let words = "break yield super".split(" ");
+
+function test(s) {
+    return words.includes(s);
+}
+noInline(test);
+
+let search = 'yield';
+for (let i = 0; i < testLoopCount; i++) {
+    if (!test(search))
+        throw new Error("bad");
+    if (i == 1)
+        words.push('good');
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3739,6 +3739,39 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIncludesString, UCPUStrictInt32, (JSGloba
     OPERATION_RETURN(scope, arrayIncludesString(globalObject, butterfly, searchElement, index));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationCopyOnWriteArrayIncludesString, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, JSString* searchElement, int32_t index))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (JSImmutableButterfly::isOnlyAtomStringsStructure(vm, butterfly)) {
+        AtomString search = searchElement->toAtomString(globalObject);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        UCPUStrictInt32 result = toUCPUStrictInt32(0);
+        if (vm.atomStringToJSStringMap.contains(search.impl())) {
+            int32_t length = butterfly->publicLength();
+            auto data = butterfly->contiguous().data();
+            for (int32_t i = index; i < length; ++i) {
+                JSValue value = data[i].get();
+                if (asString(value)->getValueImpl() == search.impl()) {
+                    result = toUCPUStrictInt32(1);
+                    break;
+                }
+            }
+        }
+#if ASSERT_ENABLED
+        UCPUStrictInt32 expected = arrayIncludesString(globalObject, butterfly, searchElement, index);
+        ASSERT(expected == result);
+#endif
+        OPERATION_RETURN(scope, result);
+    }
+
+    OPERATION_RETURN(scope, arrayIncludesString(globalObject, butterfly, searchElement, index));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationArrayIncludesValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject* globalObject, Butterfly* butterfly, EncodedJSValue encodedValue, int32_t index))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -369,6 +369,7 @@ JSC_DECLARE_JIT_OPERATION(operationThrowStaticError, void, (JSGlobalObject*, JSS
 JSC_DECLARE_JIT_OPERATION(operationHasOwnProperty, size_t, (JSGlobalObject*, JSObject*, EncodedJSValue));
 
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationCopyOnWriteArrayIncludesString, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, JSString*, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesValueDouble, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationArrayIncludesValueInt32OrContiguous, UCPUStrictInt32, (JSGlobalObject*, Butterfly*, EncodedJSValue, int32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueContiguous, UCPUStrictInt32, (Butterfly*, EncodedJSValue, int32_t));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -7713,7 +7713,7 @@ IGNORE_CLANG_WARNINGS_END
             };
 
             if (isCopyOnWriteArrayWithContiguous()) {
-                operation = operationCopyOnWriteArrayIndexOfString;
+                operation = isArrayIncludes ? operationCopyOnWriteArrayIncludesString : operationCopyOnWriteArrayIndexOfString;
                 LValue targetStructureID = encodeStructureID(weakPointer(vm().immutableButterflyOnlyAtomStringsStructure.get()));
                 LValue butterflyStructureID = m_out.load32(m_out.add(storage, m_out.constIntPtr(-JSImmutableButterfly::offsetOfData())), m_heaps.JSCell_structureID);
                 m_out.branch(m_out.equal(butterflyStructureID, targetStructureID), unsure(slowCase), unsure(checkSearchRopeString));
@@ -7792,7 +7792,7 @@ IGNORE_CLANG_WARNINGS_END
             m_out.jump(continuation);
 
             m_out.appendTo(slowCase, continuation);
-            ValueFromBlock slowCaseResult = isArrayIncludes ? m_out.anchor(vmCall(Int32, operationArrayIncludesString, weakPointer(globalObject), storage, searchElement, startIndex)) : m_out.anchor(vmCall(Int64, operation, weakPointer(globalObject), storage, searchElement, startIndex));
+            ValueFromBlock slowCaseResult = m_out.anchor(vmCall(isArrayIncludes ? Int32 : Int64, operation, weakPointer(globalObject), storage, searchElement, startIndex));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);


### PR DESCRIPTION
#### 75407e050ae41b67b11adc5e979358c93fb7c6f1
<pre>
[JSC] Optimize `Array#includes` for Dense Atom String Arrays
<a href="https://bugs.webkit.org/show_bug.cgi?id=288695">https://bugs.webkit.org/show_bug.cgi?id=288695</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/291398@main">https://commits.webkit.org/291398@main</a> changed to optimize
`Array#indexOf` for Dense Atom String Arrays.

This patchs changes to optimize `Array#includes` with
similar way.

atom-string-array-includes-found                            1.4965+-0.1362            1.3702+-0.1567          might be 1.0922x faster
atom-string-array-includes-not-found                        1.2062+-0.0506            1.1678+-0.1170          might be 1.0329x faster
atom-string-array-split-empty-includes-not-found            1.6092+-0.2217     ^      1.2057+-0.1462        ^ definitely 1.3347x faster
atom-string-array-split-empty-includes-found                1.5131+-0.2733            1.4254+-0.1409          might be 1.0615x faster
atom-string-array-split-space-includes-non-rope-found       1.8479+-0.3436            1.4556+-0.1462          might be 1.2695x faster
atom-string-array-split-space-includes-rope-not-found       1.6478+-0.3292     ^      1.1771+-0.0951        ^ definitely 1.3998x faster
atom-string-array-split-space-includes-rope-found           1.4504+-0.4927            1.3585+-0.0612          might be 1.0677x faster
atom-string-array-split-space-includes-non-rope-not-found   1.4120+-0.0332     ^      1.1569+-0.0743        ^ definitely 1.2205x faster

* JSTests/microbenchmarks/atom-string-array-includes-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-includes-not-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-split-empty-includes-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-split-empty-includes-not-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-split-space-includes-non-rope-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-split-space-includes-non-rope-not-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-split-space-includes-rope-found.js: Added.
* JSTests/microbenchmarks/atom-string-array-split-space-includes-rope-not-found.js: Added.
* JSTests/stress/atom-string-array-includes.js: Added.
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75407e050ae41b67b11adc5e979358c93fb7c6f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97921 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43448 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71049 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28471 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95924 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9605 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51377 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1684 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42761 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/85632 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1658 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99942 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91588 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19974 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14638 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80070 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79947 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79370 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13000 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25134 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114236 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19645 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/32987 "Found 7 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.bytecode-cache, microbenchmarks/memcpy-wasm-medium.js.mini-mode, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch-with-delegate-catch.js.wasm-slow-memory, wasm.yaml/wasm/v8/multi-value.js.wasm-eager (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23105 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->