### PR TITLE
@font-face descriptor accepts a single font-family name  and not a list

### DIFF
--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -145,12 +145,9 @@ StyleRuleFontFace* CSSFontFace::cssConnection() const
     );
 }
 
-// FIXME: Don't use a list here and rename to setFamily. https://bugs.webkit.org/show_bug.cgi?id=196381
-void CSSFontFace::setFamilies(CSSValueList& family)
+void CSSFontFace::setFamily(CSSValue& family)
 {
-    ASSERT(family.length());
-
-    RefPtr oldFamily = std::exchange(m_families, &family);
+    RefPtr oldFamily = std::exchange(m_family, &family);
     mutableProperties().setProperty(CSSPropertyFontFamily, family);
 
     iterateClients(m_clients, [&](CSSFontFaceClient& client) {
@@ -352,16 +349,10 @@ void CSSFontFace::setDisplay(CSSValue& loadingBehaviorValue)
 
 String CSSFontFace::family() const
 {
-    // Code to extract the name of the first family is needed because we incorrectly use a list of families.
-    // FIXME: Consider switching to getPropertyValue after https://bugs.webkit.org/show_bug.cgi?id=196381 is fixed.
-    auto family = properties().getPropertyCSSValue(CSSPropertyFontFamily);
-    auto familyList = dynamicDowncast<CSSValueList>(family.get());
-    if (!familyList)
+    auto family = dynamicDowncast<CSSPrimitiveValue>(familyPropertyValue());
+    if (!family || !family->isFontFamily())
         return { };
-    auto firstFamily = dynamicDowncast<CSSPrimitiveValue>(familyList->item(0));
-    if (!firstFamily || !firstFamily->isFontFamily())
-        return { };
-    return firstFamily->stringValue();
+    return family->stringValue();
 }
 
 String CSSFontFace::style() const
@@ -399,9 +390,9 @@ String CSSFontFace::display() const
     return properties().getPropertyValue(CSSPropertyFontDisplay);
 }
 
-RefPtr<CSSValueList> CSSFontFace::families() const
+RefPtr<CSSValue> CSSFontFace::familyPropertyValue() const
 {
-    return m_families;
+    return m_family;
 }
 
 bool CSSFontFace::rangesMatchCodePoint(char32_t character) const

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -74,7 +74,7 @@ public:
     static Ref<CSSFontFace> create(CSSFontSelector&, StyleRuleFontFace* cssConnection = nullptr, FontFace* wrapper = nullptr, bool isLocalFallback = false);
     virtual ~CSSFontFace();
 
-    void setFamilies(CSSValueList&);
+    void setFamily(CSSValue&);
     void setStyle(CSSValue&);
     void setWeight(CSSValue&);
     void setWidth(CSSValue&);
@@ -105,7 +105,7 @@ public:
 
     struct UnicodeRange;
 
-    RefPtr<CSSValueList> families() const;
+    RefPtr<CSSValue> familyPropertyValue() const;
     std::span<const UnicodeRange> ranges() const { ASSERT(m_status != Status::Failure); return m_ranges.span(); }
 
     void setFontSelectionCapabilities(FontSelectionCapabilities capabilities) { m_fontSelectionCapabilities = capabilities; }
@@ -181,7 +181,7 @@ private:
     Document* document();
 
     const std::variant<Ref<MutableStyleProperties>, Ref<StyleRuleFontFace>> m_propertiesOrCSSConnection;
-    RefPtr<CSSValueList> m_families;
+    RefPtr<CSSValue> m_family;
     Vector<UnicodeRange> m_ranges;
 
     FontFeatureSettings m_featureSettings;
@@ -210,7 +210,7 @@ public:
     virtual ~CSSFontFaceClient() = default;
     virtual void fontLoaded(CSSFontFace&) { }
     virtual void fontStateChanged(CSSFontFace&, CSSFontFace::Status /*oldState*/, CSSFontFace::Status /*newState*/) { }
-    virtual void fontPropertyChanged(CSSFontFace&, CSSValueList* /*oldFamilies*/ = nullptr) { }
+    virtual void fontPropertyChanged(CSSFontFace&, CSSValue* /*oldFamilies*/ = nullptr) { }
     virtual void updateStyleIfNeeded(CSSFontFace&) { }
 };
 

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -106,14 +106,14 @@ public:
 private:
     CSSFontFaceSet(CSSFontSelector*);
 
-    void removeFromFacesLookupTable(const CSSFontFace&, const CSSValueList& familiesToSearchFor);
+    void removeFromFacesLookupTable(const CSSFontFace&, const CSSValue& familyToSearchFor);
     void addToFacesLookupTable(CSSFontFace&);
 
     void incrementActiveCount();
     void decrementActiveCount();
 
     void fontStateChanged(CSSFontFace&, CSSFontFace::Status oldState, CSSFontFace::Status newState) final;
-    void fontPropertyChanged(CSSFontFace&, CSSValueList* oldFamilies = nullptr) final;
+    void fontPropertyChanged(CSSFontFace&, CSSValue* oldFamily = nullptr) final;
 
     void ensureLocalFontFacesForFamilyRegistered(const AtomString&);
 

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -177,7 +177,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     }
 
     const StyleProperties& style = fontFaceRule.properties();
-    RefPtr familyList = dynamicDowncast<CSSValueList>(style.getPropertyCSSValue(CSSPropertyFontFamily));
+    RefPtr family = style.getPropertyCSSValue(CSSPropertyFontFamily);
     RefPtr fontStyle = style.getPropertyCSSValue(CSSPropertyFontStyle);
     RefPtr fontWeight = style.getPropertyCSSValue(CSSPropertyFontWeight);
     RefPtr fontWidth = style.getPropertyCSSValue(CSSPropertyFontWidth);
@@ -187,10 +187,10 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     RefPtr featureSettings = style.getPropertyCSSValue(CSSPropertyFontFeatureSettings);
     RefPtr display = style.getPropertyCSSValue(CSSPropertyFontDisplay);
     RefPtr sizeAdjust = style.getPropertyCSSValue(CSSPropertySizeAdjust);
-    if (!familyList || !srcList || (unicodeRange && !rangeList))
+    if (!family || !srcList || (unicodeRange && !rangeList))
         return;
 
-    if (!familyList->length())
+    if (!dynamicDowncast<CSSPrimitiveValue>(family)->isFontFamily())
         return;
 
     if (!srcList->length())
@@ -199,7 +199,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     SetForScope creatingFont(m_creatingFont, true);
     auto fontFace = CSSFontFace::create(*this, &fontFaceRule);
 
-    fontFace->setFamilies(*familyList);
+    fontFace->setFamily(*family);
     if (fontStyle)
         fontFace->setStyle(*fontStyle);
     if (fontWeight)

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -186,8 +186,7 @@ ExceptionOr<void> FontFace::setFamily(ScriptExecutionContext& context, const Str
 {
     if (family.isNull())
         return Exception { ExceptionCode::SyntaxError };
-    // FIXME: Don't use a list here. https://bugs.webkit.org/show_bug.cgi?id=196381
-    m_backing->setFamilies(CSSValueList::createCommaSeparated(context.cssValuePool().createFontFamilyValue(AtomString { family })));
+    m_backing->setFamily(context.cssValuePool().createFontFamilyValue(AtomString { family }));
     return { };
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -769,12 +769,7 @@ RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange& range, const CSS
     if (!name || !range.atEnd())
         return nullptr;
 
-    // FIXME-NEWPARSER: https://bugs.webkit.org/show_bug.cgi?id=196381 For compatibility with the old parser, we have to make
-    // a list here, even though the list always contains only a single family name.
-    // Once the old parser is gone, we can delete this function, make the caller
-    // use consumeFamilyName instead, and then patch the @font-face code to
-    // not expect a list with a single name in it.
-    return CSSValueList::createCommaSeparated(name.releaseNonNull());
+    return name;
 }
 
 // MARK: @font-face 'src'


### PR DESCRIPTION
#### 5d798ad14f24c524a68cd6f93bc694fac3f66e05
<pre>
@font-face descriptor accepts a single font-family name  and not a list
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::setFamily):
(WebCore::CSSFontFace::family const):
(WebCore::CSSFontFace::familyPropertyValue const):
(WebCore::CSSFontFace::setFamilies): Deleted.
(WebCore::CSSFontFace::families const): Deleted.
* Source/WebCore/css/CSSFontFace.h:
(WebCore::CSSFontFaceClient::fontPropertyChanged):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered):
(WebCore::CSSFontFaceSet::addToFacesLookupTable):
(WebCore::CSSFontFaceSet::removeFromFacesLookupTable):
(WebCore::CSSFontFaceSet::remove):
(WebCore::CSSFontFaceSet::fontPropertyChanged):
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontFaceRule):
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::setFamily):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontFaceFontFamily):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d798ad14f24c524a68cd6f93bc694fac3f66e05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20997 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71097 "Failure limit exceed. At least found 393 new test failures: fast/css/svg-font-face-duplicate-crash.html fast/text/font-face-set-cssom.html fast/text/font-face-set-remove-safely.html fast/text/font-with-no-space-glyph.html fast/text/svg-small-caps.html fonts/font-weight-invalid-crash.html http/tests/misc/SVGFont-delayed-load.html http/tests/misc/acid3.html imported/blink/fast/dom/discard-svg-font-face-crash.svg imported/blink/fast/dom/remove-svg-font-face-element-crash.xhtml ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28515 "Found 7 new test failures: fast/css/svg-font-face-duplicate-crash.html fast/text/font-face-set-cssom.html fast/text/font-face-set-remove-safely.html fast/text/font-with-no-space-glyph.html fast/text/svg-small-caps.html fonts/font-weight-invalid-crash.html http/tests/misc/SVGFont-delayed-load.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95995 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9662 "Found 60 new test failures: compositing/tiling/tiled-reflection-inwindow.html fast/events/autoscroll-with-software-keyboard.html fast/mediastream/microphone-interruption-and-audio-session.html fast/text/font-face-set-cssom.html fast/text/svg-small-caps.html http/tests/IndexedDB/storage-limit-1.https.html http/tests/app-privacy-report/user-attribution-cors-preflight-redirect.html http/tests/scroll-to-text-fragment/generation-deal-with-newlines-in-directive.html svg/W3C-SVG-1.1-SE/paths-dom-02-f.svg svg/W3C-SVG-1.1-SE/types-dom-04-b.svg ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51425 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9355 "Found 33 new test failures: imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-position-try-006.html imported/w3c/web-platform-tests/html/semantics/disabled-elements/event-propagate-disabled-keyboard.tentative.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html imported/w3c/web-platform-tests/svg/import/animate-elem-03-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-24-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-36-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-40-t-manual.svg imported/w3c/web-platform-tests/svg/import/fonts-desc-01-t-manual.svg ... (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1785 "Found 60 new test failures: fast/text/font-face-set-cssom.html fast/text/svg-small-caps.html fast/workers/worker-page-cache.html http/tests/security/clipboard/copy-paste-html-cross-origin-iframe-across-origin.html http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/proper-nested-upgrades.html http/tests/security/mixedContent/redirect-https-to-http-script-in-iframe-UpgradeMixedContent.html imported/w3c/web-platform-tests/css/css-anchor-position/position-try-container-query.html imported/w3c/web-platform-tests/css/css-grid/abspos/orthogonal-positioned-grid-descendants-003.html imported/w3c/web-platform-tests/css/css-grid/alignment/grid-alignment-implies-size-change-008.html ... (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42832 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79647 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1761 "Found 60 new test failures: fast/css/aspect-ratio-min-height-replaced.html fast/text/font-face-set-cssom.html fast/text/svg-small-caps.html http/tests/xmlhttprequest/state-after-network-error.html imported/w3c/web-platform-tests/editing/other/insertparagraph-in-child-of-head.tentative.html?designMode=on&white-space=normal imported/w3c/web-platform-tests/service-workers/service-worker/extendable-event-async-waituntil.https.html imported/w3c/web-platform-tests/svg/import/animate-elem-03-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-24-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-36-t-manual.svg imported/w3c/web-platform-tests/svg/import/animate-elem-40-t-manual.svg ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20045 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14691 "Found 60 new test failures: accessibility/mac/scrolling-in-pdf-crash.html fast/css/svg-font-face-duplicate-crash.html fast/text/font-face-set-cssom.html fast/text/font-face-set-remove-safely.html fast/text/font-with-no-space-glyph.html fast/text/glyph-display-lists/glyph-display-list-color.html fast/text/glyph-display-lists/glyph-display-list-colr-unshared.html fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80122 "Failure limit exceed. At least found 337 new test failures: fast/css/svg-font-face-duplicate-crash.html fast/text/font-face-set-cssom.html fast/text/font-face-set-remove-safely.html fast/text/font-with-no-space-glyph.html fast/text/svg-small-caps.html fonts/font-weight-invalid-crash.html http/tests/misc/SVGFont-delayed-load.html http/tests/misc/acid3.html imported/blink/fast/dom/discard-svg-font-face-crash.svg imported/blink/fast/dom/remove-svg-font-face-element-crash.xhtml ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80048 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79423 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23971 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1279 "Found 60 new test failures: compositing/repaint/become-overlay-composited-layer.html compositing/repaint/copy-forward-dirty-region-purged.html fast/media/mq-invalid-media-feature-04.html fast/mediastream/MediaDevices-addEventListener.html fast/text/font-face-set-cssom.html fast/text/svg-small-caps.html http/tests/navigation/page-cache-shared-worker.html imported/w3c/web-platform-tests/dom/nodes/ParentNode-querySelector-All-xht.xht imported/w3c/web-platform-tests/dom/nodes/ParentNode-querySelector-All.html imported/w3c/web-platform-tests/mixed-content/gen/worker-classic.http-rp/unset/fetch.https.html ... (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13089 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25205 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21457 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->