### PR TITLE
Reset the resumeTime and accumulated time on svg.setCurrentTime

### DIFF
--- a/LayoutTests/svg/animations/getCurrentTime-pause-unpause-setCurrentTime-expected.txt
+++ b/LayoutTests/svg/animations/getCurrentTime-pause-unpause-setCurrentTime-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVGSVGElement.getCurrentTime() with setCurrentTime() when animation is paused and unpaused
+

--- a/LayoutTests/svg/animations/getCurrentTime-pause-unpause-setCurrentTime.html
+++ b/LayoutTests/svg/animations/getCurrentTime-pause-unpause-setCurrentTime.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<title>SVGSVGElement.getCurrentTime() with setCurrentTime() when animation is paused and unpaused</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg height="0">
+  <rect fill="green" width="20" height="20">
+    <animate attributeName="x" from="0" to="200" begin="0s" dur="3s"></animate>
+  </rect>
+</svg>
+<script>
+async_test(t => {
+  window.onload = t.step_func(() => {
+    let svg = document.querySelector("svg");
+    svg.pauseAnimations();
+    assert_equals(svg.getCurrentTime(), 0, 'initial');
+
+    t.step_timeout(t.step_func(() => {
+      svg.setCurrentTime(0.5);
+      assert_approx_equals(svg.getCurrentTime(), 0.5, 0.01);
+      svg.unpauseAnimations();
+
+      t.step_timeout(t.step_func(() => {
+        svg.setCurrentTime(1);
+        assert_approx_equals(svg.getCurrentTime(), 1, 0.01);
+        svg.pauseAnimations();
+
+        t.step_timeout(t.step_func(() => {
+          svg.setCurrentTime(2);
+          assert_approx_equals(svg.getCurrentTime(), 2, 0.01);
+          svg.unpauseAnimations();
+
+          t.step_timeout(t.step_func_done(() => {
+            svg.setCurrentTime(3.5);
+            assert_approx_equals(svg.getCurrentTime(), 3.5, 0.01);
+          }), 20);
+        }), 20);
+      }), 0);
+    }), 0);
+  });
+});
+</script>

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -95,7 +96,7 @@ SMILTime SMILTimeContainer::elapsed() const
         return 0_s;
     if (isPaused())
         return m_accumulatedActiveTime;
-    return MonotonicTime::now() + m_accumulatedActiveTime - m_resumeTime;
+    return MonotonicTime::now() + m_accumulatedActiveTime - lastResumeTime();
 }
 
 bool SMILTimeContainer::isActive() const
@@ -142,7 +143,7 @@ void SMILTimeContainer::pause()
 
     m_pauseTime = MonotonicTime::now();
     if (m_beginTime) {
-        m_accumulatedActiveTime += m_pauseTime - m_resumeTime;
+        m_accumulatedActiveTime += m_pauseTime - lastResumeTime();
         m_timer.stop();
     }
 }
@@ -177,11 +178,12 @@ void SMILTimeContainer::setElapsed(SMILTime time)
     MonotonicTime now = MonotonicTime::now();
     m_beginTime = now - Seconds { time.value() };
 
+    m_resumeTime = MonotonicTime();
     if (m_pauseTime) {
-        m_resumeTime = m_pauseTime = now;
+        m_pauseTime = now;
         m_accumulatedActiveTime = Seconds(time.value());
     } else
-        m_resumeTime = m_beginTime;
+        m_accumulatedActiveTime = 0_s;
 
     processScheduledAnimations([](auto& animation) {
         animation.reset();

--- a/Source/WebCore/svg/animation/SMILTimeContainer.h
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2008-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -79,6 +80,7 @@ private:
     void processScheduledAnimations(NOESCAPE const Function<void(SVGSMILElement&)>&);
     void updateDocumentOrderIndexes();
     void sortByPriority(AnimationsVector& smilElements, SMILTime elapsed);
+    MonotonicTime lastResumeTime() const { return m_resumeTime ? m_resumeTime : m_beginTime; }
 
     MonotonicTime m_beginTime;
     MonotonicTime m_pauseTime;


### PR DESCRIPTION
#### 826544af20863d0d83c6d8b4b416cb8a7f18d19c
<pre>
Reset the resumeTime and accumulated time on svg.setCurrentTime

<a href="https://bugs.webkit.org/show_bug.cgi?id=288906">https://bugs.webkit.org/show_bug.cgi?id=288906</a>
<a href="https://rdar.apple.com/145907044">rdar://145907044</a>

Reviewed by Antoine Quint.

In 141765@main, we merged below Blink commit [1] but it was not complete fix.

[1] <a href="https://source.chromium.org/chromium/chromium/src/+/8c2c842380f44d69584abfb74633ef1049c37473">https://source.chromium.org/chromium/chromium/src/+/8c2c842380f44d69584abfb74633ef1049c37473</a>

In [1] merge, we didn&apos;t added `lastResumeTime()` and it also led to issue where we were not
resetting the m_resumeTime and m_accumulatedActiveTime because of while the animation is paused
that time was getting accumulated if we unpaused the animation later. This bug is represented
by the test included in this merge [2].

[2] <a href="https://source.chromium.org/chromium/chromium/src/+/22866929d6e642fd4b64a37434507aab037c41de">https://source.chromium.org/chromium/chromium/src/+/22866929d6e642fd4b64a37434507aab037c41de</a>

* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::elapsed const):
(WebCore::SMILTimeContainer::pause):
(WebCore::SMILTimeContainer::setElapsed):
* Source/WebCore/svg/animation/SMILTimeContainer.h:
* LayoutTests/svg/animations/getCurrentTime-pause-unpause-setCurrentTime.html:
* LayoutTests/svg/animations/getCurrentTime-pause-unpause-setCurrentTime-expected.txt:

Canonical link: <a href="https://commits.webkit.org/291486@main">https://commits.webkit.org/291486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc8f0a52dd15b9c51c7f084aef95ce959f4f8f51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2129 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97923 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43450 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71051 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28475 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95926 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51379 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1689 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42763 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79597 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99944 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80073 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79462 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23918 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13002 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14876 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25136 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19647 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->