### PR TITLE
[GStreamer] Add support for allowed output caps hints in ElementHarness

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -39,9 +39,9 @@ public:
         WTF_MAKE_TZONE_ALLOCATED(Stream);
 
     public:
-        static Ref<Stream> create(GRefPtr<GstPad>&& pad, RefPtr<GStreamerElementHarness>&& downstreamHarness)
+        static Ref<Stream> create(GRefPtr<GstPad>&& pad, RefPtr<GStreamerElementHarness>&& downstreamHarness, GRefPtr<GstCaps>&& allowedOutputCaps = nullptr)
         {
-            return adoptRef(*new Stream(WTFMove(pad), WTFMove(downstreamHarness)));
+            return adoptRef(*new Stream(WTFMove(pad), WTFMove(downstreamHarness), WTFMove(allowedOutputCaps)));
         }
 
         ~Stream();
@@ -58,13 +58,14 @@ public:
         const RefPtr<GStreamerElementHarness> downstreamHarness() const { return m_downstreamHarness; }
 
     private:
-        Stream(GRefPtr<GstPad>&&, RefPtr<GStreamerElementHarness>&&);
+        Stream(GRefPtr<GstPad>&&, RefPtr<GStreamerElementHarness>&&, GRefPtr<GstCaps>&&);
 
         GstFlowReturn chainSample(GRefPtr<GstSample>&&);
         bool sinkEvent(GRefPtr<GstEvent>&&);
 
         GRefPtr<GstPad> m_pad;
         RefPtr<GStreamerElementHarness> m_downstreamHarness;
+        GRefPtr<GstCaps> m_allowedOutputCaps;
 
         GRefPtr<GstPad> m_targetPad;
 
@@ -79,9 +80,9 @@ public:
 
     using PadLinkCallback = Function<RefPtr<GStreamerElementHarness>(const GRefPtr<GstPad>&)>;
     using ProcessSampleCallback = Function<void(Stream&, GRefPtr<GstSample>&&)>;
-    static Ref<GStreamerElementHarness> create(GRefPtr<GstElement>&& element, ProcessSampleCallback&& processOutputSampleCallback, std::optional<PadLinkCallback> padLinkCallback = std::nullopt)
+    static Ref<GStreamerElementHarness> create(GRefPtr<GstElement>&& element, ProcessSampleCallback&& processOutputSampleCallback, std::optional<PadLinkCallback>&& padLinkCallback = std::nullopt, GRefPtr<GstCaps>&& allowedOutputCaps = nullptr)
     {
-        return adoptRef(*new GStreamerElementHarness(WTFMove(element), WTFMove(processOutputSampleCallback), WTFMove(padLinkCallback)));
+        return adoptRef(*new GStreamerElementHarness(WTFMove(element), WTFMove(processOutputSampleCallback), WTFMove(padLinkCallback), WTFMove(allowedOutputCaps)));
     }
     ~GStreamerElementHarness();
 
@@ -106,7 +107,7 @@ public:
     void dumpGraph(ASCIILiteral filenamePrefix);
 
 private:
-    GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessSampleCallback&&, std::optional<PadLinkCallback>&&);
+    GStreamerElementHarness(GRefPtr<GstElement>&&, ProcessSampleCallback&&, std::optional<PadLinkCallback>&&, GRefPtr<GstCaps>&&);
 
     GstFlowReturn pushBufferFull(GRefPtr<GstBuffer>&&);
 
@@ -119,6 +120,7 @@ private:
     GRefPtr<GstElement> m_element;
     ProcessSampleCallback m_processOutputSampleCallback;
     std::optional<PadLinkCallback> m_padLinkCallback;
+    GRefPtr<GstCaps> m_streamAllowedOutputCaps;
 
     GRefPtr<GstCaps> m_inputCaps;
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp
@@ -427,6 +427,59 @@ TEST_F(GStreamerTest, harnessDecodeMP4Video)
     ASSERT_GT(bufferTracker.totalVideoBuffers, 100);
 }
 
+TEST_F(GStreamerTest, harnessCustomCaps)
+{
+    GRefPtr<GstElement> element = gst_element_factory_make("identity", nullptr);
+    auto caps = adoptGRef(gst_caps_new_empty_simple("foo/bar"));
+    auto harness = WebCore::GStreamerElementHarness::create(WTFMove(element), [](auto&, auto&&) { }, std::nullopt, GRefPtr(caps));
+
+    // The identity element has a single source pad. Fetch the corresponding stream.
+    ASSERT_FALSE(harness->outputStreams().isEmpty());
+    auto& stream = harness->outputStreams().first();
+
+    // Harness has not started processing data yet.
+    ASSERT_NULL(stream->pullSample());
+    ASSERT_NULL(stream->pullEvent());
+
+    // Push a sample and expect initial events and an output buffer.
+    auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, 64, nullptr));
+    GstMappedBuffer mappedInputBuffer(buffer.get(), GST_MAP_READWRITE);
+    memsetSpan(mappedInputBuffer.mutableSpan<uint8_t>(), 2);
+    ASSERT_TRUE(mappedInputBuffer);
+    EXPECT_EQ(mappedInputBuffer.size(), 64);
+    auto sample = adoptGRef(gst_sample_new(buffer.get(), caps.get(), nullptr, nullptr));
+    EXPECT_TRUE(harness->pushSample(WTFMove(sample)));
+
+    auto event = stream->pullEvent();
+    ASSERT_NOT_NULL(event.get());
+    EXPECT_STREQ(GST_EVENT_TYPE_NAME(event.get()), "stream-start");
+
+    event = stream->pullEvent();
+    ASSERT_NOT_NULL(event.get());
+    EXPECT_STREQ(GST_EVENT_TYPE_NAME(event.get()), "caps");
+    GstCaps* eventCaps;
+    gst_event_parse_caps(event.get(), &eventCaps);
+    ASSERT_TRUE(gst_caps_is_equal(eventCaps, caps.get()));
+
+    event = stream->pullEvent();
+    ASSERT_NOT_NULL(event.get());
+    EXPECT_STREQ(GST_EVENT_TYPE_NAME(event.get()), "segment");
+
+    ASSERT_TRUE(gst_caps_is_equal(stream->outputCaps().get(), caps.get()));
+
+    // The harnessed element is identity, so output buffers should be the same as input buffers.
+    auto outputSample = stream->pullSample();
+    auto outputBuffer = gst_sample_get_buffer(outputSample.get());
+    GstMappedBuffer mappedOutputBuffer(outputBuffer, GST_MAP_READ);
+    ASSERT_TRUE(mappedOutputBuffer);
+    EXPECT_EQ(mappedOutputBuffer.size(), 64);
+    EXPECT_TRUE(equalSpans(mappedInputBuffer.span<uint8_t>(), mappedOutputBuffer.span<uint8_t>()));
+
+    // Harness is now empty.
+    ASSERT_NULL(stream->pullSample());
+    ASSERT_NULL(stream->pullEvent());
+}
+
 } // namespace TestWebKitAPI
 
 #endif // USE(GSTREAMER)


### PR DESCRIPTION
#### 7478268ef2e01a7eb7aee7d2579c190a3065a559
<pre>
[GStreamer] Add support for allowed output caps hints in ElementHarness
<a href="https://bugs.webkit.org/show_bug.cgi?id=288914">https://bugs.webkit.org/show_bug.cgi?id=288914</a>

Reviewed by Xabier Rodriguez-Calvar.

Instead of accepting ANY caps on its output pad, a Stream created by the harness can now provide
hints for the caps negotiation. This will be useful for hardware video decoding support in our
WebCodec backend.

Driving-by, also require from the video decoder to attach video metas to its output buffers. This is
a requirement for hardware video decoding (for vaapi decoders at least).

* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::GStreamerInternalVideoDecoder):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::GStreamerElementHarness):
(WebCore::GStreamerElementHarness::Stream::Stream):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:
(WebCore::GStreamerElementHarness::Stream::create):
(WebCore::GStreamerElementHarness::create):
* Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GstElementHarness.cpp:
(TestWebKitAPI::TEST_F(GStreamerTest, harnessCustomCaps)):

Canonical link: <a href="https://commits.webkit.org/291698@main">https://commits.webkit.org/291698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e6304eedeaaa4df57bb00fc6bcdbe9a079fd057

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43462 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71063 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28480 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95938 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9621 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51391 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1721 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42775 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79606 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19988 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14649 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/nodes/ParentNode-querySelector-All-xht.xht (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80083 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79984 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79385 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19878 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23930 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1215 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13014 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19972 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25148 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->