### PR TITLE
Address UncountedCallArgsChecker exceptions in ViewTransitionTypeSet.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -607,7 +607,6 @@ dom/Traversal.cpp
 dom/TreeScope.cpp
 dom/TreeWalker.cpp
 dom/ViewTransition.cpp
-dom/ViewTransitionTypeSet.cpp
 dom/VisitedLinkState.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
 dom/mac/ImageControlsMac.cpp

--- a/Source/WebCore/dom/ViewTransitionTypeSet.cpp
+++ b/Source/WebCore/dom/ViewTransitionTypeSet.cpp
@@ -54,9 +54,9 @@ void ViewTransitionTypeSet::clearFromSetLike()
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (!m_document)
         return;
-    if (m_document->documentElement()) {
+    if (RefPtr documentElement = m_document->documentElement()) {
         styleInvalidation.emplace(
-            *m_document->documentElement(),
+            *documentElement,
             CSSSelector::PseudoClass::ActiveViewTransitionType,
             Style::PseudoClassChangeInvalidation::AnyValue
         );
@@ -70,9 +70,9 @@ void ViewTransitionTypeSet::addToSetLike(const AtomString& type)
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (!m_document)
         return;
-    if (m_document->documentElement()) {
+    if (RefPtr documentElement = m_document->documentElement()) {
         styleInvalidation.emplace(
-            *m_document->documentElement(),
+            *documentElement,
             CSSSelector::PseudoClass::ActiveViewTransitionType,
             Style::PseudoClassChangeInvalidation::AnyValue
         );
@@ -86,9 +86,9 @@ bool ViewTransitionTypeSet::removeFromSetLike(const AtomString& type)
     std::optional<Style::PseudoClassChangeInvalidation> styleInvalidation;
     if (!m_document)
         return false;
-    if (m_document->documentElement()) {
+    if (RefPtr documentElement = m_document->documentElement()) {
         styleInvalidation.emplace(
-            *m_document->documentElement(),
+            *documentElement,
             CSSSelector::PseudoClass::ActiveViewTransitionType,
             Style::PseudoClassChangeInvalidation::AnyValue
         );


### PR DESCRIPTION
#### 82ffe2c817e04a25950e9f8beb72eb90e3f9d45a
<pre>
Address UncountedCallArgsChecker exceptions in ViewTransitionTypeSet.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288920">https://bugs.webkit.org/show_bug.cgi?id=288920</a>
<a href="https://rdar.apple.com/145921791">rdar://145921791</a>

Reviewed by Chris Dumez.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/ViewTransitionTypeSet.cpp:
(WebCore::ViewTransitionTypeSet::clearFromSetLike):
(WebCore::ViewTransitionTypeSet::addToSetLike):
(WebCore::ViewTransitionTypeSet::removeFromSetLike):

Canonical link: <a href="https://commits.webkit.org/291446@main">https://commits.webkit.org/291446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2ea99ff9f76d587d5a75b35346d64ba38bcf23f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97946 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43473 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/94997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71069 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51397 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1715 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42786 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79613 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99968 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/19999 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14655 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80091 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20250 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79392 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23937 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13026 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14851 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19983 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25159 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19670 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->