### PR TITLE
Address UncountedCallArgsChecker exceptions in DocumentFullscreen.cpp/h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -545,10 +545,7 @@ dom/DataTransferItemList.cpp
 dom/Document.cpp
 dom/DocumentFontLoader.cpp
 dom/DocumentFragment.cpp
-dom/DocumentFullscreen.cpp
-dom/DocumentFullscreen.h
 dom/DocumentInlines.h
-dom/DocumentOrShadowRootFullscreen.cpp
 dom/DocumentStorageAccess.cpp
 dom/Element.cpp
 dom/ElementData.cpp

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -107,13 +107,13 @@ protected:
 
 private:
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const { return document().logger(); }
+    const Logger& logger() const { return protectedDocument()->logger(); }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "DocumentFullscreen"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 
-    Document* mainFrameDocument() { return document().mainFrameDocument(); }
+    Document* mainFrameDocument() { return protectedDocument()->mainFrameDocument(); }
     RefPtr<Document> protectedMainFrameDocument() { return mainFrameDocument(); }
 
     bool didEnterFullscreen();

--- a/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
@@ -43,7 +43,7 @@ Element* DocumentOrShadowRootFullscreen::fullscreenElement(TreeScope& treeScope)
     CheckedPtr documentFullscreen = document->fullscreenIfExists();
     if (!documentFullscreen)
         return nullptr;
-    return treeScope.ancestorElementInThisScope(documentFullscreen->fullscreenElement());
+    return treeScope.ancestorElementInThisScope(documentFullscreen->protectedFullscreenElement().get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -77,6 +77,8 @@ public:
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() { return *m_mainFrame; }
     const Frame& mainFrame() const { return *m_mainFrame; }
+    Ref<Frame> protectedMainFrame() { return mainFrame(); }
+    Ref<const Frame> protectedMainFrame() const { return mainFrame(); }
     bool isMainFrame() const { return this == m_mainFrame.get(); }
     WEBCORE_EXPORT void disownOpener();
     WEBCORE_EXPORT void updateOpener(Frame&, NotifyUIProcess = NotifyUIProcess::Yes);


### PR DESCRIPTION
#### 567aaa4ab32e6aa52a8c3b6109aa83bac0963b27
<pre>
Address UncountedCallArgsChecker exceptions in DocumentFullscreen.cpp/h
<a href="https://bugs.webkit.org/show_bug.cgi?id=288921">https://bugs.webkit.org/show_bug.cgi?id=288921</a>
<a href="https://rdar.apple.com/145923306">rdar://145923306</a>

Reviewed by Chris Dumez.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::requestFullscreen):
(WebCore::DocumentFullscreen::willEnterFullscreen):
(WebCore::DocumentFullscreen::elementEnterFullscreen):
(WebCore::DocumentFullscreen::finishExitFullscreen):
(WebCore::DocumentFullscreen::didExitFullscreen):
(WebCore::DocumentFullscreen::dispatchPendingEvents):
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp:
(WebCore::DocumentOrShadowRootFullscreen::fullscreenElement):
* Source/WebCore/page/Frame.h:
(WebCore::Frame::protectedMainFrame):
(WebCore::Frame::protectedMainFrame const):

Canonical link: <a href="https://commits.webkit.org/291452@main">https://commits.webkit.org/291452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0271d782111f4d4a1eea68cc57f8d60288f8fb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92960 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20963 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28492 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95962 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51404 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42799 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79620 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99981 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20012 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79987 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19712 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23946 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13044 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/19996 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23143 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21424 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->