### PR TITLE
Pause silent push timer in webpushd for inspected workers

### DIFF
--- a/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt
@@ -1,6 +1,6 @@
 Received ServiceWorker Console Message: doTest: {"type":"PUSHEVENT","message":"NO-SHOWNOTIFICATION"}
 Received ServiceWorker Console Message: doPush: NO-SHOWNOTIFICATION
-Received ServiceWorker Console Message: Push event ended without showing any notification may trigger removal of the push subscription.
+Received ServiceWorker Console Message: Push event handling completed without showing any notification via ServiceWorkerRegistration.showNotification(). This may trigger removal of the push subscription.
 
 PASS push without showNotification call
 

--- a/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt
@@ -1,6 +1,6 @@
 Received ServiceWorker Console Message: doTest: {"type":"PUSHEVENT","message":"SHOWNOTIFICATION-LATE"}
 Received ServiceWorker Console Message: doPush: SHOWNOTIFICATION-LATE
-Received ServiceWorker Console Message: Push event ended without showing any notification may trigger removal of the push subscription.
+Received ServiceWorker Console Message: Push event handling completed without showing any notification via ServiceWorkerRegistration.showNotification(). This may trigger removal of the push subscription.
 Received ServiceWorker Console Message: showNotification was called outside of any push event lifetime. PushEvent.waitUntil can be used to extend the push event lifetime as necessary.
 
 PASS push with late showNotification call

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -291,7 +291,7 @@ void ServiceWorkerThread::queueTaskToFirePushEvent(std::optional<Vector<uint8_t>
             bool showedNotification = !serviceWorkerGlobalScope->hasPendingSilentPushEvent();
             serviceWorkerGlobalScope->setHasPendingSilentPushEvent(false);
             if (!showedNotification)
-                serviceWorkerGlobalScope->addConsoleMessage(MessageSource::Storage, MessageLevel::Error, "Push event ended without showing any notification may trigger removal of the push subscription."_s, 0);
+                serviceWorkerGlobalScope->addConsoleMessage(MessageSource::Storage, MessageLevel::Error, "Push event handling completed without showing any notification via ServiceWorkerRegistration.showNotification(). This may trigger removal of the push subscription."_s, 0);
             bool success = !hasRejectedAnyPromise && showedNotification;
 
             RELEASE_LOG_ERROR_IF(!success, ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushEvent failed to process push event (rejectedPromise = %d, showedNotification = %d)", hasRejectedAnyPromise, showedNotification);

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -232,6 +232,15 @@ void NetworkNotificationManager::getAppBadgeForTesting(CompletionHandler<void(st
     connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAppBadgeForTesting(), WTFMove(completionHandler));
 }
 
+void NetworkNotificationManager::setServiceWorkerIsBeingInspected(const URL& scopeURL, bool isInspected)
+{
+    RefPtr connection = m_connection;
+    if (!connection)
+        return;
+
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::SetServiceWorkerIsBeingInspected { scopeURL, isInspected }, []() { });
+}
+
 static void getPushPermissionStateImpl(WebPushD::Connection* connection, WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
     if (!connection)

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -36,6 +36,8 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/NotificationDirection.h>
 #include <WebCore/PushSubscriptionData.h>
+#include <WebCore/ServiceWorkerIdentifier.h>
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/text/WTFString.h>
@@ -80,6 +82,8 @@ public:
 
     void getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&&);
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge) final;
+
+    void setServiceWorkerIsBeingInspected(const URL&, bool isInspected);
 
 private:
     NetworkNotificationManager(const String& webPushMachServiceName, WebPushD::WebPushDaemonConnectionConfiguration&&, NetworkProcess&);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -119,6 +119,7 @@ private:
     void skipWaiting(WebCore::ServiceWorkerIdentifier, CompletionHandler<void()>&&);
 
     // Messages back from the SW host process
+    void setAsInspected(WebCore::ServiceWorkerIdentifier, bool);
     void workerTerminated(WebCore::ServiceWorkerIdentifier);
 
     // Messages to the SW host WebProcess

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -39,6 +39,7 @@
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
+#include <wtf/HashSet.h>
 #include <wtf/Identified.h>
 #include <wtf/OSObjectPtr.h>
 #include <wtf/ObjectIdentifier.h>
@@ -75,6 +76,7 @@ class PushClientConnection : public RefCounted<PushClientConnection>, public Ide
     WTF_MAKE_TZONE_ALLOCATED(PushClientConnection);
 public:
     static RefPtr<PushClientConnection> create(xpc_connection_t, IPC::Decoder&);
+    virtual ~PushClientConnection();
 
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
@@ -115,6 +117,7 @@ private:
     void requestPushPermission(WebCore::SecurityOriginData&&, CompletionHandler<void(bool)>&&);
     void setHostAppAuditTokenData(const Vector<uint8_t>&);
     void getPushTopicsForTesting(CompletionHandler<void(Vector<String>, Vector<String>)>&&);
+    void setServiceWorkerIsBeingInspected(URL&& scopeURL, bool isInspected, CompletionHandler<void()>&&);
 
     void showNotification(const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>, CompletionHandler<void()>&&);
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);
@@ -129,6 +132,7 @@ private:
     String m_pushPartitionString;
     Markable<WTF::UUID> m_dataStoreIdentifier;
     bool m_declarativeWebPushEnabled { false };
+    HashSet<WebCore::SecurityOriginData> m_inspectedServiceWorkerOrigins;
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -45,6 +45,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     RequestPushPermission(WebCore::SecurityOriginData origin) -> (bool granted)
     SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
     GetAppBadgeForTesting() -> (std::optional<uint64_t> badge)
+    SetServiceWorkerIsBeingInspected(URL scopeURL, bool isInspected) -> ()
     SetProtocolVersionForTesting(unsigned version) -> ()
 }
 

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -119,6 +119,8 @@ public:
 
     void setProtocolVersionForTesting(PushClientConnection&, unsigned, CompletionHandler<void()>&&);
 
+    void setServiceWorkerOriginIsBeingInspected(const WebCore::SecurityOriginData&, bool isInspected);
+
 private:
     WebPushDaemon();
 
@@ -178,6 +180,8 @@ private:
     std::unique_ptr<WebClipCache> m_webClipCache;
     String m_webClipCachePath;
 #endif
+
+    HashMap<WebCore::SecurityOriginData, int> m_inspectedServiceWorkerOrigins;
 };
 
 } // namespace WebPushD

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -700,10 +700,16 @@ void WebPushDaemon::silentPushTimerFired()
         if (it->expirationTime > now)
             break;
 
-        auto origin = WebCore::SecurityOriginData::fromURL(URL { it->scope }).toString();
-        m_pushService->incrementSilentPushCount(it->identifier, origin, [identifier = it->identifier, origin](unsigned newSilentPushCount) {
-            RELEASE_LOG(Push, "showNotification not called in time for %{public}s (origin = %{sensitive}s), silent push count is now %u", identifier.debugDescription().utf8().data(), origin.utf8().data(), newSilentPushCount);
-        });
+        auto origin = WebCore::SecurityOriginData::fromURL(URL { it->scope });
+        auto originString = origin.toString();
+        if (m_inspectedServiceWorkerOrigins.contains(origin))
+            RELEASE_LOG(Push, "showNotification not called in time for %{public}s (origin = %{sensitive}s), but not incrementing silent push count since it is being inspected", it->identifier.debugDescription().utf8().data(), originString.utf8().data());
+        else {
+            m_pushService->incrementSilentPushCount(it->identifier, originString, [identifier = it->identifier, originString](unsigned newSilentPushCount) {
+                RELEASE_LOG(Push, "showNotification not called in time for %{public}s (origin = %{sensitive}s), silent push count is now %u", identifier.debugDescription().utf8().data(), originString.utf8().data(), newSilentPushCount);
+            });
+        }
+
         it = m_potentialSilentPushes.erase(it);
     }
 
@@ -1264,6 +1270,21 @@ void WebPushDaemon::setProtocolVersionForTesting(PushClientConnection& connectio
 {
     s_protocolVersion = version;
     completionHandler();
+}
+
+void WebPushDaemon::setServiceWorkerOriginIsBeingInspected(const WebCore::SecurityOriginData& origin, bool isInspected)
+{
+    auto result = m_inspectedServiceWorkerOrigins.add(origin, 0);
+
+    if (!isInspected) {
+        auto count = --result.iterator->value;
+        if (count <= 0)
+            m_inspectedServiceWorkerOrigins.remove(result.iterator);
+        RELEASE_LOG(Push, "Service worker for origin %{sensitive}s no longer being inspected (inspection count = %d)", origin.toString().utf8().data(), count);
+    } else {
+        auto count = ++result.iterator->value;
+        RELEASE_LOG(Push, "Service worker for origin %{sensitive}s is being inspected (inspection count = %d); suspending silent push enforcement", origin.toString().utf8().data(), count);
+    }
 }
 
 } // namespace WebPushD


### PR DESCRIPTION
#### 0fdb3301a885ff83a70bba892c6aa8b184ecc616
<pre>
Pause silent push timer in webpushd for inspected workers
<a href="https://bugs.webkit.org/show_bug.cgi?id=288924">https://bugs.webkit.org/show_bug.cgi?id=288924</a>
<a href="https://rdar.apple.com/144997342">rdar://144997342</a>

Reviewed by Brady Eidson.

When a service worker is being inspected and built-in notifications are on, the silent push
enforcement timer in webpushd is not suspended. This can cause a push subscription to be erroneously
removed.

Fix this by not enforcing the silent push heuristic when an origin is being inspected. For
simplicity, we currently suspend enforcement until the related service worker is killed.

Combined changes:
* LayoutTests/http/wpt/service-workers/push-console-messages-no-showNotification.https-expected.txt:
* LayoutTests/http/wpt/service-workers/push-console-messages-showNotification-late.https-expected.txt:
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFirePushEvent):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::setServiceWorkerIsBeingInspected):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::setAsInspected):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::~PushClientConnection):
(WebPushD::PushClientConnection::setServiceWorkerIsBeingInspected):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::silentPushTimerFired):
(WebPushD::WebPushDaemon::setServiceWorkerOriginIsBeingInspected):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::(WebPushDBuiltInTest, ImplicitSilentPushTimerCancelledOnShowingNotification)):
(TestWebKitAPI::(WebPushDBuiltInTest, ImplicitSilentPushTimerIgnoredForInspectedContexts)):

Canonical link: <a href="https://commits.webkit.org/291553@main">https://commits.webkit.org/291553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/027202521a02f05515acb7608f514dc689632d0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95332 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21292 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28679 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96284 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9844 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51618 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9538 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43122 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100311 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20586 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79619 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19779 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24163 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20318 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25495 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21746 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->