### PR TITLE
Reintroduce animation listener to transform property of model

### DIFF
--- a/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
+++ b/Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift
@@ -202,8 +202,8 @@ final public class WKStageModeInteractionDriver: NSObject {
     private func subscribeToPitchChanges() {
         if pitchAnimationIsPlaying {
             withObservationTracking {
-#if USE_APPLE_INTERNAL_SDK
-                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=288873
+#if canImport(RealityFoundation, _version: 380)
+                _ = self.interactionContainer.proto_observableComponents[Transform.self]
 #endif
             } onChange: {
                 Task { @MainActor in
@@ -221,8 +221,9 @@ final public class WKStageModeInteractionDriver: NSObject {
     private func subscribeToYawChanges() {
         if yawAnimationIsPlaying {
             withObservationTracking {
-#if USE_APPLE_INTERNAL_SDK
-                // FIXME: https://bugs.webkit.org/show_bug.cgi?id=288873
+#if canImport(RealityFoundation, _version: 380)
+                // By default, we do not care about the proxy, but we use the update to set the deceleration of the turntable container
+                _ = turntableAnimationProxyEntity.proto_observableComponents[Transform.self]
 #endif
             } onChange: {
                 Task { @MainActor in


### PR DESCRIPTION
#### 16e2089d8197c71d3734cdde6c9dbecb4554ede9
<pre>
Reintroduce animation listener to transform property of model
<a href="https://bugs.webkit.org/show_bug.cgi?id=288873">https://bugs.webkit.org/show_bug.cgi?id=288873</a>
<a href="https://rdar.apple.com/145880944">rdar://145880944</a>

Reviewed by Wenson Hsieh.

Reintroduce the pitch and yaw observation in &lt;model&gt; stage mode,
guarded with the proper version check of the relevant framework.

* Source/WebKit/WebKitSwift/StageMode/WKStageMode.swift:
(WKStageModeInteractionDriver.subscribeToPitchChanges):
(WKStageModeInteractionDriver.subscribeToYawChanges):

Canonical link: <a href="https://commits.webkit.org/291462@main">https://commits.webkit.org/291462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71537a51f2cee834757e109ba36fb69e997beecb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43490 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12796 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71078 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28495 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51406 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9331 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42803 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79623 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99985 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20016 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14667 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80101 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/79991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79402 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23948 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13050 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20000 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25176 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21428 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->