### PR TITLE
Fix UncountedCallArgsChecker & UncheckedCallArgsChecker warnings in ViewTransition.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -12,7 +12,6 @@ dom/Document.cpp
 dom/Element.cpp
 dom/MouseRelatedEvent.cpp
 dom/PendingScript.cpp
-dom/ViewTransition.cpp
 editing/CompositeEditCommand.cpp
 editing/Editor.cpp
 editing/EditorCommand.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -18,7 +18,6 @@ dom/BroadcastChannel.cpp
 dom/Document.cpp
 dom/ScriptExecutionContext.cpp
 dom/TreeScope.cpp
-dom/ViewTransition.cpp
 editing/cocoa/DataDetection.mm
 editing/cocoa/WebContentReaderCocoa.mm
 editing/mac/FrameSelectionMac.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -468,7 +468,6 @@ css/CSSToStyleMap.cpp
 css/CSSValueList.cpp
 css/CSSValuePair.cpp
 css/CSSVariableReferenceValue.cpp
-css/CSSViewTransitionRule.h
 css/CSSViewValue.cpp
 css/CSSViewValue.h
 css/ComputedStyleExtractor.cpp
@@ -603,7 +602,6 @@ dom/TextDecoderStreamDecoder.h
 dom/Traversal.cpp
 dom/TreeScope.cpp
 dom/TreeWalker.cpp
-dom/ViewTransition.cpp
 dom/VisitedLinkState.cpp
 dom/WindowOrWorkerGlobalScopeTrustedTypes.cpp
 dom/mac/ImageControlsMac.cpp

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -68,7 +68,7 @@ public:
     StyleRuleType styleRuleType() const final { return StyleRuleType::ViewTransition; }
 
     AtomString navigation() const;
-    Vector<AtomString> types() const { return m_viewTransitionRule->types(); }
+    Vector<AtomString> types() const { return Ref { m_viewTransitionRule }->types(); }
 
 private:
     CSSViewTransitionRule(StyleRuleViewTransition&, CSSStyleSheet* parent);

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -124,7 +124,7 @@ RefPtr<ViewTransition> ViewTransition::resolveInboundCrossDocumentViewTransition
 
     document.setActiveViewTransition(RefPtr { viewTransition });
 
-    viewTransition->m_updateCallbackDone.second->resolve();
+    Ref { viewTransition->m_updateCallbackDone.second }->resolve();
     viewTransition->m_phase = ViewTransitionPhase::UpdateCallbackCalled;
 
     // FIXME: Setup implementation-defined timeout.
@@ -182,35 +182,35 @@ void ViewTransition::skipViewTransition(ExceptionOr<JSC::JSValue>&& reason)
         });
 
         if (m_isCrossDocument)
-            m_updateCallbackDone.second->resolve();
+            Ref { m_updateCallbackDone.second }->resolve();
     }
 
-    document()->clearRenderingIsSuppressedForViewTransition();
+    protectedDocument()->clearRenderingIsSuppressedForViewTransition();
 
-    if (document()->activeViewTransition() == this)
+    if (protectedDocument()->activeViewTransition() == this)
         clearViewTransition();
 
     m_phase = ViewTransitionPhase::Done;
 
     if (reason.hasException())
-        m_ready.second->reject(reason.releaseException());
+        Ref { m_ready.second }->reject(reason.releaseException());
     else {
-        m_ready.second->rejectWithCallback([&] (auto&) {
+        Ref { m_ready.second }->rejectWithCallback([&] (auto&) {
             return reason.releaseReturnValue();
         }, RejectAsHandled::Yes);
     }
 
-    m_updateCallbackDone.first->whenSettled([this, protectedThis = Ref { *this }] {
+    Ref { m_updateCallbackDone.first }->whenSettled([this, protectedThis = Ref { *this }] {
         if (isContextStopped())
             return;
 
-        switch (m_updateCallbackDone.first->status()) {
+        switch (Ref { m_updateCallbackDone.first }->status()) {
         case DOMPromise::Status::Fulfilled:
-            m_finished.second->resolve();
+            Ref { m_finished.second }->resolve();
             break;
         case DOMPromise::Status::Rejected:
-            m_finished.second->rejectWithCallback([&] (auto&) {
-                return m_updateCallbackDone.first->result();
+            Ref { m_finished.second }->rejectWithCallback([&] (auto&) {
+                return Ref { m_updateCallbackDone.first }->result();
             }, RejectAsHandled::Yes);
             break;
         case DOMPromise::Status::Pending:
@@ -253,18 +253,18 @@ void ViewTransition::callUpdateCallback()
 
     if (!m_updateCallback) {
         auto promiseAndWrapper = createPromiseAndWrapper(document);
-        promiseAndWrapper.second->resolve();
+        Ref { promiseAndWrapper.second }->resolve();
         callbackPromise = WTFMove(promiseAndWrapper.first);
     } else {
-        auto result = m_updateCallback->handleEvent();
+        auto result = RefPtr { m_updateCallback }->handleEvent();
         callbackPromise = result.type() == CallbackResultType::Success ? result.releaseReturnValue() : nullptr;
         if (!callbackPromise || callbackPromise->isSuspended()) {
             auto promiseAndWrapper = createPromiseAndWrapper(document);
             // FIXME: First case should reject with `ExceptionCode::ExistingExceptionError`.
             if (result.type() == CallbackResultType::ExceptionThrown)
-                promiseAndWrapper.second->reject(ExceptionCode::TypeError);
+                Ref { promiseAndWrapper.second }->reject(ExceptionCode::TypeError);
             else
-                promiseAndWrapper.second->reject();
+                Ref { promiseAndWrapper.second }->reject();
             callbackPromise = WTFMove(promiseAndWrapper.first);
         }
     }
@@ -276,16 +276,16 @@ void ViewTransition::callUpdateCallback()
         m_updateCallbackTimeout = nullptr;
         switch (callbackPromise->status()) {
         case DOMPromise::Status::Fulfilled:
-            m_updateCallbackDone.second->resolve();
+            Ref { m_updateCallbackDone.second }->resolve();
             activateViewTransition();
             break;
         case DOMPromise::Status::Rejected:
-            m_updateCallbackDone.second->rejectWithCallback([&] (auto&) {
+            Ref { m_updateCallbackDone.second }->rejectWithCallback([&] (auto&) {
                 return callbackPromise->result();
             }, RejectAsHandled::No);
             if (m_phase == ViewTransitionPhase::Done)
                 return;
-            m_ready.second->markAsHandled();
+            Ref { m_ready.second }->markAsHandled();
             skipViewTransition(callbackPromise->result());
             break;
         case DOMPromise::Status::Pending:
@@ -322,9 +322,9 @@ void ViewTransition::setupViewTransition()
     }
 
     if (m_isCrossDocument)
-        document()->setRenderingIsSuppressedForViewTransitionImmediately();
+        protectedDocument()->setRenderingIsSuppressedForViewTransitionImmediately();
     else
-        document()->setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
+        protectedDocument()->setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
 
     protectedDocument()->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [this, weakThis = WeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();
@@ -358,13 +358,14 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
     if (!renderer.element())
         return nullAtom();
 
-    if (transitionName.isAuto() && scope == &Style::Scope::forNode(*renderer.element()) && renderer.element()->hasID())
+    Ref element = *renderer.element();
+    if (transitionName.isAuto() && scope == &Style::Scope::forNode(element) && element->hasID())
         return renderer.element()->getIdAttribute();
 
     if (isCrossDocument)
         return nullAtom();
 
-    return makeAtomString("-ua-auto-"_s, String::number(renderer.element()->identifier().toRawValue()));
+    return makeAtomString("-ua-auto-"_s, String::number(element->identifier().toRawValue()));
 }
 
 static ExceptionOr<void> checkDuplicateViewTransitionName(const AtomString& name, ListHashSet<AtomString>& usedTransitionNames)
@@ -396,8 +397,8 @@ static LayoutRect captureOverflowRect(RenderLayerModelObject& renderer)
         return { };
 
     if (renderer.isDocumentElementRenderer()) {
-        auto& frameView = renderer.view().frameView();
-        return { { }, LayoutSize { frameView.frameRect().width(), frameView.frameRect().height() } };
+        CheckedRef frameView = renderer.view().frameView();
+        return { { }, LayoutSize { frameView->frameRect().width(), frameView->frameRect().height() } };
     }
 
     return renderer.layer()->calculateLayerBounds(renderer.layer(), LayoutSize(), { RenderLayer::IncludeFilterOutsets, RenderLayer::ExcludeHiddenDescendants, RenderLayer::IncludeCompositedDescendants, RenderLayer::PreserveAncestorFlags });
@@ -425,7 +426,7 @@ static RefPtr<ImageBuffer> snapshotElementVisualOverflowClippedToViewport(LocalF
         auto& view = layerRenderer->view();
         layerRenderer = view;
 
-        auto scrollPosition = view.frameView().scrollPosition();
+        auto scrollPosition = CheckedRef { view.frameView() }->scrollPosition();
         paintRect.moveBy(scrollPosition);
     }
 
@@ -433,7 +434,8 @@ static RefPtr<ImageBuffer> snapshotElementVisualOverflowClippedToViewport(LocalF
     float scaleFactor = frame.page()->deviceScaleFactor();
 
     ASSERT(frame.document());
-    auto hostWindow = (frame.document()->view() && frame.document()->view()->root()) ? frame.document()->view()->root()->hostWindow() : nullptr;
+    RefPtr frameView = frame.document()->view();
+    auto hostWindow = (frameView && frameView->root()) ? RefPtr { frameView->root() }->hostWindow() : nullptr;
 
     auto buffer = ImageBuffer::create(paintRect.size(), RenderingMode::Accelerated, RenderingPurpose::Snapshot, scaleFactor, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8, hostWindow);
     if (!buffer)
@@ -491,7 +493,7 @@ ExceptionOr<void> ViewTransition::captureOldState()
     protectedDocument()->updateStyleIfNeeded();
 
     if (CheckedPtr view = document()->renderView()) {
-        Ref frame = view->frameView().frame();
+        Ref frame = CheckedRef { view->frameView() }->frame();
         m_initialLargeViewportSize = view->sizeForCSSLargeViewportUnits();
         m_initialPageZoom = frame->pageZoomFactor() * frame->frameScaleFactor();
 
@@ -500,7 +502,7 @@ ExceptionOr<void> ViewTransition::captureOldState()
             if (!styleable)
                 return { };
 
-            if (auto name = effectiveViewTransitionName(renderer, styleable->element, document()->styleScope(), isCrossDocument()); !name.isNull()) {
+            if (auto name = effectiveViewTransitionName(renderer, Ref { styleable->element }, document()->styleScope(), isCrossDocument()); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
                     return check.releaseException();
 
@@ -528,15 +530,18 @@ ExceptionOr<void> ViewTransition::captureOldState()
 
         auto styleable = Styleable::fromRenderer(renderer);
         ASSERT(styleable);
-        capture.classList = effectiveViewTransitionClassList(renderer, styleable->element, document()->styleScope());
+        Ref element = styleable->element;
+        capture.classList = effectiveViewTransitionClassList(renderer, element, document()->styleScope());
 
-        auto transitionName = effectiveViewTransitionName(renderer, styleable->element, document()->styleScope(), isCrossDocument());
+        auto transitionName = effectiveViewTransitionName(renderer, element, document()->styleScope(), isCrossDocument());
         m_namedElements.add(transitionName, capture);
     }
 
     for (auto& [name, capturedElement] : m_namedElements.map()) {
-        if (capturedElement->initiallyIntersectsViewport && capturedElement->oldImage && *capturedElement->oldImage)
-            (*capturedElement->oldImage)->flushDrawingContextAsync();
+        if (capturedElement->initiallyIntersectsViewport && capturedElement->oldImage) {
+            if (RefPtr oldImage = *capturedElement->oldImage)
+                oldImage->flushDrawingContextAsync();
+        }
     }
 
     for (auto& renderer : captureRenderers)
@@ -559,10 +564,10 @@ bool ViewTransition::updatePropertiesForRenderer(CapturedElement& capturedElemen
         // group styles rule
         if (!capturedElement.groupStyleProperties) {
             capturedElement.groupStyleProperties = properties;
-            protectedDocument()->styleScope().resolver().setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
+            Ref { protectedDocument()->styleScope().resolver() }->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
             changed = true;
         } else
-            changed |= capturedElement.groupStyleProperties->mergeAndOverrideOnConflict(*properties);
+            changed |= RefPtr { capturedElement.groupStyleProperties }->mergeAndOverrideOnConflict(*properties);
     }
     return changed;
 }
@@ -579,7 +584,8 @@ ExceptionOr<void> ViewTransition::captureNewState()
             if (!styleable)
                 return { };
 
-            if (auto name = effectiveViewTransitionName(renderer, styleable->element, document()->styleScope(), isCrossDocument()); !name.isNull()) {
+            Ref element = styleable->element;
+            if (auto name = effectiveViewTransitionName(renderer, element, document()->styleScope(), isCrossDocument()); !name.isNull()) {
                 if (auto check = checkDuplicateViewTransitionName(name, usedTransitionNames); check.hasException())
                     return check.releaseException();
 
@@ -588,7 +594,7 @@ ExceptionOr<void> ViewTransition::captureNewState()
                     m_namedElements.add(name, capturedElement);
                 }
                 auto namedElement = m_namedElements.find(name);
-                namedElement->classList = effectiveViewTransitionClassList(renderer, styleable->element, document()->styleScope());
+                namedElement->classList = effectiveViewTransitionClassList(renderer, element, document()->styleScope());
                 namedElement->newElement = *styleable;
 
                 updatePropertiesForRenderer(*namedElement, dynamicDowncast<RenderBoxModelObject>(renderer), name);
@@ -660,7 +666,7 @@ void ViewTransition::setupDynamicStyleSheet(const AtomString& name, const Captur
         CSSPropertyTransform,
         CSSPropertyBackdropFilter,
     };
-    Ref keyframe = StyleRuleKeyframe::create(capturedElement.oldProperties->copyProperties(keyframeProperties));
+    Ref keyframe = StyleRuleKeyframe::create(RefPtr { capturedElement.oldProperties }->copyProperties(keyframeProperties));
     keyframe->setKeyText("from"_s);
 
     Ref keyframes = StyleRuleKeyframes::create(AtomString(makeString("-ua-view-transition-group-anim-"_s, name)));
@@ -691,7 +697,7 @@ ExceptionOr<void> ViewTransition::checkForViewportSizeChange()
     if (!view)
         return Exception { ExceptionCode::InvalidStateError, "Skipping view transition because viewport size changed."_s };
 
-    Ref frame = view->frameView().frame();
+    Ref frame = CheckedRef { view->frameView() }->frame();
     if (view->sizeForCSSLargeViewportUnits() != m_initialLargeViewportSize || m_initialPageZoom != (frame->pageZoomFactor() * frame->frameScaleFactor()))
         return Exception { ExceptionCode::InvalidStateError, "Skipping view transition because viewport size changed."_s };
     return { };
@@ -703,7 +709,7 @@ void ViewTransition::activateViewTransition()
     if (m_phase == ViewTransitionPhase::Done)
         return;
 
-    document()->clearRenderingIsSuppressedForViewTransition();
+    protectedDocument()->clearRenderingIsSuppressedForViewTransition();
 
     // Ensure style & render tree are up-to-date.
     protectedDocument()->updateStyleIfNeeded();
@@ -733,7 +739,7 @@ void ViewTransition::activateViewTransition()
     // of capture new state.
     updatePseudoElementSizes();
 
-    m_ready.second->resolve();
+    Ref { m_ready.second }->resolve();
 }
 
 // https://drafts.csswg.org/css-view-transitions/#handle-transition-frame-algorithm
@@ -750,11 +756,12 @@ void ViewTransition::handleTransitionFrame()
         if (!documentElement->animations(pseudoElementIdentifier))
             return false;
 
+        Ref timeline = protectedDocument()->timeline();
         for (auto& animation : *documentElement->animations(pseudoElementIdentifier)) {
             auto playState = animation->playState();
             if (playState == WebAnimation::PlayState::Paused || playState == WebAnimation::PlayState::Running)
                 return true;
-            if (document()->timeline().hasPendingAnimationEventForAnimation(animation))
+            if (timeline->hasPendingAnimationEventForAnimation(animation))
                 return true;
         }
         return false;
@@ -774,7 +781,7 @@ void ViewTransition::handleTransitionFrame()
     if (!hasActiveAnimations) {
         m_phase = ViewTransitionPhase::Done;
         clearViewTransition();
-        m_finished.second->resolve();
+        Ref { m_finished.second }->resolve();
         return;
     }
 
@@ -841,11 +848,11 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
     overflowRect = captureOverflowRect(renderer);
 
     Ref<MutableStyleProperties> props = styleExtractor.copyProperties(transitionProperties);
-    auto& frameView = renderer.view().frameView();
+    CheckedRef frameView = renderer.view().frameView();
 
     if (renderer.isDocumentElementRenderer()) {
-        size.setWidth(frameView.frameRect().width());
-        size.setHeight(frameView.frameRect().height());
+        size.setWidth(frameView->frameRect().width());
+        size.setHeight(frameView->frameRect().height());
     } else if (CheckedPtr renderBox = dynamicDowncast<RenderBoxModelObject>(&renderer)) {
         size = renderBox->borderBoundingBox().size();
 
@@ -853,11 +860,11 @@ Ref<MutableStyleProperties> ViewTransition::copyElementBaseProperties(RenderLaye
             auto layoutOffset = layerToLayoutOffset(renderer);
             transform->translate(layoutOffset.x(), layoutOffset.y());
 
-            auto offset = -toFloatSize(frameView.visibleContentRect().location());
+            auto offset = -toFloatSize(frameView->visibleContentRect().location());
             transform->translateRight(offset.width(), offset.height());
 
             auto mapped = transform->mapRect(overflowRect);
-            intersectsViewport = mapped.intersects(frameView.boundsRect());
+            intersectsViewport = mapped.intersects(frameView->boundsRect());
 
             // Apply the inverse of what will be added by the default value of 'transform-origin',
             // since the computed transform has already included it.
@@ -950,7 +957,7 @@ RenderViewTransitionCapture* ViewTransition::viewTransitionNewPseudoForCapturedE
     auto styleable = Styleable::fromRenderer(renderer);
     if (!styleable)
         return nullptr;
-    auto capturedName = styleable->element.viewTransitionCapturedName(styleable->pseudoElementIdentifier);
+    auto capturedName = Ref { styleable->element }->viewTransitionCapturedName(styleable->pseudoElementIdentifier);
     if (capturedName.isNull())
         return nullptr;
 
@@ -977,9 +984,9 @@ void ViewTransition::stop()
         return;
 
     m_phase = ViewTransitionPhase::Done;
-    document()->unregisterForVisibilityStateChangedCallbacks(*this);
+    protectedDocument()->unregisterForVisibilityStateChangedCallbacks(*this);
 
-    if (document()->activeViewTransition() == this)
+    if (protectedDocument()->activeViewTransition() == this)
         clearViewTransition();
 }
 

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -238,7 +238,7 @@ private:
     FloatSize m_initialLargeViewportSize;
     float m_initialPageZoom;
 
-    RefPtr<ViewTransitionUpdateCallback>  m_updateCallback;
+    RefPtr<ViewTransitionUpdateCallback> m_updateCallback;
     bool m_isCrossDocument { false };
 
     using PromiseAndWrapper = std::pair<Ref<DOMPromise>, Ref<DeferredPromise>>;


### PR DESCRIPTION
#### af7232d76ba4f4ccf50abb61fb4b8857b9f80486
<pre>
Fix UncountedCallArgsChecker &amp; UncheckedCallArgsChecker warnings in ViewTransition.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288922">https://bugs.webkit.org/show_bug.cgi?id=288922</a>
<a href="https://rdar.apple.com/145923985">rdar://145923985</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/CSSViewTransitionRule.h:
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::resolveInboundCrossDocumentViewTransition):
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
(WebCore::effectiveViewTransitionName):
(WebCore::captureOverflowRect):
(WebCore::snapshotElementVisualOverflowClippedToViewport):
(WebCore::ViewTransition::captureOldState):
(WebCore::ViewTransition::updatePropertiesForRenderer):
(WebCore::ViewTransition::captureNewState):
(WebCore::ViewTransition::setupDynamicStyleSheet):
(WebCore::ViewTransition::checkForViewportSizeChange):
(WebCore::ViewTransition::activateViewTransition):
(WebCore::ViewTransition::handleTransitionFrame):
(WebCore::ViewTransition::copyElementBaseProperties):
(WebCore::ViewTransition::viewTransitionNewPseudoForCapturedElement):
(WebCore::ViewTransition::stop):

Canonical link: <a href="https://commits.webkit.org/291465@main">https://commits.webkit.org/291465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02221951af516bb2b1e8ffadcc2a201faad2ba5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/92976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/97975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43502 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12808 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/20979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71084 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28502 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/95978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51412 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1737 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42815 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79631 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/99998 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14675 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80107 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20279 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80000 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79408 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13062 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14861 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20012 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25188 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19699 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21440 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->