### PR TITLE
[JSC] `\-` shouldn't be parsed as range with `v` flag

### DIFF
--- a/JSTests/stress/regexp-v-flag-non-range-hyphen.js
+++ b/JSTests/stress/regexp-v-flag-non-range-hyphen.js
@@ -1,0 +1,47 @@
+function compareArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected length ${b.length} but got length ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+    }
+}
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+{
+    const regex = /[\d\-a]/v;
+
+    for (let i = 0; i < 10; i++)
+        compareArray(regex.exec(i.toString()), [i.toString()]);
+    compareArray(regex.exec("-"), ["-"]);
+    compareArray(regex.exec("a"), ["a"]);
+
+    shouldBe(regex.exec("b"), null);
+}
+
+{
+    const regex = /[\p{sc=Hiragana}\-a]/v;
+
+    compareArray(regex.exec("あ"), ["あ"]);
+    compareArray(regex.exec("い"), ["い"]);
+    compareArray(regex.exec("ん"), ["ん"]);
+    compareArray(regex.exec("-"), ["-"]);
+    compareArray(regex.exec("a"), ["a"]);
+
+    shouldBe(regex.exec("b"), null);
+}
+
+{
+    const regex = /[\d\x2Da]/v;
+
+    for (let i = 0; i < 10; i++)
+        compareArray(regex.exec(i.toString()), [i.toString()]);
+    compareArray(regex.exec("-"), ["-"]);
+    compareArray(regex.exec("a"), ["a"]);
+
+    shouldBe(regex.exec("b"), null);
+}

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1151,7 +1151,7 @@ public:
         m_alternative->m_terms.append(PatternTerm::WordBoundary(invert, m_flags));
     }
 
-    void atomPatternCharacter(char32_t ch)
+    void atomPatternCharacter(char32_t ch, bool)
     {
         // We handle case-insensitive checking of unicode characters which do have both
         // cases by handling them as if they were defined using a CharacterClass.
@@ -1207,7 +1207,7 @@ public:
                         auto string = characterClass->m_strings[i];
 
                         for (auto ch : string)
-                            atomPatternCharacter(ch);
+                            atomPatternCharacter(ch, /* hyphenIsRange */ false);
 
                         ++alternativeCount;
                     }
@@ -1341,7 +1341,7 @@ public:
                 auto string = newCharacterClass->m_strings[i];
 
                 for (auto ch : string)
-                    atomPatternCharacter(ch);
+                    atomPatternCharacter(ch, /* hyphenIsRange */ false);
 
                 ++alternativeCount;
             }

--- a/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
+++ b/Source/JavaScriptCore/yarr/YarrSyntaxChecker.cpp
@@ -37,7 +37,7 @@ public:
     void assertionBOL() { }
     void assertionEOL() { }
     void assertionWordBoundary(bool) { }
-    void atomPatternCharacter(char32_t) { }
+    void atomPatternCharacter(char32_t, bool) { }
     void atomBuiltInCharacterClass(BuiltInCharacterClassID, bool) { }
     void atomCharacterClassBegin(bool = false) { }
     void atomCharacterClassAtom(UChar) { }

--- a/Source/WebCore/contentextensions/URLFilterParser.cpp
+++ b/Source/WebCore/contentextensions/URLFilterParser.cpp
@@ -76,7 +76,7 @@ public:
         return m_parseStatus;
     }
 
-    void atomPatternCharacter(UChar character)
+    void atomPatternCharacter(UChar character, bool)
     {
         if (hasError())
             return;


### PR DESCRIPTION
#### 7adb2e46f423468de209bb1f19bddad6f9b629cb
<pre>
[JSC] `\-` shouldn&apos;t be parsed as range with `v` flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=288223">https://bugs.webkit.org/show_bug.cgi?id=288223</a>

Reviewed by Yusuke Suzuki.

`[\d\-a]` should be parsed as a character class consisting of `\d`,a hyphen
(0x002D), and `a`. However, in the current JSC implementation, if the `v`
flag is enabled, the hyphen is treated as a range operator, causing a syntax
error to be thrown. This patch fixes that behavior.

This patch adds a `hyphenIsRange` argument to the `atomPatternCharacter` method
in `ClassSetParserDelegate`. This matches the interface of the
`atomPatternCharacter` method in `CharacterClassParserDelegate`.

* JSTests/stress/regexp-v-flag-non-range-hyphen.js: Added.
(compareArray):
(throw.new.Error):
(shouldBe):
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::atomPatternCharacter):
(JSC::Yarr::Parser::parseClassSet):

Canonical link: <a href="https://commits.webkit.org/291709@main">https://commits.webkit.org/291709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eecc374a0859eadaeeba2513251880bc8a852158

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98727 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44247 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13590 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71548 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28920 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84706 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51882 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2333 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43562 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86431 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100761 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92387 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80563 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79901 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20757 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25935 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115037 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20444 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->