### PR TITLE
Remove `m_pendingExitFullscreen`

### DIFF
--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -193,10 +193,6 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
         if (!checkedThis)
             return completionHandler(Exception { ExceptionCode::TypeError });
 
-        // Don't allow fullscreen if we're inside an exitFullscreen operation.
-        if (m_pendingExitFullscreen)
-            return handleError("Fullscreen request aborted by a request to exit fullscreen."_s, EmitErrorEvent::Yes, WTFMove(completionHandler));
-
         // Don't allow fullscreen if document is hidden.
         auto document = protectedDocument();
         if (document->hidden() && mode != HTMLMediaElementEnums::VideoFullscreenModeInWindow)
@@ -446,8 +442,6 @@ void DocumentFullscreen::exitFullscreen(CompletionHandler<void(ExceptionOr<void>
         element->removeFromTopLayer();
     }
 
-    m_pendingExitFullscreen = true;
-
     // Return promise, and run the remaining steps in parallel.
     exitingDocument->eventLoop().queueTask(TaskSource::MediaElement, [this, scope = CompletionHandlerScope(WTFMove(completionHandler)), weakThis = WeakPtr { *this }, mode, identifier = LOGIDENTIFIER] () mutable {
         auto completionHandler = scope.release();
@@ -457,7 +451,6 @@ void DocumentFullscreen::exitFullscreen(CompletionHandler<void(ExceptionOr<void>
 
         RefPtr page = this->page();
         if (!page) {
-            m_pendingExitFullscreen = false;
             ERROR_LOG(identifier, "task - Document not in page; bailing.");
             return completionHandler({ });
         }
@@ -466,7 +459,6 @@ void DocumentFullscreen::exitFullscreen(CompletionHandler<void(ExceptionOr<void>
         RefPtr exitedFullscreenElement = fullscreenElement();
         if (!exitedFullscreenElement) {
             INFO_LOG(identifier, "task - No fullscreen element.");
-            m_pendingExitFullscreen = false;
             return completionHandler({ });
         }
 
@@ -564,7 +556,6 @@ void DocumentFullscreen::didExitFullscreen(CompletionHandler<void(ExceptionOr<vo
 {
     if (backForwardCacheState() != Document::NotInBackForwardCache) {
         ERROR_LOG(LOGIDENTIFIER, "Document in the BackForwardCache; bailing");
-        m_pendingExitFullscreen = false;
         return completionHandler(Exception { ExceptionCode::TypeError });
     }
     INFO_LOG(LOGIDENTIFIER);
@@ -578,8 +569,6 @@ void DocumentFullscreen::didExitFullscreen(CompletionHandler<void(ExceptionOr<vo
         exitedFullscreenElement->didStopBeingFullscreenElement();
 
     m_areKeysEnabledInFullscreen = false;
-
-    m_pendingExitFullscreen = false;
 
     completionHandler({ });
 }
@@ -614,8 +603,6 @@ void DocumentFullscreen::fullyExitFullscreen()
     }
 
     INFO_LOG(LOGIDENTIFIER);
-
-    m_pendingExitFullscreen = true;
 
     protectedDocument()->eventLoop().queueTask(TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, mainFrameDocument = WTFMove(mainFrameDocument), identifier = LOGIDENTIFIER] {
 #if RELEASE_LOG_DISABLED

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -128,7 +128,6 @@ private:
 
     bool m_areKeysEnabledInFullscreen { false };
     bool m_isAnimatingFullscreen { false };
-    bool m_pendingExitFullscreen { false };
 
 #if !RELEASE_LOG_DISABLED
     const uint64_t m_logIdentifier;


### PR DESCRIPTION
#### 65cba3323ec207a937d2c26d794ce4f528e14ad1
<pre>
Remove `m_pendingExitFullscreen`
<a href="https://bugs.webkit.org/show_bug.cgi?id=288939">https://bugs.webkit.org/show_bug.cgi?id=288939</a>
<a href="https://rdar.apple.com/145967977">rdar://145967977</a>

Reviewed by NOBODY (OOPS!).

Now that we have proper asynchronous code, we shouldn&apos;t need to track whether we&apos;re exiting fullscreen when requesting fullscreen.

* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::requestFullscreen):
(WebCore::DocumentFullscreen::exitFullscreen):
(WebCore::DocumentFullscreen::didExitFullscreen):
(WebCore::DocumentFullscreen::fullyExitFullscreen):
* Source/WebCore/dom/DocumentFullscreen.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65cba3323ec207a937d2c26d794ce4f528e14ad1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98001 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43528 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71105 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28522 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1774 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42841 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79654 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1753 "Found 1 new test failure: fullscreen/full-screen-enter-while-exiting.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100026 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20054 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14699 "Found 1 new test failure: fullscreen/full-screen-enter-while-exiting.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80130 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20306 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79431 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23978 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1268 "Found 1 new test failure: fullscreen/full-screen-enter-while-exiting.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13108 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20038 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25214 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19725 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->