### PR TITLE
REGRESSION(291247@main): Crash in JSC::MarkedBlock::vm under WebCore::Element::attachShadow if ScopedCustomElementRegistryEnabled is off

### DIFF
--- a/LayoutTests/fast/shadow-dom/scoped-custom-element-registry-disabled-expected.txt
+++ b/LayoutTests/fast/shadow-dom/scoped-custom-element-registry-disabled-expected.txt
@@ -1,0 +1,5 @@
+PASS document.createElement('div').attachShadow({mode: 'open'}) instanceof ShadowRoot is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/shadow-dom/scoped-custom-element-registry-disabled.html
+++ b/LayoutTests/fast/shadow-dom/scoped-custom-element-registry-disabled.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ScopedCustomElementRegistryEnabled=false ] -->
+<script src="../../resources/js-test.js"></script>
+<script>
+shouldBeTrue("document.createElement('div').attachShadow({mode: 'open'}) instanceof ShadowRoot");
+</script>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3270,8 +3270,10 @@ ExceptionOr<ShadowRoot&> Element::attachShadow(const ShadowRootInit& init, Custo
         return Exception { ExceptionCode::NotSupportedError };
     }
     RefPtr<CustomElementRegistry> registry;
-    if (auto* wrapper = jsDynamicCast<JSCustomElementRegistry*>(init.customElements))
-        registry = &wrapper->wrapped();
+    if (document().settings().scopedCustomElementRegistryEnabled() && !init.customElements.isEmpty()) {
+        if (auto* wrapper = jsDynamicCast<JSCustomElementRegistry*>(init.customElements))
+            registry = &wrapper->wrapped();
+    }
     auto scopedRegistry = ShadowRoot::ScopedCustomElementRegistry::No;
     if (registryKind == CustomElementRegistryKind::Null) {
         ASSERT(!registry);


### PR DESCRIPTION
#### 2733dd0b557056043b7bd39872e3f962581f4372
<pre>
REGRESSION(291247@main): Crash in JSC::MarkedBlock::vm under WebCore::Element::attachShadow if ScopedCustomElementRegistryEnabled is off
<a href="https://bugs.webkit.org/show_bug.cgi?id=288918">https://bugs.webkit.org/show_bug.cgi?id=288918</a>

Reviewed by Ryosuke Niwa.

customElements of ShadowRootInit is abailable only if ScopedCustomElementRegistryEnabled.
After &lt;<a href="https://commits.webkit.org/291247@main">https://commits.webkit.org/291247@main</a>&gt;, Element::attachShadow
crashed by accessing init.customElements if ScopedCustomElementRegistryEnabled was off.

Element::attachShadow should check the setting and the value is not
empty before accessing it.

* LayoutTests/fast/shadow-dom/scoped-custom-element-registry-disabled-expected.txt: Added.
* LayoutTests/fast/shadow-dom/scoped-custom-element-registry-disabled.html: Added.
* Source/WebCore/dom/Element.cpp:

Canonical link: <a href="https://commits.webkit.org/291477@main">https://commits.webkit.org/291477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f155dc915ea5927202ceb169245a6f9efe27f226

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12846 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21018 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71114 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28531 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96016 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9680 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51442 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1791 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42853 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100038 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14709 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80140 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80054 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79441 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1285 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13126 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14871 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25226 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->