### PR TITLE
[macOS] Add support for bottom and right obscured content insets

### DIFF
--- a/LayoutTests/tiled-drawing/scrolling/scroll-with-bottom-right-content-inset-expected.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-with-bottom-right-content-inset-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+</style>
+<script>
+window.internals?.setUsesOverlayScrollbars(true);
+</script>
+</head>
+<body></body>
+</html>

--- a/LayoutTests/tiled-drawing/scrolling/scroll-with-bottom-right-content-inset.html
+++ b/LayoutTests/tiled-drawing/scrolling/scroll-with-bottom-right-content-inset.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.wide, .tall {
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.wide {
+    width: 800px;
+    height: 50px;
+    background: orange;
+}
+
+.tall {
+    width: 50px;
+    height: 600px;
+    background: plum;
+}
+
+body::-webkit-scrollbar {
+    display: none;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+window.internals?.setUsesOverlayScrollbars(true);
+
+addEventListener("load", async () => {
+    window.testRunner?.waitUntilDone();
+    await window.testRunner?.setObscuredContentInsets(0, 150, 50, 0);
+
+    eventSender.mouseMoveTo(300, 300);
+
+    async function scrollWithDeltas(x, y) {
+        await UIHelper.startMonitoringWheelEvents();
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "began", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "changed", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "changed", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "none", "begin", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(x, y, "none", "continue", true);
+        eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end", true);
+        await UIHelper.waitForScrollCompletion();
+    }
+
+    await scrollWithDeltas(-10, 0);
+    await scrollWithDeltas(0, -10);
+
+    window.testRunner?.notifyDone();
+});
+</script>
+</head>
+<body>
+    <div class="wide"></div>
+    <div class="tall"></div>
+</body>
+</html>

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -309,10 +309,10 @@ IntSize ScrollView::sizeForUnobscuredContent(VisibleContentRectIncludesScrollbar
         return platformVisibleContentSize(scrollbarInclusion == VisibleContentRectIncludesScrollbars::Yes);
 
     auto obscuredContentInsets = this->obscuredContentInsets();
-    IntSize visibleContentSize = sizeForVisibleContent(scrollbarInclusion);
-    visibleContentSize.setWidth(visibleContentSize.width() - obscuredContentInsets.left());
-    visibleContentSize.setHeight(visibleContentSize.height() - obscuredContentInsets.top());
-    return visibleContentSize;
+    return sizeForVisibleContent(scrollbarInclusion) - roundedIntSize(FloatSize {
+        obscuredContentInsets.left() + obscuredContentInsets.right(),
+        obscuredContentInsets.top() + obscuredContentInsets.bottom()
+    });
 }
 
 IntRect ScrollView::visibleContentRectInternal(VisibleContentRectIncludesScrollbars scrollbarInclusion, VisibleContentRectBehavior visibleContentRectBehavior) const


### PR DESCRIPTION
#### 9e0ec97f7980fc2630c81b844c603a40b160a936
<pre>
[macOS] Add support for bottom and right obscured content insets
<a href="https://bugs.webkit.org/show_bug.cgi?id=288946">https://bugs.webkit.org/show_bug.cgi?id=288946</a>
<a href="https://rdar.apple.com/145983150">rdar://145983150</a>

Reviewed by Richard Robinson.

Adjust logic in `sizeForUnobscuredContent` to shrink the unobscured content size by the right and
bottom content insets (not just left/top insets).

* LayoutTests/tiled-drawing/scrolling/scroll-with-bottom-right-content-inset-expected.html: Added.
* LayoutTests/tiled-drawing/scrolling/scroll-with-bottom-right-content-inset.html: Added.

Add a new layout test to exercise support for bottom/right content insets by scrolling to reveal the
bottom/right content inset areas. The top/left bars should be scrolled out of view, such that the
final ref snapshot should be a completely blank view.

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::sizeForUnobscuredContent const):

Canonical link: <a href="https://commits.webkit.org/291479@main">https://commits.webkit.org/291479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a972bf49815008238871df5bdc5657f3a585f1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98023 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43550 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71123 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96026 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9689 "Found 1 new test failure: fast/forms/ios/focus-input-in-fixed.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84166 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51452 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9383 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1801 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42863 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100048 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80149 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79450 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19726 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/23996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25236 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19747 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23207 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21488 "Build is in progress. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | 
<!--EWS-Status-Bubble-End-->