### PR TITLE
element.append() should only take the last occurrence of an element to insert it as a child

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append-expected.txt
@@ -15,6 +15,7 @@ PASS Element.append() with only text as an argument, on a parent having no child
 PASS Element.append() with only one element as an argument, on a parent having no child.
 PASS Element.append() with null as an argument, on a parent having a child.
 PASS Element.append() with one element and text as argument, on a parent having a child.
+PASS Element.append() with the same element twice.
 PASS DocumentFragment.append() without any argument, on a parent having no child.
 PASS DocumentFragment.append() with null as an argument, on a parent having no child.
 PASS DocumentFragment.append() with undefined as an argument, on a parent having no child.
@@ -22,4 +23,5 @@ PASS DocumentFragment.append() with only text as an argument, on a parent having
 PASS DocumentFragment.append() with only one element as an argument, on a parent having no child.
 PASS DocumentFragment.append() with null as an argument, on a parent having a child.
 PASS DocumentFragment.append() with one element and text as argument, on a parent having a child.
+PASS DocumentFragment.append() with the same element twice.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html
@@ -59,6 +59,16 @@ function test_append(node, nodeName) {
         assert_equals(parent.childNodes[1], x);
         assert_equals(parent.childNodes[2].textContent, 'text');
     }, nodeName + '.append() with one element and text as argument, on a parent having a child.');
+
+    test(function() {
+        const parent = node.cloneNode();
+        const x = document.createElement('x');
+        const y = document.createElement('y');
+        parent.append(x, y, x);
+        assert_equals(parent.childNodes.length, 2);
+        assert_equals(parent.childNodes[0], y);
+        assert_equals(parent.childNodes[1], x);
+    }, nodeName + '.append() with the same element twice.');
 }
 
 test_append(document.createElement('div'), 'Element');

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1171,6 +1171,17 @@ ExceptionOr<void> ContainerNode::append(FixedVector<NodeOrString>&& vector)
         return result.releaseException();
 
     auto newChildren = result.releaseReturnValue();
+    // If the newChildren set has duplicate values, keep only the last occurrence of each element before making them children of this node.
+    for (size_t i = 0; i < newChildren.size(); ++i) {
+        for (size_t j = i+1; j < newChildren.size(); ++j) {
+            if (newChildren[i].ptr() == newChildren[j].ptr()) {
+                newChildren.remove(i);
+                i--;
+                break;
+            }
+        }
+    }
+
     if (auto checkResult = ensurePreInsertionValidityForPhantomDocumentFragment(newChildren); checkResult.hasException())
         return checkResult;
 


### PR DESCRIPTION
#### 4c4b236b26aeb78484ad74e6d70c8ce4a4687699
<pre>
element.append() should only take the last occurrence of an element to insert it as a child
<a href="https://bugs.webkit.org/show_bug.cgi?id=288955">https://bugs.webkit.org/show_bug.cgi?id=288955</a>

Reviewed by NOBODY (OOPS!).

element.append() should only take the last occurrence of an element to insert it as a child.
In the current implementation, when append had duplicate values, it was adding the first occurrence of the element as a child.
This was causing a WPT test case to fail.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/ParentNode-append.html:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::append):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c4b236b26aeb78484ad74e6d70c8ce4a4687699

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98071 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71165 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28584 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84252 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51493 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1884 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42911 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79714 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1868 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100098 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20124 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14766 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/grid-definition/grid-support-flexible-lengths-001.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80192 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79493 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24038 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1381 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13212 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20108 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25284 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23255 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->