### PR TITLE
max-width do not work on tables

### DIFF
--- a/LayoutTests/fast/table/table-width-exceeding-max-width-expected.txt
+++ b/LayoutTests/fast/table/table-width-exceeding-max-width-expected.txt
@@ -1,0 +1,2 @@
+This test checks that a table with 'width' exceeding 'max-width' is correctly constrained.
+PASS

--- a/LayoutTests/fast/table/table-width-exceeding-max-width.html
+++ b/LayoutTests/fast/table/table-width-exceeding-max-width.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<style>
+#a {
+  height: 100px; 
+  max-width: 100px;
+  width: 500px;
+  background: red;
+  display: table;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('#a')">
+    <div>This test checks that a table with 'width' exceeding 'max-width' is correctly constrained.</div>
+    <div id="a" data-expected-width="100"></div>
+</body>

--- a/LayoutTests/fast/table/table-with-content-width-exceeding-max-width-expected.txt
+++ b/LayoutTests/fast/table/table-with-content-width-exceeding-max-width-expected.txt
@@ -1,0 +1,3 @@
+This test checks that a table with 'width' and content wider than 'max-width' is not constrained.
+XXXXXXXXXXXXXXXXXXXX
+PASS

--- a/LayoutTests/fast/table/table-with-content-width-exceeding-max-width.html
+++ b/LayoutTests/fast/table/table-with-content-width-exceeding-max-width.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+#a {
+  height: 100px; 
+  max-width: 100px;
+  width: 50px;
+  background: red;
+  display: table;
+  font: 10px/1 Ahem;
+}
+</style>
+<script src="../../resources/check-layout.js"></script>
+<body onload="checkLayout('#a')">
+    <div>This test checks that a table with 'width' and content wider than 'max-width' is not constrained.</div>
+    <div id="a" data-expected-width="200">XXXXXXXXXXXXXXXXXXXX</div>
+</body>


### PR DESCRIPTION
#### aa519424b949fb1773144da25fbf191375afa136
<pre>
max-width do not work on tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=12396">https://bugs.webkit.org/show_bug.cgi?id=12396</a>
<a href="https://rdar.apple.com/96554687">rdar://96554687</a>

Reviewed by Alan Baradlay.

This aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/364480a952dc2eb710b26f82543e08bd4bac825b">https://chromium.googlesource.com/chromium/src.git/+/364480a952dc2eb710b26f82543e08bd4bac825b</a>

The issue was that we would set the minimum logical width to
the &apos;width&apos; but wouldn&apos;t apply the &apos;max-width&apos; in this case.
Note that we shouldn&apos;t apply &apos;max-width&apos; in all cases or else
we could end up having the content overflow its containing
table (which is not allowed per the specification).

This fix also address FIXME added by Blink by to ensure the
computed minimum preferred logical width never falls below
the intrinsic content width. Previously, the fixed table width
could override the content size, potentially violating layout
expectations and differing from other browsers.

* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::applyPreferredLogicalWidthQuirks const):
* LayoutTests/fast/table/table-with-content-width-exceeding-max-width.html:
* LayoutTests/fast/table/table-width-exceeding-max-width.html:
* LayoutTests/fast/table/table-with-content-width-exceeding-max-width-expected.txt:
* LayoutTests/fast/table/table-width-exceeding-max-width-expected.txt:

Canonical link: <a href="https://commits.webkit.org/303644@main">https://commits.webkit.org/303644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b301151453cb15387c99afc02d2cd284699707e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/133146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/5647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/44260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/140699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/85185 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/b5e18c72-6fb1-4d9b-a637-81f282d4611e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/135016 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/6145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/5510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/101833 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/69233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/af2ab090-8591-43d8-9fd8-a931b08456b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/136093 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/4346 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/119326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/82629 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/f2c6d2ed-bd8b-4d70-a499-64172ae81bd0/7670cb21-e58b-4d2c-9f3e-9519402e6eda) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/4230 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/1813 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🛠 wpe-cairo ](https://ews-build.webkit.org/#/builders/WPE-Cairo-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/113306 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/37443 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/143346 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/5317 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/38021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/110211 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/5399 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/4567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/110392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/27973 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/4110 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/115583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/59015 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/5372 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/33937 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/5216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/68824 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/5461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/5328 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->