### PR TITLE
[TFC] Remove 'relative' length from Table Layout

### DIFF
--- a/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/table/TableLayout.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -75,7 +75,6 @@ struct GridSpace {
     enum class Type {
         Percent,
         Fixed,
-        Relative,
         Auto
     };
     Type type { Type::Auto };
@@ -240,7 +239,6 @@ static Vector<LayoutUnit> distributeAvailableSpace(const TableGrid& grid, Layout
             return;
         // Setup the priority lists. We use these when expanding/shrinking slots.
         Vector<size_t> autoColumnIndexes;
-        Vector<size_t> relativeColumnIndexes;
         Vector<size_t> fixedColumnIndexes;
         Vector<size_t> percentColumnIndexes;
 
@@ -251,9 +249,6 @@ static Vector<LayoutUnit> distributeAvailableSpace(const TableGrid& grid, Layout
                 break;
             case GridSpace::Type::Fixed:
                 fixedColumnIndexes.append(columnIndex);
-                break;
-            case GridSpace::Type::Relative:
-                relativeColumnIndexes.append(columnIndex);
                 break;
             case GridSpace::Type::Auto:
                 autoColumnIndexes.append(columnIndex);
@@ -290,8 +285,6 @@ static Vector<LayoutUnit> distributeAvailableSpace(const TableGrid& grid, Layout
             if (hasSpaceToDistribute())
                 expandSpace(percentColumnIndexes);
             if (hasSpaceToDistribute())
-                expandSpace(relativeColumnIndexes);
-            if (hasSpaceToDistribute())
                 expandSpace(autoColumnIndexes);
             ASSERT(!hasSpaceToDistribute());
             return;
@@ -322,8 +315,6 @@ static Vector<LayoutUnit> distributeAvailableSpace(const TableGrid& grid, Layout
         };
         shrinkSpace(autoColumnIndexes);
         if (needsMoreSpace())
-            shrinkSpace(relativeColumnIndexes);
-        if (needsMoreSpace())
             shrinkSpace(fixedColumnIndexes);
         if (needsMoreSpace())
             shrinkSpace(percentColumnIndexes);
@@ -351,9 +342,6 @@ TableFormattingContext::TableLayout::DistributedSpaces TableFormattingContext::T
         case LengthType::Percent:
             columnWidth = computedLogicalWidth.value() * availableHorizontalSpace / 100.0f;
             type = GridSpace::Type::Percent;
-            break;
-        case LengthType::Relative:
-            ASSERT_NOT_IMPLEMENTED_YET();
             break;
         default:
             break;


### PR DESCRIPTION
#### a3680b56e2990d81bee73172bf588d72d032676d
<pre>
[TFC] Remove &apos;relative&apos; length from Table Layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=288958">https://bugs.webkit.org/show_bug.cgi?id=288958</a>
<a href="https://rdar.apple.com/146000799">rdar://146000799</a>

Reviewed by Antti Koivisto.

Relative length support was allowed by HTML4 on COLGROUP and COL&apos;s
&apos;width&apos; attribute [1], but it never made it to HTML5.

[1] <a href="https://www.w3.org/TR/html4/struct/tables.html#h-11.2.4.1">https://www.w3.org/TR/html4/struct/tables.html#h-11.2.4.1</a>

It was also removed from current table layout code in 253879@main.

* Source/WebCore/layout/formattingContexts/table/TableLayout.cpp:
(WebCore::Layout::distributeAvailableSpace):
(WebCore::Layout::TableFormattingContext::TableLayout::distributedHorizontalSpace):

Canonical link: <a href="https://commits.webkit.org/291493@main">https://commits.webkit.org/291493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3067c01184c23726040d0b1d7a9b0e0215d3865b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93051 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98050 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43577 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12883 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21057 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28566 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84214 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51475 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1848 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100076 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14743 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80172 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24018 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13182 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20087 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25263 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19774 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23234 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->