### PR TITLE
Fix ISO_MALLOC export macros on Windows

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h
@@ -42,7 +42,7 @@ namespace IDBClient {
 class IDBConnectionProxy;
 }
 
-class WEBCORE_EXPORT IDBDatabaseNameAndVersionRequest final : public ThreadSafeRefCounted<IDBDatabaseNameAndVersionRequest>, public IDBActiveDOMObject {
+class IDBDatabaseNameAndVersionRequest final : public ThreadSafeRefCounted<IDBDatabaseNameAndVersionRequest>, public IDBActiveDOMObject {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBDatabaseNameAndVersionRequest, WEBCORE_EXPORT);
 public:
     using InfoCallback = Function<void(std::optional<Vector<IDBDatabaseNameAndVersion>>&&)>;

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -62,7 +62,7 @@ namespace IDBClient {
 
 class IDBConnectionToServer;
 
-class WEBCORE_EXPORT IDBConnectionProxy final {
+class IDBConnectionProxy final {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(IDBConnectionProxy, WEBCORE_EXPORT);
 public:
     IDBConnectionProxy(IDBConnectionToServer&, PAL::SessionID);

--- a/Source/WebCore/Modules/reporting/Report.h
+++ b/Source/WebCore/Modules/reporting/Report.h
@@ -34,21 +34,21 @@ namespace WebCore {
 
 class FormData;
 
-class WEBCORE_EXPORT Report : public RefCounted<Report> {
+class Report : public RefCounted<Report> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(Report, WEBCORE_EXPORT);
 public:
-    static Ref<Report> create(const String& type, const String& url, RefPtr<ReportBody>&&);
+    WEBCORE_EXPORT static Ref<Report> create(const String& type, const String& url, RefPtr<ReportBody>&&);
 
-    ~Report();
+    WEBCORE_EXPORT ~Report();
 
-    const String& type() const;
-    const String& url() const;
-    const RefPtr<ReportBody>& body() const;
+    WEBCORE_EXPORT const String& type() const;
+    WEBCORE_EXPORT const String& url() const;
+    WEBCORE_EXPORT const RefPtr<ReportBody>& body() const;
 
     static Ref<FormData> createReportFormDataForViolation(const String& type, const URL&, const String& userAgent, const String& destination, NOESCAPE const Function<void(JSON::Object&)>& populateBody);
 
 private:
-    explicit Report(const String& type, const String& url, RefPtr<ReportBody>&&);
+    WEBCORE_EXPORT explicit Report(const String& type, const String& url, RefPtr<ReportBody>&&);
 
     String m_type;
     String m_url;

--- a/Source/WebCore/Modules/reporting/ReportBody.h
+++ b/Source/WebCore/Modules/reporting/ReportBody.h
@@ -32,7 +32,7 @@ namespace WebCore {
 
 enum class ViolationReportType : uint8_t;
 
-class WEBCORE_EXPORT ReportBody : public RefCounted<ReportBody> {
+class ReportBody : public RefCounted<ReportBody> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ReportBody, WEBCORE_EXPORT);
 public:
     virtual ~ReportBody();

--- a/Source/WebCore/Modules/reporting/ReportingScope.h
+++ b/Source/WebCore/Modules/reporting/ReportingScope.h
@@ -44,31 +44,31 @@ class Report;
 class ReportingObserver;
 class ScriptExecutionContext;
 
-class WEBCORE_EXPORT ReportingScope final : public RefCountedAndCanMakeWeakPtr<ReportingScope>, public ContextDestructionObserver {
+class ReportingScope final : public RefCountedAndCanMakeWeakPtr<ReportingScope>, public ContextDestructionObserver {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(ReportingScope, WEBCORE_EXPORT);
 public:
     static Ref<ReportingScope> create(ScriptExecutionContext&);
-    virtual ~ReportingScope();
+    WEBCORE_EXPORT virtual ~ReportingScope();
 
     void removeAllObservers();
     void clearReports();
 
     void registerReportingObserver(ReportingObserver&);
     void unregisterReportingObserver(ReportingObserver&);
-    void notifyReportObservers(Ref<Report>&&);
+    WEBCORE_EXPORT void notifyReportObservers(Ref<Report>&&);
     void appendQueuedReportsForRelevantType(ReportingObserver&);
 
     bool containsObserver(const ReportingObserver&) const;
 
-    static MemoryCompactRobinHoodHashMap<String, String> parseReportingEndpointsFromHeader(const String&, const URL& baseURL);
+    WEBCORE_EXPORT static MemoryCompactRobinHoodHashMap<String, String> parseReportingEndpointsFromHeader(const String&, const URL& baseURL);
     void parseReportingEndpoints(const String&, const URL& baseURL);
 
     String endpointURIForToken(const String&) const;
 
-    void generateTestReport(String&& message, String&& group);
+    WEBCORE_EXPORT void generateTestReport(String&& message, String&& group);
 
 private:
-    explicit ReportingScope(ScriptExecutionContext&);
+    WEBCORE_EXPORT explicit ReportingScope(ScriptExecutionContext&);
 
     Vector<Ref<ReportingObserver>> m_reportingObservers;
     Deque<Ref<Report>> m_queuedReports;

--- a/Source/WebCore/dom/StaticNodeList.cpp
+++ b/Source/WebCore/dom/StaticNodeList.cpp
@@ -37,6 +37,11 @@ WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(StaticNodeList);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(StaticWrapperNodeList);
 WTF_MAKE_TZONE_OR_ISO_ALLOCATED_IMPL(StaticElementList);
 
+StaticNodeList::StaticNodeList(Vector<Ref<Node>>&& nodes)
+    : m_nodes(WTFMove(nodes))
+{
+}
+
 unsigned StaticNodeList::length() const
 {
     return m_nodes.size();

--- a/Source/WebCore/dom/StaticNodeList.h
+++ b/Source/WebCore/dom/StaticNodeList.h
@@ -34,22 +34,21 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT StaticNodeList final : public NodeList {
+class StaticNodeList final : public NodeList {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(StaticNodeList, WEBCORE_EXPORT);
 public:
+    WEBCORE_EXPORT virtual ~StaticNodeList() = default;
+
     static Ref<StaticNodeList> create(Vector<Ref<Node>>&& nodes = { })
     {
         return adoptRef(*new StaticNodeList(WTFMove(nodes)));
     }
 
-    unsigned length() const override;
-    Node* item(unsigned index) const override;
+    WEBCORE_EXPORT unsigned length() const override;
+    WEBCORE_EXPORT Node* item(unsigned index) const override;
 
 private:
-    StaticNodeList(Vector<Ref<Node>>&& nodes)
-        : m_nodes(WTFMove(nodes))
-    { }
-
+    WEBCORE_EXPORT StaticNodeList(Vector<Ref<Node>>&& nodes);
     Vector<Ref<Node>> m_nodes;
 };
 

--- a/Source/WebCore/dom/TrustedHTML.h
+++ b/Source/WebCore/dom/TrustedHTML.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT TrustedHTML : public ScriptWrappable, public RefCounted<TrustedHTML> {
+class TrustedHTML : public ScriptWrappable, public RefCounted<TrustedHTML> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedHTML, WEBCORE_EXPORT);
 public:
     static Ref<TrustedHTML> create(const String& data);

--- a/Source/WebCore/dom/TrustedScript.h
+++ b/Source/WebCore/dom/TrustedScript.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT TrustedScript final : public ScriptWrappable, public RefCounted<TrustedScript> {
+class TrustedScript final : public ScriptWrappable, public RefCounted<TrustedScript> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedScript, WEBCORE_EXPORT);
 public:
     static Ref<TrustedScript> create(const String& data);

--- a/Source/WebCore/dom/TrustedScriptURL.h
+++ b/Source/WebCore/dom/TrustedScriptURL.h
@@ -31,7 +31,7 @@
 
 namespace WebCore {
 
-class WEBCORE_EXPORT TrustedScriptURL : public ScriptWrappable, public RefCounted<TrustedScriptURL> {
+class TrustedScriptURL : public ScriptWrappable, public RefCounted<TrustedScriptURL> {
     WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT(TrustedScriptURL, WEBCORE_EXPORT);
 public:
     static Ref<TrustedScriptURL> create(const String& data);


### PR DESCRIPTION
#### a4ec5bc90ef582f44245ad7632c12bfe8386da80
<pre>
Fix ISO_MALLOC export macros on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=288970">https://bugs.webkit.org/show_bug.cgi?id=288970</a>

Reviewed by Fujii Hironori.

On Windows - if a class has a &apos;dllexport&apos; attribute, all it&apos;s members
get &apos;dllexport&apos;-ed by default. Adding the &apos;dllexport&apos; attribute to a
member of that class generates an error:

attribute &apos;dllexport&apos; cannot be applied to member of &apos;dllexport&apos; class

This means using WTF_MAKE_TZONE_OR_ISO_ALLOCATED_EXPORT on a
WEBCORE_EXPORT class causes a compilation error on Windows when libpas
is enabled.

To get around this, we can remove the class-level WEBCORE_EXPORT and
replace with appropriate method-level WEBCORE_EXPORT.

* Source/WebCore/Modules/indexeddb/IDBDatabaseNameAndVersionRequest.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/reporting/Report.h:
(): Deleted.
* Source/WebCore/Modules/reporting/ReportBody.h:
(): Deleted.
* Source/WebCore/Modules/reporting/ReportingScope.h:
* Source/WebCore/dom/StaticNodeList.cpp:
(WebCore::StaticNodeList::StaticNodeList):
* Source/WebCore/dom/StaticNodeList.h:
* Source/WebCore/dom/TrustedHTML.h:
(): Deleted.
* Source/WebCore/dom/TrustedScript.h:
* Source/WebCore/dom/TrustedScriptURL.h:
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/291811@main">https://commits.webkit.org/291811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e63742620551d31ff46856a6da41e3b4b4cb5954

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3375 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99054 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44573 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71762 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29110 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2600 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101095 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80763 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80131 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24686 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2043 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26260 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20769 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->