### PR TITLE
Crash under WebDiagnosticLoggingClient::logDiagnosticMessage()

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
@@ -45,66 +45,85 @@ WebDiagnosticLoggingClient::WebDiagnosticLoggingClient(WebPage& page)
 
 WebDiagnosticLoggingClient::~WebDiagnosticLoggingClient() = default;
 
-Ref<WebPage> WebDiagnosticLoggingClient::protectedPage() const
-{
-    return m_page.get();
-}
-
 void WebDiagnosticLoggingClient::logDiagnosticMessage(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    ASSERT(!page->corePage() || page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess(message, description, ShouldSample::No));
+    page->send(Messages::WebPageProxy::LogDiagnosticMessageFromWebProcess(message, description, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithResult(const String& message, const String& description, WebCore::DiagnosticLoggingResultType result, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    ASSERT(!page->corePage() || page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithResultFromWebProcess(message, description, result, ShouldSample::No));
+    page->send(Messages::WebPageProxy::LogDiagnosticMessageWithResultFromWebProcess(message, description, result, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithValue(const String& message, const String& description, double value, unsigned significantFigures, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    ASSERT(!page->corePage() || page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithValueFromWebProcess(message, description, value, significantFigures, ShouldSample::No));
+    page->send(Messages::WebPageProxy::LogDiagnosticMessageWithValueFromWebProcess(message, description, value, significantFigures, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy(const String& message, const String& description, WebCore::ShouldSample shouldSample)
 {
-    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    ASSERT(!page->corePage() || page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess(message, description, ShouldSample::No));
+    page->send(Messages::WebPageProxy::LogDiagnosticMessageWithEnhancedPrivacyFromWebProcess(message, description, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary(const String& message, const String& description, const ValueDictionary& value, ShouldSample shouldSample)
 {
-    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    ASSERT(!page->corePage() || page->corePage()->settings().diagnosticLoggingEnabled());
 
     if (!shouldLogAfterSampling(shouldSample))
         return;
 
-    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess(message, description, value, ShouldSample::No));
+    page->send(Messages::WebPageProxy::LogDiagnosticMessageWithValueDictionaryFromWebProcess(message, description, value, ShouldSample::No));
 }
 
 void WebDiagnosticLoggingClient::logDiagnosticMessageWithDomain(const String& message, WebCore::DiagnosticLoggingDomain domain)
 {
-    ASSERT(!m_page->corePage() || m_page->corePage()->settings().diagnosticLoggingEnabled());
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
 
-    protectedPage()->send(Messages::WebPageProxy::LogDiagnosticMessageWithDomainFromWebProcess(message, domain));
+    ASSERT(!page->corePage() || page->corePage()->settings().diagnosticLoggingEnabled());
+
+    page->send(Messages::WebPageProxy::LogDiagnosticMessageWithDomainFromWebProcess(message, domain));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h
@@ -28,7 +28,7 @@
 
 #include <WebCore/DiagnosticLoggingClient.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/WeakRef.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
 
@@ -49,9 +49,7 @@ private:
     void logDiagnosticMessageWithValueDictionary(const String& message, const String& description, const ValueDictionary&, WebCore::ShouldSample) override;
     void logDiagnosticMessageWithDomain(const String& message, WebCore::DiagnosticLoggingDomain) override;
 
-    Ref<WebPage> protectedPage() const;
-
-    WeakRef<WebPage> m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 }


### PR DESCRIPTION
#### b2d0c319229e9309db73f75cf54041dc1844e2ec
<pre>
Crash under WebDiagnosticLoggingClient::logDiagnosticMessage()
<a href="https://bugs.webkit.org/show_bug.cgi?id=288971">https://bugs.webkit.org/show_bug.cgi?id=288971</a>
<a href="https://rdar.apple.com/145885111">rdar://145885111</a>

Reviewed by Sihui Liu.

WebDiagnosticLoggingClient was dereferencing its m_page (WebPage) data member which was
null and a WeakRef type. The WebDiagnosticLoggingClient is owned by the WebCore::Page,
not WebKit::WebPage. As a result, it is possible for m_page to become null.

To address the crashes, make m_page a WeakPtr and null check it before using it.

* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp:
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessage):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithResult):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithValue):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithEnhancedPrivacy):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithValueDictionary):
(WebKit::WebDiagnosticLoggingClient::logDiagnosticMessageWithDomain):
(WebKit::WebDiagnosticLoggingClient::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.h:

Canonical link: <a href="https://commits.webkit.org/291530@main">https://commits.webkit.org/291530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88b663ccbfc05ce14b763dc82a2fd614adba1832

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93196 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98195 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43722 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21204 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9796 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51564 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9491 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43036 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/1937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100224 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20248 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19764 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24111 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20232 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/19919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23379 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->