### PR TITLE
[GStreamer][MSE] Avoid adding redundant tracks to MediaPlayer

### DIFF
--- a/LayoutTests/media/media-source/media-source-vttsimple-expected.txt
+++ b/LayoutTests/media/media-source/media-source-vttsimple-expected.txt
@@ -13,6 +13,9 @@ RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
 EVENT(update)
 
 Verify track properties.
+EXPECTED (video.videoTracks.length == '1') OK
+EXPECTED (video.audioTracks.length == '0') OK
+EXPECTED (video.textTracks.length == '1') OK
 RUN(track = video.textTracks[0])
 EXPECTED (track.id == '4') OK
 

--- a/LayoutTests/media/media-source/media-source-vttsimple.html
+++ b/LayoutTests/media/media-source/media-source-vttsimple.html
@@ -40,6 +40,9 @@
         }
 
         consoleWrite('<br/>Verify track properties.');
+        testExpected('video.videoTracks.length', 1);
+        testExpected('video.audioTracks.length', 0);
+        testExpected('video.textTracks.length', 1);
         run('track = video.textTracks[0]');
         testExpected('track.id', '4');
 

--- a/LayoutTests/media/media-source/media-source-webm-expected.txt
+++ b/LayoutTests/media/media-source/media-source-webm-expected.txt
@@ -12,5 +12,8 @@ EXPECTED ((videoHeight == 240 || videoHeight == 0) == 'true') OK
 Append a media segment.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
 EVENT(update)
+EXPECTED (video.videoTracks.length == '1') OK
+EXPECTED (video.audioTracks.length == '0') OK
+EXPECTED (video.textTracks.length == '0') OK
 END OF TEST
 

--- a/LayoutTests/media/media-source/media-source-webm.html
+++ b/LayoutTests/media/media-source/media-source-webm.html
@@ -58,6 +58,10 @@
             run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
             await waitFor(sourceBuffer, 'update');
 
+            testExpected('video.videoTracks.length', 1);
+            testExpected('video.audioTracks.length', 0);
+            testExpected('video.textTracks.length', 0);
+
             endTest();
         } catch (e) {
             failTest(`Caught exception: "${e}"`);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1739,7 +1739,7 @@ void MediaPlayerPrivateGStreamer::updateTracks([[maybe_unused]] const GRefPtr<Gs
         bool isTrackCached = m_##type##Tracks.contains(streamId);       \
         if (!isTrackCached) { \
             auto track = Type##TrackPrivateGStreamer::create(*this, type##TrackIndex, stream); \
-            if (player)                                                 \
+            if (player && !useMediaSource)                              \
                 player->add##Type##Track(track);                        \
             m_##type##Tracks.add(streamId, WTFMove(track));             \
         }                                                               \
@@ -1755,6 +1755,8 @@ void MediaPlayerPrivateGStreamer::updateTracks([[maybe_unused]] const GRefPtr<Gs
         type##TrackIndex++;                                             \
     } G_STMT_END
 
+    // FIXME: We probably don't need to create any *TrackPrivateGStreamer in MSE.
+    bool useMediaSource = isMediaSource();
     unsigned audioTrackIndex = 0;
     unsigned videoTrackIndex = 0;
     unsigned textTrackIndex = 0;


### PR DESCRIPTION
#### efcd4ab82387046eaa2a8534c34e085d32c41a25
<pre>
[GStreamer][MSE] Avoid adding redundant tracks to MediaPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=288974">https://bugs.webkit.org/show_bug.cgi?id=288974</a>

Reviewed by Alicia Boya Garcia.

In MSE, WebKit already adds tracks to the HTMLMediaElement and the SourceBuffer in
SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment, so we need to
avoid adding each Track again in updateTracks.

* LayoutTests/media/media-source/media-source-vttsimple-expected.txt:
* LayoutTests/media/media-source/media-source-vttsimple.html: Explicitly test for the number of tracks.
* LayoutTests/media/media-source/media-source-webm-expected.txt:
* LayoutTests/media/media-source/media-source-webm.html: Ditto.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::updateTracks): Don&apos;t add Tracks to MediaPlayer if in MSE.

Canonical link: <a href="https://commits.webkit.org/291559@main">https://commits.webkit.org/291559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ade8c271ad9bf6b51234946eb6dd4ba5448ab02e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95340 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71293 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28687 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96292 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9856 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51626 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9548 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43130 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100320 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20342 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80313 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79628 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19785 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24173 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1506 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13459 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25503 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20013 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23473 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21754 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->