### PR TITLE
REGRESSION(291449@main): [MacOS Debug] Two tests are constant crashes in http/wpt/webauthn/public-key-credential (failure in EWS)

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h
@@ -27,9 +27,9 @@
 
 #if ENABLE(WEB_AUTHN)
 
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 OBJC_CLASS TKSmartCard;
 
@@ -38,7 +38,7 @@ namespace WebKit {
 class CcidService;
 using DataReceivedCallback = Function<void(Vector<uint8_t>&&)>;
 
-class CcidConnection : public RefCountedAndCanMakeWeakPtr<CcidConnection> {
+class CcidConnection : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<CcidConnection> {
 public:
     static Ref<CcidConnection> create(RetainPtr<TKSmartCard>&&, CcidService&);
     ~CcidConnection();

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm
@@ -62,7 +62,7 @@ const uint8_t kGetUidCommand[] = {
 
 void CcidConnection::detectContactless()
 {
-    transact(Vector(std::span { kGetUidCommand }), [weakThis = WeakPtr { *this }] (Vector<uint8_t>&& response) mutable {
+    transact(Vector(std::span { kGetUidCommand }), [weakThis = ThreadSafeWeakPtr { *this }] (Vector<uint8_t>&& response) mutable {
         ASSERT(RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
@@ -75,7 +75,7 @@ void CcidConnection::detectContactless()
 
 void CcidConnection::trySelectFidoApplet()
 {
-    transact(Vector(std::span { kCtapNfcAppletSelectionCommand }), [weakThis = WeakPtr { *this }] (Vector<uint8_t>&& response) mutable {
+    transact(Vector(std::span { kCtapNfcAppletSelectionCommand }), [weakThis = ThreadSafeWeakPtr { *this }] (Vector<uint8_t>&& response) mutable {
         ASSERT(RunLoop::isMain());
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)


### PR DESCRIPTION
#### 82fd30b6339c2071c19f87169eadd47576224d17
<pre>
REGRESSION(291449@main): [MacOS Debug] Two tests are constant crashes in http/wpt/webauthn/public-key-credential (failure in EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=288975">https://bugs.webkit.org/show_bug.cgi?id=288975</a>
<a href="https://rdar.apple.com/146027480">rdar://146027480</a>

Reviewed by Ryosuke Niwa.

After 291449@main, CcidConnection also gets ref/deref&apos;d on the main thread but it
wasn&apos;t ThreadSafeRefCounted. As a result, it would hit the threading assertions in
RefCounted.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidConnection.mm:
(WebKit::CcidConnection::detectContactless):
(WebKit::CcidConnection::trySelectFidoApplet):

Canonical link: <a href="https://commits.webkit.org/291520@main">https://commits.webkit.org/291520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/064e6ade7d48b5e0b6e90f10d9cba194ee1aebd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43650 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/12957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71197 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28609 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51525 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9451 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/42963 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100150 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14792 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20428 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79527 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19758 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1388 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25336 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19847 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->