### PR TITLE
Use ref-counting forwarding for `DocumentFullscreen`

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -53,7 +53,8 @@ public:
 #define DEBUG_LOG(...)      Ref { logger() }->debugVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 
 #define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { thisPtr->logger() }->logAlwaysVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERROR_LOG_WITH_THIS(thisPtr, ...)     Ref { thisPtr->logger() }->errorVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { thisPtr->logger() }->errorVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { thisPtr->logger() }->infoVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #else
 #define ALWAYS_LOG(...)     Ref { logger() }->logAlways(logChannel(), __VA_ARGS__)
 #define ERROR_LOG(...)      Ref { logger() }->error(logChannel(), __VA_ARGS__)
@@ -63,6 +64,7 @@ public:
 
 #define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { thisPtr->logger() }->logAlways(thisPtr->logChannel(), __VA_ARGS__)
 #define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { thisPtr->logger() }->error(thisPtr->logChannel(), __VA_ARGS__)
+#define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { thisPtr->logger() }->info(thisPtr->logChannel(), __VA_ARGS__)
 #endif
 
 #define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_)
@@ -112,6 +114,10 @@ public:
 #define INFO_LOG(channelName, ...)    (UNUSED_PARAM(channelName))
 #define DEBUG_LOG(channelName, ...)   (UNUSED_PARAM(channelName))
 #define WILL_LOG(_level_)    false
+
+#define ALWAYS_LOG_WITH_THIS(thisPtr, channelName, ...)   (UNUSED_PARAM(channelName))
+#define ERROR_LOG_WITH_THIS(thisPtr, channelName, ...)    (UNUSED_PARAM(channelName))
+#define INFO_LOG_WITH_THIS(thisPtr, channelName, ...)     (UNUSED_PARAM(channelName))
 
 #define ALWAYS_LOG_IF(condition, ...)     ((void)0)
 #define ERROR_LOG_IF(condition, ...)      ((void)0)

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -411,7 +411,7 @@ ALWAYS_INLINE bool matchesFullscreenPseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesAnimatingFullscreenTransitionPseudoClass(const Element& element)
 {
-    CheckedPtr documentFullscreen = element.document().fullscreenIfExists();
+    RefPtr documentFullscreen = element.document().fullscreenIfExists();
     if (!documentFullscreen || &element != documentFullscreen->fullscreenElement())
         return false;
     return documentFullscreen->isAnimatingFullscreen();
@@ -421,7 +421,7 @@ ALWAYS_INLINE bool matchesFullscreenDocumentPseudoClass(const Element& element)
 {
     // While a Document is in the fullscreen state, the 'full-screen-document' pseudoclass applies
     // to all elements of that Document.
-    CheckedPtr documentFullscreen = element.document().fullscreenIfExists();
+    RefPtr documentFullscreen = element.document().fullscreenIfExists();
     return documentFullscreen && documentFullscreen->fullscreenElement();
 }
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -912,7 +912,7 @@ void Document::commonTeardown()
     stopActiveDOMObjects();
 
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr fullscreen = m_fullscreen.get())
+    if (RefPtr fullscreen = m_fullscreen.get())
         fullscreen->clearPendingEvents();
 #endif
 
@@ -1013,7 +1013,7 @@ VisitedLinkState& Document::ensureVisitedLinkState()
 DocumentFullscreen& Document::ensureFullscreen()
 {
     ASSERT(m_constructionDidFinish);
-    lazyInitialize(m_fullscreen, makeUnique<DocumentFullscreen>(*this));
+    lazyInitialize(m_fullscreen, makeUniqueWithoutRefCountedCheck<DocumentFullscreen>(*this));
     return *m_fullscreen;
 }
 #endif
@@ -8614,12 +8614,12 @@ const DocumentFullscreen& Document::fullscreen() const
     return *m_fullscreen;
 }
 
-CheckedRef<DocumentFullscreen> Document::checkedFullscreen()
+Ref<DocumentFullscreen> Document::protectedFullscreen()
 {
     return fullscreen();
 }
 
-CheckedRef<const DocumentFullscreen> Document::checkedFullscreen() const
+Ref<const DocumentFullscreen> Document::protectedFullscreen() const
 {
     return fullscreen();
 }
@@ -9125,7 +9125,7 @@ Element* eventTargetElementForDocument(Document* document)
     if (!document)
         return nullptr;
 #if ENABLE(FULLSCREEN_API) && ENABLE(VIDEO)
-    if (CheckedPtr documentFullscreen = document->fullscreenIfExists(); documentFullscreen && documentFullscreen->isFullscreen() && is<HTMLVideoElement>(documentFullscreen->fullscreenElement()))
+    if (RefPtr documentFullscreen = document->fullscreenIfExists(); documentFullscreen && documentFullscreen->isFullscreen() && is<HTMLVideoElement>(documentFullscreen->fullscreenElement()))
         return documentFullscreen->fullscreenElement();
 #endif
     Element* element = document->focusedElement();

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1418,8 +1418,8 @@ public:
     const DocumentFullscreen* fullscreenIfExists() const { return m_fullscreen.get(); }
     WEBCORE_EXPORT DocumentFullscreen& fullscreen();
     WEBCORE_EXPORT const DocumentFullscreen& fullscreen() const;
-    CheckedRef<DocumentFullscreen> checkedFullscreen(); // Defined in DocumentInlines.h.
-    CheckedRef<const DocumentFullscreen> checkedFullscreen() const; // Defined in DocumentInlines.h.
+    WEBCORE_EXPORT Ref<DocumentFullscreen> protectedFullscreen();
+    WEBCORE_EXPORT Ref<const DocumentFullscreen> protectedFullscreen() const;
 #endif
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -41,22 +41,24 @@ namespace WebCore {
 
 class RenderStyle;
 
-class DocumentFullscreen final : public CanMakeWeakPtr<DocumentFullscreen>, public CanMakeCheckedPtr<DocumentFullscreen> {
+class DocumentFullscreen final : public CanMakeWeakPtr<DocumentFullscreen> {
     WTF_MAKE_TZONE_ALLOCATED(DocumentFullscreen);
-    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DocumentFullscreen);
 public:
     DocumentFullscreen(Document&);
     ~DocumentFullscreen() = default;
 
+    void ref() const { m_document->ref(); }
+    void deref() const { m_document->deref(); }
+
     // Document+Fullscreen.idl methods.
     static void exitFullscreen(Document&, RefPtr<DeferredPromise>&&);
     static bool fullscreenEnabled(Document&);
-    static bool webkitFullscreenEnabled(Document& document) { return document.fullscreen().enabledByPermissionsPolicy(); }
-    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(document.fullscreen().protectedFullscreenElement().get()); };
+    static bool webkitFullscreenEnabled(Document& document) { return document.protectedFullscreen()->enabledByPermissionsPolicy(); }
+    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(document.protectedFullscreen()->protectedFullscreenElement().get()); };
     WEBCORE_EXPORT static void webkitExitFullscreen(Document&);
-    static bool webkitIsFullScreen(Document& document) { return document.fullscreen().isFullscreen(); };
-    static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return document.fullscreen().isFullscreenKeyboardInputAllowed(); };
-    static void webkitCancelFullScreen(Document& document) { document.fullscreen().fullyExitFullscreen(); };
+    static bool webkitIsFullScreen(Document& document) { return document.protectedFullscreen()->isFullscreen(); };
+    static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return document.protectedFullscreen()->isFullscreenKeyboardInputAllowed(); };
+    static void webkitCancelFullScreen(Document& document) { document.protectedFullscreen()->fullyExitFullscreen(); };
 
     // Helpers.
     Document& document() { return m_document.get(); }

--- a/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
@@ -40,7 +40,7 @@ namespace WebCore {
 Element* DocumentOrShadowRootFullscreen::fullscreenElement(TreeScope& treeScope)
 {
     Ref document = treeScope.documentScope();
-    CheckedPtr documentFullscreen = document->fullscreenIfExists();
+    RefPtr documentFullscreen = document->fullscreenIfExists();
     if (!documentFullscreen)
         return nullptr;
     return treeScope.ancestorElementInThisScope(documentFullscreen->protectedFullscreenElement().get());

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7247,7 +7247,7 @@ bool HTMLMediaElement::taintsOrigin(const SecurityOrigin& origin) const
 bool HTMLMediaElement::isFullscreen() const
 {
 #if ENABLE(FULLSCREEN_API)
-    CheckedPtr documentFullscreen = document().fullscreenIfExists();
+    RefPtr documentFullscreen = document().fullscreenIfExists();
     if (documentFullscreen && documentFullscreen->isFullscreen() && documentFullscreen->fullscreenElement() == this)
         return true;
 #endif
@@ -7258,7 +7258,7 @@ bool HTMLMediaElement::isFullscreen() const
 bool HTMLMediaElement::isStandardFullscreen() const
 {
 #if ENABLE(FULLSCREEN_API)
-    CheckedPtr documentFullscreen = document().fullscreenIfExists();
+    RefPtr documentFullscreen = document().fullscreenIfExists();
     if (documentFullscreen && documentFullscreen->isFullscreen() && documentFullscreen->fullscreenElement() == this)
         return true;
 #endif
@@ -7340,7 +7340,7 @@ void HTMLMediaElement::enterFullscreen(VideoFullscreenMode mode)
         m_waitingToEnterFullscreen = true;
         auto fullscreenCheckType = m_ignoreFullscreenPermissionsPolicy ? DocumentFullscreen::ExemptIFrameAllowFullscreenRequirement : DocumentFullscreen::EnforceIFrameAllowFullscreenRequirement;
         m_ignoreFullscreenPermissionsPolicy = false;
-        protectedDocument()->checkedFullscreen()->requestFullscreen(*this, fullscreenCheckType, [weakThis = WeakPtr { *this }](ExceptionOr<void> result) {
+        protectedDocument()->protectedFullscreen()->requestFullscreen(*this, fullscreenCheckType, [weakThis = WeakPtr { *this }](ExceptionOr<void> result) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis || !result.hasException())
                 return;
@@ -7412,7 +7412,7 @@ void HTMLMediaElement::exitFullscreen()
     if (document().fullscreen().fullscreenElement() == this) {
         if (document().fullscreen().isFullscreen()) {
             m_changingVideoFullscreenMode = true;
-            protectedDocument()->checkedFullscreen()->fullyExitFullscreen();
+            protectedDocument()->protectedFullscreen()->fullyExitFullscreen();
         }
 
         if (isInWindowOrStandardFullscreen(m_videoFullscreenMode))

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -657,7 +657,7 @@ bool MediaElementSession::canShowControlsManager(PlaybackControlsPurpose purpose
 
 #if ENABLE(FULLSCREEN_API)
     // Elements which are not descendants of the current fullscreen element cannot be main content.
-    if (CheckedPtr documentFullscreen = m_element.document().fullscreenIfExists()) {
+    if (RefPtr documentFullscreen = m_element.document().fullscreenIfExists()) {
         RefPtr fullscreenElement = documentFullscreen->fullscreenElement();
         if (fullscreenElement && !m_element.isDescendantOf(*fullscreenElement)) {
             INFO_LOG(LOGIDENTIFIER, "returning FALSE: outside of full screen");
@@ -1362,7 +1362,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
 
     bool isOutsideOfFullscreen = false;
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr documentFullscreen = document->fullscreenIfExists()) {
+    if (RefPtr documentFullscreen = document->fullscreenIfExists()) {
         if (RefPtr fullscreenElement = document->fullscreen().fullscreenElement())
             isOutsideOfFullscreen = m_element.isDescendantOf(*fullscreenElement);
     }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3901,7 +3901,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
 
 #if ENABLE(FULLSCREEN_API)
     RefPtr document = frame->document();
-    if (CheckedPtr documentFullscreen = document->fullscreenIfExists(); documentFullscreen && documentFullscreen->isFullscreen()) {
+    if (RefPtr documentFullscreen = document->fullscreenIfExists(); documentFullscreen && documentFullscreen->isFullscreen()) {
         if (initialKeyEvent.type() == PlatformEvent::Type::KeyDown && initialKeyEvent.windowsVirtualKeyCode() == VK_ESCAPE) {
             documentFullscreen->fullyExitFullscreen();
             return true;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4573,7 +4573,7 @@ Color LocalFrameView::documentBackgroundColor() const
 
 #if ENABLE(FULLSCREEN_API)
     Color fullscreenBackgroundColor = [&] () -> Color {
-        CheckedPtr documentFullscreen = backgroundDocument->fullscreenIfExists();
+        RefPtr documentFullscreen = backgroundDocument->fullscreenIfExists();
         if (!documentFullscreen)
             return { };
 
@@ -4581,7 +4581,7 @@ Color LocalFrameView::documentBackgroundColor() const
         if (!fullscreenElement)
             return { };
 
-        auto* fullscreenRenderer = fullscreenElement->renderer();
+        CheckedPtr fullscreenRenderer = fullscreenElement->renderer();
         if (!fullscreenRenderer)
             return { };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2154,7 +2154,7 @@ void Page::updateRendering()
 
 #if ENABLE(FULLSCREEN_API)
     runProcessingStep(RenderingUpdateStep::Fullscreen, [] (Document& document) {
-        document.checkedFullscreen()->dispatchPendingEvents();
+        document.protectedFullscreen()->dispatchPendingEvents();
     });
 #else
     m_renderingUpdateRemainingSteps.last().remove(RenderingUpdateStep::Fullscreen);
@@ -4242,7 +4242,7 @@ Document* Page::outermostFullscreenDocument() const
     RefPtr<Document> outermostFullscreenDocument;
     RefPtr currentDocument = localMainFrame->document();
     while (currentDocument) {
-        RefPtr fullscreenElement = currentDocument->fullscreen().fullscreenElement();
+        RefPtr fullscreenElement = currentDocument->protectedFullscreen()->fullscreenElement();
         if (!fullscreenElement)
             break;
 

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -119,7 +119,7 @@ void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
 
     if (document->settings().fullscreenRequirementForScreenOrientationLockingEnabled()) {
 #if ENABLE(FULLSCREEN_API)
-        if (CheckedPtr documentFullscreen = document->fullscreenIfExists(); !documentFullscreen || !documentFullscreen->isFullscreen()) {
+        if (RefPtr documentFullscreen = document->fullscreenIfExists(); !documentFullscreen || !documentFullscreen->isFullscreen()) {
 #else
         if (true) {
 #endif

--- a/Source/WebCore/page/ios/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/ios/ContentChangeObserver.cpp
@@ -64,10 +64,10 @@ static bool isHiddenBehindFullscreenElement(const Node& descendantCandidate)
         return false;
     }
 
-    CheckedPtr documentFullscreen = mainFrameDocument->fullscreenIfExists();
+    RefPtr documentFullscreen = mainFrameDocument->fullscreenIfExists();
     if (!documentFullscreen)
         return false;
-    auto* topMostFullScreenElement = documentFullscreen->fullscreenElement();
+    RefPtr topMostFullScreenElement = documentFullscreen->fullscreenElement();
     if (!topMostFullScreenElement)
         return false;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -304,10 +304,10 @@ RenderLayerBacking::RenderLayerBacking(RenderLayer& layer)
             return false;
 
         // Only use background layers on the fullscreen element's backdrop.
-        CheckedPtr documentFullscreen = box->document().fullscreenIfExists();
+        RefPtr documentFullscreen = box->document().fullscreenIfExists();
         if (!documentFullscreen)
             return false;
-        auto* fullscreenElement = documentFullscreen->fullscreenElement();
+        RefPtr fullscreenElement = documentFullscreen->fullscreenElement();
         if (!fullscreenElement || !fullscreenElement->renderer() || fullscreenElement->renderer()->backdropRenderer() != &renderer)
             return false;
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3258,11 +3258,11 @@ bool RenderLayerCompositor::canBeComposited(const RenderLayer& layer) const
 enum class FullScreenDescendant { Yes, No, NotApplicable };
 static FullScreenDescendant isDescendantOfFullScreenLayer(const RenderLayer& layer)
 {
-    CheckedPtr manager = layer.renderer().document().fullscreenIfExists();
-    if (!manager)
+    RefPtr documentFullscreen = layer.renderer().document().fullscreenIfExists();
+    if (!documentFullscreen)
         return FullScreenDescendant::NotApplicable;
 
-    RefPtr fullScreenElement = manager->fullscreenElement();
+    RefPtr fullScreenElement = documentFullscreen->fullscreenElement();
     if (!fullScreenElement)
         return FullScreenDescendant::NotApplicable;
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -757,7 +757,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
         if (hasInertAttribute(element))
             return true;
 #if ENABLE(FULLSCREEN_API)
-        if (CheckedPtr documentFullscreen = m_document->fullscreenIfExists(); documentFullscreen && documentFullscreen->fullscreenElement() && element == m_document->documentElement())
+        if (RefPtr documentFullscreen = m_document->fullscreenIfExists(); documentFullscreen && documentFullscreen->fullscreenElement() && element == m_document->documentElement())
             return true;
 #endif
         return false;
@@ -771,7 +771,7 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
             style.setEffectiveInert(false);
 
 #if ENABLE(FULLSCREEN_API)
-        if (CheckedPtr documentFullscreen = m_document->fullscreenIfExists(); documentFullscreen && m_element == documentFullscreen->fullscreenElement() && !hasInertAttribute(m_element.get()))
+        if (RefPtr documentFullscreen = m_document->fullscreenIfExists(); documentFullscreen && m_element == documentFullscreen->fullscreenElement() && !hasInertAttribute(m_element.get()))
             style.setEffectiveInert(false);
 #endif
 
@@ -1038,7 +1038,7 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         }
     }
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr documentFullscreen = m_document->fullscreenIfExists(); documentFullscreen && m_document->quirks().needsFullscreenObjectFitQuirk()) {
+    if (RefPtr documentFullscreen = m_document->fullscreenIfExists(); documentFullscreen && m_document->quirks().needsFullscreenObjectFitQuirk()) {
         static MainThreadNeverDestroyed<const AtomString> playerClassName("top-player-video-element"_s);
         bool isFullscreen = documentFullscreen->isFullscreen();
         if (is<HTMLVideoElement>(*m_element) && isFullscreen && m_element->hasClassName(playerClassName) && style.objectFit() == ObjectFit::Fill)

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -232,7 +232,7 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
 #endif // ENABLE(MATHML)
 
 #if ENABLE(FULLSCREEN_API)
-    if (CheckedPtr documentFullscreen = element.document().fullscreenIfExists(); !fullscreenStyleSheet && documentFullscreen) {
+    if (RefPtr documentFullscreen = element.document().fullscreenIfExists(); !fullscreenStyleSheet && documentFullscreen) {
         fullscreenStyleSheet = parseUASheet(StringImpl::createWithoutCopying(fullscreenUserAgentStyleSheet));
         addToDefaultStyle(*fullscreenStyleSheet);
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -567,12 +567,12 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 
 #if ENABLE(FULLSCREEN_API)
     RefPtr document = m_localFrame->document();
-    if (document && document->fullscreen().fullscreenElement()) {
+    if (document && document->protectedFullscreen()->fullscreenElement()) {
         Ref fullScreenManager = webPage->fullScreenManager();
         RefPtr element = fullScreenManager->element();
         fullScreenManager->exitFullScreenForElement(element.get(), [element] {
             if (element)
-                element->protectedDocument()->fullscreen().didExitFullscreen([](auto) { });
+                element->protectedDocument()->protectedFullscreen()->didExitFullscreen([](auto) { });
         });
     }
 #endif

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -260,7 +260,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
 
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = frame.document()) {
-        if (CheckedPtr documentFullscreen = document->fullscreenIfExists()) {
+        if (RefPtr documentFullscreen = document->fullscreenIfExists()) {
             if (documentFullscreen->fullscreenElement())
                 documentFullscreen->fullyExitFullscreen();
         }

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -3346,8 +3346,8 @@ IGNORE_WARNINGS_END
 
 #if ENABLE(FULLSCREEN_API)
     if (RefPtr document = core([frame DOMDocument]); document) {
-        if (CheckedPtr fullscreenManager = document->fullscreenIfExists()) {
-            if (RefPtr element = fullscreenManager->fullscreenElement()) {
+        if (RefPtr documentFullscreen = document->fullscreenIfExists()) {
+            if (RefPtr element = documentFullscreen->fullscreenElement()) {
                 SEL selector = @selector(webView:closeFullScreenWithListener:);
                 if ([_private->UIDelegate respondsToSelector:selector]) {
                     auto listener = adoptNS([[WebKitFullScreenListener alloc] initWithElement:element.get() initialCompletionHandler:nullptr finalCompletionHandler:nullptr]);


### PR DESCRIPTION
#### fcc73527e93d3d4948deec6328f1260245a7d856
<pre>
Use ref-counting forwarding for `DocumentFullscreen`
<a href="https://bugs.webkit.org/show_bug.cgi?id=288981">https://bugs.webkit.org/show_bug.cgi?id=288981</a>
<a href="https://rdar.apple.com/146036494">rdar://146036494</a>

Reviewed by Chris Dumez.

Also address some smarter C++ warnings that appeared as a result.

* Source/WTF/wtf/LoggerHelper.h:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesAnimatingFullscreenTransitionPseudoClass):
(WebCore::matchesFullscreenDocumentPseudoClass):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::commonTeardown):
(WebCore::Document::ensureFullscreen):
(WebCore::Document::protectedFullscreen):
(WebCore::Document::protectedFullscreen const):
(WebCore::eventTargetElementForDocument):
(WebCore::Document::checkedFullscreen): Deleted.
(WebCore::Document::checkedFullscreen const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::fullscreenEnabled):
(WebCore::DocumentFullscreen::requestFullscreen):
(WebCore::DocumentFullscreen::willEnterFullscreen):
(WebCore::DocumentFullscreen::elementEnterFullscreen):
(WebCore::documentsToUnfullscreen):
(WebCore::DocumentFullscreen::exitFullscreen):
(WebCore::DocumentFullscreen::webkitExitFullscreen):
(WebCore::DocumentFullscreen::finishExitFullscreen):
(WebCore::DocumentFullscreen::fullyExitFullscreen):
(WebCore::DocumentFullscreen::queueFullscreenChangeEventForDocument):
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp:
(WebCore::DocumentOrShadowRootFullscreen::fullscreenElement):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::isFullscreen const):
(WebCore::HTMLMediaElement::isStandardFullscreen const):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::exitFullscreen):
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::canShowControlsManager const):
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::documentBackgroundColor const):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::Page::outermostFullscreenDocument const):
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/page/ios/ContentChangeObserver.cpp:
(WebCore::isHiddenBehindFullscreenElement):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::RenderLayerBacking):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::isDescendantOfFullScreenLayer):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _didStartProvisionalLoadForFrame:]):

Canonical link: <a href="https://commits.webkit.org/291560@main">https://commits.webkit.org/291560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2909507629c2a2cdf6a7857fb4b3d45de38bc7f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43826 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95350 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13145 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21313 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28695 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84392 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/51635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9556 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2024 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43140 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86010 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79842 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/2038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100330 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91966 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20352 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80312 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24181 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1513 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13474 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14931 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25513 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114616 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20023 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33056 "Found 11 new JSC stress test failures: microbenchmarks/memcpy-wasm-medium.js.dfg-eager, microbenchmarks/memcpy-wasm-small.js.bytecode-cache, microbenchmarks/memcpy-wasm-small.js.dfg-eager, wasm.yaml/wasm/function-tests/memcpy-wasm-loop.js.wasm-eager-jettison, wasm.yaml/wasm/spec-tests/float_exprs.wast.js.default-wasm, wasm.yaml/wasm/stress/live-funcref-across-loop-tier-up.js.wasm-eager-jettison, wasm.yaml/wasm/stress/repro_1289.js.default-wasm, wasm.yaml/wasm/stress/repro_1289.js.wasm-collect-continuously, wasm.yaml/wasm/stress/repro_1289.js.wasm-eager-jettison, wasm.yaml/wasm/stress/simple-inline-exception-inlinee-catch.js.wasm-collect-continuously ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23483 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21764 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->