### PR TITLE
Remove calling notifyChildInserted in executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent in ContainerNodeAlgorithms.cpp

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -334,7 +334,6 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 template<typename DOMInsertionWork>
 static ALWAYS_INLINE void executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent(ContainerNode& containerNode, Node& child, DOMInsertionWork doNodeInsertion)
 {
-    NodeVector postInsertionNotificationTargets;
     {
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
@@ -345,9 +344,7 @@ static ALWAYS_INLINE void executeParserNodeInsertionIntoIsolatedTreeWithoutNotif
 
         doNodeInsertion();
         ChildListMutationScope(containerNode).childAdded(child);
-        notifyChildNodeInserted(containerNode, child, postInsertionNotificationTargets);
     }
-    ASSERT(postInsertionNotificationTargets.isEmpty());
     containerNode.setHasHeldBackChildrenChanged();
 }
 


### PR DESCRIPTION
#### 601a3f85ff36a7cbb4e1aa21d37a99fe268312f1
<pre>
Remove calling notifyChildInserted in executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent in ContainerNodeAlgorithms.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=288982">https://bugs.webkit.org/show_bug.cgi?id=288982</a>
<a href="https://rdar.apple.com/146035398">rdar://146035398</a>

Reviewed by Ryosuke Niwa.

This PR is put up currently to test correctness on Layout Tests.

When parsing and constructing a temporary DocumentFragment using the HTMLFastPathParser,
we insert un-connected nodes and update the node flags of this node&apos;s subtree by calling
notifyChildInserted via executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent.
notifyChildInserted does a traversal of the inserted node&apos;s subtree to do this updating.
When appending the constructed DocumentFragment&apos;s children to be children of the ContainerNode
that the user has called .innerHTML on, we also call notifyChildInserted on the each of these
fragment nodes from appendChildWithoutPreInsertionValidityCheck via replaceChildrenWithFragment.
This visits and updates the node flags of every node in the DocumentFragment tree.
Skip the traversals to update the node flags when inserting nodes into the DocumentFragment,
since we always finally update the flags of the inserted nodes when they are inserted into
the permanent Document. This is a .64% progression on SP3.

This PR was influenced by this Chromium commit: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/6174392">https://chromium-review.googlesource.com/c/chromium/src/+/6174392</a>

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::executeParserNodeInsertionIntoIsolatedTreeWithoutNotifyingParent):

Canonical link: <a href="https://commits.webkit.org/291710@main">https://commits.webkit.org/291710@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9024e4364e5ede093428b19a102ada7f7812cde5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43772 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95296 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13086 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71259 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28662 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9912 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51593 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2313 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43086 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100274 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20298 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14951 "Found 2 new test failures: fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html ipc/large-vector-allocate-failure-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80282 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80628 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79598 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19892 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24141 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13413 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20282 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25459 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19969 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->