### PR TITLE
AX: Remote SVGs can share renderers, breaking the accessibility tree

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/svg-duplicated-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/svg-duplicated-expected.txt
@@ -1,0 +1,6 @@
+This test verifies that we don't enter an infinite loop when we have two references to the same remote SVG file.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello   world

--- a/LayoutTests/accessibility/ax-thread-text-apis/svg-duplicated.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/svg-duplicated.html
@@ -1,0 +1,24 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body id="body" role="group">
+
+Hello
+<img src="../resources/svg-face.svg" alt="image 1" />
+<img src="../resources/svg-face.svg" alt="image 2" />
+world 
+
+<script>
+var output = "This test verifies that we don't enter an infinite loop when we have two references to the same remote SVG file.\n";
+
+if (window.accessibilityController) {
+    var container = accessibilityController.accessibleElementById("body");
+    container.textMarkerRangeForElement(container)
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2366,6 +2366,13 @@ void AccessibilityRenderObject::addRemoteSVGChildren()
     if (!root)
         return;
 
+    // FIXME: It's possible for an SVG that is rendered twice to share renderers. We don't want to add this as a child of both parents
+    // in this case, as it will create an invalid parent-child relationship in the accessibility tree.
+    // If it's parent is a WebArea, that is just the default value given when the object was created, so still add the child in that case.
+    RefPtr parent = root->parentObject();
+    if (parent && parent->roleValue() != AccessibilityRole::WebArea)
+        return;
+
     // In order to connect the AX hierarchy from the SVG root element from the loaded resource
     // the parent must be set, because there's no other way to get back to who created the image.
     root->setParent(this);

--- a/Source/WebCore/accessibility/AccessibilitySVGRoot.h
+++ b/Source/WebCore/accessibility/AccessibilitySVGRoot.h
@@ -38,12 +38,12 @@ public:
     static Ref<AccessibilitySVGRoot> create(AXID, RenderObject&, AXObjectCache*);
     virtual ~AccessibilitySVGRoot();
 
+    AccessibilityObject* parentObject() const final;
     void setParent(AccessibilityRenderObject*);
     bool hasAccessibleContent() const;
 private:
     explicit AccessibilitySVGRoot(AXID, RenderObject&, AXObjectCache*);
 
-    AccessibilityObject* parentObject() const final;
     bool isAccessibilitySVGRoot() const final { return true; }
 
     AccessibilityRole determineAccessibilityRole() final;


### PR DESCRIPTION
#### 51ff7b13c7cad0be9490546d9ed82649e098a1fc
<pre>
AX: Remote SVGs can share renderers, breaking the accessibility tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=289001">https://bugs.webkit.org/show_bug.cgi?id=289001</a>
<a href="https://rdar.apple.com/145677641">rdar://145677641</a>

Reviewed by Tyler Wilcock.

When creating text marker ranges in AXTextMarker, we compute the order of the start and end text marker
by locating them in the accessibility tree. This method, `partialOrderByTraversal` walks the tree forward
and backward until it can locate one marker starting from the other. This walk uses nextInPreOrder and
previousInPreOrder, which walk the tree including ignored objects.

This new behavior, enabled with the AX Thread Text APIs feature, exposed an issue with remote SVG elements:
remote SVG elements can share renderers, which leads to two accessibility objects having the same child
(with the same AXID). This creates issues when walking the tree, and can lead us into an infinite loop.

To prevent this, if we detect that an SVG root object is already parented in another valid AX object, don&apos;t
add it as a child of a different element.

* LayoutTests/accessibility/ax-thread-text-apis/svg-duplicated-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/svg-duplicated.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addRemoteSVGChildren):
* Source/WebCore/accessibility/AccessibilitySVGRoot.h:

Canonical link: <a href="https://commits.webkit.org/291544@main">https://commits.webkit.org/291544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14be47d9790e05bc7e4a56f1f608addd0e6f3a73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71231 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28635 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84300 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51562 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1936 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79775 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1928 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100217 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80253 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79561 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1429 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20227 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25404 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23374 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->