### PR TITLE
[Grid] Introduce grid area logical sizes cache.

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -87,6 +87,8 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
         return;
 
     m_intrinsicLogicalHeightsForRowSizingFirstPass.reset();
+    m_gridAreaLogicalSizesCache.clear();
+
     const RenderStyle& newStyle = this->style();
 
     auto hasDifferentTrackSizes = [&newStyle, &oldStyle](GridTrackSizingDirection direction) {
@@ -326,6 +328,8 @@ void RenderGrid::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
 
 void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 {
+    m_gridAreaLogicalSizesCache.clear();
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -464,6 +468,8 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
 void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
 {
+    m_gridAreaLogicalSizesCache.clear();
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -1312,6 +1318,8 @@ void RenderGrid::dirtyGrid(SubgridDidChange subgridDidChange)
     if (currentGrid().needsItemsPlacement())
         return;
 
+    m_gridAreaLogicalSizesCache.clear();
+
     currentGrid().setNeedsItemsPlacement(true);
 
     auto currentChild = this;
@@ -1432,7 +1440,11 @@ void RenderGrid::layoutGridItems(GridLayoutState& gridLayoutState)
         // Setting the definite grid area's sizes. It may imply that the
         // item must perform a layout if its area differs from the one
         // used during the track sizing algorithm.
-        updateGridAreaLogicalSize(*gridItem, gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForColumns), gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForRows));
+        auto gridAreaLogicalWidth = gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForColumns);
+        auto gridAreaLogicalHeight = gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForRows);
+        m_gridAreaLogicalSizesCache.set(*gridItem, GridAreaLogicalSize { gridAreaLogicalWidth, gridAreaLogicalHeight });
+
+        updateGridAreaLogicalSize(*gridItem, gridAreaLogicalWidth, gridAreaLogicalHeight);
 
         LayoutRect oldGridItemRect = gridItem->frameRect();
 

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -309,6 +309,10 @@ private:
     bool m_hasAnyBaselineAlignmentItem { false };
 
     mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
+
+    using GridAreaLogicalSize = std::pair<LayoutUnit, LayoutUnit>;
+    UncheckedKeyHashMap<SingleThreadWeakRef<const RenderBox>, GridAreaLogicalSize> m_gridAreaLogicalSizesCache;
+
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 9bf8fc29e54de3bfeb86ca988f42c659961880a7
<pre>
[Grid] Introduce grid area logical sizes cache.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289004">https://bugs.webkit.org/show_bug.cgi?id=289004</a>
<a href="https://rdar.apple.com/problem/146051830">rdar://problem/146051830</a>

Reviewed by NOBODY (OOPS!).

This patch introduces a cache that stores the logical size of each grid
item&apos;s grid area. The grid area of an item is computed during the track
sizing algorithm and is used during layoutGridItems to set the item&apos;s
grid area logical width/height before calling layout on it as this
represents the item&apos;s containing block. We can use this as an
opportunity to cache these computed values to potentially use in a
subsequent layout in certain conditions which will be determined in a
future patch.

With the introduction of this cache we will want to invalidate it
basically whenever the grid experiences any sort of style mutation that
requires layout or whenever the content of the grid changes. The former
is done in a straightforward manner via RenderGrid::styleDidChange. The
latter is done inside of dirtyGrid, which is called at different points
in time when we need to perform item placement again including when:

1. A renderer is attached or detached from the RenderGrid
2.) A grid item&apos;s style changes such that it requires it to be placed
again

We will also aggressively invalidate this cache at the beginning of
RenderGrid::layoutGrid since we have no use for it yet. With respect to
the scenarios described above, this would represent another case where
a grid item&apos;s content/styling would have been mutated and could possibly
influence the sizes of the tracks and the sizes of the grid areas as a
result. I plan to add a fast path in which we would not invalidate this
cache during layout and instead use the sizes in scenarios where the
grid content does not influence the sizes of the tracks.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
(WebCore::RenderGrid::dirtyGrid):
(WebCore::RenderGrid::layoutGridItems):
* Source/WebCore/rendering/RenderGrid.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9bf8fc29e54de3bfeb86ca988f42c659961880a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98191 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43718 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71232 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51563 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9486 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1941 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100218 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14826 "Found 1 new test failure: ipc/large-vector-allocate-failure-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80254 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79562 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24110 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13359 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20228 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25405 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19915 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21656 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->