### PR TITLE
Handle overflow, underflow in XPath substring position, length

### DIFF
--- a/LayoutTests/fast/xpath/substring-overflow-expected.txt
+++ b/LayoutTests/fast/xpath/substring-overflow-expected.txt
@@ -1,0 +1,25 @@
+Test for XPath substring() function behavior, adapted from Chromium XPathFunctionsTest.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.evaluate("substring(\"motor car\", 6)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is " car"
+PASS document.evaluate("substring(\"metadata\", 4, 3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "ada"
+PASS document.evaluate("substring(\"123456\", 1.5, 2.6)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "234"
+PASS document.evaluate("substring(\"12345\", 0, 3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "12"
+PASS document.evaluate("substring(\"12345\", 5, -3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"12345\", -3, 5)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "1"
+PASS document.evaluate("substring(\"12345\", number(\"NaN\"), 3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"12345\", 1, number(\"NaN\"))", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"\", 0, 1)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"well hello there\", 6, 5)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "hello"
+PASS document.evaluate("substring(\"hello, world!\", -4, 10)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "hello"
+PASS document.evaluate("substring(\"hello\", -9007199254740990, 1)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"hello, world!\", 1, -3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"foo\", -9007199254740991, 1)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS document.evaluate("substring(\"12345\", -42, 999999999)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is "12345"
+PASS document.evaluate("substring(\"no way\", 999999999, 7)", document.body, null, XPathResult.STRING_TYPE, null).stringValue is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/xpath/substring-overflow.html
+++ b/LayoutTests/fast/xpath/substring-overflow.html
@@ -1,0 +1,28 @@
+<html>
+<head><script src="../../resources/js-test.js"></script></head>
+<body>
+
+<script>
+
+description("Test for XPath substring() function behavior, adapted from Chromium XPathFunctionsTest.");
+
+shouldBe('document.evaluate("substring(\\"motor car\\", 6)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '" car"');
+shouldBe('document.evaluate("substring(\\"metadata\\", 4, 3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"ada"');
+shouldBe('document.evaluate("substring(\\"123456\\", 1.5, 2.6)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"234"');
+shouldBe('document.evaluate("substring(\\"12345\\", 0, 3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"12"');
+shouldBe('document.evaluate("substring(\\"12345\\", 5, -3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"12345\\", -3, 5)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"1"');
+shouldBe('document.evaluate("substring(\\"12345\\", number(\\"NaN\\"), 3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"12345\\", 1, number(\\"NaN\\"))", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"\\", 0, 1)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"well hello there\\", 6, 5)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"hello"');
+shouldBe('document.evaluate("substring(\\"hello, world!\\", -4, 10)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"hello"');
+shouldBe('document.evaluate("substring(\\"hello\\", -9007199254740990, 1)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"hello, world!\\", 1, -3)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"foo\\", -9007199254740991, 1)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+shouldBe('document.evaluate("substring(\\"12345\\", -42, 999999999)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '"12345"');
+shouldBe('document.evaluate("substring(\\"no way\\", 999999999, 7)", document.body, null, XPathResult.STRING_TYPE, null).stringValue', '""');
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 138f2bcd7d8bf9f912e746cc1ac9d1761402fcb8
<pre>
Handle overflow, underflow in XPath substring position, length
<a href="https://bugs.webkit.org/show_bug.cgi?id=256769">https://bugs.webkit.org/show_bug.cgi?id=256769</a>
&lt;<a href="https://rdar.apple.com/109624368">rdar://109624368</a>&gt;

Reviewed by Alexey Proskuryakov.

Handle overflow, underflow in XPath substring position, length.

Add LayoutTests/fast/xpath/substring-overflow.html to verify
functionality.

Merge chromium commit: <a href="https://chromium.googlesource.com/chromium/src.git/+/047653201597a4e5c3912d8c2c35adaa2ed6e6ec">https://chromium.googlesource.com/chromium/src.git/+/047653201597a4e5c3912d8c2c35adaa2ed6e6ec</a>

* LayoutTests/fast/xpath/substring-overflow-expected.txt: Added.
* LayoutTests/fast/xpath/substring-overflow.html: Added.
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::computeSubstringStartEnd):
(WebCore::XPath::FunSubstring::evaluate const):

Canonical link: <a href="https://commits.webkit.org/292121@main">https://commits.webkit.org/292121@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/398d9453544145a269294820f2f4eaec09c401d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14609 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100043 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45513 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/97063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23031 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29775 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85796 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52802 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3521 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44851 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/81020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102088 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22056 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80867 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20209 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2832 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15298 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22029 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/27152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23427 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->