### PR TITLE
Move WebKit utility functions out of XPCSPI.h and rename

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		339B7B1127C45EF50072BF9A /* FixedWidthDouble.h in Headers */ = {isa = PBXBuildFile; fileRef = 33479C1C27236F2000B2E1B7 /* FixedWidthDouble.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A1337AA28F915B400F29B73 /* UniqueRefVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1337A928F915B400F29B73 /* UniqueRefVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		3A5BCFA3298768E300E0ABB2 /* RefVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A5BCFA2298768E300E0ABB2 /* RefVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		44235FF72D76449300F4A6CB /* XPCExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 44235FF62D76448F00F4A6CB /* XPCExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4427C5AA21F6D6C300A612A4 /* ASCIICType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */; };
 		4448265228D18CA600D916E8 /* VectorCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 4448265128D18CA600D916E8 /* VectorCF.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		4606FEE72B1E901800D704F1 /* WeakRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 4606FEE62B1E901800D704F1 /* WeakRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1240,6 +1241,7 @@
 		3A5BCFA2298768E300E0ABB2 /* RefVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RefVector.h; sourceTree = "<group>"; };
 		413FE8F51F8D2EAB00F6D7D7 /* CallbackAggregator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallbackAggregator.h; sourceTree = "<group>"; };
 		430B47871AAAAC1A001223DA /* StringCommon.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringCommon.h; sourceTree = "<group>"; };
+		44235FF62D76448F00F4A6CB /* XPCExtras.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPCExtras.h; sourceTree = "<group>"; };
 		4427C5A921F6D6C300A612A4 /* ASCIICType.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASCIICType.cpp; sourceTree = "<group>"; };
 		4434F91B27948A65007E3E8A /* TollFreeBridging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TollFreeBridging.h; sourceTree = "<group>"; };
 		4448265128D18CA600D916E8 /* VectorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VectorCF.h; sourceTree = "<group>"; };
@@ -2059,6 +2061,7 @@
 				53FC70CE23FB950C005B1990 /* OSLogPrintStream.h */,
 				53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */,
 				37C7CC291EA40A73007BD956 /* WeakLinking.h */,
+				44235FF62D76448F00F4A6CB /* XPCExtras.h */,
 			);
 			path = darwin;
 			sourceTree = "<group>";
@@ -3801,6 +3804,7 @@
 				DDF307C227C086DF006A526F /* WTFString.h in Headers */,
 				FFE39CB02B1D7472004972B0 /* wuint.h in Headers */,
 				FF41AC672A79C9BA00AC0FA5 /* WYHash.h in Headers */,
+				44235FF72D76449300F4A6CB /* XPCExtras.h in Headers */,
 				DDF306EA27C08654006A526F /* XPCSPI.h in Headers */,
 				145DE2882CE95CE700F9F1D2 /* ZippedRange.h in Headers */,
 			);

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -691,6 +691,7 @@ elseif (APPLE)
 
         darwin/OSLogPrintStream.h
         darwin/WeakLinking.h
+        darwin/XPCExtras.h
 
         spi/cf/CFBundleSPI.h
         spi/cf/CFStringSPI.h

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -78,6 +78,7 @@ list(APPEND WTF_PUBLIC_HEADERS
 
     darwin/OSLogPrintStream.h
     darwin/WeakLinking.h
+    darwin/XPCExtras.h
 
     spi/cf/CFBundleSPI.h
     spi/cf/CFStringSPI.h

--- a/Source/WTF/wtf/darwin/XPCExtras.h
+++ b/Source/WTF/wtf/darwin/XPCExtras.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/StdLibExtras.h>
+#include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/WTFString.h>
+
+#if OS(DARWIN)
+
+namespace WTF {
+
+inline std::span<const uint8_t> xpcDictionaryGetData(xpc_object_t xdict, ASCIILiteral key)
+{
+    size_t dataSize { 0 };
+    auto* data = static_cast<const uint8_t*>(xpc_dictionary_get_data(xdict, key.characters(), &dataSize)); // NOLINT
+    return unsafeMakeSpan(data, dataSize);
+}
+
+// ASCIILiteral version of XPC_ERROR_KEY_DESCRIPTION.
+static constexpr auto xpcErrorDescriptionKey = "XPCErrorDescription"_s;
+
+inline String xpcDictionaryGetString(xpc_object_t xdict, ASCIILiteral key)
+{
+    auto* cstring = xpc_dictionary_get_string(xdict, key.characters()); // NOLINT
+    if (!cstring)
+        return { };
+    return String::fromUTF8(cstring);
+}
+
+inline String xpcStringGetString(xpc_object_t xvalue)
+{
+    return String::fromUTF8(unsafeMakeSpan(xpc_string_get_string_ptr(xvalue), xpc_string_get_length(xvalue))); // NOLINT
+}
+
+} // namespace WTF
+
+using WTF::xpcDictionaryGetData;
+using WTF::xpcDictionaryGetString;
+using WTF::xpcErrorDescriptionKey;
+using WTF::xpcStringGetString;
+
+#endif // OS(DARWIN)

--- a/Source/WTF/wtf/spi/darwin/XPCSPI.h
+++ b/Source/WTF/wtf/spi/darwin/XPCSPI.h
@@ -27,10 +27,6 @@
 
 #include <dispatch/dispatch.h>
 #include <os/object.h>
-#include <span>
-#include <wtf/StdLibExtras.h>
-#include <wtf/text/ASCIILiteral.h>
-#include <wtf/text/WTFString.h>
 
 #if HAVE(XPC_API) || USE(APPLE_INTERNAL_SDK)
 #include <xpc/xpc.h>
@@ -258,26 +254,3 @@ void xpc_release(xpc_object_t);
 #endif
 
 WTF_EXTERN_C_END
-
-inline std::span<const uint8_t> xpc_dictionary_get_data_span(xpc_object_t xdict, ASCIILiteral key)
-{
-    size_t dataSize { 0 };
-    auto* data = static_cast<const uint8_t*>(xpc_dictionary_get_data(xdict, key.characters(), &dataSize)); // NOLINT
-    return unsafeMakeSpan(data, dataSize);
-}
-
-// ASCIILiteral version of XPC_ERROR_KEY_DESCRIPTION.
-static constexpr auto xpcErrorDescriptionKey = "XPCErrorDescription"_s;
-
-inline String xpc_dictionary_get_wtfstring(xpc_object_t xdict, ASCIILiteral key)
-{
-    auto* cstring = xpc_dictionary_get_string(xdict, key.characters()); // NOLINT
-    if (!cstring)
-        return { };
-    return String::fromUTF8(cstring);
-}
-
-inline String xpc_string_get_wtfstring(xpc_object_t xvalue)
-{
-    return String::fromUTF8(unsafeMakeSpan(xpc_string_get_string_ptr(xvalue), xpc_string_get_length(xvalue))); // NOLINT
-}

--- a/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm
@@ -36,6 +36,7 @@
 #import <pal/spi/cocoa/NSXPCConnectionSPI.h>
 #import <pal/spi/cocoa/SecKeyProxySPI.h>
 #import <wtf/MainThread.h>
+#import <wtf/darwin/XPCExtras.h>
 
 namespace WebKit {
 
@@ -62,7 +63,7 @@ void AuthenticationManager::initializeConnection(IPC::Connection* connection)
             if (type == XPC_TYPE_ERROR || !weakThis)
                 return;
 
-            if (type != XPC_TYPE_DICTIONARY || xpc_dictionary_get_wtfstring(event.get(), ClientCertificateAuthentication::XPCMessageNameKey) != ClientCertificateAuthentication::XPCMessageNameValue) {
+            if (type != XPC_TYPE_DICTIONARY || xpcDictionaryGetString(event.get(), ClientCertificateAuthentication::XPCMessageNameKey) != ClientCertificateAuthentication::XPCMessageNameValue) {
                 ASSERT_NOT_REACHED();
                 return;
             }

--- a/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm
@@ -34,7 +34,7 @@
 #import "MessageSenderInlines.h"
 #import "PushClientConnectionMessages.h"
 #import "WebPushDaemonConstants.h"
-#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/darwin/XPCExtras.h>
 
 namespace WebKit::WebPushD { 
 
@@ -72,7 +72,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
         if (xpc_dictionary_get_uint64(reply, WebPushD::protocolVersionKey) != WebPushD::protocolVersionValue)
             return completionHandler(nullptr);
 
-        auto data = xpc_dictionary_get_data_span(reply, WebPushD::protocolEncodedMessageKey);
+        auto data = xpcDictionaryGetData(reply, WebPushD::protocolEncodedMessageKey);
         auto decoder = IPC::Decoder::create(data, { });
 
         completionHandler(decoder.get());

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm
@@ -29,6 +29,7 @@
 #import "DaemonEncoder.h"
 #import "PrivateClickMeasurementXPCUtilities.h"
 #import <wtf/NeverDestroyed.h>
+#import <wtf/darwin/XPCExtras.h>
 
 namespace WebKit::PCM {
 
@@ -49,7 +50,7 @@ void Connection::connectionReceivedEvent(xpc_object_t request)
 {
     if (xpc_get_type(request) != XPC_TYPE_DICTIONARY)
         return;
-    String debugMessage = xpc_dictionary_get_wtfstring(request, protocolDebugMessageKey);
+    String debugMessage = xpcDictionaryGetString(request, protocolDebugMessageKey);
     if (!debugMessage)
         return;
     auto messageLevel = static_cast<JSC::MessageLevel>(xpc_dictionary_get_uint64(request, protocolDebugMessageLevelKey));

--- a/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm
@@ -31,6 +31,7 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/Entitlements.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/spi/cocoa/SecuritySPI.h>
 
 namespace WebKit {
@@ -132,7 +133,7 @@ void LaunchServicesDatabaseObserver::handleEvent(xpc_connection_t connection, xp
         return;
     }
     if (xpc_get_type(event) == XPC_TYPE_DICTIONARY) {
-        String messageName = xpc_dictionary_get_wtfstring(event, xpcMessageNameKey);
+        String messageName = xpcDictionaryGetString(event, xpcMessageNameKey);
         if (messageName != LaunchServicesDatabaseXPCConstants::xpcRequestLaunchServicesDatabaseUpdateMessageName)
             return;
         startObserving(connection);

--- a/Source/WebKit/Platform/IPC/DaemonConnection.h
+++ b/Source/WebKit/Platform/IPC/DaemonConnection.h
@@ -33,7 +33,7 @@
 
 #if PLATFORM(COCOA)
 #include <wtf/OSObjectPtr.h>
-#include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/darwin/XPCExtras.h>
 #endif
 
 namespace WebKit {

--- a/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm
@@ -109,7 +109,7 @@ void ConnectionToMachService<Traits>::sendWithReply(typename Traits::MessageType
             ASSERT_NOT_REACHED();
             return completionHandler({ });
         }
-        completionHandler(xpc_dictionary_get_data_span(reply, Traits::protocolEncodedMessageKey));
+        completionHandler(xpcDictionaryGetData(reply, Traits::protocolEncodedMessageKey));
     });
 }
 

--- a/Source/WebKit/Platform/cocoa/MediaCapability.mm
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.mm
@@ -31,6 +31,7 @@
 #import "XPCUtilities.h"
 #import <BrowserEngineKit/BECapability.h>
 #import <WebCore/SecurityOrigin.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -75,7 +76,7 @@ String MediaCapability::environmentIdentifier() const
     xpc_object_t xpcObject = [m_mediaEnvironment createXPCRepresentation];
     if (!xpcObject)
         return emptyString();
-    return xpc_dictionary_get_wtfstring(xpcObject, "identifier"_s);
+    return xpcDictionaryGetString(xpcObject, "identifier"_s);
 #endif
 
     return { };

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.h
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/darwin/XPCExtras.h>
 
 namespace WebKit {
 

--- a/Source/WebKit/Platform/cocoa/XPCUtilities.mm
+++ b/Source/WebKit/Platform/cocoa/XPCUtilities.mm
@@ -65,7 +65,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 void handleXPCExitMessage(xpc_object_t event)
 {
     if (xpc_get_type(event) == XPC_TYPE_DICTIONARY) {
-        String messageName = xpc_dictionary_get_wtfstring(event, messageNameKey);
+        String messageName = xpcDictionaryGetString(event, messageNameKey);
         if (messageName == exitProcessMessage) {
             RELEASE_LOG_ERROR(IPC, "Received exit message, exiting now.");
             terminateProcess(EXIT_FAILURE);

--- a/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
+++ b/Source/WebKit/Shared/Cocoa/XPCEndpoint.h
@@ -29,7 +29,7 @@
 
 #include <WebKit/WKBase.h>
 #include <wtf/OSObjectPtr.h>
-#include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/darwin/XPCExtras.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebKit {

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm
@@ -41,7 +41,7 @@
 #import <wtf/RunLoop.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/cocoa/Entitlements.h>
-#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/darwin/XPCExtras.h>
 
 // FIXME: Add daemon plist to repository.
 
@@ -68,7 +68,7 @@ static void connectionEventHandler(xpc_object_t request)
     }
 
     auto messageType { static_cast<PCM::MessageType>(xpc_dictionary_get_uint64(request, PCM::protocolMessageTypeKey)) };
-    auto encodedMessage = xpc_dictionary_get_data_span(request, PCM::protocolEncodedMessageKey);
+    auto encodedMessage = xpcDictionaryGetData(request, PCM::protocolEncodedMessageKey);
     decodeMessageAndSendToManager(Daemon::Connection::create(xpc_dictionary_get_remote_connection(request)), messageType, encodedMessage, replySender(messageType, request));
 }
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h
@@ -35,7 +35,7 @@
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 #if !USE(RUNNINGBOARD)
-#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/darwin/XPCExtras.h>
 #endif
 
 // FIXME: This should be moved to an SPI header.

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm
@@ -79,19 +79,19 @@ bool XPCServiceInitializerDelegate::getConnectionIdentifier(IPC::Connection::Ide
 
 bool XPCServiceInitializerDelegate::getClientIdentifier(String& clientIdentifier)
 {
-    clientIdentifier = xpc_dictionary_get_wtfstring(m_initializerMessage, "client-identifier"_s);
+    clientIdentifier = xpcDictionaryGetString(m_initializerMessage, "client-identifier"_s);
     return !clientIdentifier.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getClientBundleIdentifier(String& clientBundleIdentifier)
 {
-    clientBundleIdentifier = xpc_dictionary_get_wtfstring(m_initializerMessage, "client-bundle-identifier"_s);
+    clientBundleIdentifier = xpcDictionaryGetString(m_initializerMessage, "client-bundle-identifier"_s);
     return !clientBundleIdentifier.isEmpty();
 }
 
 bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehaviors& behaviors)
 {
-    auto behaviorData = xpc_dictionary_get_data_span(m_initializerMessage, "client-sdk-aligned-behaviors"_s);
+    auto behaviorData = xpcDictionaryGetData(m_initializerMessage, "client-sdk-aligned-behaviors"_s);
     if (behaviorData.empty())
         return false;
     auto storageBytes = behaviors.storageBytes();
@@ -105,7 +105,7 @@ bool XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors(SDKAlignedBehav
 
 bool XPCServiceInitializerDelegate::getProcessIdentifier(std::optional<WebCore::ProcessIdentifier>& identifier)
 {
-    auto parsedIdentifier = parseInteger<uint64_t>(xpc_dictionary_get_wtfstring(m_initializerMessage, "process-identifier"_s));
+    auto parsedIdentifier = parseInteger<uint64_t>(xpcDictionaryGetString(m_initializerMessage, "process-identifier"_s));
     if (!parsedIdentifier)
         return false;
     if (!ObjectIdentifier<WebCore::ProcessIdentifierType>::isValidIdentifier(*parsedIdentifier))
@@ -117,7 +117,7 @@ bool XPCServiceInitializerDelegate::getProcessIdentifier(std::optional<WebCore::
 
 bool XPCServiceInitializerDelegate::getClientProcessName(String& clientProcessName)
 {
-    clientProcessName = xpc_dictionary_get_wtfstring(m_initializerMessage, "ui-process-name"_s);
+    clientProcessName = xpcDictionaryGetString(m_initializerMessage, "ui-process-name"_s);
     return !clientProcessName.isEmpty();
 }
 
@@ -125,32 +125,32 @@ bool XPCServiceInitializerDelegate::getExtraInitializationData(HashMap<String, S
 {
     xpc_object_t extraDataInitializationDataObject = xpc_dictionary_get_value(m_initializerMessage, "extra-initialization-data");
 
-    auto inspectorProcess = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "inspector-process"_s);
+    auto inspectorProcess = xpcDictionaryGetString(extraDataInitializationDataObject, "inspector-process"_s);
     if (!inspectorProcess.isEmpty())
         extraInitializationData.add("inspector-process"_s, inspectorProcess);
 
-    auto serviceWorkerProcess = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "service-worker-process"_s);
+    auto serviceWorkerProcess = xpcDictionaryGetString(extraDataInitializationDataObject, "service-worker-process"_s);
     if (!serviceWorkerProcess.isEmpty())
         extraInitializationData.add("service-worker-process"_s, WTFMove(serviceWorkerProcess));
-    auto registrableDomain = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "registrable-domain"_s);
+    auto registrableDomain = xpcDictionaryGetString(extraDataInitializationDataObject, "registrable-domain"_s);
     if (!registrableDomain.isEmpty())
         extraInitializationData.add("registrable-domain"_s, WTFMove(registrableDomain));
 
-    auto isPrewarmedProcess = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "is-prewarmed"_s);
+    auto isPrewarmedProcess = xpcDictionaryGetString(extraDataInitializationDataObject, "is-prewarmed"_s);
     if (!isPrewarmedProcess.isEmpty())
         extraInitializationData.add("is-prewarmed"_s, isPrewarmedProcess);
 
-    auto isLockdownModeEnabled = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "enable-lockdown-mode"_s);
+    auto isLockdownModeEnabled = xpcDictionaryGetString(extraDataInitializationDataObject, "enable-lockdown-mode"_s);
     if (!isLockdownModeEnabled.isEmpty())
         extraInitializationData.add("enable-lockdown-mode"_s, isLockdownModeEnabled);
 
     if (!isClientSandboxed()) {
-        auto userDirectorySuffix = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "user-directory-suffix"_s);
+        auto userDirectorySuffix = xpcDictionaryGetString(extraDataInitializationDataObject, "user-directory-suffix"_s);
         if (!userDirectorySuffix.isEmpty())
             extraInitializationData.add("user-directory-suffix"_s, userDirectorySuffix);
     }
 
-    auto alwaysRunsAtBackgroundPriority = xpc_dictionary_get_wtfstring(extraDataInitializationDataObject, "always-runs-at-background-priority"_s);
+    auto alwaysRunsAtBackgroundPriority = xpcDictionaryGetString(extraDataInitializationDataObject, "always-runs-at-background-priority"_s);
     if (!alwaysRunsAtBackgroundPriority.isEmpty())
         extraInitializationData.add("always-runs-at-background-priority"_s, alwaysRunsAtBackgroundPriority);
 

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -41,9 +41,9 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/StdLibExtras.h>
 #import <wtf/WTFProcess.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/spi/cocoa/OSLogSPI.h>
 #import <wtf/spi/darwin/SandboxSPI.h>
-#import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/MakeString.h>
 
 #if __has_include(<WebKitAdditions/DyldCallbackAdditions.h>)
@@ -113,7 +113,7 @@ NEVER_INLINE NO_RETURN_DUE_TO_CRASH static void crashDueWebKitFrameworkVersionMi
 }
 static void checkFrameworkVersion(xpc_object_t message)
 {
-    auto uiProcessWebKitBundleVersion = xpc_dictionary_get_wtfstring(message, "WebKitBundleVersion"_s);
+    auto uiProcessWebKitBundleVersion = xpcDictionaryGetString(message, "WebKitBundleVersion"_s);
     auto webkitBundleVersion = ASCIILiteral::fromLiteralUnsafe(WEBKIT_BUNDLE_VERSION);
     if (!uiProcessWebKitBundleVersion.isNull() && uiProcessWebKitBundleVersion != webkitBundleVersion) {
         auto errorMessage = makeString("WebKit framework version mismatch: "_s, uiProcessWebKitBundleVersion, " != "_s, webkitBundleVersion);
@@ -154,7 +154,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
         handleXPCExitMessage(event);
 #endif
 
-        String messageName = xpc_dictionary_get_wtfstring(event, "message-name"_s);
+        String messageName = xpcDictionaryGetString(event, "message-name"_s);
         if (!messageName) {
             RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: 'message-name' is not present in the XPC dictionary");
             return;
@@ -169,7 +169,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
                 Vector<String> newLanguages;
                 @autoreleasepool {
                     xpc_array_apply(languages, makeBlockPtr([&newLanguages](size_t index, xpc_object_t value) {
-                        newLanguages.append(xpc_string_get_wtfstring(value));
+                        newLanguages.append(xpcStringGetString(value));
                         return true;
                     }).get());
                 }
@@ -190,7 +190,7 @@ void XPCServiceEventHandler(xpc_connection_t peer)
             });
 #endif
 
-            String serviceName = xpc_dictionary_get_wtfstring(event, "service-name"_s);
+            String serviceName = xpcDictionaryGetString(event, "service-name"_s);
             if (!serviceName) {
                 RELEASE_LOG_ERROR(IPC, "XPCServiceEventHandler: 'service-name' is not present in the XPC dictionary");
                 return;

--- a/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
+++ b/Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm
@@ -48,8 +48,8 @@
 #import <wtf/SoftLinking.h>
 #import <wtf/Threading.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/spi/cf/CFBundleSPI.h>
-#import <wtf/spi/darwin/XPCSPI.h>
 #import <wtf/text/CString.h>
 #import <wtf/text/WTFString.h>
 
@@ -450,7 +450,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
 #endif
 
         if (event)
-            LOG_ERROR("Error while launching %s: %s", logName.data(), xpc_dictionary_get_wtfstring(event, xpcErrorDescriptionKey).utf8().data());
+            LOG_ERROR("Error while launching %s: %s", logName.data(), xpcDictionaryGetString(event, xpcErrorDescriptionKey).utf8().data());
         else
             LOG_ERROR("Error while launching %s: No xpc_object_t event available.", logName.data());
 
@@ -509,7 +509,7 @@ void ProcessLauncher::finishLaunchingProcess(ASCIILiteral name)
         // launching and we already took care of cleaning things up.
         if (isLaunching() && xpc_get_type(reply) != XPC_TYPE_ERROR) {
             ASSERT(xpc_get_type(reply) == XPC_TYPE_DICTIONARY);
-            ASSERT(xpc_dictionary_get_wtfstring(reply, "message-name"_s) == "process-finished-launching"_s);
+            ASSERT(xpcDictionaryGetString(reply, "message-name"_s) == "process-finished-launching"_s);
 
 #if ASSERT_ENABLED
             mach_port_urefs_t sendRightCount = 0;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm
@@ -37,6 +37,7 @@
 #import "XPCEndpoint.h"
 #import <wtf/EnumTraits.h>
 #import <wtf/RuntimeApplicationChecks.h>
+#import <wtf/darwin/XPCExtras.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <UIKit/UIKit.h>
@@ -62,7 +63,7 @@ bool NetworkProcessProxy::XPCEventHandler::handleXPCEvent(xpc_object_t event) co
     if (!event || xpc_get_type(event) == XPC_TYPE_ERROR)
         return false;
 
-    auto messageName = xpc_dictionary_get_wtfstring(event, XPCEndpoint::xpcMessageNameKey);
+    auto messageName = xpcDictionaryGetString(event, XPCEndpoint::xpcMessageNameKey);
     if (messageName.isEmpty())
         return false;
 

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm
@@ -31,7 +31,7 @@
 #import "XPCEndpoint.h"
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <wtf/cocoa/Entitlements.h>
-#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/text/WTFString.h>
 
 namespace WebKit {
@@ -48,7 +48,7 @@ LaunchServicesDatabaseManager& LaunchServicesDatabaseManager::singleton()
 
 void LaunchServicesDatabaseManager::handleEvent(xpc_object_t message)
 {
-    String messageName = xpc_dictionary_get_wtfstring(message, XPCEndpoint::xpcMessageNameKey);
+    String messageName = xpcDictionaryGetString(message, XPCEndpoint::xpcMessageNameKey);
     if (messageName == LaunchServicesDatabaseXPCConstants::xpcUpdateLaunchServicesDatabaseMessageName) {
 #if HAVE(LSDATABASECONTEXT)
         auto database = xpc_dictionary_get_value(message, LaunchServicesDatabaseXPCConstants::xpcLaunchServicesDatabaseKey);

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -56,7 +56,7 @@
 #import <wtf/URL.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/SpanCocoa.h>
-#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/text/MakeString.h>
 
 #if HAVE(MOBILE_KEY_BAG)
@@ -306,7 +306,7 @@ void WebPushDaemon::connectionEventHandler(xpc_object_t request)
         return;
     }
 
-    auto data = xpc_dictionary_get_data_span(request, protocolEncodedMessageKey);
+    auto data = xpcDictionaryGetData(request, protocolEncodedMessageKey);
     if (!data.data()) {
         RELEASE_LOG_ERROR(Push, "WebPushDaemon::connectionEventHandler - No encoded message data in xpc message");
         tryCloseRequestConnection(request);

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h
@@ -34,7 +34,7 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
-#include <wtf/spi/darwin/XPCSPI.h>
+#include <wtf/darwin/XPCExtras.h>
 
 using WebKit::WebPushD::PushMessageForTesting;
 

--- a/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
+++ b/Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm
@@ -180,7 +180,7 @@ bool Connection::performSendWithAsyncReplyWithoutUsingIPCConnection(UniqueRef<IP
             return completionHandler(nullptr);
         }
 
-        auto data = xpc_dictionary_get_data_span(reply, WebKit::WebPushD::protocolEncodedMessageKey);
+        auto data = xpcDictionaryGetData(reply, WebKit::WebPushD::protocolEncodedMessageKey);
         auto decoder = IPC::Decoder::create(data, { });
         ASSERT(decoder);
 

--- a/Tools/Scripts/do-webcore-rename
+++ b/Tools/Scripts/do-webcore-rename
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 
-# Copyright (C) 2006-2020 Apple Inc. All rights reserved.
+# Copyright (C) 2006-2025 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -82,6 +82,7 @@ find(\&wanted, "Tools/gdb");
 find(\&wanted, "Tools/lldb");
 find(\&wanted, "Tools/DumpRenderTree");
 find(\&wanted, "Tools/MiniBrowser");
+find(\&wanted, "Tools/Scripts/webkitpy/style/checkers");
 find(\&wanted, "Tools/TestRunnerShared");
 find(\&wanted, "Tools/TestWebKitAPI");
 find(\&wanted, "Tools/WebKitTestRunner");
@@ -107,8 +108,9 @@ sub wanted
 my $isDOMTypeRename = 0;
 my %renames = (
     # Renames go here in the form of:
-    "RandomNumber.h" => "WeakRandomNumber.h",
-    "RandomNumber.cpp" => "WeakRandomNumber.cpp",
+    "xpc_dictionary_get_data_span" => "xpcDictionaryGetData",
+    "xpc_dictionary_get_wtfstring" => "xpcDictionaryGetString",
+    "xpc_string_get_wtfstring" => "xpcStringGetString",
 );
 
 my %renamesContemplatedForTheFuture = (

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3561,15 +3561,15 @@ def check_safer_cpp(clean_lines, line_number, error):
 
     uses_xpc_dictionary_get_data = search(r'xpc_dictionary_get_data\(', line)
     if uses_xpc_dictionary_get_data:
-        error(line_number, 'safercpp/xpc_dictionary_get_data', 4, "Use xpc_dictionary_get_data_span() instead of xpc_dictionary_get_data().")
+        error(line_number, 'safercpp/xpc_dictionary_get_data', 4, "Use xpcDictionaryGetData() instead of xpc_dictionary_get_data().")
 
     uses_xpc_dictionary_get_string = search(r'xpc_dictionary_get_string\(', line)
     if uses_xpc_dictionary_get_string:
-        error(line_number, 'safercpp/xpc_dictionary_get_string', 4, "Use xpc_dictionary_get_wtfstring() instead of xpc_dictionary_get_string().")
+        error(line_number, 'safercpp/xpc_dictionary_get_string', 4, "Use xpcDictionaryGetString() instead of xpc_dictionary_get_string().")
 
     uses_xpc_string_get_string_ptr = search(r'xpc_string_get_string_ptr\(', line)
     if uses_xpc_string_get_string_ptr:
-        error(line_number, 'safercpp/xpc_string_get_string_ptr', 4, "Use xpc_string_get_wtfstring() instead of xpc_string_get_string_ptr().")
+        error(line_number, 'safercpp/xpc_string_get_string_ptr', 4, "Use xpcStringGetString() instead of xpc_string_get_string_ptr().")
 
 
 def check_style(clean_lines, line_number, file_extension, class_state, file_state, enum_state, error):

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6340,17 +6340,17 @@ class WebKitStyleTest(CppStyleTestBase):
 
         self.assert_lint(
             'auto* result = xpc_dictionary_get_data(dictionary, "foo", &size);',
-            'Use xpc_dictionary_get_data_span() instead of xpc_dictionary_get_data().  [safercpp/xpc_dictionary_get_data] [4]',
+            'Use xpcDictionaryGetData() instead of xpc_dictionary_get_data().  [safercpp/xpc_dictionary_get_data] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'auto* result = xpc_dictionary_get_string(dictionary, "foo");',
-            'Use xpc_dictionary_get_wtfstring() instead of xpc_dictionary_get_string().  [safercpp/xpc_dictionary_get_string] [4]',
+            'Use xpcDictionaryGetString() instead of xpc_dictionary_get_string().  [safercpp/xpc_dictionary_get_string] [4]',
             'foo.cpp')
 
         self.assert_lint(
             'auto* result = xpc_string_get_string_ptr(value);',
-            'Use xpc_string_get_wtfstring() instead of xpc_string_get_string_ptr().  [safercpp/xpc_string_get_string_ptr] [4]',
+            'Use xpcStringGetString() instead of xpc_string_get_string_ptr().  [safercpp/xpc_string_get_string_ptr] [4]',
             'foo.cpp')
 
     def test_ctype_fucntion(self):

--- a/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm
@@ -53,7 +53,7 @@ private:
     }
     void handleEvent(xpc_connection_t connection, xpc_object_t event) final
     {
-        String messageName = xpc_dictionary_get_wtfstring(event, XPCEndpoint::xpcMessageNameKey);
+        String messageName = xpcDictionaryGetString(event, XPCEndpoint::xpcMessageNameKey);
         if (messageName == testMessageFromClient) {
             endpointReceivedMessageFromClient = true;
 
@@ -68,7 +68,7 @@ class XPCEndpointClient final : public WebKit::XPCEndpointClient {
 private:
     void handleEvent(xpc_object_t event) final
     {
-        String messageName = xpc_dictionary_get_wtfstring(event, XPCEndpoint::xpcMessageNameKey);
+        String messageName = xpcDictionaryGetString(event, XPCEndpoint::xpcMessageNameKey);
         if (messageName == testMessageFromEndpoint)
             clientReceivedMessageFromEndpoint = true;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -62,7 +62,7 @@
 #import <wtf/UUID.h>
 #import <wtf/UniqueRef.h>
 #import <wtf/cocoa/SpanCocoa.h>
-#import <wtf/spi/darwin/XPCSPI.h>
+#import <wtf/darwin/XPCExtras.h>
 #import <wtf/text/Base64.h>
 #import <wtf/text/MakeString.h>
 
@@ -292,7 +292,7 @@ bool WebPushXPCConnectionMessageSender::performSendWithAsyncReplyWithoutUsingIPC
             return completionHandler(nullptr);
         }
 
-        auto data = xpc_dictionary_get_data_span(reply, WebKit::WebPushD::protocolEncodedMessageKey);
+        auto data = xpcDictionaryGetData(reply, WebKit::WebPushD::protocolEncodedMessageKey);
         auto decoder = IPC::Decoder::create(data, { });
         ASSERT(decoder);
 


### PR DESCRIPTION
#### 0120a229cb5fff55f5c7107f79d76b94a422b59d
<pre>
Move WebKit utility functions out of XPCSPI.h and rename
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=288984">https://bugs.webkit.org/show_bug.cgi?id=288984</a>&gt;
&lt;<a href="https://rdar.apple.com/146054630">rdar://146054630</a>&gt;

Reviewed by Chris Dumez and Geoffrey Garen.

Introduce &lt;wtf/darwin/XPCExtras.h&gt;, move helper functions into this
header, and rename helper functions to match camelCase.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/PlatformMac.cmake:
- Update build system files to add XPCExtras.h.
* Source/WTF/wtf/darwin/XPCExtras.h: Add.
(WTF::xpcDictionaryGetData): Add.
(WTF::xpcErrorDescriptionKey): Add.
(WTF::xpcDictionaryGetString): Add.
(WTF::xpcStringGetString): Add.
- Move from XPCSPI.h and rename.
* Source/WTF/wtf/spi/darwin/XPCSPI.h:
(xpc_dictionary_get_data_span): Delete.
(xpcErrorDescriptionKey): Delete.
(xpc_dictionary_get_wtfstring): Delete.
(xpc_string_get_wtfstring): Delete.
- Move to XPCExtras.h and rename.

* Source/WebKit/NetworkProcess/Authentication/cocoa/AuthenticationManagerCocoa.mm:
(WebKit::AuthenticationManager::initializeConnection):
* Source/WebKit/NetworkProcess/Notifications/Cocoa/WebPushDaemonConnectionCocoa.mm:
(WebKit::WebPushD::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementConnectionCocoa.mm:
(WebKit::PCM::Connection::connectionReceivedEvent):
* Source/WebKit/NetworkProcess/cocoa/LaunchServicesDatabaseObserver.mm:
(WebKit::LaunchServicesDatabaseObserver::handleEvent):
* Source/WebKit/Platform/IPC/DaemonConnection.h:
* Source/WebKit/Platform/IPC/cocoa/DaemonConnectionCocoa.mm:
(WebKit::Daemon::ConnectionToMachService&lt;Traits&gt;::sendWithReply const):
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::MediaCapability::environmentIdentifier const):
* Source/WebKit/Platform/cocoa/XPCUtilities.h:
* Source/WebKit/Platform/cocoa/XPCUtilities.mm:
(WebKit::handleXPCExitMessage):
* Source/WebKit/Shared/Cocoa/XPCEndpoint.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonEntryPoint.mm:
(WebKit::connectionEventHandler):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceEntryPoint.mm:
(WebKit::XPCServiceInitializerDelegate::getClientIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientBundleIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientSDKAlignedBehaviors):
(WebKit::XPCServiceInitializerDelegate::getProcessIdentifier):
(WebKit::XPCServiceInitializerDelegate::getClientProcessName):
(WebKit::XPCServiceInitializerDelegate::getExtraInitializationData):
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::checkFrameworkVersion):
(WebKit::XPCServiceEventHandler):
* Source/WebKit/UIProcess/Launcher/cocoa/ProcessLauncherCocoa.mm:
(WebKit::ProcessLauncher::finishLaunchingProcess):
* Source/WebKit/UIProcess/Network/NetworkProcessProxyCocoa.mm:
(WebKit::NetworkProcessProxy::XPCEventHandler::handleXPCEvent const):
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.mm:
(WebKit::LaunchServicesDatabaseManager::handleEvent):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::connectionEventHandler):
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.h:
* Source/WebKit/webpushd/webpushtool/WebPushToolConnection.mm:
(WebPushTool::Connection::performSendWithAsyncReplyWithoutUsingIPCConnection const):
- Update for rename.

* Tools/Scripts/do-webcore-rename:
- Add Tools/Scripts/webkitpy/style/checkers to list of paths to check
  for renames.
* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
* Tools/TestWebKitAPI/Tests/WebKit/XPCEndpoint.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::WebPushXPCConnectionMessageSender::performSendWithAsyncReplyWithoutUsingIPCConnection const):
- Update for rename.

Canonical link: <a href="https://commits.webkit.org/291874@main">https://commits.webkit.org/291874@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99f91bf7b11265a60abb6aba0a9695222e2cd435

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44795 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71916 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29255 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97269 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85121 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52262 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/93762 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2805 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44113 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80433 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101323 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92933 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21319 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15535 "Found 2 new test failures: svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-default-context.svg svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-ltr-context.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80919 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80301 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2225 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14536 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26482 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115583 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20990 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24450 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->