### PR TITLE
REGRESSION(262954@main): [GTK] Attempts access to disengaged optional with caret blinking disabled

### DIFF
--- a/Source/WebCore/platform/SimpleCaretAnimator.cpp
+++ b/Source/WebCore/platform/SimpleCaretAnimator.cpp
@@ -45,14 +45,13 @@ void SimpleCaretAnimator::updateAnimationProperties()
 
     setBlinkingSuspended(!caretBlinkInterval);
 
-    // Ensure the caret is always visible when blinking is suspended.
-    if (isBlinkingSuspended() && m_presentationProperties.blinkState == PresentationProperties::BlinkState::On) {
-        m_blinkTimer.startOneShot(caretBlinkInterval.value_or(0_ms));
+    if (isBlinkingSuspended()) {
+        // Ensure the caret is always visible when blinking is suspended.
+        if (m_presentationProperties.blinkState == PresentationProperties::BlinkState::On)
+            m_blinkTimer.startOneShot(caretBlinkInterval.value_or(0_ms));
         return;
     }
 
-    // If blinking is disabled, set isBlinkingSuspended() would have made the
-    // previous check return early and at this point there must be an interval.
     ASSERT(caretBlinkInterval.has_value());
 
     if (currentTime - m_lastTimeCaretPaintWasToggled >= caretBlinkInterval) {


### PR DESCRIPTION
#### 09ad2dad9a7a592b16b06a87bd803e7878f36523
<pre>
REGRESSION(262954@main): [GTK] Attempts access to disengaged optional with caret blinking disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=289007">https://bugs.webkit.org/show_bug.cgi?id=289007</a>

Reviewed by Carlos Garcia Campos.

* Source/WebCore/platform/SimpleCaretAnimator.cpp:
(WebCore::SimpleCaretAnimator::updateAnimationProperties): Always return
early when caret blinking is suspended, regardless of the current
blinking state; but nevertheless still schedule toggling the visibility
if needed.

Canonical link: <a href="https://commits.webkit.org/291555@main">https://commits.webkit.org/291555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e969ceb8b02f542f21a263ac14781eaba4d36ecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93204 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12759 "Hash e969ceb8 for PR 41808 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43730 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71240 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28645 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51572 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9494 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1950 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43044 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79783 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20256 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14835 "Found 1 new test failure: ipc/large-vector-allocate-failure-crash.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80264 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79573 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13371 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14928 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25417 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19927 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23387 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21668 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->