### PR TITLE
[Grid]

### DIFF
--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -87,6 +87,8 @@ void RenderGrid::styleDidChange(StyleDifference diff, const RenderStyle* oldStyl
         return;
 
     m_intrinsicLogicalHeightsForRowSizingFirstPass.reset();
+    m_gridAreaLogicalSizesCache.clear();
+
     const RenderStyle& newStyle = this->style();
 
     auto hasDifferentTrackSizes = [&newStyle, &oldStyle](GridTrackSizingDirection direction) {
@@ -326,6 +328,8 @@ void RenderGrid::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit)
 
 void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 {
+    m_gridAreaLogicalSizesCache.clear();
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -464,6 +468,8 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
 void RenderGrid::layoutMasonry(RelayoutChildren relayoutChildren)
 {
+    m_gridAreaLogicalSizesCache.clear();
+
     LayoutRepainter repainter(*this);
     {
         LayoutStateMaintainer statePusher(*this, locationOffset(), isTransformed() || hasReflection() || writingMode().isBlockFlipped());
@@ -1312,6 +1318,8 @@ void RenderGrid::dirtyGrid(SubgridDidChange subgridDidChange)
     if (currentGrid().needsItemsPlacement())
         return;
 
+    m_gridAreaLogicalSizesCache.clear();
+
     currentGrid().setNeedsItemsPlacement(true);
 
     auto currentChild = this;
@@ -1432,7 +1440,11 @@ void RenderGrid::layoutGridItems(GridLayoutState& gridLayoutState)
         // Setting the definite grid area's sizes. It may imply that the
         // item must perform a layout if its area differs from the one
         // used during the track sizing algorithm.
-        updateGridAreaLogicalSize(*gridItem, gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForColumns), gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForRows));
+        auto gridAreaLogicalWidth = gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForColumns);
+        auto gridAreaLogicalHeight = gridAreaBreadthForGridItemIncludingAlignmentOffsets(*gridItem, GridTrackSizingDirection::ForRows);
+        m_gridAreaLogicalSizesCache.set(*gridItem, GridAreaLogicalSize { gridAreaLogicalWidth, gridAreaLogicalHeight });
+
+        updateGridAreaLogicalSize(*gridItem, gridAreaLogicalWidth, gridAreaLogicalHeight);
 
         LayoutRect oldGridItemRect = gridItem->frameRect();
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -212,6 +212,104 @@ void RenderGrid::repeatTracksSizingIfNeeded(LayoutUnit availableSpaceForColumns,
     }
 }
 
+bool RenderGrid::isEligibleForExtrinsicTrackSizesFastPath() const
+{
+    if (m_gridAreaLogicalSizesCache.isEmpty())
+        return false;
+
+    auto& gridStyle = style();
+
+    auto isInBlockBox = [&] {
+        if (auto* containingBlock = this->containingBlock())
+            return containingBlock->isBlockBox();
+        return false;
+    };
+
+    auto allTracksAreExtrinsicallySized = [&] {
+        for (auto& column : gridStyle.gridTrackSizes(GridTrackSizingDirection::ForColumns)) {
+            if (column.isContentSized())
+                return false;
+        }
+
+
+        for (auto& row : gridStyle.gridTrackSizes(GridTrackSizingDirection::ForRows)) {
+            if (row.isContentSized())
+                return false;
+        }
+        return true;
+    };
+
+    auto& currentGrid = this->currentGrid();
+    if (selfNeedsLayout()
+        || !allTracksAreExtrinsicallySized()
+        || !isInBlockBox()
+        || !gridStyle.logicalWidth().isAuto()
+        || currentGrid.needsItemsPlacement()
+        || currentGrid.autoRepeatTracks(GridTrackSizingDirection::ForColumns)
+        || currentGrid.autoRepeatTracks(GridTrackSizingDirection::ForRows)
+        || !gridStyle.logicalHeight().isFixed()
+        || isOutOfFlowPositioned()
+        || isFieldset()
+        || !firstChildBox()) {
+        return false;
+    }
+
+    for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
+        auto& gridItemStyle = gridItem.style();
+
+        if (gridItem.isOutOfFlowPositioned()
+            || hasAutoMarginsInColumnAxis(gridItem)
+            || hasAutoMarginsInRowAxis(gridItem)
+            || isBaselineAlignmentForGridItem(gridItem)
+            || GridLayoutFunctions::isOrthogonalGridItem(*this, gridItem)
+            || gridItemStyle.hasAspectRatio())
+            return false;
+
+        if (auto* renderGrid = dynamicDowncast<RenderGrid>(gridItem)) {
+            if (renderGrid->isSubgrid() || renderGrid->isMasonry())
+                return false;
+        }
+
+        if (auto* gridItemElement = gridItem.element(); gridItemElement && gridItemElement->isReplaced(gridItem.style()))
+            return false;
+    }
+    return true;
+}
+
+void RenderGrid::performExtrinsicTrackSizesFastPath(GridLayoutState& gridLayoutState, LayoutRepainter& layoutRepainter)
+{
+    ASSERT(isEligibleForExtrinsicTrackSizesFastPath());
+    {
+        for (auto& gridItem : childrenOfType<RenderBox>(*this)) {
+            auto [ gridAreaLogicalWidth, gridAreaLogicalHeight ] = m_gridAreaLogicalSizesCache.get(gridItem);
+            gridItem.setGridAreaContentLogicalWidth(gridAreaLogicalWidth);
+            gridItem.setGridAreaContentLogicalHeight(gridAreaLogicalHeight);
+
+            auto oldGridItemRect = gridItem.frameRect();
+
+            applyStretchAlignmentToGridItemIfNeeded(gridItem, gridLayoutState);
+
+            gridItem.layoutIfNeeded();
+
+            setLogicalPositionForGridItem(gridItem);
+            if (gridItem.checkForRepaintDuringLayout())
+                gridItem.repaintDuringLayoutIfMoved(oldGridItemRect);
+        }
+        endAndCommitUpdateScrollInfoAfterLayoutTransaction();
+        computeOverflow(layoutOverflowLogicalBottom(*this));
+        updateDescendantTransformsAfterLayout();
+    }
+
+
+    updateLayerTransform();
+
+    updateScrollInfoAfterLayout();
+
+    layoutRepainter.repaintAfterLayout();
+
+    clearNeedsLayout();
+}
+
 bool RenderGrid::canPerformSimplifiedLayout() const
 {
     // We cannot perform a simplified layout if we need to position the items and we have some
@@ -353,8 +451,11 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
         resetLogicalHeightBeforeLayoutIfNeeded();
 
-        updateLogicalWidth();
-
+        bool logicalWidthChanged = recomputeLogicalWidth();
+        if (!logicalWidthChanged && isEligibleForExtrinsicTrackSizesFastPath()) {
+            performExtrinsicTrackSizesFastPath(gridLayoutState, repainter);
+            return;
+        }
         // Fieldsets need to find their legend and position it inside the border of the object.
         // The legend then gets skipped during normal layout. The same is true for ruby text.
         // It doesn't get included in the normal layout process but is instead skipped.

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -309,6 +309,10 @@ private:
     bool m_hasAnyBaselineAlignmentItem { false };
 
     mutable std::optional<GridItemSizeCache> m_intrinsicLogicalHeightsForRowSizingFirstPass;
+
+    using GridAreaLogicalSize = std::pair<LayoutUnit, LayoutUnit>;
+    UncheckedKeyHashMap<SingleThreadWeakRef<const RenderBox>, GridAreaLogicalSize> m_gridAreaLogicalSizesCache;
+
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class GridArea;
 class GridLayoutState;
 class GridSpan;
+class LayoutRepainter;
 
 struct ContentAlignmentData {
     LayoutUnit positionOffset;
@@ -196,6 +197,9 @@ private:
         auto itemSpan = gridAxisDirection == GridTrackSizingDirection::ForColumns ? area.columns : area.rows;
         return itemSpan.startLine() <  gridAxisLinesCount && itemSpan.endLine() < gridAxisLinesCount;
     }
+
+    bool isEligibleForExtrinsicTrackSizesFastPath() const;
+    void performExtrinsicTrackSizesFastPath(GridLayoutState&, LayoutRepainter&);
 
     bool canPerformSimplifiedLayout() const final;
     void prepareGridItemForPositionedLayout(RenderBox&);


### PR DESCRIPTION
#### d07032e53cc515cd6046641a1bd582254beccad0
<pre>
[Grid] Add extrinsic sized tracks fast path.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

WIP.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::isEligibleForExtrinsicTrackSizesFastPath const):
(WebCore::RenderGrid::performExtrinsicTrackSizesFastPath):
(WebCore::RenderGrid::layoutGrid):
* Source/WebCore/rendering/RenderGrid.h:
</pre>
----------------------------------------------------------------------
#### 9bf8fc29e54de3bfeb86ca988f42c659961880a7
<pre>
[Grid] Introduce grid area logical sizes cache.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289004">https://bugs.webkit.org/show_bug.cgi?id=289004</a>
<a href="https://rdar.apple.com/problem/146051830">rdar://problem/146051830</a>

Reviewed by NOBODY (OOPS!).

This patch introduces a cache that stores the logical size of each grid
item&apos;s grid area. The grid area of an item is computed during the track
sizing algorithm and is used during layoutGridItems to set the item&apos;s
grid area logical width/height before calling layout on it as this
represents the item&apos;s containing block. We can use this as an
opportunity to cache these computed values to potentially use in a
subsequent layout in certain conditions which will be determined in a
future patch.

With the introduction of this cache we will want to invalidate it
basically whenever the grid experiences any sort of style mutation that
requires layout or whenever the content of the grid changes. The former
is done in a straightforward manner via RenderGrid::styleDidChange. The
latter is done inside of dirtyGrid, which is called at different points
in time when we need to perform item placement again including when:

1. A renderer is attached or detached from the RenderGrid
2.) A grid item&apos;s style changes such that it requires it to be placed
again

We will also aggressively invalidate this cache at the beginning of
RenderGrid::layoutGrid since we have no use for it yet. With respect to
the scenarios described above, this would represent another case where
a grid item&apos;s content/styling would have been mutated and could possibly
influence the sizes of the tracks and the sizes of the grid areas as a
result. I plan to add a fast path in which we would not invalidate this
cache during layout and instead use the sizes in scenarios where the
grid content does not influence the sizes of the tracks.

* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::styleDidChange):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
(WebCore::RenderGrid::dirtyGrid):
(WebCore::RenderGrid::layoutGridItems):
* Source/WebCore/rendering/RenderGrid.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f022ae4f009fdb92e7f1bbc6dc5c2cf2023843e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98363 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21378 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71338 "Found 70 new test failures: compositing/layer-creation/will-change-layer-creation.html compositing/patterns/direct-pattern-compositing-position.html css3/filters/backdrop/backdrop-filter-does-not-size-properly-absolute.html fast/canvas/canvas-bg-multiple-removal.html fast/canvas/image-buffer-backend-variants.html fast/css/acid2-pixel.html fast/css/acid2.html fast/css/empty-generated-content.html fast/inline/list-marker-float-crash.html fast/inline/list-marker-inside-container-with-margin.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28729 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51672 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79881 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2097 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100394 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80358 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79678 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1569 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13540 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25576 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20086 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21827 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->