### PR TITLE
Move inline functions of Node class from ContainerNode.h to NodeInlines.h

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -571,7 +571,6 @@ dom/Observable.cpp
 dom/PendingScript.cpp
 dom/Position.cpp
 dom/PositionIterator.cpp
-dom/PositionIterator.h
 dom/ProcessingInstruction.cpp
 dom/QualifiedName.cpp
 dom/Range.cpp

--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -32,6 +32,7 @@
 
 #include "AXObjectCache.h"
 #include "MathMLNames.h"
+#include "NodeInlines.h"
 #include "RenderStyleInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/accessibility/AccessibilityTree.cpp
+++ b/Source/WebCore/accessibility/AccessibilityTree.cpp
@@ -33,7 +33,7 @@
 #include "AccessibilityTreeItem.h"
 #include "Element.h"
 #include "HTMLNames.h"
-
+#include "NodeInlines.h"
 #include <wtf/Deque.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSNodeCustom.h
+++ b/Source/WebCore/bindings/js/JSNodeCustom.h
@@ -28,6 +28,7 @@
 
 #include "JSDOMBinding.h"
 #include "JSNode.h"
+#include "NodeInlines.h"
 #include "WebCoreOpaqueRoot.h"
 
 namespace JSC {

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -192,55 +192,9 @@ inline ContainerNode::ContainerNode(Document& document, NodeType type, OptionSet
     ASSERT(!isTextNode());
 }
 
-inline unsigned Node::countChildNodes() const
-{
-    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
-    return containerNode ? containerNode->countChildNodes() : 0;
-}
-
-inline Node* Node::traverseToChildAt(unsigned index) const
-{
-    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
-    return containerNode ? containerNode->traverseToChildAt(index) : nullptr;
-}
-
-inline Node* Node::firstChild() const
-{
-    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
-    return containerNode ? containerNode->firstChild() : nullptr;
-}
-
-inline RefPtr<Node> Node::protectedFirstChild() const
-{
-    return firstChild();
-}
-
-inline Node* Node::lastChild() const
-{
-    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
-    return containerNode ? containerNode->lastChild() : nullptr;
-}
-
-inline RefPtr<Node> Node::protectedLastChild() const
-{
-    return lastChild();
-}
-
-inline bool Node::hasChildNodes() const
-{
-    return firstChild();
-}
-
 inline ContainerNode& TreeScope::rootNode() const
 {
     return m_rootNode.get();
-}
-
-inline Node& Node::rootNode() const
-{
-    if (isInTreeScope())
-        return treeScope().rootNode();
-    return traverseToRootNode();
 }
 
 inline ContainerNode& ContainerNode::rootNode() const
@@ -248,24 +202,6 @@ inline ContainerNode& ContainerNode::rootNode() const
     if (isInTreeScope())
         return treeScope().rootNode();
     return traverseToRootNode();
-}
-
-inline void collectChildNodes(Node& node, NodeVector& children)
-{
-    for (SUPPRESS_UNCOUNTED_LOCAL Node* child = node.firstChild(); child; child = child->nextSibling())
-        children.append(*child);
-}
-
-inline void Node::setParentNode(ContainerNode* parent)
-{
-    ASSERT(isMainThread());
-    m_parentNode = parent;
-    m_refCountAndParentBit = (m_refCountAndParentBit & s_refCountMask) | !!parent;
-}
-
-inline RefPtr<ContainerNode> Node::protectedParentNode() const
-{
-    return parentNode();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -103,6 +103,7 @@
 #include "Logging.h"
 #include "MutationObserverInterestGroup.h"
 #include "MutationRecord.h"
+#include "NodeInlines.h"
 #include "NodeName.h"
 #include "NodeRenderStyle.h"
 #include "PlatformMouseEvent.h"

--- a/Source/WebCore/dom/ElementAndTextDescendantIterator.h
+++ b/Source/WebCore/dom/ElementAndTextDescendantIterator.h
@@ -27,6 +27,7 @@
 
 #include "Element.h"
 #include "ElementIteratorAssertions.h"
+#include "NodeInlines.h"
 #include "Text.h"
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -29,7 +29,7 @@
 #include "HTMLSlotElement.h"
 #include "LocalDOMWindow.h"
 #include "MouseEvent.h"
-#include "Node.h"
+#include "NodeInlines.h"
 #include "PseudoElement.h"
 #include "ShadowRoot.h"
 #include "TouchEvent.h"

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -146,7 +146,7 @@ public:
     NodeType nodeType() const { return nodeTypeFromBitFields(m_typeBitFields); }
     virtual size_t approximateMemoryCost() const { return sizeof(*this); }
     ContainerNode* parentNode() const;
-    inline RefPtr<ContainerNode> protectedParentNode() const; // Defined in ContainerNode.h.
+    inline RefPtr<ContainerNode> protectedParentNode() const;
     static constexpr ptrdiff_t parentNodeMemoryOffset() { return OBJECT_OFFSETOF(Node, m_parentNode); }
     inline Element* parentElement() const;
     inline RefPtr<Element> protectedParentElement() const;
@@ -157,10 +157,10 @@ public:
     RefPtr<Node> protectedNextSibling() const { return m_next.get(); }
     static constexpr ptrdiff_t nextSiblingMemoryOffset() { return OBJECT_OFFSETOF(Node, m_next); }
     WEBCORE_EXPORT RefPtr<NodeList> childNodes();
-    inline Node* firstChild() const; // Defined in ContainerNode.h
-    inline RefPtr<Node> protectedFirstChild() const; // Defined in ContainerNode.h
-    inline Node* lastChild() const; // Defined in ContainerNode.h
-    inline RefPtr<Node> protectedLastChild() const; // Defined in ContainerNode.h
+    inline Node* firstChild() const;
+    inline RefPtr<Node> protectedFirstChild() const;
+    inline Node* lastChild() const;
+    inline RefPtr<Node> protectedLastChild() const;
     inline bool hasAttributes() const;
     inline NamedNodeMap* attributesMap() const;
     Node* pseudoAwareNextSibling() const;
@@ -308,8 +308,8 @@ public:
     ContainerNode* parentInComposedTree() const;
     WEBCORE_EXPORT Element* parentElementInComposedTree() const;
     Element* parentOrShadowHostElement() const;
-    inline void setParentNode(ContainerNode*); // Defined in ContainerNode.h.
-    Node& rootNode() const;
+    inline void setParentNode(ContainerNode*);
+    inline Node& rootNode() const;
     WEBCORE_EXPORT Node& traverseToRootNode() const;
     Node& shadowIncludingRoot() const;
 
@@ -981,6 +981,8 @@ inline NodeClass& Node::traverseToRootNodeInternal(const NodeClass& node)
 }
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Node&);
+
+inline void collectChildNodes(Node&, NodeVector&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -84,4 +84,68 @@ inline unsigned Node::length() const
     return countChildNodes();
 }
 
+inline unsigned Node::countChildNodes() const
+{
+    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
+    return containerNode ? containerNode->countChildNodes() : 0;
+}
+
+inline Node* Node::traverseToChildAt(unsigned index) const
+{
+    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
+    return containerNode ? containerNode->traverseToChildAt(index) : nullptr;
+}
+
+inline Node* Node::firstChild() const
+{
+    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
+    return containerNode ? containerNode->firstChild() : nullptr;
+}
+
+inline RefPtr<Node> Node::protectedFirstChild() const
+{
+    return firstChild();
+}
+
+inline Node* Node::lastChild() const
+{
+    auto* containerNode = dynamicDowncast<ContainerNode>(*this);
+    return containerNode ? containerNode->lastChild() : nullptr;
+}
+
+inline RefPtr<Node> Node::protectedLastChild() const
+{
+    return lastChild();
+}
+
+inline bool Node::hasChildNodes() const
+{
+    return firstChild();
+}
+
+inline Node& Node::rootNode() const
+{
+    if (isInTreeScope())
+        return treeScope().rootNode();
+    return traverseToRootNode();
+}
+
+inline void Node::setParentNode(ContainerNode* parent)
+{
+    ASSERT(isMainThread());
+    m_parentNode = parent;
+    m_refCountAndParentBit = (m_refCountAndParentBit & s_refCountMask) | !!parent;
+}
+
+inline RefPtr<ContainerNode> Node::protectedParentNode() const
+{
+    return parentNode();
+}
+
+inline void collectChildNodes(Node& node, NodeVector& children)
+{
+    for (SUPPRESS_UNCOUNTED_LOCAL Node* child = node.firstChild(); child; child = child->nextSibling())
+        children.append(*child);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/NodeTraversal.h
+++ b/Source/WebCore/dom/NodeTraversal.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "ContainerNode.h"
+#include "NodeInlines.h"
 #include "Text.h"
 
 namespace WebCore {

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -322,16 +322,7 @@ inline Position firstPositionInNode(Node* anchorNode)
     return Position(anchorNode, Position::PositionIsBeforeChildren);
 }
 
-inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode)
-{
-    if (auto* characterData = dynamicDowncast<CharacterData>(*anchorNode))
-        return offset < characterData->length();
-
-    unsigned currentOffset = 0;
-    for (Node* node = anchorNode->firstChild(); node && currentOffset < offset; node = node->nextSibling())
-        currentOffset++;
-    return offset < currentOffset;
-}
+inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/PositionInlines.h
+++ b/Source/WebCore/dom/PositionInlines.h
@@ -37,4 +37,15 @@ Position lastPositionInNode(Node* anchorNode)
     return Position(anchorNode, Position::PositionIsAfterChildren);
 }
 
+inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode)
+{
+    if (auto* characterData = dynamicDowncast<CharacterData>(*anchorNode))
+        return offset < characterData->length();
+
+    unsigned currentOffset = 0;
+    for (Node* node = anchorNode->firstChild(); node && currentOffset < offset; node = node->nextSibling())
+        currentOffset++;
+    return offset < currentOffset;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -41,6 +41,13 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
+PositionIterator::PositionIterator(const Position& pos)
+    : m_anchorNode(pos.anchorNode())
+    , m_nodeAfterPositionInAnchor(m_anchorNode->traverseToChildAt(pos.deprecatedEditingOffset()))
+    , m_offsetInAnchor(m_nodeAfterPositionInAnchor ? 0 : pos.deprecatedEditingOffset())
+{
+}
+
 PositionIterator::operator Position() const
 {
     auto anchorNode = protectedNode();

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -35,12 +35,7 @@ namespace WebCore {
 // Conversion to/from Position is O(n) in the offset.
 class PositionIterator {
 public:
-    PositionIterator(const Position& pos)
-        : m_anchorNode(pos.anchorNode())
-        , m_nodeAfterPositionInAnchor(m_anchorNode->traverseToChildAt(pos.deprecatedEditingOffset()))
-        , m_offsetInAnchor(m_nodeAfterPositionInAnchor ? 0 : pos.deprecatedEditingOffset())
-    {
-    }
+    PositionIterator(const Position&);
     operator Position() const;
 
     void increment();

--- a/Source/WebCore/dom/RangeBoundaryPoint.h
+++ b/Source/WebCore/dom/RangeBoundaryPoint.h
@@ -39,7 +39,7 @@ public:
     unsigned offset() const;
     Node* childBefore() const;
 
-    void set(Ref<Node>&& container, unsigned offset, RefPtr<Node>&& childBefore);
+    inline void set(Ref<Node>&& container, unsigned offset, RefPtr<Node>&& childBefore);
     void setOffset(unsigned);
 
     void setToBeforeNode(Node&);
@@ -76,14 +76,6 @@ inline Node* RangeBoundaryPoint::childBefore() const
 inline unsigned RangeBoundaryPoint::offset() const
 {
     return m_offset;
-}
-
-inline void RangeBoundaryPoint::set(Ref<Node>&& container, unsigned offset, RefPtr<Node>&& childBefore)
-{
-    ASSERT(childBefore == (offset ? container->traverseToChildAt(offset - 1) : nullptr));
-    m_container = WTFMove(container);
-    m_offset = offset;
-    m_childBefore = WTFMove(childBefore);
 }
 
 inline void RangeBoundaryPoint::setOffset(unsigned offset)

--- a/Source/WebCore/dom/RangeBoundaryPointInlines.h
+++ b/Source/WebCore/dom/RangeBoundaryPointInlines.h
@@ -37,4 +37,12 @@ void RangeBoundaryPoint::setToAfterContents(Ref<Node>&& container)
     m_childBefore = container->lastChild();
 }
 
+inline void RangeBoundaryPoint::set(Ref<Node>&& container, unsigned offset, RefPtr<Node>&& childBefore)
+{
+    ASSERT(childBefore == (offset ? container->traverseToChildAt(offset - 1) : nullptr));
+    m_container = WTFMove(container);
+    m_offset = offset;
+    m_childBefore = WTFMove(childBefore);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -41,6 +41,7 @@
 #include "HTMLNames.h"
 #include "HTMLSpanElement.h"
 #include "LocalFrame.h"
+#include "NodeInlines.h"
 #include "NodeList.h"
 #include "NodeTraversal.h"
 #include "RenderObject.h"

--- a/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
+++ b/Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp
@@ -27,7 +27,7 @@
 #include "RemoveNodePreservingChildrenCommand.h"
 
 #include "Editing.h"
-#include "Node.h"
+#include "NodeInlines.h"
 #include <wtf/Assertions.h>
 
 namespace WebCore {

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -33,6 +33,7 @@
 
 #include "CaretRectComputation.h"
 #include "InlineRunAndOffset.h"
+#include "NodeInlines.h"
 #include "VisiblePosition.h"
 
 namespace WebCore {

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -33,6 +33,7 @@
 
 #include "Editing.h"
 #include "HTMLSpanElement.h"
+#include "NodeInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -37,7 +37,7 @@
 #include "IntRect.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
-#include "Node.h"
+#include "NodeInlines.h"
 #include "Page.h"
 #include "RenderInline.h"
 #include "RenderLayer.h"

--- a/Source/WebCore/xml/XPathPath.cpp
+++ b/Source/WebCore/xml/XPathPath.cpp
@@ -29,6 +29,7 @@
 #include "XPathPath.h"
 
 #include "Document.h"
+#include "NodeInlines.h"
 #include "XPathPredicate.h"
 #include "XPathStep.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -30,6 +30,7 @@
 #import "WKBundleAPICast.h"
 #import "WKDOMInternals.h"
 #import <WebCore/Document.h>
+#import <WebCore/NodeInlines.h>
 #import <WebCore/RenderObject.h>
 #import <WebCore/SimpleRange.h>
 #import <wtf/MainThread.h>

--- a/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/HTMLHtmlElement.h>
 #include <WebCore/HTMLInputElement.h>
 #include <WebCore/HTMLParserIdioms.h>
+#include <WebCore/NodeInlines.h>
 #include <WebCore/ParserContentPolicy.h>
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/Settings.h>


### PR DESCRIPTION
#### 647445dd15fa6223ee4108d7d9c2c300323d88a1
<pre>
Move inline functions of Node class from ContainerNode.h to NodeInlines.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=289026">https://bugs.webkit.org/show_bug.cgi?id=289026</a>

Reviewed by Ryosuke Niwa.

Some inline functions of Node class were defined in ContainerNode.h.
&lt;<a href="https://commits.webkit.org/291488@main">https://commits.webkit.org/291488@main</a>&gt; added NodeInlines.h. Move the
inline functions to NodeInlines.h.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
* Source/WebCore/accessibility/AccessibilityTree.cpp:
* Source/WebCore/bindings/js/JSNodeCustom.h:
* Source/WebCore/dom/ContainerNode.h:
(WebCore::Node::countChildNodes const): Deleted.
(WebCore::Node::traverseToChildAt const): Deleted.
(WebCore::Node::firstChild const): Deleted.
(WebCore::Node::protectedFirstChild const): Deleted.
(WebCore::Node::lastChild const): Deleted.
(WebCore::Node::protectedLastChild const): Deleted.
(WebCore::Node::hasChildNodes const): Deleted.
(WebCore::Node::rootNode const): Deleted.
(WebCore::collectChildNodes): Deleted.
(WebCore::Node::setParentNode): Deleted.
(WebCore::Node::protectedParentNode const): Deleted.
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/ElementAndTextDescendantIterator.h:
* Source/WebCore/dom/EventPath.cpp:
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::countChildNodes const):
(WebCore::Node::traverseToChildAt const):
(WebCore::Node::firstChild const):
(WebCore::Node::protectedFirstChild const):
(WebCore::Node::lastChild const):
(WebCore::Node::protectedLastChild const):
(WebCore::Node::hasChildNodes const):
(WebCore::Node::rootNode const):
(WebCore::Node::setParentNode):
(WebCore::Node::protectedParentNode const):
(WebCore::collectChildNodes):
* Source/WebCore/dom/NodeTraversal.h:
* Source/WebCore/dom/Position.h:
(WebCore::offsetIsBeforeLastNodeOffset): Deleted.
* Source/WebCore/dom/PositionInlines.h:
(WebCore::offsetIsBeforeLastNodeOffset):
* Source/WebCore/dom/PositionIterator.cpp:
(WebCore::PositionIterator::PositionIterator):
* Source/WebCore/dom/PositionIterator.h:
(WebCore::PositionIterator::PositionIterator): Deleted.
* Source/WebCore/dom/RangeBoundaryPoint.h:
(WebCore::RangeBoundaryPoint::set): Deleted.
* Source/WebCore/dom/RangeBoundaryPointInlines.h:
(WebCore::RangeBoundaryPoint::set):
* Source/WebCore/editing/ApplyStyleCommand.cpp:
* Source/WebCore/editing/RemoveNodePreservingChildrenCommand.cpp:
* Source/WebCore/editing/RenderedPosition.cpp:
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp:
* Source/WebCore/page/SpatialNavigation.cpp:
* Source/WebCore/xml/XPathPath.cpp:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
* Tools/TestWebKitAPI/Tests/WebCore/HTMLParserIdioms.cpp:

Canonical link: <a href="https://commits.webkit.org/291613@main">https://commits.webkit.org/291613@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b503738fc4bc8260b1ff25560fd06134323a0b72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93422 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98423 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95472 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71380 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28758 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96424 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9932 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51714 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2115 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43262 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79900 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2141 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100454 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80392 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79719 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24253 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1601 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13600 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14978 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25636 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23605 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->