### PR TITLE
Partially revert "Web Inspector: The new ServiceWorkerDebuggableProxy needs to adopt auto inspection"

### DIFF
--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -67,7 +67,7 @@ public:
     void stop(Function<void()>&& terminatedCallback = { });
 
     void startRunningDebuggerTasks();
-    WEBCORE_EXPORT void stopRunningDebuggerTasks();
+    void stopRunningDebuggerTasks();
 
     void suspend();
     void resume();

--- a/Source/WebCore/workers/WorkerRunLoop.h
+++ b/Source/WebCore/workers/WorkerRunLoop.h
@@ -67,7 +67,7 @@ public:
     virtual Type type() const = 0;
 
     void postTask(ScriptExecutionContext::Task&&);
-    WEBCORE_EXPORT void postDebuggerTask(ScriptExecutionContext::Task&&);
+    void postDebuggerTask(ScriptExecutionContext::Task&&);
 
     WEBCORE_EXPORT static String defaultMode();
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.cpp
@@ -51,10 +51,17 @@ ServiceWorkerDebuggable::ServiceWorkerDebuggable(ServiceWorkerThreadProxy& servi
 {
 }
 
-void ServiceWorkerDebuggable::connect(FrontendChannel& channel, bool, bool)
+void ServiceWorkerDebuggable::connect(FrontendChannel& channel, bool isAutomaticInspection, bool immediatelyPause)
 {
-    if (RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get())
+    if (RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get()) {
+#if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
+        serviceWorkerThreadProxy->inspectorProxy().connectToWorker(channel, *this, isAutomaticInspection, immediatelyPause);
+#else
+        UNUSED_PARAM(isAutomaticInspection);
+        UNUSED_PARAM(immediatelyPause);
         serviceWorkerThreadProxy->inspectorProxy().connectToWorker(channel);
+#endif
+    }
 }
 
 void ServiceWorkerDebuggable::disconnect(FrontendChannel& channel)

--- a/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerDebuggable.h
@@ -53,6 +53,8 @@ public:
     void disconnect(Inspector::FrontendChannel&) final;
     void dispatchMessageFromRemote(String&& message) final;
 
+    bool automaticInspectionAllowed() const final { return true; }
+
 private:
     ServiceWorkerDebuggable(ServiceWorkerThreadProxy&, const ServiceWorkerContextData&);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
@@ -74,15 +74,21 @@ void ServiceWorkerInspectorProxy::connectToWorker(FrontendChannel& channel)
 
 #if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
 
-void ServiceWorkerInspectorProxy::connectToWorker(FrontendChannel& channel, bool isAutomaticConnection, bool immediatelyPause, Function<void()>&& frontendInitializedCallback)
+void ServiceWorkerInspectorProxy::connectToWorker(FrontendChannel& channel, ServiceWorkerDebuggable& debuggable, bool isAutomaticConnection, bool immediatelyPause)
 {
     m_channel = &channel;
 
     RefPtr serviceWorkerThreadProxy = m_serviceWorkerThreadProxy.get();
     SWContextManager::singleton().setAsInspected(serviceWorkerThreadProxy->identifier(), true);
+
+    ThreadSafeWeakPtr weakDebuggable = ThreadSafeWeakPtr { debuggable };
     serviceWorkerThreadProxy->thread().runLoop().postDebuggerTask(
-        [isAutomaticConnection, immediatelyPause, frontendInitializedCallback = WTFMove(frontendInitializedCallback)](ScriptExecutionContext& context) mutable {
-            downcast<WorkerGlobalScope>(context).inspectorController().connectFrontend(isAutomaticConnection, immediatelyPause, WTFMove(frontendInitializedCallback));
+        [weakDebuggable, isAutomaticConnection, immediatelyPause](ScriptExecutionContext& context) {
+            Function<void()> handleFrontendInitialized = [weakDebuggable] {
+                if (RefPtr debuggable = weakDebuggable.get())
+                    debuggable->unpauseForInitializedInspector();
+            };
+            downcast<WorkerGlobalScope>(context).inspectorController().connectFrontend(isAutomaticConnection, immediatelyPause, WTFMove(handleFrontendInitialized));
         });
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ServiceWorkerDebuggable.h"
 #include <wtf/Forward.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -52,7 +53,7 @@ public:
 
     WEBCORE_EXPORT void connectToWorker(Inspector::FrontendChannel&);
 #if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
-    WEBCORE_EXPORT void connectToWorker(Inspector::FrontendChannel&, bool isAutomaticConnection, bool immediatelyPause, Function<void()>&& frontendInitializedCallback);
+    WEBCORE_EXPORT void connectToWorker(Inspector::FrontendChannel&, ServiceWorkerDebuggable&, bool isAutomaticConnection = false, bool immediatelyPause = false);
 #endif
     WEBCORE_EXPORT void disconnectFromWorker(Inspector::FrontendChannel&);
     WEBCORE_EXPORT void sendMessageToWorker(String&&);

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -86,8 +86,18 @@ ServiceWorkerThreadProxy::ServiceWorkerThreadProxy(Ref<Page>&& page, ServiceWork
 
 #if ENABLE(REMOTE_INSPECTOR)
     m_remoteDebuggable->init();
+
+#if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
+    thread().runLoop().postDebuggerTask([this, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        callOnMainThread([this, protectedThis] {
+            threadStartedRunningDebuggerTasks();
+        });
+    });
+#else
     m_remoteDebuggable->setInspectable(m_page->inspectable());
-#endif
+#endif // not ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
+
+#endif // not ENABLE(REMOTE_INSPECTOR)
 }
 
 ServiceWorkerThreadProxy::~ServiceWorkerThreadProxy()
@@ -100,6 +110,21 @@ ServiceWorkerThreadProxy::~ServiceWorkerThreadProxy()
 
     m_serviceWorkerThread->clearProxies();
 }
+
+#if ENABLE(REMOTE_INSPECTOR) && ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
+
+void ServiceWorkerThreadProxy::threadStartedRunningDebuggerTasks()
+{
+    m_remoteDebuggable->setInspectable(m_page->inspectable());
+
+    // In case the worker is paused running debugger tasks, ensure we break out of
+    // the pause since this will be the last debugger task we send to the worker.
+    thread().runLoop().postDebuggerTask([this, protectedThis = Ref { *this }](ScriptExecutionContext&) {
+        thread().stopRunningDebuggerTasks();
+    });
+}
+
+#endif
 
 void ServiceWorkerThreadProxy::setLastNavigationWasAppInitiated(bool wasAppInitiated)
 {

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -100,6 +100,10 @@ public:
 
     WEBCORE_EXPORT void setInspectable(bool);
 
+#if ENABLE(REMOTE_INSPECTOR) && ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
+    ServiceWorkerDebuggable& remoteDebuggable() { return m_remoteDebuggable; }
+#endif
+
     uint32_t checkedPtrCount() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCount(); }
     uint32_t checkedPtrCountWithoutThreadCheck() const { return CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::checkedPtrCountWithoutThreadCheck(); }
     void incrementCheckedPtrCount() const { CanMakeThreadSafeCheckedPtr<ServiceWorkerThreadProxy>::incrementCheckedPtrCount(); }
@@ -110,6 +114,10 @@ private:
 
     WEBCORE_EXPORT static void networkStateChanged(bool isOnLine);
     bool postTaskForModeToWorkerOrWorkletGlobalScope(ScriptExecutionContext::Task&&, const String& mode);
+
+#if ENABLE(REMOTE_INSPECTOR) && ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
+    void threadStartedRunningDebuggerTasks();
+#endif
 
     // WorkerLoaderProxy
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -273,22 +273,16 @@ void WebProcessProxy::setupLogStream(uint32_t pid, IPC::StreamServerConnectionHa
 #endif // ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)
 
 #if ENABLE(REMOTE_INSPECTOR)
-void WebProcessProxy::createServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL&& url, CompletionHandler<void(bool)>&& completionHandler)
+void WebProcessProxy::createServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL&& url)
 {
     MESSAGE_CHECK_URL(url);
     RELEASE_LOG(Inspector, "WebProcessProxy::createServiceWorkerDebuggable");
     if (!shouldEnableRemoteInspector())
         return;
     Ref serviceWorkerDebuggableProxy = ServiceWorkerDebuggableProxy::create(url.string(), identifier, *this);
-    m_serviceWorkerDebuggableProxies.add(identifier, serviceWorkerDebuggableProxy);
-    serviceWorkerDebuggableProxy->init();
     serviceWorkerDebuggableProxy->setInspectable(true);
-#if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
-    completionHandler(serviceWorkerDebuggableProxy->wasRequestedToWaitForAutoInspection());
-#else
-    bool shouldWaitForAutomaticInspection = false;
-    completionHandler(shouldWaitForAutomaticInspection);
-#endif
+    serviceWorkerDebuggableProxy->init();
+    m_serviceWorkerDebuggableProxies.add(identifier, serviceWorkerDebuggableProxy);
 }
 
 void WebProcessProxy::deleteServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -677,9 +677,8 @@ private:
 #endif
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
-    void createServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier, URL&&, CompletionHandler<void(bool)>&&);
+    void createServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier, URL&&);
     void deleteServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier);
-    void unpauseServiceWorkerDebuggableForInitializedInspector(WebCore::ServiceWorkerIdentifier);
     void sendMessageToInspector(WebCore::ServiceWorkerIdentifier, String&& message);
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -102,8 +102,8 @@ messages -> WebProcessProxy WantsDispatchMessage {
 #endif
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
-    CreateServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL url) -> (bool shouldPauseAndWaitForAutoInspection) Async
+    CreateServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier, URL url)
     DeleteServiceWorkerDebuggable(WebCore::ServiceWorkerIdentifier identifier)
-    SendMessageToInspector(WebCore::ServiceWorkerIdentifier identifier, String message);
+    SendMessageToInspector(WebCore::ServiceWorkerIdentifier identifier, String message));
 #endif
 }

--- a/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.cpp
+++ b/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.cpp
@@ -30,7 +30,6 @@
 #include "WebProcessProxy.h"
 #include "WebSWContextManagerConnectionMessages.h"
 #include <JavaScriptCore/RemoteConnectionToTarget.h>
-#include <JavaScriptCore/RemoteInspectionTarget.h>
 
 #if ENABLE(REMOTE_INSPECTOR)
 
@@ -54,19 +53,11 @@ ServiceWorkerDebuggableProxy::ServiceWorkerDebuggableProxy(const String& url, We
 {
 }
 
-void ServiceWorkerDebuggableProxy::connect(FrontendChannel& channel, bool isAutomaticConnection, bool immediatelyPause)
+void ServiceWorkerDebuggableProxy::connect(FrontendChannel& channel, bool, bool)
 {
     RELEASE_LOG(Inspector, "ServiceWorkerDebuggableProxy::connect");
-
-#if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
-    // FIXME: Due to this debuggable not actually paused to wait for the inspector, it might not've been in the
-    // RemoteInspector's m_pausedAutomaticInspectionCandidates, which was used to determine the value of
-    // isAutomaticConnection. Handle this in a more elegant way.
-    isAutomaticConnection |= m_wasRequestedToWaitForAutoInspection;
-#endif
-
     if (RefPtr webProcessProxy = m_webProcessProxy.get())
-        webProcessProxy->send(Messages::WebSWContextManagerConnection::ConnectToInspector(m_identifier, isAutomaticConnection, immediatelyPause), 0);
+        webProcessProxy->send(Messages::WebSWContextManagerConnection::ConnectToInspector(m_identifier), 0);
 }
 
 void ServiceWorkerDebuggableProxy::disconnect(FrontendChannel& channel)
@@ -82,17 +73,6 @@ void ServiceWorkerDebuggableProxy::dispatchMessageFromRemote(String&& message)
     if (RefPtr webProcessProxy = m_webProcessProxy.get())
         webProcessProxy->send(Messages::WebSWContextManagerConnection::DispatchMessageFromInspector(m_identifier, WTFMove(message)), 0);
 }
-
-#if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
-void ServiceWorkerDebuggableProxy::pauseWaitingForAutomaticInspection()
-{
-    m_wasRequestedToWaitForAutoInspection = true;
-
-    // This debuggable may live in the UI process, the same process receiving responses from the remote inspector,
-    // so it shouldn't be blocked. Instead, the underlying service worker was already blocked. The web process
-    // will handle the unpausing from this point on.
-}
-#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.h
+++ b/Source/WebKit/WebProcess/Inspector/ServiceWorkerDebuggableProxy.h
@@ -54,24 +54,14 @@ public:
     void disconnect(Inspector::FrontendChannel&) final;
     void dispatchMessageFromRemote(String&& message) final;
 
-#if ENABLE(REMOTE_INSPECTOR_SERVICE_WORKER_AUTO_INSPECTION)
-    bool automaticInspectionAllowed() const final { return true; }
-    void pauseWaitingForAutomaticInspection() final;
-
-    bool wasRequestedToWaitForAutoInspection() const { return m_wasRequestedToWaitForAutoInspection; }
-#endif
-
 private:
     ServiceWorkerDebuggableProxy(const String& url, WebCore::ServiceWorkerIdentifier, WebProcessProxy&);
 
     String m_scopeURL;
     WebCore::ServiceWorkerIdentifier m_identifier;
     WeakPtr<WebProcessProxy> m_webProcessProxy;
-    bool m_wasRequestedToWaitForAutoInspection { false };
 };
 
 } // namespace WebKit
-
-SPECIALIZE_TYPE_TRAITS_CONTROLLABLE_TARGET(WebKit::ServiceWorkerDebuggableProxy, ServiceWorker);
 
 #endif // ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.h
@@ -136,7 +136,7 @@ private:
     void setRegistrationUpdateViaCache(WebCore::ServiceWorkerRegistrationIdentifier, WebCore::ServiceWorkerUpdateViaCache);
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
-    void connectToInspector(WebCore::ServiceWorkerIdentifier, bool isAutomaticConnection, bool immediatelyPause);
+    void connectToInspector(WebCore::ServiceWorkerIdentifier);
     void disconnectFromInspector(WebCore::ServiceWorkerIdentifier);
     void dispatchMessageFromInspector(WebCore::ServiceWorkerIdentifier, String&&);
 #endif

--- a/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
+++ b/Source/WebKit/WebProcess/Storage/WebSWContextManagerConnection.messages.in
@@ -60,7 +60,7 @@ messages -> WebSWContextManagerConnection {
     SetRegistrationUpdateViaCache(WebCore::ServiceWorkerRegistrationIdentifier identifier, enum:uint8_t WebCore::ServiceWorkerUpdateViaCache updateViaCache)
 
 #if ENABLE(REMOTE_INSPECTOR) && PLATFORM(COCOA)
-    ConnectToInspector(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, bool isAutomaticConnection, bool immediatelyPause)
+    ConnectToInspector(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier)
     DisconnectFromInspector(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier)
     DispatchMessageFromInspector(WebCore::ServiceWorkerIdentifier serviceWorkerIdentifier, String message)
 #endif


### PR DESCRIPTION
#### c462fb0e7b200810d1644442f652470a346b1885
<pre>
Partially revert &quot;Web Inspector: The new ServiceWorkerDebuggableProxy needs to adopt auto inspection&quot;
<a href="https://webkit.org/b/289027">https://webkit.org/b/289027</a>
<a href="https://rdar.apple.com/problem/146064991">rdar://problem/146064991</a>

Reviewed by BJ Burg.

This reverts most of commit 50e5a0f85821c2e0ff2373edab9b7f8ce01d997e,
except for the feature flag, leaving it absent from WTF/PlatformEnable.h.

Work reverted:
    Web Inspector: The new ServiceWorkerDebuggableProxy needs to adopt auto inspection
    <a href="https://rdar.apple.com/145795990">rdar://145795990</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=288776">https://bugs.webkit.org/show_bug.cgi?id=288776</a>

Canonical link: <a href="https://commits.webkit.org/291572@main">https://commits.webkit.org/291572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44b12fc84b378cc12a5cf40c86a96716826c580b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2607 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43846 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21334 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96322 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9886 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/51653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9574 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43160 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79860 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/2060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100351 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20372 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79655 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19789 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24198 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25533 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23503 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->