### PR TITLE
Percent-width blocks cannot form a re-layout boundary

### DIFF
--- a/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden-expected.txt
+++ b/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden-expected.txt
@@ -1,0 +1,5 @@
+There should be a blue square below.
+
+
+PASS #root 1
+

--- a/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden.html
+++ b/LayoutTests/fast/css-intrinsic-dimensions/resize-inside-percent-width-overflow-hidden.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<p>There should be a blue square below.</p>
+<div id="root" style="width:fit-content;" data-expected-width="100">
+    <div style="width:100%; height:10em; overflow:hidden;" data-expected-width="100">
+        <div id="child" style="width:20px; height:100px; background:blue;"></div>
+    </div>
+</div>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/check-layout-th.js"></script>
+<script>
+    document.body.offsetTop;
+    document.getElementById("child").style.width = "100px";
+    checkLayout("#root");
+</script>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -4,7 +4,7 @@
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
  *           (C) 2004 Allan Sandfeld Jensen (kde@carewolf.com)
  * Copyright (C) 2004-2024 Apple Inc. All rights reserved.
- * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2009-2017 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  *
  * This library is free software; you can redistribute it and/or
@@ -560,7 +560,7 @@ static inline bool objectIsRelayoutBoundary(const RenderElement* object)
     if (object->document().settings().layerBasedSVGEngineEnabled() && object->isSVGLayerAwareRenderer())
         return false;
 
-    if (object->style().width().isIntrinsicOrAuto() || object->style().height().isIntrinsicOrAuto() || object->style().height().isPercentOrCalculated())
+    if (object->style().width().isIntrinsicOrAuto() || object->style().height().isIntrinsicOrAuto() || object->style().height().isPercentOrCalculated() || object->style().width().isPercentOrCalculated())
         return false;
 
     // Table parts can't be relayout roots since the table is responsible for layouting all the parts.


### PR DESCRIPTION
#### 8fafd9511671ba8d5e5aa08bf850404746b3b0a3
<pre>
Percent-width blocks cannot form a re-layout boundary

<a href="https://bugs.webkit.org/show_bug.cgi?id=247913">https://bugs.webkit.org/show_bug.cgi?id=247913</a>
<a href="https://rdar.apple.com/102577429">rdar://102577429</a>

Reviewed by Alan Baradlay.

This patch is to align Webkit behavior with Blink / Chromium and Gecko / Firefox.

Inspired by (+ Tests): <a href="https://chromium.googlesource.com/chromium/src.git/+/da179e152dff0ab3e3dabc72299bd4fb586881c9">https://chromium.googlesource.com/chromium/src.git/+/da179e152dff0ab3e3dabc72299bd4fb586881c9</a>

A block with non-visible overflow can only form a re-layout boundary if both
width and height are fixed.

The block may be inside a shrink-to-fit container (there&apos;s no cheap and
reliable way to detect that), so that changes inside it may affect its width.

Instead of `isFixed()` checks done in 256901@main, this patch adds missing
check of `width` being PercentOrCalculated.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::objectIsRelayoutBoundary):
of relayout for non-fixed container
* LayoutTests/fast/css-intrinsic-dimension/resize-inside-percent-width-overflow-hidden.html: Added Test Case
* LayoutTests/fast/css-intrinsic-dimension/resize-inside-percent-width-overflow-hidden-expected.txt: Added Test Case Expectations

Canonical link: <a href="https://commits.webkit.org/291607@main">https://commits.webkit.org/291607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ad3e4fa57a7c8f1f519b55c60509c8a650fa362

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43785 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71267 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28667 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9825 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51601 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/1982 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43099 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/1983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100288 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20311 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80286 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79602 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19819 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13426 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20295 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25472 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/19982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23442 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->