### PR TITLE
Address Safer more CPP failures in UIProcess/

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -3,7 +3,6 @@ UIProcess/API/C/mac/WKPagePrivateMac.mm
 UIProcess/API/Cocoa/WKBrowsingContextController.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/WKWebsiteDataStore.mm
-UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/FullScreen/WebFullScreenManager.cpp
 WebProcess/Inspector/WebInspectorInternal.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -2,7 +2,6 @@ UIProcess/API/C/WKContext.cpp
 UIProcess/API/C/WKPage.cpp
 UIProcess/API/Cocoa/WKProcessPool.mm
 UIProcess/API/Cocoa/WKWebViewTesting.mm
-UIProcess/mac/DisplayCaptureSessionManager.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
 WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -155,13 +155,6 @@ UIProcess/Inspector/Agents/InspectorBrowserAgent.cpp
 UIProcess/Inspector/Cocoa/InspectorExtensionDelegate.mm
 UIProcess/Inspector/WebPageInspectorController.cpp
 UIProcess/Inspector/mac/WKInspectorViewController.mm
-UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
-UIProcess/mac/CorrectionPanel.mm
-UIProcess/mac/DisplayCaptureSessionManager.mm
-UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
-UIProcess/mac/WKFullScreenWindowController.mm
-UIProcess/mac/WKImmediateActionController.mm
-UIProcess/mac/WKPrintingView.mm
 UIProcess/mac/WKSharingServicePickerDelegate.mm
 UIProcess/mac/WKTextFinderClient.mm
 UIProcess/mac/WKViewLayoutStrategy.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -25,10 +25,6 @@ UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKDownload.mm
 UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
 UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
-UIProcess/Gamepad/UIGamepadProvider.cpp
-UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp
-UIProcess/mac/DisplayCaptureSessionManager.mm
-UIProcess/mac/WKImmediateActionController.mm
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/Automation/WebAutomationSessionProxy.cpp

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp
@@ -114,8 +114,8 @@ void UIGamepadProvider::platformGamepadConnected(PlatformGamepad& gamepad, Event
 
     scheduleGamepadStateSync();
 
-    for (auto& pool : m_processPoolsUsingGamepads)
-        pool.gamepadConnected(*m_gamepads[gamepad.index()], eventVisibility);
+    for (Ref pool : m_processPoolsUsingGamepads)
+        pool->gamepadConnected(*m_gamepads[gamepad.index()], eventVisibility);
 }
 
 void UIGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
@@ -127,8 +127,8 @@ void UIGamepadProvider::platformGamepadDisconnected(PlatformGamepad& gamepad)
 
     scheduleGamepadStateSync();
 
-    for (auto& pool : m_processPoolsUsingGamepads)
-        pool.gamepadDisconnected(*disconnectedGamepad);
+    for (Ref pool : m_processPoolsUsingGamepads)
+        pool->gamepadDisconnected(*disconnectedGamepad);
 }
 
 void UIGamepadProvider::platformGamepadInputActivity(EventMakesGamepadsVisible eventVisibility)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -635,7 +635,8 @@ void RemoteLayerTreeEventDispatcher::updateAnimations()
     auto now = MonotonicTime::now();
 
     auto effectStacks = std::exchange(m_effectStacks, { });
-    for (auto [layerID, effectStack] : effectStacks) {
+    for (auto [layerID, currentEffectStack] : effectStacks) {
+        Ref effectStack = currentEffectStack;
         effectStack->applyEffectsFromScrollingThread(now);
 
         // We can clear the effect stack if it's empty, but the previous

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -93,7 +93,7 @@ String CorrectionPanel::dismissInternal(ReasonForDismissingAlternativeText reaso
 
 void CorrectionPanel::recordAutocorrectionResponse(WebViewImpl& webViewImpl, NSInteger spellCheckerDocumentTag, NSCorrectionResponse response, const String& replacedString, const String& replacementString)
 {
-    if (webViewImpl.page().sessionID().isEphemeral())
+    if (webViewImpl.protectedPage()->sessionID().isEphemeral())
         return;
 
     [[NSSpellChecker sharedSpellChecker] recordResponse:response toCorrection:replacementString forWord:replacedString language:nil inSpellDocumentWithTag:spellCheckerDocumentTag];

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm
@@ -209,12 +209,12 @@ void DisplayCaptureSessionManager::promptForGetDisplayMedia(UserMediaPermissionR
     }
 
     if (WebCore::ScreenCaptureKitSharingSessionManager::isAvailable()) {
-        if (!page.preferences().useGPUProcessForDisplayCapture()) {
+        if (!page.protectedPreferences()->useGPUProcessForDisplayCapture()) {
             WebCore::ScreenCaptureKitSharingSessionManager::singleton().promptForGetDisplayMedia(toScreenCaptureKitPromptType(promptType), WTFMove(completionHandler));
             return;
         }
 
-        Ref gpuProcess = page.configuration().processPool().ensureGPUProcess();
+        Ref gpuProcess = page.configuration().protectedProcessPool()->ensureGPUProcess();
         gpuProcess->updateSandboxAccess(false, false, true);
         gpuProcess->promptForGetDisplayMedia(toScreenCaptureKitPromptType(promptType), WTFMove(completionHandler));
         return;
@@ -252,12 +252,12 @@ void DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt(WebPageProxy& pag
     if (!isAvailable() || !WebCore::ScreenCaptureKitSharingSessionManager::isAvailable())
         return;
 
-    if (!page.preferences().useGPUProcessForDisplayCapture()) {
+    if (!page.protectedPreferences()->useGPUProcessForDisplayCapture()) {
         WebCore::ScreenCaptureKitSharingSessionManager::singleton().cancelGetDisplayMediaPrompt();
         return;
     }
 
-    auto gpuProcess = page.configuration().processPool().gpuProcess();
+    RefPtr gpuProcess = page.configuration().processPool().gpuProcess();
     if (!gpuProcess)
         return;
 

--- a/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm
@@ -92,7 +92,10 @@ bool UserMediaPermissionRequestProxyMac::canRequestDisplayCapturePermission()
 #if ENABLE(MEDIA_STREAM)
     auto overridePreference = DisplayCaptureSessionManager::singleton().overrideCanRequestDisplayCapturePermissionForTesting();
     RefPtr manager = this->manager();
-    if (!manager || !manager->page() || (!overridePreference && manager->page()->preferences().requireUAGetDisplayMediaPrompt()))
+    if (!manager)
+        return false;
+    RefPtr page = manager->page();
+    if (!page || (!overridePreference && page->protectedPreferences()->requireUAGetDisplayMediaPrompt()))
         return false;
 
     return DisplayCaptureSessionManager::singleton().canRequestDisplayCapturePermission();

--- a/Source/WebKit/UIProcess/mac/WKPrintingView.h
+++ b/Source/WebKit/UIProcess/mac/WKPrintingView.h
@@ -52,7 +52,7 @@ class WebFrameProxy;
     WeakObjCPtr<NSPrintOperation> _printOperation;
     RetainPtr<NSView> _wkView;
 
-    RefPtr<WebKit::WebFrameProxy> _webFrame;
+    const RefPtr<WebKit::WebFrameProxy> _webFrame;
     Vector<WebCore::IntRect> _printingPageRects;
     double _totalScaleFactorForPrinting;
     HashMap<WebCore::IntRect, RefPtr<WebCore::ShareableBitmap>> _pagePreviews;


### PR DESCRIPTION
#### bb658823cf9b5a18c98db4ed188112532a564773
<pre>
Address Safer more CPP failures in UIProcess/
<a href="https://bugs.webkit.org/show_bug.cgi?id=289032">https://bugs.webkit.org/show_bug.cgi?id=289032</a>

Reviewed by Geoffrey Garen and Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.cpp:
(WebKit::UIGamepadProvider::platformGamepadConnected):
(WebKit::UIGamepadProvider::platformGamepadDisconnected):
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.cpp:
(WebKit::ServiceWorkerNotificationHandler::singleton):
(WebKit::ServiceWorkerNotificationHandler::showNotification):
(WebKit::ServiceWorkerNotificationHandler::cancelNotification):
(WebKit::ServiceWorkerNotificationHandler::clearNotifications):
(WebKit::ServiceWorkerNotificationHandler::didDestroyNotification):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):
* Source/WebKit/UIProcess/mac/CorrectionPanel.mm:
(WebKit::CorrectionPanel::recordAutocorrectionResponse):
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.mm:
(WebKit::DisplayCaptureSessionManager::promptForGetDisplayMedia):
(WebKit::DisplayCaptureSessionManager::cancelGetDisplayMediaPrompt):
* Source/WebKit/UIProcess/mac/UserMediaPermissionRequestProxyMac.mm:
(WebKit::UserMediaPermissionRequestProxyMac::canRequestDisplayCapturePermission):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController cancelOperation:]):
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
(-[WKFullScreenWindowController exitFullScreen:]):
(-[WKFullScreenWindowController exitFullScreenImmediately]):
(-[WKFullScreenWindowController requestExitFullScreen]):
(-[WKFullScreenWindowController finishedExitFullScreenAnimationAndExitImmediately:]):
(-[WKFullScreenWindowController completeFinishExitFullScreenAnimation]):
(-[WKFullScreenWindowController _manager]):
(-[WKFullScreenWindowController _videoPresentationManager]):
(-[WKFullScreenWindowController _startExitFullScreenAnimationWithDuration:]):
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _webHitTestResult]):
(-[WKImmediateActionController _defaultAnimationController]):
(-[WKImmediateActionController _animationControllerForDataDetectedText]):
(-[WKImmediateActionController _animationControllerForDataDetectedLink]):
* Source/WebKit/UIProcess/mac/WKPrintingView.h:
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView initWithFrameProxy:view:]):
(-[WKPrintingView _delayedResumeAutodisplayTimerFired]):
(-[WKPrintingView _preparePDFDataForPrintingOnSecondaryThread]):
(-[WKPrintingView _askPageToComputePageRects]):
(-[WKPrintingView _drawPreview:]):

Canonical link: <a href="https://commits.webkit.org/291605@main">https://commits.webkit.org/291605@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4515f26efec70c7136b287a78e1a8ac92e2b0623

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93367 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43893 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71341 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28732 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84453 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51675 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9599 "Found 1 new test failure: imported/w3c/web-platform-tests/svg/struct/scripted/blank.svg (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43207 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79882 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100398 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80362 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20671 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79682 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13544 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14973 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25580 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20090 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21831 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->