### PR TITLE
AX: Add fast path for text marker ordering when one marker is the start of the root web area

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/range-from-webarea-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/range-from-webarea-expected.txt
@@ -1,0 +1,8 @@
+This test verifies the the correct ranges are returned when one of the markers points to a webarea.
+Web area to end of content string: Hello world
+End of content to web area start string: Hello world
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello world

--- a/LayoutTests/accessibility/ax-thread-text-apis/range-from-webarea.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/range-from-webarea.html
@@ -1,0 +1,32 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/accessibility-helper.js"></script>
+</head>
+<body id="body">
+
+<p id="content">
+Hello world
+</p>
+
+<script>
+var output = "This test verifies the the correct ranges are returned when one of the markers points to a webarea.\n";
+
+if (window.accessibilityController) {
+    const webArea = accessibilityController.rootElement.childAtIndex(0);
+    const webAreaRange = webArea.textMarkerRangeForElement(webArea);
+    const webareaStartMarker = webArea.startTextMarkerForTextMarkerRange(webAreaRange);
+
+    const contentMarkerRange = webArea.textMarkerRangeForElement(accessibilityController.accessibleElementById("content").childAtIndex(0));
+    const endOfContentMarker = webArea.endTextMarkerForTextMarkerRange(contentMarkerRange);
+    const webAreaToContentRange = webArea.textMarkerRangeForMarkers(webareaStartMarker, endOfContentMarker);
+    output += `Web area to end of content string: ${webArea.stringForTextMarkerRange(webAreaToContentRange)}\n`;
+
+    const contentToWebAreaRange = webArea.textMarkerRangeForMarkers(endOfContentMarker, webareaStartMarker);
+    output += `End of content to web area start string: ${webArea.stringForTextMarkerRange(webAreaToContentRange)}\n`;
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -732,6 +732,16 @@ bool AXCoreObject::supportsRequiredAttribute() const
     }
 }
 
+bool AXCoreObject::isRootWebArea() const
+{
+    if (roleValue() != AccessibilityRole::WebArea)
+        return false;
+
+    RefPtr parent = parentObject();
+    // If the parent is a scroll area, and the scroll area has no parent, we are at the root web area.
+    return parent && parent->roleValue() == AccessibilityRole::ScrollArea && !parent->parentObject();
+}
+
 bool AXCoreObject::hasPopup() const
 {
     return !equalLettersIgnoringASCIICase(popupValue(), "false"_s);

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -816,6 +816,7 @@ public:
     virtual bool isSecureField() const = 0;
     virtual bool isNativeTextControl() const = 0;
     bool isWebArea() const { return roleValue() == AccessibilityRole::WebArea; }
+    bool isRootWebArea() const;
     bool isCheckbox() const { return roleValue() == AccessibilityRole::Checkbox; }
     bool isRadioButton() const { return roleValue() == AccessibilityRole::RadioButton; }
     bool isListBox() const { return roleValue() == AccessibilityRole::ListBox; }


### PR DESCRIPTION
#### d49d59b1464d5196a8fafae70423b3e9ded4830b
<pre>
AX: Add fast path for text marker ordering when one marker is the start of the root web area
<a href="https://bugs.webkit.org/show_bug.cgi?id=289034">https://bugs.webkit.org/show_bug.cgi?id=289034</a>
<a href="https://rdar.apple.com/146075994">rdar://146075994</a>

Reviewed by Tyler Wilcock.

When we have a text marker at the root web area with offset 0, nothing can come before it.
With this knowledge, we can add a fast path to partialOrderByTraversal, so that we don&apos;t
have to walk the entire AX tree to determine ordering.

* LayoutTests/accessibility/ax-thread-text-apis/range-from-webarea-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/range-from-webarea.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::isRootWebArea const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::partialOrderByTraversal const):

Canonical link: <a href="https://commits.webkit.org/291578@main">https://commits.webkit.org/291578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbb04037a9c3e43fd41ace8a7757dcd42298629f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98305 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21319 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71306 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28703 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84401 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9562 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2033 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43146 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100337 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80327 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80321 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79642 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19792 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13481 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25519 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20029 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->