### PR TITLE
[Wasm] GC Structs should have their backing store allocated by a TrailingArray

### DIFF
--- a/JSTests/wasm/gc/struct-write-barrier.js
+++ b/JSTests/wasm/gc/struct-write-barrier.js
@@ -1,0 +1,35 @@
+// requireOptions("--collectContinuously=1")
+
+import * as assert from "../assert.js";
+import { instantiate } from "./wast-wrapper.js";
+
+let wat = `
+    (module
+        (type $Cell (struct (field i32)))
+        (type $Wrapper (struct (field (mut (ref null $Cell)))))
+
+        (func (export "init") (result (ref $Wrapper))
+            (struct.new_default $Wrapper)
+        )
+
+        (func (export "set") (param (ref $Wrapper) i32)
+            (local.get 0)
+            (struct.new $Cell (local.get 1))
+            (struct.set $Wrapper 0)
+        )
+
+        (func (export "get") (param (ref $Wrapper)) (result (ref null $Cell))
+            (local.get 0)
+            (struct.get $Wrapper 0)
+        )
+    )
+`
+
+let instance = await instantiate(wat, {});
+
+let wrapper = instance.exports.init();
+
+for (let i = 0; i < wasmTestLoopCount; ++i) {
+    instance.exports.set(wrapper, i);
+    instance.exports.get(wrapper);
+}

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -1600,14 +1600,6 @@ PartialResult WARN_UNUSED_RETURN BBQJIT::addArrayInitData(uint32_t dstTypeIndex,
     return { };
 }
 
-void BBQJIT::emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value)
-{
-    m_jit.loadPtr(MacroAssembler::Address(structGPR, JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
-    emitStructPayloadSet(wasmScratchGPR, structType, fieldIndex, value);
-    if (isRefType(structType.field(fieldIndex).type))
-        emitWriteBarrier(structGPR);
-}
-
 PartialResult WARN_UNUSED_RETURN BBQJIT::addRefTest(ExpressionType reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result)
 {
     Vector<Value, 8> arguments = {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1217,9 +1217,8 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayInitData(uint32_t dstTypeIndex, ExpressionType dst, ExpressionType dstOffset, uint32_t srcDataIndex, ExpressionType srcOffset, ExpressionType size);
 
-    void emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value);
-
-    void emitStructPayloadSet(GPRReg payloadGPR, const StructType& structType, uint32_t fieldIndex, Value value);
+    // Returns true if a writeBarrier/mutatorFence is needed.
+    bool WARN_UNUSED_RETURN emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value);
 
     PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t typeIndex, ExpressionType& result);
 

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -838,6 +838,12 @@ struct WasmOrJSImportableFunctionCallLinkInfo final : public WasmOrJSImportableF
     static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(WasmOrJSImportableFunctionCallLinkInfo, callLinkInfo); }
 };
 
+#if ASSERT_ENABLED
+void validateWasmValue(uint64_t wasmValue, Type expectedType);
+#else
+ALWAYS_INLINE void validateWasmValue(uint64_t, Type) { }
+#endif
+
 } } // namespace JSC::Wasm
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp
@@ -991,7 +991,7 @@ private:
 
     void emitArrayNullCheck(Value*, ExceptionType);
     void emitArraySetUnchecked(uint32_t, Value*, Value*, Value*);
-    void emitStructSet(Value*, uint32_t, const StructType&, Value*);
+    bool WARN_UNUSED_RETURN emitStructSet(Value*, uint32_t, const StructType&, Value*);
     ExpressionType WARN_UNUSED_RETURN pushArrayNew(uint32_t typeIndex, Value* initValue, ExpressionType size);
     using ArraySegmentOperation = EncodedJSValue SYSV_ABI (&)(JSC::JSWebAssemblyInstance*, uint32_t, uint32_t, uint32_t, uint32_t);
     ExpressionType WARN_UNUSED_RETURN pushArrayNewFromSegment(ArraySegmentOperation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType);
@@ -3054,28 +3054,27 @@ Value* OMGIRGenerator::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueT
     return sanitizeAtomicResult(op, valueType, result);
 }
 
-void OMGIRGenerator::emitStructSet(Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
+bool OMGIRGenerator::emitStructSet(Value* structValue, uint32_t fieldIndex, const StructType& structType, Value* argument)
 {
     structValue = truncate(structValue); // payload
     auto fieldType = structType.field(fieldIndex).type;
-    Value* payloadBase = append<MemoryValue>(heapTop(), m_proc, memoryKind(Load), pointerType(), origin(), structValue, JSWebAssemblyStruct::offsetOfPayload());
-    int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.offsetOfField(fieldIndex));
+    int32_t fieldOffset = fixupPointerPlusOffset(structValue, JSWebAssemblyStruct::offsetOfData() + structType.offsetOfFieldInPayload(fieldIndex));
 
     if (fieldType.is<PackedType>()) {
         switch (structType.field(fieldIndex).type.as<PackedType>()) {
         case PackedType::I8:
-            append<MemoryValue>(heapTop(), m_proc, memoryKind(Store8), origin(), argument, payloadBase, fieldOffset);
-            return;
+            append<MemoryValue>(heapTop(), m_proc, memoryKind(Store8), origin(), argument, structValue, fieldOffset);
+            return false;
         case PackedType::I16:
-            append<MemoryValue>(heapTop(), m_proc, memoryKind(Store16), origin(), argument, payloadBase, fieldOffset);
-            return;
+            append<MemoryValue>(heapTop(), m_proc, memoryKind(Store16), origin(), argument, structValue, fieldOffset);
+            return false;
         }
     }
 
     ASSERT(fieldType.is<Type>());
-    append<MemoryValue>(heapTop(), m_proc, memoryKind(Store), origin(), argument, payloadBase, fieldOffset);
-    if (isRefType(fieldType.unpacked()))
-        emitWriteBarrier(structValue, instanceValue());
+    append<MemoryValue>(heapTop(), m_proc, memoryKind(Store), origin(), argument, structValue, fieldOffset);
+    // FIXME: We should be able elide this write barrier if we know we're storing jsNull();
+    return isRefType(fieldType.unpacked());
 }
 
 auto OMGIRGenerator::atomicCompareExchange(ExtAtomicOpType op, Type valueType, ExpressionType pointer, ExpressionType expected, ExpressionType value, ExpressionType& result, uint32_t offset) -> PartialResult
@@ -3730,8 +3729,12 @@ auto OMGIRGenerator::addStructNew(uint32_t typeIndex, ArgumentList& args, Expres
     }
 
     const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
+    bool needsWriteBarrier = false;
     for (uint32_t i = 0; i < args.size(); ++i)
-        emitStructSet(structValue, i, structType, get(args[i]));
+        needsWriteBarrier |= emitStructSet(structValue, i, structType, get(args[i]));
+
+    if (needsWriteBarrier)
+        emitWriteBarrier(structValue, instanceValue());
 
     result = push(structValue);
 
@@ -3765,7 +3768,9 @@ auto OMGIRGenerator::addStructNewDefault(uint32_t typeIndex, ExpressionType& res
             initValue = m_currentBlock->appendNew<Const32Value>(m_proc, origin(), 0);
         else
             initValue = m_currentBlock->appendNew<Const64Value>(m_proc, origin(), 0);
-        emitStructSet(structValue, i, structType, initValue);
+        // We know all the values here are not cells so we don't need a writeBarrier.
+        bool needsWriteBarrier = emitStructSet(structValue, i, structType, initValue);
+        UNUSED_VARIABLE(needsWriteBarrier);
     }
 
     result = push(structValue);
@@ -3786,17 +3791,17 @@ auto OMGIRGenerator::addStructGet(ExtGCOpType structGetKind, ExpressionType stru
         });
     }
 
-    Value* payloadBase = append<MemoryValue>(heapTop(), m_proc, memoryKind(Load), pointerType(), origin(), truncate(get(structReference)), JSWebAssemblyStruct::offsetOfPayload());
-    int32_t fieldOffset = fixupPointerPlusOffset(payloadBase, *structType.offsetOfField(fieldIndex));
+    Value* structValue = truncate(get(structReference));
+    int32_t fieldOffset = fixupPointerPlusOffset(structValue, JSWebAssemblyStruct::offsetOfData() + structType.offsetOfFieldInPayload(fieldIndex));
 
     if (fieldType.is<PackedType>()) {
         Value* load;
         switch (fieldType.as<PackedType>()) {
         case PackedType::I8:
-            load = append<MemoryValue>(heapTop(), m_proc, memoryKind(Load8Z), Int32, origin(), payloadBase, fieldOffset);
+            load = append<MemoryValue>(heapTop(), m_proc, memoryKind(Load8Z), Int32, origin(), structValue, fieldOffset);
             break;
         case PackedType::I16:
-            load = append<MemoryValue>(heapTop(), m_proc, memoryKind(Load16Z), Int32, origin(), payloadBase, fieldOffset);
+            load = append<MemoryValue>(heapTop(), m_proc, memoryKind(Load16Z), Int32, origin(), structValue, fieldOffset);
             break;
         }
         Value* postProcess = load;
@@ -3818,7 +3823,7 @@ auto OMGIRGenerator::addStructGet(ExtGCOpType structGetKind, ExpressionType stru
     }
 
     ASSERT(fieldType.is<Type>());
-    result = push<MemoryValue>(heapTop(), m_proc, memoryKind(Load), toB3Type(resultType), origin(), payloadBase, fieldOffset);
+    result = push<MemoryValue>(heapTop(), m_proc, memoryKind(Load), toB3Type(resultType), origin(), structValue, fieldOffset);
 
     return { };
 }
@@ -3833,7 +3838,10 @@ auto OMGIRGenerator::addStructSet(ExpressionType structReference, const StructTy
         });
     }
 
-    emitStructSet(get(structReference), fieldIndex, structType, get(value));
+    Value* structValue = get(structReference);
+    bool needsWriteBarrier = emitStructSet(structValue, fieldIndex, structType, get(value));
+    if (needsWriteBarrier)
+        emitWriteBarrier(structValue, instanceValue());
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1588,15 +1588,6 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmRefFunc, EncodedJSValue, (JSWebAs
     return refFunc(instance, index);
 }
 
-JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmStructNew, EncodedJSValue, (JSWebAssemblyInstance* instance, uint32_t typeIndex, bool useDefault, uint64_t* arguments))
-{
-    CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);
-    assertCalleeIsReferenced(callFrame, instance);
-    VM& vm = instance->vm();
-    NativeCallFrameTracer tracer(vm, callFrame);
-    return structNew(instance, typeIndex, useDefault, arguments);
-}
-
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (JSWebAssemblyInstance* instance, uint32_t typeIndex))
 {
     CallFrame* callFrame = DECLARE_WASM_CALL_FRAME(instance);

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -104,7 +104,6 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationMemoryAtomicNotify, int32_t, (JSWebA
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmMemoryInit, UCPUStrictInt32, (JSWebAssemblyInstance*, unsigned dataSegmentIndex, uint32_t dstAddress, uint32_t srcAddress, uint32_t length));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmDataDrop, void, (JSWebAssemblyInstance*, unsigned dataSegmentIndex));
 
-JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructNew, EncodedJSValue, (JSWebAssemblyInstance*, uint32_t, bool, uint64_t*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructNewEmpty, EncodedJSValue, (JSWebAssemblyInstance*, uint32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructGet, EncodedJSValue, (EncodedJSValue, uint32_t));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationWasmStructSet, void, (JSWebAssemblyInstance*, EncodedJSValue, uint32_t, EncodedJSValue));

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -116,10 +116,8 @@ void StructType::dump(PrintStream& out) const
 {
     out.print("("_s);
     CommaPrinter comma;
-    for (StructFieldCount fieldIndex = 0; fieldIndex < fieldCount(); ++fieldIndex) {
-        out.print(comma, makeString(field(fieldIndex).type));
-        out.print(comma, field(fieldIndex).mutability ? "immutable"_s : "mutable"_s);
-    }
+    for (StructFieldCount fieldIndex = 0; fieldIndex < fieldCount(); ++fieldIndex)
+        out.print(comma, field(fieldIndex).mutability ? "immutable "_s : "mutable "_s, makeString(field(fieldIndex).type));
     out.print(")"_s);
 }
 
@@ -129,8 +127,7 @@ StructType::StructType(void* payload, StructFieldCount fieldCount, const FieldTy
     , m_hasRecursiveReference(false)
 {
     bool hasRecursiveReference = false;
-    // Account for the internal header in m_payload.m_storage.data
-    unsigned currentFieldOffset = FixedVector<uint8_t>::Storage::offsetOfData();
+    unsigned currentFieldOffset = 0;
     for (unsigned fieldIndex = 0; fieldIndex < m_fieldCount; ++fieldIndex) {
         const auto& fieldType = fieldTypes[fieldIndex];
         hasRecursiveReference |= isRefWithRecursiveReference(fieldType.type);
@@ -138,7 +135,7 @@ StructType::StructType(void* payload, StructFieldCount fieldCount, const FieldTy
 
         const auto& fieldStorageType = field(fieldIndex).type;
         currentFieldOffset = WTF::roundUpToMultipleOf(typeAlignmentInBytes(fieldStorageType), currentFieldOffset);
-        *offsetOfField(fieldIndex) = currentFieldOffset;
+        fieldOffsetFromInstancePayload(fieldIndex) = currentFieldOffset;
         currentFieldOffset += typeSizeInBytes(fieldStorageType);
     }
 
@@ -155,8 +152,7 @@ void ArrayType::dump(PrintStream& out) const
 {
     out.print("("_s);
     CommaPrinter comma;
-    out.print(comma, makeString(elementType().type));
-    out.print(comma, elementType().mutability ? "immutable"_s : "mutable"_s);
+    out.print(comma, elementType().mutability ? "immutable "_s : "mutable "_s, makeString(elementType().type));
     out.print(")"_s);
 }
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,22 +31,25 @@
 #include "WasmTypeDefinitionInlines.h"
 #include "WebAssemblyGCObjectBase.h"
 #include <wtf/Ref.h>
+#include <wtf/TrailingArray.h>
 
 namespace JSC {
 
 class JSWebAssemblyInstance;
 
-class JSWebAssemblyStruct final : public WebAssemblyGCObjectBase {
+class JSWebAssemblyStruct final : public WebAssemblyGCObjectBase, private TrailingArray<JSWebAssemblyStruct, uint8_t> {
 public:
     using Base = WebAssemblyGCObjectBase;
+    using TrailingArrayType = TrailingArray<JSWebAssemblyStruct, uint8_t>;
+    friend TrailingArrayType;
     static constexpr DestructionMode needsDestruction = NeedsDestruction;
 
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    static CompleteSubspace* subspaceFor(VM& vm)
     {
-        return vm.webAssemblyStructSpace<mode>();
+        return vm.heap.webAssemblyStructSpace<mode>();
     }
 
     DECLARE_EXPORT_INFO;
@@ -60,14 +63,14 @@ public:
     uint64_t get(uint32_t) const;
     void set(uint32_t, uint64_t);
     void set(uint32_t, v128_t);
-    const Wasm::StructType* structType() const { return m_type->as<Wasm::StructType>(); }
-    Wasm::FieldType fieldType(uint32_t fieldIndex) const { return structType()->field(fieldIndex); }
+    const Wasm::TypeDefinition& typeDefinition() const { return m_type.get(); }
+    const Wasm::StructType& structType() const { return *m_type->as<Wasm::StructType>(); }
+    Wasm::FieldType fieldType(uint32_t fieldIndex) const { return structType().field(fieldIndex); }
 
-    // Returns the offset for m_payload.m_storage
-    static constexpr ptrdiff_t offsetOfPayload() { return OBJECT_OFFSETOF(JSWebAssemblyStruct, m_payload) + FixedVector<uint8_t>::offsetOfStorage(); }
+    uint8_t* fieldPointer(uint32_t fieldIndex) { return &at(structType().offsetOfFieldInPayload(fieldIndex)); }
+    const uint8_t* fieldPointer(uint32_t fieldIndex) const { return const_cast<JSWebAssemblyStruct*>(this)->fieldPointer(fieldIndex); }
 
-    const uint8_t* fieldPointer(uint32_t fieldIndex) const;
-    uint8_t* fieldPointer(uint32_t fieldIndex);
+    using TrailingArrayType::offsetOfData;
 
 protected:
     JSWebAssemblyStruct(VM&, Structure*, Ref<const Wasm::TypeDefinition>&&, RefPtr<const Wasm::RTT>&&);
@@ -76,8 +79,6 @@ protected:
     // FIXME: It is possible to encode the type information in the structure field of Wasm.Struct and remove this field.
     // https://bugs.webkit.org/show_bug.cgi?id=244838
     Ref<const Wasm::TypeDefinition> m_type;
-
-    FixedVector<uint8_t> m_payload;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 70614e20d83803524eb0aad97a9d11cc99a7b4ab
<pre>
[Wasm] GC Structs should have their backing store allocated by a TrailingArray
<a href="https://bugs.webkit.org/show_bug.cgi?id=289031">https://bugs.webkit.org/show_bug.cgi?id=289031</a>
<a href="https://rdar.apple.com/146071849">rdar://146071849</a>

Reviewed by Yusuke Suzuki.

Right now we allocate an out of line backing store for each wasm GC struct. Not only is this an extra
indirection on access but the malloc/free of this buffer is a significant overhead in the benchmark.

This change is about a 40% improvement on that subtest.

To make a trailing array work, wasm GC structs are now allocated out of a CompleteSubspace rather than
an IsoSubspace. This means we currently lose a bit of our Iso-heaping guarantees from the IsoSubspace
but in the future we can improve IsoAlignedMemoryAllocator to work for complete subspaces as well.

I also added a new validateWasmValue to help with future wasm GC debugging. Although, in my case it was
actually a missing write barrier.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::webAssemblyInstanceSpaceSlow): Deleted.
* Source/JavaScriptCore/heap/Heap.h:
(JSC::Heap::webAssemblyInstanceSpace): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructSet): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructPayloadSet): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructNew):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::addStructSet):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitStructPayloadSet): Deleted.
* Source/JavaScriptCore/wasm/WasmFormat.cpp:
(JSC::Wasm::validateWasmValue):
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::validateWasmValue):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):
(JSC::Wasm::OMGIRGenerator::addStructGet):
(JSC::Wasm::OMGIRGenerator::addStructSet):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator32_64.cpp:
(JSC::Wasm::OMGIRGenerator::emitStructSet):
(JSC::Wasm::OMGIRGenerator::addStructNew):
(JSC::Wasm::OMGIRGenerator::addStructNewDefault):
(JSC::Wasm::OMGIRGenerator::addStructGet):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::StructType::dump const):
(JSC::Wasm::StructType::StructType):
(JSC::Wasm::ArrayType::dump const):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:
(JSC::Wasm::StructType::offsetOfFieldInPayload const):
(JSC::Wasm::StructType::fieldOffsetFromInstancePayload):
(JSC::Wasm::StructType::offsetOfField const): Deleted.
(JSC::Wasm::StructType::offsetOfField): Deleted.
(JSC::Wasm::StructType::offsetOfFieldInternal const): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.cpp:
(JSC::JSWebAssemblyStruct::JSWebAssemblyStruct):
(JSC::JSWebAssemblyStruct::create):
(JSC::JSWebAssemblyStruct::visitChildrenImpl):
(JSC::JSWebAssemblyStruct::fieldPointer const): Deleted.
(JSC::JSWebAssemblyStruct::fieldPointer): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyStruct.h:

Canonical link: <a href="https://commits.webkit.org/291579@main">https://commits.webkit.org/291579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5efb4ab080851676db6977933597fc1c98d9081d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93334 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12892 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43860 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21348 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71323 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96336 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/9891 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51656 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43174 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86044 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2071 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100365 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92000 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20386 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80343 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80344 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79661 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19791 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/24206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25547 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114650 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20057 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->