### PR TITLE
Web Inspector: improve performance of `WI.OpenResourceDialog`

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
+++ b/Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js
@@ -130,11 +130,10 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
             return treeElement;
         }
 
+        console.assert(!this._treeOutline.children.length, this._treeOutline);
+
         for (let result of this._filteredResults) {
             let resource = result.resource;
-            if (this._treeOutline.findTreeElement(resource))
-                continue;
-
             let treeElement = createTreeElement(resource);
             if (!treeElement)
                 continue;
@@ -217,8 +216,6 @@ WI.OpenResourceDialog = class OpenResourceDialog extends WI.Dialog
 
         for (let consoleSnippet of WI.consoleManager.snippets)
             this._addResource(consoleSnippet);
-
-        this._updateFilterThrottler.force();
 
         this._inputElement.focus();
         this._clear();


### PR DESCRIPTION
#### a2b69f499e169dacc4ed01f1b698290a257c143c
<pre>
Web Inspector: improve performance of `WI.OpenResourceDialog`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289036">https://bugs.webkit.org/show_bug.cgi?id=289036</a>

Reviewed by BJ Burg.

These were discovered while debugging a website with a large number of resources (e.g. &gt;10,000).

* Source/WebInspectorUI/UserInterface/Views/OpenResourceDialog.js:
(WI.OpenResourceDialog.prototype._populateResourceTreeOutline):
(WI.OpenResourceDialog.prototype.didPresentDialog):
The caller will already `WI.TreeOutline.prototype.removeChildren` so there&apos;s no need to check `WI.TreeOutline.prototype.findTreeElement`, especially since `WI.ResourceQueryController` shouldn&apos;t ever give the same `WI.Resource` more than once.
Also remove duplicate `Throttler.prototype.force` as it&apos;s already called by `WI.OpenResourceDialog.prototype._clear`.

* Source/WebInspectorUI/UserInterface/Views/TreeOutline.js:
(WI.TreeOutline):
(WI.TreeOutline.prototype.appendChild):
(WI.TreeOutline.prototype.insertChild):
(WI.TreeOutline.prototype.removeChildAtIndex):
(WI.TreeOutline.prototype.removeChildren):
(WI.TreeOutline.prototype._rememberTreeElementAndDescendants): Renamed from `_rememberTreeElement`.
(WI.TreeOutline.prototype._forgetTreeElementAndDescendants): Renamed from `_forgetTreeElement`.
(WI.TreeOutline.prototype.getCachedTreeElement):
(WI.TreeOutline.prototype._forgetChildrenRecursive): Deleted.
Use a `Multimap` instead of an object of arrays as that should be faster to insert/remove `WI.TreeElement`.
Don&apos;t call `Debouncer.prototype.delayForFrame` for each child that&apos;s added/removed as we only need to do it once for the overall operation.

Drive-by: remove unused `_cachedNumberOfDescendants`.
Canonical link: <a href="https://commits.webkit.org/291998@main">https://commits.webkit.org/291998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11c949eb95027bca70b5a93066c3511dca40b81f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14265 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99696 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45168 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14540 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22685 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29518 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97678 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52551 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44508 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101738 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21704 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81213 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80596 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20112 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/126/builds/25153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14921 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21683 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/21349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/24816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->