### PR TITLE
Address Safer CPP failures in WebCore/Modules/indexeddb/server

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp
@@ -92,7 +92,7 @@ IDBError MemoryIDBBackingStore::beginTransaction(const IDBTransactionInfo& info)
     } else if (transaction->isWriting()) {
         for (auto& iterator : m_objectStoresByName) {
             if (info.objectStores().contains(iterator.key))
-                transaction->addExistingObjectStore(*iterator.value);
+                transaction->addExistingObjectStore(Ref { *iterator.value });
         }
     }
 
@@ -185,7 +185,7 @@ IDBError MemoryIDBBackingStore::renameObjectStore(const IDBResourceIdentifier& t
     ASSERT(transaction);
     ASSERT(transaction->isVersionChange());
 
-    auto objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     ASSERT(objectStore);
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError };
@@ -213,7 +213,7 @@ IDBError MemoryIDBBackingStore::clearObjectStore(const IDBResourceIdentifier& tr
     ASSERT_UNUSED(transaction, transaction->isWriting());
 #endif
 
-    auto objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError };
 
@@ -239,7 +239,7 @@ IDBError MemoryIDBBackingStore::deleteIndex(const IDBResourceIdentifier& transac
     ASSERT(rawTransaction);
     ASSERT(rawTransaction->isVersionChange());
 
-    auto* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError };
 
@@ -267,7 +267,7 @@ IDBError MemoryIDBBackingStore::renameIndex(const IDBResourceIdentifier& transac
     ASSERT(transaction);
     ASSERT(transaction->isVersionChange());
 
-    auto objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     ASSERT(objectStore);
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError };
@@ -319,7 +319,7 @@ IDBError MemoryIDBBackingStore::keyExistsInObjectStore(const IDBResourceIdentifi
 {
     LOG(IndexedDB, "MemoryIDBBackingStore::keyExistsInObjectStore");
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     RELEASE_ASSERT(objectStore);
 
     keyExists = objectStore->containsRecord(keyData);
@@ -333,7 +333,7 @@ IDBError MemoryIDBBackingStore::deleteRange(const IDBResourceIdentifier& transac
     if (!m_transactions.contains(transactionIdentifier))
         return IDBError { ExceptionCode::UnknownError, "No backing store transaction found to delete from"_s };
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore)
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
@@ -349,7 +349,7 @@ IDBError MemoryIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
     if (!transaction)
         return IDBError { ExceptionCode::UnknownError, "No backing store transaction found to put record"_s };
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreInfo.identifier());
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreInfo.identifier());
     if (!objectStore)
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found to put record"_s };
 
@@ -363,7 +363,7 @@ IDBError MemoryIDBBackingStore::getRecord(const IDBResourceIdentifier& transacti
     if (!m_transactions.contains(transactionIdentifier))
         return IDBError { ExceptionCode::UnknownError, "No backing store transaction found to get record"_s };
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore)
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
@@ -411,7 +411,7 @@ IDBError MemoryIDBBackingStore::getIndexRecord(const IDBResourceIdentifier& tran
     if (!m_transactions.contains(transactionIdentifier))
         return IDBError { ExceptionCode::UnknownError, "No backing store transaction found to get record"_s };
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore)
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
@@ -426,7 +426,7 @@ IDBError MemoryIDBBackingStore::getCount(const IDBResourceIdentifier& transactio
     if (!m_transactions.contains(transactionIdentifier))
         return IDBError { ExceptionCode::UnknownError, "No backing store transaction found to get count"_s };
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore)
         return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
@@ -441,7 +441,7 @@ IDBError MemoryIDBBackingStore::generateKeyNumber(const IDBResourceIdentifier& t
     ASSERT_UNUSED(transactionIdentifier, m_transactions.contains(transactionIdentifier));
     ASSERT_UNUSED(transactionIdentifier, m_transactions.get(transactionIdentifier)->isWriting());
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     RELEASE_ASSERT(objectStore);
 
     keyNumber = objectStore->currentKeyGeneratorValue();
@@ -459,7 +459,7 @@ IDBError MemoryIDBBackingStore::revertGeneratedKeyNumber(const IDBResourceIdenti
     ASSERT_UNUSED(transactionIdentifier, m_transactions.contains(transactionIdentifier));
     ASSERT_UNUSED(transactionIdentifier, m_transactions.get(transactionIdentifier)->isWriting());
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     RELEASE_ASSERT(objectStore);
 
     objectStore->setKeyGeneratorValue(keyNumber);
@@ -473,7 +473,7 @@ IDBError MemoryIDBBackingStore::maybeUpdateKeyGeneratorNumber(const IDBResourceI
     ASSERT_UNUSED(transactionIdentifier, m_transactions.contains(transactionIdentifier));
     ASSERT_UNUSED(transactionIdentifier, m_transactions.get(transactionIdentifier)->isWriting());
 
-    MemoryObjectStore* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     RELEASE_ASSERT(objectStore);
 
     if (newKeyNumber < objectStore->currentKeyGeneratorValue())
@@ -519,7 +519,7 @@ IDBError MemoryIDBBackingStore::openCursor(const IDBResourceIdentifier& transact
         break;
     }
     case IndexedDB::CursorSource::Index:
-        auto* objectStore = m_objectStoresByIdentifier.get(info.objectStoreIdentifier());
+        RefPtr objectStore = m_objectStoresByIdentifier.get(info.objectStoreIdentifier());
         if (!objectStore)
             return IDBError { ExceptionCode::UnknownError, "No backing store object store found"_s };
 
@@ -616,7 +616,7 @@ IDBError MemoryIDBBackingStore::addIndex(const IDBResourceIdentifier& transactio
     if (!transaction || !transaction->isVersionChange())
         return IDBError { ExceptionCode::UnknownError, "Transaction is not in version change mode."_s };
 
-    auto* objectStore = m_objectStoresByIdentifier.get(indexInfo.objectStoreIdentifier());
+    RefPtr objectStore = m_objectStoresByIdentifier.get(indexInfo.objectStoreIdentifier());
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError, "Object store does not exist in backing store."_s };
 
@@ -646,7 +646,7 @@ void MemoryIDBBackingStore::revertAddIndex(const IDBResourceIdentifier& transact
     if (!rawTransaction || !rawTransaction->isVersionChange())
         return;
 
-    auto* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (objectStore)
         objectStoreInfo->deleteIndex(indexIdentifier);
 
@@ -660,7 +660,7 @@ IDBError MemoryIDBBackingStore::updateIndexRecordsWithIndexKey(const IDBResource
     if (!transaction || !transaction->isVersionChange())
         return IDBError { ExceptionCode::UnknownError, "Transaction is not in version change mode."_s };
 
-    auto* objectStore = m_objectStoresByIdentifier.get(indexInfo.objectStoreIdentifier());
+    RefPtr objectStore = m_objectStoresByIdentifier.get(indexInfo.objectStoreIdentifier());
     if (!objectStore)
         return IDBError { ExceptionCode::ConstraintError, "Object store does not exist in backing store."_s };
 
@@ -679,7 +679,7 @@ void MemoryIDBBackingStore::forEachObjectStoreRecord(const IDBResourceIdentifier
         return;
     }
 
-    auto* objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
+    RefPtr objectStore = m_objectStoresByIdentifier.get(objectStoreIdentifier);
     if (!objectStore) {
         IDBError error { ExceptionCode::ConstraintError, "Object store does not exist in backing store."_s };
         apply(makeUnexpected(WTFMove(error)));

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp
@@ -53,11 +53,6 @@ MemoryIndex::MemoryIndex(const IDBIndexInfo& info, MemoryObjectStore& objectStor
 
 MemoryIndex::~MemoryIndex() = default;
 
-WeakPtr<MemoryObjectStore> MemoryIndex::objectStore()
-{
-    return m_objectStore;
-}
-
 RefPtr<MemoryObjectStore> MemoryIndex::protectedObjectStore()
 {
     return m_objectStore.get();
@@ -124,7 +119,8 @@ IDBGetResult MemoryIndex::getResultForKeyRange(IndexedDB::IndexRecordType type, 
     if (!keyValue)
         return { };
 
-    return type == IndexedDB::IndexRecordType::Key ? IDBGetResult(*keyValue) : IDBGetResult(*keyValue, m_objectStore->valueForKeyRange(*keyValue), m_objectStore->info().keyPath());
+    RefPtr objectStore = m_objectStore.get();
+    return type == IndexedDB::IndexRecordType::Key ? IDBGetResult(*keyValue) : IDBGetResult(*keyValue, objectStore->valueForKeyRange(*keyValue), objectStore->info().keyPath());
 }
 
 uint64_t MemoryIndex::countForKeyRange(const IDBKeyRangeData& inRange)
@@ -154,7 +150,8 @@ void MemoryIndex::getAllRecords(const IDBKeyRangeData& keyRangeData, std::option
 {
     LOG(IndexedDB, "MemoryIndex::getAllRecords");
 
-    result = { type, m_objectStore->info().keyPath() };
+    RefPtr objectStore = m_objectStore.get();
+    result = { type, objectStore->info().keyPath() };
 
     if (!m_records)
         return;
@@ -179,7 +176,7 @@ void MemoryIndex::getAllRecords(const IDBKeyRangeData& keyRangeData, std::option
         for (auto& keyValue : allValues) {
             result.addKey(IDBKeyData(keyValue));
             if (type == IndexedDB::GetAllType::Values)
-                result.addValue(m_objectStore->valueForKeyRange(keyValue));
+                result.addValue(objectStore->valueForKeyRange(keyValue));
         }
 
         currentCount += allValues.size();

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -83,7 +83,7 @@ public:
 
     IndexValueStore* valueStore() { return m_records.get(); }
 
-    WeakPtr<MemoryObjectStore> objectStore();
+    MemoryObjectStore* objectStore() { return m_objectStore.get(); }
     RefPtr<MemoryObjectStore> protectedObjectStore();
 
     void cursorDidBecomeClean(MemoryIndexCursor&);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -91,7 +91,7 @@ private:
 
     WeakPtr<UniqueIDBDatabase> m_database;
     WeakPtr<UniqueIDBDatabaseManager> m_manager;
-    Ref<IDBConnectionToClient> m_connectionToClient;
+    const Ref<IDBConnectionToClient> m_connectionToClient;
     IDBResourceIdentifier m_openRequestIdentifier;
 
     bool m_closePending { false };

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -95,10 +95,6 @@ Modules/indexeddb/IDBTransaction.cpp
 Modules/indexeddb/client/IDBConnectionProxy.cpp
 Modules/indexeddb/client/IDBConnectionToServer.cpp
 Modules/indexeddb/client/TransactionOperation.h
-Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp
-Modules/indexeddb/server/MemoryIDBBackingStore.cpp
-Modules/indexeddb/server/MemoryIndex.cpp
-Modules/indexeddb/server/UniqueIDBDatabaseConnection.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediarecorder/MediaRecorder.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -25,7 +25,6 @@ Modules/indexeddb/IDBObjectStore.cpp
 Modules/indexeddb/IDBTransaction.cpp
 Modules/indexeddb/WindowOrWorkerGlobalScopeIndexedDatabase.cpp
 Modules/indexeddb/client/IDBConnectionProxy.cpp
-Modules/indexeddb/server/MemoryIDBBackingStore.cpp
 Modules/mediacapabilities/MediaCapabilities.cpp
 Modules/mediacontrols/MediaControlsHost.cpp
 Modules/mediarecorder/MediaRecorder.cpp


### PR DESCRIPTION
#### 8d22725db7d0e5cb8de208c864a426fdb36e1964
<pre>
Address Safer CPP failures in WebCore/Modules/indexeddb/server
<a href="https://bugs.webkit.org/show_bug.cgi?id=289069">https://bugs.webkit.org/show_bug.cgi?id=289069</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/Modules/indexeddb/server/MemoryBackingStoreTransaction.cpp:
(WebCore::IDBServer::MemoryBackingStoreTransaction::abort):
* Source/WebCore/Modules/indexeddb/server/MemoryIDBBackingStore.cpp:
(WebCore::IDBServer::MemoryIDBBackingStore::beginTransaction):
(WebCore::IDBServer::MemoryIDBBackingStore::renameObjectStore):
(WebCore::IDBServer::MemoryIDBBackingStore::clearObjectStore):
(WebCore::IDBServer::MemoryIDBBackingStore::deleteIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::renameIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::keyExistsInObjectStore):
(WebCore::IDBServer::MemoryIDBBackingStore::deleteRange):
(WebCore::IDBServer::MemoryIDBBackingStore::addRecord):
(WebCore::IDBServer::MemoryIDBBackingStore::getRecord):
(WebCore::IDBServer::MemoryIDBBackingStore::getIndexRecord):
(WebCore::IDBServer::MemoryIDBBackingStore::getCount):
(WebCore::IDBServer::MemoryIDBBackingStore::generateKeyNumber):
(WebCore::IDBServer::MemoryIDBBackingStore::revertGeneratedKeyNumber):
(WebCore::IDBServer::MemoryIDBBackingStore::maybeUpdateKeyGeneratorNumber):
(WebCore::IDBServer::MemoryIDBBackingStore::openCursor):
(WebCore::IDBServer::MemoryIDBBackingStore::addIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::revertAddIndex):
(WebCore::IDBServer::MemoryIDBBackingStore::updateIndexRecordsWithIndexKey):
(WebCore::IDBServer::MemoryIDBBackingStore::forEachObjectStoreRecord):
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.cpp:
(WebCore::IDBServer::MemoryIndex::getResultForKeyRange const):
(WebCore::IDBServer::MemoryIndex::getAllRecords const):
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/291609@main">https://commits.webkit.org/291609@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4348bd02d3ce4e3de6d9ae9565354579d3fe40b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93358 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2646 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71335 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28726 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84447 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51669 "Found 1 new API test failure: /WPE/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2077 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43198 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100482 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80366 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79733 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13535 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14976 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20394 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25571 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23541 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->