### PR TITLE
Web Inspector: REGRESSION(290430@main): Assertion Failed at CallingContextTreeNode.js:76

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js
@@ -49,6 +49,7 @@ WI.HeapAllocationsTimelineRecord = class HeapAllocationsTimelineRecord extends W
         return await new Promise((resolve, reject) => {
             let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
             workerProxy.createImportedSnapshot(snapshotStringData, title, ({objectId, snapshot: serializedSnapshot}) => {
+                // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
                 const target = null;
                 let snapshot = WI.HeapSnapshotProxy.deserialize(target, objectId, serializedSnapshot);
                 snapshot.snapshotStringData = snapshotStringData;
@@ -59,6 +60,8 @@ WI.HeapAllocationsTimelineRecord = class HeapAllocationsTimelineRecord extends W
 
     toJSON()
     {
+        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
+
         return {
             type: this.type,
             timestamp: this._timestamp,

--- a/Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js
@@ -49,12 +49,15 @@ WI.ScriptTimelineRecord = class ScriptTimelineRecord extends WI.TimelineRecord
 
     static async fromJSON(json)
     {
-        let {eventType, startTime, endTime, stackTrace, sourceCodeLocation, details, profilePayload, target, extraDetails} = json;
+        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
+        let target = WI.assumingMainTarget();
+
+        let {eventType, startTime, endTime, stackTrace, sourceCodeLocation, details, profilePayload, extraDetails} = json;
 
         if (typeof details === "object" && details.__type === "GarbageCollection")
             details = WI.GarbageCollection.fromJSON(details);
 
-        return new WI.ScriptTimelineRecord(eventType, startTime, endTime, {stackTrace, sourceCodeLocation, details, profilePayload, target, extraDetails});
+        return new WI.ScriptTimelineRecord(target, eventType, startTime, endTime, {stackTrace, sourceCodeLocation, details, profilePayload, target, extraDetails});
     }
 
     toJSON()
@@ -62,7 +65,7 @@ WI.ScriptTimelineRecord = class ScriptTimelineRecord extends WI.TimelineRecord
         // FIXME: stackTrace
         // FIXME: sourceCodeLocation
         // FIXME: profilePayload
-        // FIXME: target
+        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
 
         return {
             type: this.type,

--- a/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
+++ b/Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js
@@ -71,7 +71,8 @@ WI.TimelineRecording = class TimelineRecording extends WI.Object
 
     static async import(identifier, json, displayName)
     {
-        const target = WI.assumingMainTarget();
+        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
+        let target = WI.assumingMainTarget();
 
         let {startTime, endTime, discontinuities, instrumentTypes, records, markers, memoryPressureEvents, sampleStackTraces, sampleDurations} = json;
         let importedDisplayName = WI.UIString("Imported - %s").format(displayName);

--- a/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
+++ b/Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js
@@ -66,6 +66,7 @@ WI.HeapSnapshotWorkerProxy = class HeapSnapshotWorkerProxy extends WI.Object
 
     createImportedSnapshot(snapshotStringData, title, callback)
     {
+        // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
         const targetId = null;
         this.performAction("createSnapshot", targetId, snapshotStringData, title, callback);
     }

--- a/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js
@@ -409,6 +409,7 @@ WI.HeapAllocationsTimelineView = class HeapAllocationsTimelineView extends WI.Ti
             let snapshotStringData = result.text;
             let workerProxy = WI.HeapSnapshotWorkerProxy.singleton();
             workerProxy.createImportedSnapshot(snapshotStringData, result.filename, ({objectId, snapshot: serializedSnapshot}) => {
+                // FIXME: <https://webkit.org/b/287738> support exporting and importing data from worker targets
                 const target = null;
                 let snapshot = WI.HeapSnapshotProxy.deserialize(target, objectId, serializedSnapshot);
                 snapshot.snapshotStringData = snapshotStringData;


### PR DESCRIPTION
#### b2348a683116e9a05cdebd4663c4baa1385ba26e
<pre>
Web Inspector: REGRESSION(290430@main): Assertion Failed at CallingContextTreeNode.js:76
<a href="https://bugs.webkit.org/show_bug.cgi?id=289070">https://bugs.webkit.org/show_bug.cgi?id=289070</a>

Reviewed by BJ Burg.

* Source/WebInspectorUI/UserInterface/Models/ScriptTimelineRecord.js:
(WI.ScriptTimelineRecord.async fromJSON):
(WI.ScriptTimelineRecord.prototype.toJSON):
It&apos;s no longer allowed to not have a `target` after 290430@main.

* Source/WebInspectorUI/UserInterface/Models/HeapAllocationsTimelineRecord.js:
(WI.HeapAllocationsTimelineRecord.async fromJSON):
(WI.HeapAllocationsTimelineRecord.prototype.toJSON):
* Source/WebInspectorUI/UserInterface/Models/TimelineRecording.js:
(WI.TimelineRecording.async import):
* Source/WebInspectorUI/UserInterface/Proxies/HeapSnapshotWorkerProxy.js:
(WI.HeapSnapshotWorkerProxy.prototype.createImportedSnapshot):
* Source/WebInspectorUI/UserInterface/Views/HeapAllocationsTimelineView.js:
(WI.HeapAllocationsTimelineView.prototype._importButtonNavigationItemClicked):

Drive-by: add extra FIXME comments for supporting `Worker` targets when exporting/importing timeline recordings.
Canonical link: <a href="https://commits.webkit.org/291997@main">https://commits.webkit.org/291997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1275403080ce5bb2cafc1d6f34dc4df22de737d1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12836 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98277 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43804 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71278 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28674 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84390 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51612 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2022 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43118 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79820 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100307 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20330 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14875 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80298 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20582 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80310 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79614 "Found 1 new API test failure: /WebKitGTK/TestCookieManager:/webkit/WebKitCookieManager/replace-get-all-cookies (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20111 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24161 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13445 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20314 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25491 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21742 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->