### PR TITLE
REGRESSION(291425@main): Broke TestWebKitAPI.WebKit.FindTextInImageOverlay, TestWebKitAPI.ResourceLoadStatistics.StorageAccessPromptSiteWithTrigger on Debug

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -98,7 +98,6 @@ enum class SDKAlignedBehavior {
     SessionCleanupByDefault,
     SharedNetworkProcess,
     SiteSpecificQuirksAreEnabledByDefault,
-    SkipsSerializedScriptValueRoundtripOfJavaScriptEvaluationResults,
     SnapshotAfterScreenUpdates,
     SupportsDeviceOrientationAndMotionPermissionAPI,
     SupportsInitConstructors,

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -38,7 +38,6 @@
 #include <WebCore/ExceptionDetails.h>
 #include <WebCore/SerializedScriptValue.h>
 #include <wtf/RunLoop.h>
-#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 
 namespace WebKit {
 
@@ -224,15 +223,12 @@ static RetainPtr<id> convertToObjC(JSGlobalContextRef context, JSValueRef value)
 
 Expected<JavaScriptEvaluationResult, std::optional<WebCore::ExceptionDetails>> JavaScriptEvaluationResult::extract(JSGlobalContextRef context, JSValueRef value)
 {
-    if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SkipsSerializedScriptValueRoundtripOfJavaScriptEvaluationResults)) {
-        JSRetainPtr deserializationContext = API::SerializedScriptValue::deserializationContext();
-        auto result = roundTripThroughSerializedScriptValue(context, deserializationContext.get(), value);
-        if (!result)
-            return makeUnexpected(std::nullopt);
-        return JavaScriptEvaluationResult { deserializationContext.get(), *result };
-    }
+    JSRetainPtr deserializationContext = API::SerializedScriptValue::deserializationContext();
 
-    return JavaScriptEvaluationResult { context, value };
+    auto result = roundTripThroughSerializedScriptValue(context, deserializationContext.get(), value);
+    if (!result)
+        return makeUnexpected(std::nullopt);
+    return { JavaScriptEvaluationResult { deserializationContext.get(), *result } };
 }
 
 static bool isSerializable(id argument)

--- a/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
@@ -62,11 +62,7 @@ TEST(WebKit, EvaluateJavaScriptThatThrowsAnException)
 
 static void didCreateBlob(WKTypeRef result, WKErrorRef error, void* context)
 {
-#if PLATFORM(COCOA)
-    EXPECT_EQ(WKGetTypeID(result), WKDictionaryGetTypeID());
-#else
     EXPECT_NULL(result);
-#endif
     testDone = true;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm
@@ -82,8 +82,10 @@ TEST(WKWebView, EvaluateJavaScriptErrorCases)
     [webView _test_waitForDidFinishNavigation];
 
     [webView evaluateJavaScript:@"document.body" completionHandler:^(id result, NSError *error) {
-        EXPECT_TRUE([result isKindOfClass:NSDictionary.class]);
-        EXPECT_NULL(error);
+        EXPECT_NULL(result);
+        EXPECT_WK_STREQ(@"WKErrorDomain", [error domain]);
+        EXPECT_EQ(WKErrorJavaScriptResultTypeIsUnsupported, [error code]);
+
         isDone = true;
     }];
 
@@ -920,19 +922,10 @@ TEST(EvaluateJavaScript, ReturnTypes)
     "(function(){return {"
     "    blob: new Blob(['Hello']),\n"
     "}})()";
-    NSDictionary *expectedBlob = @{
-        @"arrayBuffer" : @{ },
-        @"bytes" : @{ },
-        @"size" : @5,
-        @"slice" : @{ },
-        @"stream" : @{ },
-        @"text" : @{ },
-        @"type" : @"",
-    };
     [webView evaluateJavaScript:jsWithBlob completionHandler:^(id value, NSError *error) {
         EXPECT_FALSE(error);
         NSDictionary *dict = (NSDictionary *)value;
-        EXPECT_TRUE([[dict objectForKey:@"blob"] isEqual:expectedBlob]);
+        EXPECT_EQ([dict objectForKey:@"blob"], [NSNull null]);
     }];
 
     NSString *jsWithNestedObjects = @""
@@ -1000,7 +993,7 @@ TEST(EvaluateJavaScript, ReturnTypes)
     "aDouble: 3.14,\n"
     "file: new File(['content'], 'file.txt', { type: 'text/plain' }),\n"
     "fileList: new DataTransfer().files,\n"
-    "imageData: new ImageData(2, 2),\n"
+    "imageData: new ImageData(100, 100),\n"
     "emptyString: '',\n"
     "arrayBuffer: new ArrayBuffer(8),\n"
     "arrayBufferView: new Uint8Array(this.arrayBuffer),\n"
@@ -1043,38 +1036,11 @@ TEST(EvaluateJavaScript, ReturnTypes)
         EXPECT_TRUE([regex isKindOfClass:[NSDictionary class]]); // Converted to empty dictionary
         EXPECT_EQ([regex count], 0u);
 
-        EXPECT_TRUE([[dict objectForKey:@"blob"] isEqual:expectedBlob]);
+        EXPECT_EQ([dict objectForKey:@"blob"], [NSNull null]); // Converted to null
         EXPECT_TRUE([[dict objectForKey:@"aDouble"] isKindOfClass:[NSNumber class]]);
         EXPECT_TRUE([[dict objectForKey:@"zero"] isKindOfClass:[NSNumber class]]);
-
-        NSDictionary *expectedImageData = @{
-            @"colorSpace" : @"srgb",
-            @"height" : @2,
-            @"width" : @2,
-            @"data" : @{
-                @"0" : @0, @"1" : @0, @"2" : @0, @"3" : @0,
-                @"4" : @0, @"5" : @0, @"6" : @0, @"7" : @0,
-                @"8" : @0, @"9" : @0, @"10" : @0, @"11" : @0,
-                @"12" : @0, @"13" : @0, @"14" : @0, @"15" : @0
-            }
-        };
-        EXPECT_TRUE([[dict objectForKey:@"imageData"] isEqual:expectedImageData]);
-
-        RetainPtr<NSMutableDictionary> fileWithLastModifiedRemoved = adoptNS([[dict objectForKey:@"file"] mutableCopy]);
-        [fileWithLastModifiedRemoved removeObjectForKey:@"lastModified"]; // Nondeterministic value.
-        NSDictionary *expectedFileObject = @{
-            @"arrayBuffer" : @{ },
-            @"bytes" : @{ },
-            @"name" : @"file.txt",
-            @"size" : @7,
-            @"slice" : @{ },
-            @"stream" : @{ },
-            @"text" : @{ },
-            @"type" : @"text/plain",
-            @"webkitRelativePath" : @""
-        };
-        EXPECT_TRUE([fileWithLastModifiedRemoved isEqual:expectedFileObject]);
-
+        EXPECT_EQ([dict objectForKey:@"imageData"], [NSNull null]); // Converted to null
+        EXPECT_EQ([dict objectForKey:@"file"], [NSNull null]); // Converted to null
         NSDictionary* arrayBufferView = [dict objectForKey:@"arrayBufferView"];
         EXPECT_TRUE([arrayBufferView isKindOfClass:[NSDictionary class]]);
         EXPECT_EQ([arrayBufferView count], 0u);
@@ -1099,11 +1065,7 @@ TEST(EvaluateJavaScript, ReturnTypes)
         EXPECT_TRUE([aSet isKindOfClass:[NSDictionary class]]);
         EXPECT_EQ([aSet count], 0u);
 
-        NSDictionary *expectedFileList = @{
-            @"item" : @{ },
-            @"length" : @0,
-        };
-        EXPECT_TRUE([[dict objectForKey:@"fileList"] isEqual:expectedFileList]);
+        EXPECT_EQ([dict objectForKey:@"fileList"], [NSNull null]); // Converted to null
         NSString *emptyString = [dict objectForKey:@"emptyString"];
         EXPECT_TRUE([emptyString isKindOfClass:[NSString class]]);
         if ([emptyString isKindOfClass:[NSString class]])


### PR DESCRIPTION
#### 58ec39cb62b3308b97cc8aeb9a2053a5f2d1ab76
<pre>
REGRESSION(291425@main): Broke TestWebKitAPI.WebKit.FindTextInImageOverlay, TestWebKitAPI.ResourceLoadStatistics.StorageAccessPromptSiteWithTrigger on Debug
<a href="https://rdar.apple.com/146036731">rdar://146036731</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=288983">https://bugs.webkit.org/show_bug.cgi?id=288983</a>

Reviewed by Per Arne Vollan and Basuke Suzuki.

In 291425@main we disabled the roundtrip to SerializedScriptValue, which helps filter out unsupported objects. It turns
out some tests still need the filtering (the tests return Node after executing script). To fix the tests for now, revert
291425@main.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::extract):
* Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp:
(TestWebKitAPI::didCreateBlob):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptErrorCases)):
(ReturnTypes)):

Canonical link: <a href="https://commits.webkit.org/291600@main">https://commits.webkit.org/291600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eabefd8a92ca6fdf62553c3b5959f69229778c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98329 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43855 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71321 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28716 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51654 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2053 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43169 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86039 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100360 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/91995 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80342 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79660 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19808 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1543 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13506 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25542 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114645 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20052 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33062 "Found 288 new JSC stress test failures: microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate, microbenchmarks/memcpy-wasm-large.js.eager-jettison-no-cjit, microbenchmarks/memcpy-wasm-large.js.mini-mode, microbenchmarks/memcpy-wasm-large.js.no-cjit-collect-continuously, microbenchmarks/memcpy-wasm-large.js.no-cjit-validate-phases, microbenchmarks/memcpy-wasm-large.js.no-llint ... (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23512 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->