### PR TITLE
"Response served by service worker has redirections" may appear with NVIDIA GeForce NOW

### DIFF
--- a/LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache-worker.js
+++ b/LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache-worker.js
@@ -1,0 +1,13 @@
+onfetch = e => {
+    e.respondWith(new Promise((resolve, reject) => {
+        e.preloadResponse.then(response => { 
+            if (response) {
+                resolve(response);
+                return;
+            }
+            fetch(e.request).then(resolve, reject);
+        }, () => {
+            fetch(e.request).then(resolve, reject);
+        });
+    }));
+}

--- a/LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache.https-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache.https-expected.txt
@@ -1,0 +1,7 @@
+
+
+PASS Unregister service worker if needed
+PASS Navigate to iframe with a redirection URL - final URL is cached
+PASS Setup activating worker
+PASS Navigate to cached final URL directly
+

--- a/LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache.https.html
+++ b/LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache.https.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/common/utils.js"></script>
+<script src="resources/routines.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+var url = new URL("/WebKit/service-workers/resources/", location);
+url = url.toString();
+const urlFinal = url + "cached-after-redirection.html";
+const urlInitial = url + "redirect-to-cached-after-redirection.py";
+
+promise_test(async (test) => {
+    const registration = await navigator.serviceWorker.getRegistration(url);
+    if (registration)
+        registration.unregister();
+}, "Unregister service worker if needed");
+
+promise_test(async (test) => {
+    const iframe = await withIframe(urlInitial);
+    //iframe.remove();
+}, "Navigate to iframe with a redirection URL - final URL is cached");
+
+promise_test(async (test) => {
+    const registration = await navigator.serviceWorker.register("/WebKit/service-workers/redirect-flag-navigation-cache-worker.js", { scope : url });
+    const activeWorker = registration.installing;
+    await waitForState(activeWorker, "activated");
+    await registration.navigationPreload.enable();
+}, "Setup activating worker");
+
+promise_test(async (test) => {
+    const iframe = await withIframe(urlFinal);
+    assert_equals(iframe.contentDocument.body.innerHTML.trim(), "PASS");
+    //iframe.remove();
+}, "Navigate to cached final URL directly");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/resources/cached-after-redirection.html
+++ b/LayoutTests/http/wpt/service-workers/resources/cached-after-redirection.html
@@ -1,0 +1,3 @@
+<html>
+<body>PASS</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/resources/cached-after-redirection.html.headers
+++ b/LayoutTests/http/wpt/service-workers/resources/cached-after-redirection.html.headers
@@ -1,0 +1,1 @@
+Cache-Control: public, must-revalidate, max-age=3600

--- a/LayoutTests/http/wpt/service-workers/resources/redirect-to-cached-after-redirection.py
+++ b/LayoutTests/http/wpt/service-workers/resources/redirect-to-cached-after-redirection.py
@@ -1,0 +1,8 @@
+from wptserve.utils import isomorphic_decode
+
+
+def main(request, response):
+    headers = []
+    headers.append((b"Location", b"/WebKit/service-workers/resources/cached-after-redirection.html"))
+
+    return 302, headers, b""

--- a/Source/WebCore/workers/service/FetchEvent.cpp
+++ b/Source/WebCore/workers/service/FetchEvent.cpp
@@ -170,6 +170,8 @@ FetchEvent::PreloadResponsePromise& FetchEvent::preloadResponse(ScriptExecutionC
 
 void FetchEvent::navigationPreloadIsReady(ResourceResponse&& response)
 {
+    ASSERT(!response.isRedirected());
+
     auto* globalObject = m_handled->globalObject();
     auto* context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
     if (!context)

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp
@@ -181,6 +181,7 @@ void ServiceWorkerNavigationPreloader::didReceiveResponse(ResourceResponse&& res
     }
 
     m_response = WTFMove(response);
+    m_response.setRedirected(false);
     m_responseCompletionHandler = WTFMove(completionHandler);
 
     if (auto callback = std::exchange(m_responseCallback, { }))


### PR DESCRIPTION
#### 84bc127d4e4a6b2975f108cb4a962f36fd315341
<pre>
&quot;Response served by service worker has redirections&quot; may appear with NVIDIA GeForce NOW
<a href="https://rdar.apple.com/144571433">rdar://144571433</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289080">https://bugs.webkit.org/show_bug.cgi?id=289080</a>

Reviewed by Brady Eidson.

When navigation preloader uses the disk cache, it may retrieve a response that was fetched via a redirection. Its isRedirected flag will be set to true.
Given navigation preloader retrieved this value from the cache without redirection, we need to set the flag to false.

Otherwise, later during loading, the navigation preload response would fail security checks.

* LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache-worker.js: Added.
(onfetch.e.e.respondWith.new.Promise):
* LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache.https-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/redirect-flag-navigation-cache.https.html: Added.
* LayoutTests/http/wpt/service-workers/resources/cached-after-redirection.html: Added.
* LayoutTests/http/wpt/service-workers/resources/cached-after-redirection.html.headers: Added.
* LayoutTests/http/wpt/service-workers/resources/redirect-to-cached-after-redirection.py: Added.
(main):
* Source/WebCore/workers/service/FetchEvent.cpp:
(WebCore::FetchEvent::navigationPreloadIsReady):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerNavigationPreloader.cpp:
(WebKit::ServiceWorkerNavigationPreloader::didReceiveResponse):

Canonical link: <a href="https://commits.webkit.org/291561@main">https://commits.webkit.org/291561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d8769a34308d5a32b388f6c986ad189532b80f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93299 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12857 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43825 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95349 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71298 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28693 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51631 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2021 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43139 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79839 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100329 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20351 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14894 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79635 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13473 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20335 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25512 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20022 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->