### PR TITLE
[WGSL] Nested array types are not packed correctly

### DIFF
--- a/LayoutTests/fast/webgpu/nocrash/fuzz-145584310-expected.txt
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-145584310-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: promises created
+CONSOLE MESSAGE: the end
+CONSOLE MESSAGE: fuzz-145584310.html
+

--- a/LayoutTests/fast/webgpu/nocrash/fuzz-145584310.html
+++ b/LayoutTests/fast/webgpu/nocrash/fuzz-145584310.html
@@ -1,0 +1,182 @@
+<style>
+  :root { background: #102030e0; color: #99ddbbcc; font-size: 15px; }
+</style>
+<script id="shared">
+const log = console.log;
+
+</script>
+<script>
+globalThis.testRunner?.waitUntilDone();
+
+async function window0() {
+let adapter0 = await navigator.gpu.requestAdapter();
+let device0 = await adapter0.requestDevice({
+  defaultQueue: {},
+  requiredFeatures: [
+    'depth-clip-control',
+    'depth32float-stencil8',
+    'texture-compression-astc',
+    'indirect-first-instance',
+    'shader-f16',
+    'rg11b10ufloat-renderable',
+    'bgra8unorm-storage',
+    'timestamp-query',
+  ],
+  requiredLimits: {
+    maxStorageTexturesPerShaderStage: 4,
+    maxTextureDimension1D: 8192,
+    maxUniformBufferBindingSize: 2710603,
+    maxStorageBufferBindingSize: 156398292,
+  },
+});
+// START
+b = device0.createShaderModule({
+  code : ` 
+                    @group(0) @binding(231) var<storage, read_write> c: array<array<S0, 2> >;
+                    struct S0 {
+                   d: vec3u,   e: u32}
+                    @group(0) @binding(239) var<storage> f: array<array<array<vec2i, 1>, 12> >;
+                    fn g(v: u32) -> u32 {
+                 return v;
+                 }
+                    @compute @workgroup_size(1) fn h() 
+                   {
+                for (var i=c[6076][g(806475)].d[1];
+              i<u32(f[0][g(100753173)][0].r) ;
+              ) {}
+                }
+                   `
+})
+j = device0.createTexture({
+  size : [ 4, 4, 13 ],
+  format : 'bgra8unorm',
+  usage : GPUTextureUsage.TEXTURE_BINDING
+})
+k = j.createView({dimension : 'cube'})
+l = device0.createBindGroupLayout({
+  entries : [
+    {
+      binding : 0,
+      visibility : GPUShaderStage.VERTEX,
+      texture : {viewDimension : 'cube'}
+    },
+    {
+      binding : 1,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 3,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage'}
+    },
+    {
+      binding : 220,
+      visibility : GPUShaderStage.FRAGMENT,
+      buffer : {type : 'storage', hasDynamicOffset : true}
+    },
+    {
+      binding : 231,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'storage'}
+    },
+    {
+      binding : 239,
+      visibility : GPUShaderStage.COMPUTE,
+      buffer : {type : 'read-only-storage'}
+    }
+  ]
+})
+m = device0.createPipelineLayout({bindGroupLayouts : [ l ]})
+n = device0.createCommandEncoder()
+o = device0.createComputePipeline({layout : m, compute : {module : b}})
+p = n.beginComputePass()
+try {
+  p.setPipeline(o)
+} catch {
+}
+q = device0.createBuffer({size : 72, usage : GPUBufferUsage.STORAGE})
+s = device0.createBuffer({size : 40, usage : GPUBufferUsage.STORAGE})
+buffer44 = device0.createBuffer({size : 284, usage : GPUBufferUsage.STORAGE})
+buffer48 = device0.createBuffer({size : 60, usage : GPUBufferUsage.STORAGE})
+t = device0.createBuffer({size : 088, usage : GPUBufferUsage.STORAGE})
+bindGroup9 = device0.createBindGroup({
+  layout : l,
+  entries : [
+    {binding : 3, resource : {buffer : buffer48}},
+    {binding : 239, resource : {buffer : buffer44}},
+    {binding : 1, resource : {buffer : s}},
+    {binding : 231, resource : {buffer : t}}, {binding : 0, resource : k},
+    {binding : 220, resource : {buffer : q}}
+  ]
+})
+try {
+  p.setBindGroup(0, bindGroup9, [ 0, 0 ])
+} catch {
+}
+try {
+  p.dispatchWorkgroups(1)
+} catch {
+}
+try {
+  p.end()
+} catch {
+}
+u = n.finish()
+try {
+  device0.queue.submit([ u ])
+} catch {
+}
+// END
+await device0.queue.onSubmittedWorkDone();
+}
+
+onload = async () => {
+  try {
+  let sharedScript = document.querySelector('#shared').textContent;
+
+  let workers = [
+
+  ];
+  let promises = [ window0() ];
+  log('promises created');
+  let results = await Promise.allSettled(promises);
+  for (let result of results) {
+    if (result.status === 'rejected') { throw result.reason; }
+  }
+  log('the end')
+  log(location);
+  } catch (e) {
+    log('error');
+    log(e);
+    log(e[Symbol.toStringTag]);
+    log(e.stack);
+    if (e instanceof GPUPipelineError) {
+      log(`${e} - ${e.reason}`);
+      
+    } else if (e instanceof DOMException) {
+      if (e.name === 'OperationError') {
+      log(e.message);
+      
+      } else if (e.name === 'InvalidStateError') {
+      } else {
+        log(e);
+        
+      }
+    } else if (e instanceof GPUValidationError) {
+      
+    } else if (e instanceof GPUOutOfMemoryError) {
+      
+    } else if (e instanceof TypeError) {
+      log(e);
+      
+    } else {
+      log('unexpected error type');
+      log(e);
+      
+    }
+  }
+  globalThis.testRunner?.dumpAsText();
+  globalThis.testRunner?.notifyDone();
+};
+</script>

--- a/Source/WebGPU/WGSL/tests/valid/array-vec3.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/array-vec3.wgsl
@@ -6,6 +6,7 @@
 fn main() -> @builtin(position) vec4f {
   {
     let x = un[0].x;
+    let xy = un[0].xy;
     let y = un[0][1];
     un[0].x = x;
     un[0][1] = y;
@@ -14,6 +15,7 @@ fn main() -> @builtin(position) vec4f {
   {
     var v = un[0];
     let x = v.x;
+    let xy = v.xy;
     let y = v[1];
     v.x = x;
     v[1] = y;
@@ -22,6 +24,7 @@ fn main() -> @builtin(position) vec4f {
   {
     let v = &un[0];
     let x = v.x;
+    let xy = v.xy;
     let y = v[1];
     v.x = x;
     v[1] = y;


### PR DESCRIPTION
#### 24dad92a328381c12020352cdc88040a7ce90ec7
<pre>
[WGSL] Nested array types are not packed correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=288558">https://bugs.webkit.org/show_bug.cgi?id=288558</a>
<a href="https://rdar.apple.com/145584310">rdar://145584310</a>

Reviewed by Mike Wyrzykowski.

This originally landed in 291162@main, but hit an existing bug where we didn&apos;t
correctly unpack vec3&apos;s inside arrays. The fix is to unpack the base of a field
access when it is a vector.

The logic for packing array types in the GlobalVariableRewriter didn&apos;t
handle nested array types, so types like `array&lt;array&lt;T&gt;&gt;` wouldn&apos;t be
packed, even if `T` required packing. The code could also easily be
simplified by removing the custom logic under `packArrayType` and using
the generic `packType` function instead, which makes it correctly handle
the nested types.

* LayoutTests/fast/webgpu/nocrash/fuzz-145584310-expected.txt: Added.
* LayoutTests/fast/webgpu/nocrash/fuzz-145584310.html: Added.
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::packArrayResource):
(WGSL::RewriteGlobalVariables::packType):
(WGSL::RewriteGlobalVariables::packArrayType):

Canonical link: <a href="https://commits.webkit.org/291791@main">https://commits.webkit.org/291791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/821dc90cd1e23e41bbf3977ce06b468c34da0570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44507 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21997 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71713 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29063 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10294 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84882 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52053 "Found 1 new API test failure: /WPE/TestSSL:/webkit/WebKitWebView/ephemeral-tls-errors (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2543 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43823 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80229 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101029 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15323 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80084 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19958 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24631 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14192 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26194 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20703 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22444 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->