### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/view-timeline-dynamic.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt
@@ -1,4 +1,3 @@
-CONSOLE MESSAGE: Error: assert_equals: expected "1px" but got "100px"
 
 FAIL Multiple style/layout passes occur when necessary assert_equals: expected 100 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Dynamically changing view-timeline attachment assert_equals: ambiguous expected "-1" but got "75"
+PASS Dynamically changing view-timeline attachment
 PASS Dynamically changing view-timeline-axis
 PASS Dynamically changing view-timeline-inset
 PASS Element with scoped view-timeline becoming display:none


### PR DESCRIPTION
#### e1f5a7186f60055bb8e4b682556d73d2576c412e
<pre>
[scroll-animations] WPT test `scroll-animations/css/view-timeline-dynamic.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=289084">https://bugs.webkit.org/show_bug.cgi?id=289084</a>

Reviewed by Anne van Kesteren.

The reason we were failing the first test in the WPT test `scroll-animations/css/view-timeline-dynamic.html` was that
when a CSS Animation&apos;s timeline was changed to an inactive timeline (due to multiple possible timelines within the scope
defined by a parent element using the `timeline-scope` property) we would fail to mark that animation&apos;s target as dirty
and the timeline change would thus not be observable through the computed style.

To that end, we now catch the case where `StyleOriginatedTimelinesController::attachAnimation()` would yield an inactive
timeline due to a conflict related to `timeline-scope`, and keep that animation in `m_cssAnimationsPendingAttachment`
such that it will be re-considered at the end of the style update in `documentDidResolveStyle()`. At that juncture,
the timeline attachment will be re-considered and the target marked as dirty if necessary.

However, this fix alone changed the result of the &quot;Animations prefer non-deferred timelines&quot; test in the WPT test
`scroll-animations/css/timeline-scope.html`. Indeed, the reason we passed that test was precisely because of our old
behavior where we failed to mark style as dirty in case `timeline-scope` conflict would yield an inactive timeline.

To keep a passing result for this test we ensure that if we get into such a conflict, we still consider the current
element for a non-deferred timeline (ie. one that doesn&apos;t require `timeline-scope` to be in scope for this animation
target).

Those combined changes also progressed a part of `css/scroll-timeline-multi-pass.tentative.html` which no longer
logs an assertion failure through the console.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-multi-pass.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-dynamic-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
(WebCore::StyleOriginatedTimelinesController::attachAnimation):

Canonical link: <a href="https://commits.webkit.org/291574@main">https://commits.webkit.org/291574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a60a2fcfeda20158f291e368f571c724a50f5b4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21320 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71307 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9873 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84399 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2031 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43147 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79849 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100338 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80328 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20611 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79643 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24187 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1520 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13482 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14941 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25520 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->