### PR TITLE
[scroll-animations] WPT test `scroll-animations/css/scroll-timeline-dynamic.tentative.html` is a failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt
@@ -11,6 +11,6 @@ PASS Reverse animation direction [immediate]
 PASS Reverse animation direction [scroll]
 PASS Change to timeline attachment while paused [immediate]
 PASS Change to timeline attachment while paused [scroll]
-FAIL Switching timelines and pausing at the same time [immediate] assert_equals: expected "100px" but got "120px"
-FAIL Switching timelines and pausing at the same time [scroll] assert_equals: expected "100px" but got "120px"
+PASS Switching timelines and pausing at the same time [immediate]
+PASS Switching timelines and pausing at the same time [scroll]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html
@@ -257,10 +257,11 @@
     element.style.animationTimeline = '--timeline';
     element.style.animationPlayState = 'paused';
 
-    // Pausing should happen before the timeline is modified. (Tentative).
+    // Pausing should happen after the timeline was modified.
     // https://github.com/w3c/csswg-drafts/issues/5653
-    await assert_width(element, '100px');
+    await assert_width(element, '120px');
 
+    // Changing the play state should not change the animation current time.
     element.style.animationPlayState = 'running';
     await assert_width(element, '120px');
   }, 'Switching timelines and pausing at the same time');

--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -65,6 +65,12 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
 
     suspendEffectInvalidation();
 
+    // https://drafts.csswg.org/css-animations-2/#animation-timeline
+    // When multiple animation-* properties are set simultaneously, animation-timeline
+    // is updated first, so e.g. a change to animation-play-state applies to the
+    // simultaneously-applied timeline specified in animation-timeline.
+    syncStyleOriginatedTimeline();
+
     auto& animation = backingAnimation();
     auto* animationEffect = effect();
 
@@ -121,8 +127,6 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
         if (auto* keyframeEffect = dynamicDowncast<KeyframeEffect>(animationEffect))
             keyframeEffect->setComposite(animation.compositeOperation());
     }
-
-    syncStyleOriginatedTimeline();
 
     if (!m_overriddenProperties.contains(Property::RangeStart))
         setRangeStart(animation.range().start);


### PR DESCRIPTION
#### 75314a097510458122c6aa7b3814b3d6c5feb90d
<pre>
[scroll-animations] WPT test `scroll-animations/css/scroll-timeline-dynamic.tentative.html` is a failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=289085">https://bugs.webkit.org/show_bug.cgi?id=289085</a>

Reviewed by Anne van Kesteren.

The failing subtests in `scroll-animations/css/scroll-timeline-dynamic.tentative.html` were created 5 years ago
and with the assumption that setting both `animation-play-state` and `animation-timeline` at once would first
set the play state, and then the timeline. However, the spec issue that the test refers to [0] has since been
addressed and the CSS Animations Level 2 specification now clearly says it&apos;s the opposite [1]:

    When multiple animation-* properties are set simultaneously, animation-timeline is updated first,
    so e.g. a change to animation-play-state applies to the simultaneously-applied timeline specified
    in animation-timeline.

As a result we modify the WPT test to be in line with the current spec.

Additionally, we add this spec text as a comment in the relevant implementation code and ensure to match it
by placing the call to `syncStyleOriginatedTimeline()` up front under `CSSAnimation::syncPropertiesWithBackingAnimation()`.
Note that this doesn&apos;t change behavior since it was already called prior to handling `animation-play-state`
and the other properties that were handled prior to it had no bearing on the behavior of the procedure
to set the timeline.

[0] <a href="https://github.com/w3c/csswg-drafts/issues/5653">https://github.com/w3c/csswg-drafts/issues/5653</a>
[1] <a href="https://drafts.csswg.org/css-animations-2/#animation-timeline">https://drafts.csswg.org/css-animations-2/#animation-timeline</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-dynamic.tentative.html:
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):

Canonical link: <a href="https://commits.webkit.org/291573@main">https://commits.webkit.org/291573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7365b18280a7d2229c75a18a1b061334d6a8769

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93311 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43837 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71309 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28704 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51642 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9566 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2037 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43151 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100342 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14907 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80330 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79645 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24193 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1526 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13487 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14940 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25524 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20034 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21775 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->