### PR TITLE
REGRESSION(289248@main?): Null LocalFrame dereference during render tree teardown

### DIFF
--- a/Source/WebCore/loader/NavigationDisabler.h
+++ b/Source/WebCore/loader/NavigationDisabler.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include "LocalFrame.h"
-#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
@@ -64,7 +63,7 @@ public:
     }
 
 private:
-    WeakPtr<LocalFrame> m_frame;
+    RefPtr<LocalFrame> m_frame;
 
     static unsigned s_globalNavigationDisableCount;
 };


### PR DESCRIPTION
#### e4ba0ad28c51e91d397e62fd09fce24e84203a7e
<pre>
REGRESSION(289248@main?): Null LocalFrame dereference during render tree teardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=289096">https://bugs.webkit.org/show_bug.cgi?id=289096</a>
<a href="https://rdar.apple.com/145408212">rdar://145408212</a>

Reviewed by Simon Fraser.

Crash data indicates that dereferencing a null LocalFrame during render tree teardown has recently become
more likely. All crashes occur beneath Document::willBeRemovedFromFrame, which constructs a
NavigationDisabler that previously held a RefPtr to LocalFrame but, after 289248@main, now holds a
WeakPtr. Revert it to a RefPtr to speculatively fix this crash.

* Source/WebCore/loader/NavigationDisabler.h:

Canonical link: <a href="https://commits.webkit.org/291590@main">https://commits.webkit.org/291590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de5f8a9c54f90ca88e024f6263dc1145be142717

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21353 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71326 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28718 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96341 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9897 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51659 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9586 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2058 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43179 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2074 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100370 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/14929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80348 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20643 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79666 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1548 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13516 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20375 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25552 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20062 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->