### PR TITLE
REGRESSION (287742@main): RTL text sometimes changes direction while typing

### DIFF
--- a/LayoutTests/editing/input/typing-does-not-change-rtl-text-direction-expected.html
+++ b/LayoutTests/editing/input/typing-does-not-change-rtl-text-direction-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <p>Hello العربية world test</p>
+    </body>
+</html>

--- a/LayoutTests/editing/input/typing-does-not-change-rtl-text-direction.html
+++ b/LayoutTests/editing/input/typing-does-not-change-rtl-text-direction.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+        <p inputmode="none" contenteditable>Hello العربية world</p>
+        <script>
+            let editor = document.querySelector("p[contenteditable]");
+            editor.focus();
+            getSelection().setPosition(editor, 1);
+            document.execCommand("InsertText", true, " test");
+            editor.blur();
+        </script>
+    </body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -555,11 +555,12 @@ bool TextUtil::containsStrongDirectionalityText(StringView text)
                 return SIMD::bitNot(SIMD::bitOr(cond0, cond1, cond2, cond3));
             };
 
+            auto finalStride = span.last(stride);
             auto result = SIMD::splat<UnsignedType>(0);
-            for (; span.size() < stride; skip(span, stride))
+            for (; stride < span.size(); skip(span, stride))
                 result = SIMD::bitOr(result, maybeBidiRTL(span));
             if (!span.empty())
-                result = SIMD::bitOr(result, maybeBidiRTL(span.last(stride)));
+                result = SIMD::bitOr(result, maybeBidiRTL(finalStride));
             return SIMD::isNonZero(result);
         }
 


### PR DESCRIPTION
#### 9ce32acb6e979de9b512540b3ced40d093d78e8f
<pre>
REGRESSION (287742@main): RTL text sometimes changes direction while typing
<a href="https://bugs.webkit.org/show_bug.cgi?id=289102">https://bugs.webkit.org/show_bug.cgi?id=289102</a>
<a href="https://rdar.apple.com/146084533">rdar://146084533</a>

Reviewed by Abrar Rahman Protyasha and Alan Baradlay.

This patch fixes a subtle bug in `TextUtil::containsStrongDirectionalityText` — this helper uses
SIMD to iterate through a string buffer by a fixed stride length (i.e. 4), in order to quickly rule
out the presence of bidi RTL text in a 16-bit string. After scanning through all of the full SIMD
strides, we then do one final pass over the final stride in the span. However, after the changes in
<a href="https://commits.webkit.org/287742@main">https://commits.webkit.org/287742@main</a>, we now bail *immediately* from the main SIMD for-loop
because `span.size() &lt; stride`. Since we never modify `span` in the for loop, we end up only looking
at the last 4 `UChar`s in the string buffer, which has the effect of RTL text flipping direction as
the user types, (seeming) at random.

To fix this, we:

1.  Invert the condition of the for loop, such that we iterate if `stride &lt; span.size()`.

2.  Store a `span` to the final stride before iterating through the loop, such that we safely check
    the last 4 characters in the buffer against `maybeBidiRTL`.

As an alternative, I considered checking the final stride (`span.last(stride)`) before entering the
for loop if `(span.size() % stride)` is non-zero, but decided against this, in favor of preserving
memory locality (i.e. only iterating forwards, from start to end, through the string buffer instad
of jumping from end to start to end).

* LayoutTests/editing/input/typing-does-not-change-rtl-text-direction-expected.html: Added.
* LayoutTests/editing/input/typing-does-not-change-rtl-text-direction.html: Added.

Add a test to exercise the fix.

* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::containsStrongDirectionalityText):

See above for more details.

Canonical link: <a href="https://commits.webkit.org/291602@main">https://commits.webkit.org/291602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14f1d12633a3140f0602b39325c27b7788258970

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93361 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98361 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43887 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71337 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28727 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51671 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2068 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43201 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79884 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100392 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20413 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14939 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80356 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20665 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80357 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79676 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24222 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20397 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25574 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23544 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->