### PR TITLE
CRASH in VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -158,55 +158,59 @@ void VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing()
         return;
     }
 
-    RetainPtr pipPlacard = adoptNS([PAL::allocUIViewInstance() initWithFrame:[layerHostView() bounds]]);
-    [pipPlacard setBackgroundColor:blackUIColor()];
-    [pipPlacard setTranslatesAutoresizingMaskIntoConstraints:NO];
+    @try {
+        RetainPtr pipPlacard = adoptNS([PAL::allocUIViewInstance() initWithFrame:[layerHostView() bounds]]);
+        [pipPlacard setBackgroundColor:blackUIColor()];
+        [pipPlacard setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-    RetainPtr image = [[[PAL::getUIImageClass() systemImageNamed:@"pip"] imageWithTintColor:greyUIColor() renderingMode:UIImageRenderingModeAlwaysOriginal] imageWithConfiguration:[PAL::getUIImageSymbolConfigurationClass() configurationWithWeight:UIImageSymbolWeightThin]];
+        RetainPtr image = [[[PAL::getUIImageClass() systemImageNamed:@"pip"] imageWithTintColor:greyUIColor() renderingMode:UIImageRenderingModeAlwaysOriginal] imageWithConfiguration:[PAL::getUIImageSymbolConfigurationClass() configurationWithWeight:UIImageSymbolWeightThin]];
 
-    RetainPtr imageView = adoptNS([PAL::allocUIImageViewInstance() initWithImage:image.get()]);
-    [imageView setContentMode:UIViewContentModeScaleAspectFit];
-    [imageView setTranslatesAutoresizingMaskIntoConstraints:NO];
+        RetainPtr imageView = adoptNS([PAL::allocUIImageViewInstance() initWithImage:image.get()]);
+        [imageView setContentMode:UIViewContentModeScaleAspectFit];
+        [imageView setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-    [pipPlacard addSubview:imageView.get()];
+        [pipPlacard addSubview:imageView.get()];
 
-    auto pipLabel = adoptNS([PAL::allocUILabelInstance() init]);
-    [pipLabel setText:@"This video is playing in picture in picture."];
-    [pipLabel setTextAlignment:NSTextAlignmentCenter];
-    [pipLabel setTextColor:greyUIColor()];
-    [pipLabel setFont:[PAL::getUIFontClass() systemFontOfSize:16]];
-    [pipLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
+        auto pipLabel = adoptNS([PAL::allocUILabelInstance() init]);
+        [pipLabel setText:@"This video is playing in picture in picture."];
+        [pipLabel setTextAlignment:NSTextAlignmentCenter];
+        [pipLabel setTextColor:greyUIColor()];
+        [pipLabel setFont:[PAL::getUIFontClass() systemFontOfSize:16]];
+        [pipLabel setTranslatesAutoresizingMaskIntoConstraints:NO];
 
-    [pipPlacard addSubview:pipLabel.get()];
+        [pipPlacard addSubview:pipLabel.get()];
 
-    [NSLayoutConstraint activateConstraints:@[
-        [[imageView widthAnchor] constraintEqualToConstant:[image size].width * 8],
-        [[imageView heightAnchor] constraintEqualToConstant:[image size].height * 8],
-        [[imageView centerXAnchor] constraintEqualToAnchor:[pipPlacard centerXAnchor]],
-        [[imageView centerYAnchor] constraintEqualToAnchor:[pipPlacard centerYAnchor]],
-        [[pipLabel centerXAnchor] constraintEqualToAnchor:[pipPlacard centerXAnchor]],
-        [[pipLabel topAnchor] constraintEqualToAnchor:[imageView bottomAnchor] constant:10],
-    ]];
-
-    CGFloat placardWidth = [pipPlacard frame].size.width;
-    CGFloat placardHeight = [pipPlacard frame].size.height;
-
-    if (placardWidth < 170 || placardHeight < 170)
-        [imageView setHidden:YES];
-    if (placardHeight < 100)
-        [pipLabel setHidden:YES];
-
-    if (UIView *parentView = layerHostView().superview) {
-        [parentView.superview insertSubview:pipPlacard.get() atIndex:0];
         [NSLayoutConstraint activateConstraints:@[
-            [parentView.leadingAnchor constraintEqualToAnchor:[pipPlacard leadingAnchor]],
-            [parentView.trailingAnchor constraintEqualToAnchor:[pipPlacard trailingAnchor]],
-            [parentView.topAnchor constraintEqualToAnchor:[pipPlacard topAnchor]],
-            [parentView.bottomAnchor constraintEqualToAnchor:[pipPlacard bottomAnchor]],
+            [[imageView widthAnchor] constraintEqualToConstant:[image size].width * 8],
+            [[imageView heightAnchor] constraintEqualToConstant:[image size].height * 8],
+            [[imageView centerXAnchor] constraintEqualToAnchor:[pipPlacard centerXAnchor]],
+            [[imageView centerYAnchor] constraintEqualToAnchor:[pipPlacard centerYAnchor]],
+            [[pipLabel centerXAnchor] constraintEqualToAnchor:[pipPlacard centerXAnchor]],
+            [[pipLabel topAnchor] constraintEqualToAnchor:[imageView bottomAnchor] constant:10],
         ]];
-    }
 
-    m_pipPlacard = pipPlacard;
+        CGFloat placardWidth = [pipPlacard frame].size.width;
+        CGFloat placardHeight = [pipPlacard frame].size.height;
+
+        if (placardWidth < 170 || placardHeight < 170)
+            [imageView setHidden:YES];
+        if (placardHeight < 100)
+            [pipLabel setHidden:YES];
+
+        if (UIView *parentView = layerHostView().superview) {
+            [parentView.superview insertSubview:pipPlacard.get() atIndex:0];
+            [NSLayoutConstraint activateConstraints:@[
+                [parentView.leadingAnchor constraintEqualToAnchor:[pipPlacard leadingAnchor]],
+                [parentView.trailingAnchor constraintEqualToAnchor:[pipPlacard trailingAnchor]],
+                [parentView.topAnchor constraintEqualToAnchor:[pipPlacard topAnchor]],
+                [parentView.bottomAnchor constraintEqualToAnchor:[pipPlacard bottomAnchor]],
+            ]];
+        }
+
+        m_pipPlacard = pipPlacard;
+    } @catch (NSException *exception) {
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "user info: ", exception.reason);
+    }
 }
 
 void VideoPresentationInterfaceIOS::setupFullscreen(const FloatRect& initialRect, const FloatSize&, UIView* parentView, HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)


### PR DESCRIPTION
#### d0061c38590bdee6e6881f42c9d5e126de965915
<pre>
CRASH in VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing
<a href="https://rdar.apple.com/146108129">rdar://146108129</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289107">https://bugs.webkit.org/show_bug.cgi?id=289107</a>

Reviewed by Brent Fulgham.

Crash logging shows an exception thrown from +[NSArray arrayWithObjects:count:] within
ensurePipPlacardIsShowing(), which can only be caused by a nil object being inserted into
an objective-c literal NSArray. There are a couple of code paths which generate a literal
array in that method, but given that the failure case is that the plackard
informing the user that the video is in PiP will not be shown, we should probably not
crash here. Wrap the method in a try/catch block.

* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::ensurePipPlacardIsShowing):

Canonical link: <a href="https://commits.webkit.org/291622@main">https://commits.webkit.org/291622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d6bd0a3070209aa8707b59e40de72bd1db86a0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2719 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43950 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71371 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28755 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2116 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43264 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79902 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100456 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14976 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80387 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79714 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13602 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25638 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20147 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21888 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->