### PR TITLE
RegExp string lists should sort the longest string alternatives first if followed by an EOL assertion

### DIFF
--- a/JSTests/stress/regexp-parsing-tokens.js
+++ b/JSTests/stress/regexp-parsing-tokens.js
@@ -251,3 +251,22 @@ testRegExp(re9, "bbb", ["bb"]);
 testRegExp(re9, "c", null);
 testRegExp(re9, "cc", ["cc"]);
 testRegExp(re9, "ccc", ["cc"]);
+
+// Test 58
+let re10 = /^(?:a|aa|aaa)$/;
+testRegExp(re10, "a", ["a"]);
+testRegExp(re10, "aa", ["aa"]);
+testRegExp(re10, "aaa", ["aaa"]);
+testRegExp(re10, "aaaa", null);
+
+let re11 = /^(?:aa|a|aaa)$/;
+testRegExp(re11, "a", ["a"]);
+testRegExp(re11, "aa", ["aa"]);
+testRegExp(re11, "aaa", ["aaa"]);
+testRegExp(re11, "aaaa", null);
+
+let re12 = /^(?:aa|a|aaa)$/;
+testRegExp(re12, "a", ["a"]);
+testRegExp(re12, "aa", ["aa"]);
+testRegExp(re12, "aaa", ["aaa"]);
+testRegExp(re12, "aaaa", null);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -4282,6 +4282,18 @@ class YarrGenerator final : public YarrJITInfo {
 
             if (term->parentheses.isStringList) {
                 // This is an anchored non-capturing string list parenthesis that can't backtrack, we use the 'string list' nodes.
+                // We may need to reorder these if we have an EOL after.
+
+                if (term->parentheses.isEOLStringList) {
+                    PatternDisjunction* nestedDisjunction = term->parentheses.disjunction;
+                    nestedDisjunction->m_alternatives.last()->m_isLastAlternative = false;
+
+                    std::sort(nestedDisjunction->m_alternatives.begin(), nestedDisjunction->m_alternatives.end(), [](auto& l, auto& r) -> bool {
+                        return l->m_terms.size() > r->m_terms.size();
+                    });
+                    nestedDisjunction->m_alternatives.last()->m_isLastAlternative = true;
+                }
+
                 alternativeBeginOpCode = YarrOpCode::StringListAlternativeBegin;
                 alternativeNextOpCode = YarrOpCode::StringListAlternativeNext;
                 alternativeEndOpCode = YarrOpCode::StringListAlternativeEnd;

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1909,6 +1909,7 @@ public:
                 }
 
                 term.parentheses.isStringList = isStringList;
+                term.parentheses.isEOLStringList = (terms.size() == 3 && terms[2].type == PatternTerm::Type::AssertionEOL);
             }
 
             if (isStringList)

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -235,6 +235,7 @@ struct PatternTerm {
             bool isCopy : 1;
             bool isTerminal : 1;
             bool isStringList : 1;
+            bool isEOLStringList: 1;
         } parentheses;
         struct {
             bool bolAnchor : 1;
@@ -280,6 +281,7 @@ struct PatternTerm {
         parentheses.isCopy = false;
         parentheses.isTerminal = false;
         parentheses.isStringList = false;
+        parentheses.isEOLStringList = false;
         quantityType = QuantifierType::FixedCount;
         quantityMinCount = quantityMaxCount = 1;
     }


### PR DESCRIPTION
#### d5f2be06d7fda28b34ad3d381328087613c3a3f6
<pre>
RegExp string lists should sort the longest string alternatives first if followed by an EOL assertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=289028">https://bugs.webkit.org/show_bug.cgi?id=289028</a>
<a href="https://rdar.apple.com/146065879">rdar://146065879</a>

Reviewed by Yusuke Suzuki and Keith Miller.

If we have a EOL assertion after a string list, we need to make sure that we sort by decreasing length.
Thus, we will not have an issue of a prefix matching first, failing the EOL assertion, and failing the
entire match.

* JSTests/stress/regexp-parsing-tokens.js:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::checkForTerminalParentheses):
* Source/JavaScriptCore/yarr/YarrPattern.h:

Canonical link: <a href="https://commits.webkit.org/291631@main">https://commits.webkit.org/291631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccda7175bb6a92379478cb5b13728405cf6fd211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2722 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98428 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43953 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71378 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28760 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84489 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51712 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2118 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43267 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86137 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79903 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100459 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92093 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20479 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79727 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13605 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14991 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20463 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25641 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114743 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20150 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21891 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->