### PR TITLE
[SwiftUI] Update WebPage.DialogPresenting to latest interface (Part 2)

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift
@@ -67,50 +67,52 @@ extension WebPage {
 
 // MARK: DialogPresenting protocol
 
-/// Allows providing custom behavior to handle JavaScript actions and provide a response.
-///
-/// Typically when handling these, some UI should be presented to the user for them to provide a response,
-/// which will then be communicated back to JavaScript.
-///
-/// When these methods are invoked, JavaScript is blocked until the async method returns.
-@available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
-@available(watchOS, unavailable)
-@available(tvOS, unavailable)
-public protocol DialogPresenting {
-    /// A JavaScript `alert()` function has been invoked.
+extension WebPage {
+    /// Allows providing custom behavior to handle JavaScript actions and provide a response.
     ///
-    /// - Parameters:
-    ///   - message: The message provided by JavaScript.
-    ///   - frame: Information about the frame whose JavaScript process initiated this call.
-    @MainActor
-    func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async
+    /// Typically when handling these, some UI should be presented to the user for them to provide a response,
+    /// which will then be communicated back to JavaScript.
+    ///
+    /// When these methods are invoked, JavaScript is blocked until the async method returns.
+    @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
+    @available(watchOS, unavailable)
+    @available(tvOS, unavailable)
+    public protocol DialogPresenting {
+        /// A JavaScript `alert()` function has been invoked.
+        ///
+        /// - Parameters:
+        ///   - message: The message provided by JavaScript.
+        ///   - frame: Information about the frame whose JavaScript process initiated this call.
+        @MainActor
+        func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async
 
-    /// A JavaScript `confirm()` function has been invoked.
-    ///
-    /// - Parameters:
-    ///   - message: The message provided by JavaScript.
-    ///   - frame: Information about the frame whose JavaScript process initiated this call.
-    /// - Returns: The result of handling the invocation.
-    @MainActor
-    func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult
+        /// A JavaScript `confirm()` function has been invoked.
+        ///
+        /// - Parameters:
+        ///   - message: The message provided by JavaScript.
+        ///   - frame: Information about the frame whose JavaScript process initiated this call.
+        /// - Returns: The result of handling the invocation.
+        @MainActor
+        func handleJavaScriptConfirm(message: String, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptConfirmResult
 
-    /// A JavaScript `prompt()` function has been invoked.
-    ///
-    /// - Parameters:
-    ///   - message: The message provided by JavaScript.
-    ///   - defaultText: The initial text provided by JavaScript, intended to be displayed in some text entry field.
-    ///   - frame: Information about the frame whose JavaScript process initiated this call.
-    /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include some text returned to JavaScript.
-    @MainActor
-    func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult
+        /// A JavaScript `prompt()` function has been invoked.
+        ///
+        /// - Parameters:
+        ///   - message: The message provided by JavaScript.
+        ///   - defaultText: The initial text provided by JavaScript, intended to be displayed in some text entry field.
+        ///   - frame: Information about the frame whose JavaScript process initiated this call.
+        /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include some text returned to JavaScript.
+        @MainActor
+        func handleJavaScriptPrompt(message: String, defaultText: String?, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.JavaScriptPromptResult
 
-    /// Returns the result of handling a JavaScript request to open files.
-    ///
-    /// - Parameter parameters: The options to use for the file dialog.
-    ///   - frame: Information about the frame whose JavaScript process initiated this call.
-    /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include a set of files returned to JavaScript.
-    @MainActor
-    func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult
+        /// Returns the result of handling a JavaScript request to open files.
+        ///
+        /// - Parameter parameters: The options to use for the file dialog.
+        ///   - frame: Information about the frame whose JavaScript process initiated this call.
+        /// - Returns: The result of handling the invocation; if the result is affirmative, the response will include a set of files returned to JavaScript.
+        @MainActor
+        func handleFileInputPrompt(parameters: WKOpenPanelParameters, initiatedBy frame: WebPage.FrameInfo) async -> WebPage.FileInputPromptResult
+    }
 }
 
 // MARK: Default implementation
@@ -118,7 +120,7 @@ public protocol DialogPresenting {
 @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
-public extension DialogPresenting {
+public extension WebPage.DialogPresenting {
     /// By default, this method immediately returns.
     @MainActor
     func handleJavaScriptAlert(message: String, initiatedBy frame: WebPage.FrameInfo) async {

--- a/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift
@@ -32,12 +32,12 @@ internal import WebKit_Internal
 @_spiOnly import WebKit_Private._WKHitTestResult
 #endif
 
-private struct DefaultDialogPresenting: DialogPresenting {
+private struct DefaultDialogPresenting: WebPage.DialogPresenting {
 }
 
 @MainActor
 final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
-    init(dialogPresenter: (any DialogPresenting)?) {
+    init(dialogPresenter: (any WebPage.DialogPresenting)?) {
         self.dialogPresenter = dialogPresenter ?? DefaultDialogPresenting()
     }
 
@@ -47,7 +47,7 @@ final class WKUIDelegateAdapter: NSObject, WKUIDelegatePrivate {
     var menuBuilder: ((WebPage.ElementInfo) -> NSMenu)? = nil
 #endif
 
-    private let dialogPresenter: any DialogPresenting
+    private let dialogPresenter: any WebPage.DialogPresenting
 
     // MARK: Dialog presentation
 

--- a/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift
@@ -25,7 +25,7 @@ import Foundation
 import WebKit
 
 @MainActor
-final class DialogPresenter: DialogPresenting {
+final class DialogPresenter: WebPage.DialogPresenting {
     struct Dialog: Hashable, Identifiable, Sendable {
         enum Configuration: Sendable {
             case alert(String, @Sendable () -> Void)


### PR DESCRIPTION
#### c0ad5fdef496c172c4b7ab5c6e310e24d9b54790
<pre>
[SwiftUI] Update WebPage.DialogPresenting to latest interface (Part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=289113">https://bugs.webkit.org/show_bug.cgi?id=289113</a>
<a href="https://rdar.apple.com/146141183">rdar://146141183</a>

Reviewed by Aditya Keerthi.

Rename DialogPresenting to WebPage.DialogPresenting.

* Source/WebKit/UIProcess/API/Swift/WebPage+DialogPresenting.swift:
(DialogPresenting.handleJavaScriptAlert(_:initiatedBy:)):
(DialogPresenting.handleJavaScriptConfirm(_:initiatedBy:)):
(DialogPresenting.handleJavaScriptPrompt(_:defaultText:initiatedBy:)):
(DialogPresenting.handleFileInputPrompt(_:initiatedBy:)):
* Source/WebKit/UIProcess/Cocoa/WKUIDelegateAdapter.swift:
* Tools/SwiftBrowser/Source/ViewModel/DialogPresenter.swift:

Canonical link: <a href="https://commits.webkit.org/291589@main">https://commits.webkit.org/291589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f966a7b9aa0afc013f5c6d6c0ff7a6d8530d94c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93391 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/12951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/138/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43917 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95441 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/130/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/123/builds/21407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28738 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96393 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/130/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/138/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51681 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/130/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/138/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43231 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/130/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100423 "Built successfully") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/128/builds/20443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/123/builds/21407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/20695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/138/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/138/builds/2681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14954 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/127/builds/20427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/20114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/23574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/21855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->