### PR TITLE
Forcing VM mini mode should also force libpas mini mode

### DIFF
--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -130,7 +130,7 @@ void initialize()
 #endif
 
         if (VM::isInMiniMode())
-            WTF::fastEnableMiniMode();
+            WTF::fastEnableMiniMode(Options::forceMiniVMMode());
 
         if (Wasm::isSupported() || !Options::usePollingTraps()) {
             if (!Options::usePollingTraps())

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -307,7 +307,7 @@ void fastDecommitAlignedMemory(void* ptr, size_t size)
     OSAllocator::decommit(ptr, size);
 }
 
-void fastEnableMiniMode() { }
+void fastEnableMiniMode(bool) { }
 
 void fastDisableScavenger() { }
 
@@ -837,9 +837,9 @@ void fastDecommitAlignedMemory(void* ptr, size_t size)
     bmalloc::api::decommitAlignedPhysical(ptr, size);
 }
 
-void fastEnableMiniMode()
+void fastEnableMiniMode(bool forceMiniMode)
 {
-    bmalloc::api::enableMiniMode();
+    bmalloc::api::enableMiniMode(forceMiniMode);
 }
 
 void fastDisableScavenger()

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -199,7 +199,7 @@ WTF_EXPORT_PRIVATE void releaseFastMallocFreeMemoryForThisThread();
 WTF_EXPORT_PRIVATE void fastCommitAlignedMemory(void*, size_t);
 WTF_EXPORT_PRIVATE void fastDecommitAlignedMemory(void*, size_t);
 
-WTF_EXPORT_PRIVATE void fastEnableMiniMode();
+WTF_EXPORT_PRIVATE void fastEnableMiniMode(bool forceMiniMode = false);
 
 WTF_EXPORT_PRIVATE void fastDisableScavenger();
 

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -196,10 +196,10 @@ void decommitAlignedPhysical(void* object, size_t size, HeapKind kind)
 #endif
 }
 
-void enableMiniMode()
+void enableMiniMode(bool forceMiniMode)
 {
 #if BENABLE(LIBPAS)
-    if (!shouldAllowMiniMode())
+    if (!forceMiniMode && !shouldAllowMiniMode())
         return;
 
     // Speed up the scavenger.
@@ -217,6 +217,7 @@ void enableMiniMode()
     bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
 #endif
 #if !BUSE(LIBPAS)
+    BUNUSED(forceMiniMode);
     if (!DebugHeap::tryGet())
         Scavenger::get()->enableMiniMode();
 #endif

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -226,7 +226,7 @@ inline double percentAvailableMemoryInUse()
 BEXPORT void setScavengerThreadQOSClass(qos_class_t overrideClass);
 #endif
 
-BEXPORT void enableMiniMode();
+BEXPORT void enableMiniMode(bool forceMiniMode = false);
 
 // Used for debugging only.
 BEXPORT void disableScavenger();


### PR DESCRIPTION
#### 4fe385a64692137346a10f015213f1563124b663
<pre>
Forcing VM mini mode should also force libpas mini mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=289119">https://bugs.webkit.org/show_bug.cgi?id=289119</a>
<a href="https://rdar.apple.com/146147679">rdar://146147679</a>

Reviewed by Keith Miller.

We disable mini mode in libpas if the process is identified as either an
application or a WebKit XPC service. However, there is a JSC option to
force mini mode either via code or the __XPC_JSC_forceVMMiniMode
environment variable. We should force mini mode in libpas when this
option is set.

* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/WTF/wtf/FastMalloc.cpp:
(WTF::fastEnableMiniMode):
* Source/WTF/wtf/FastMalloc.h:
* Source/bmalloc/bmalloc/bmalloc.cpp:
(bmalloc::api::enableMiniMode):
* Source/bmalloc/bmalloc/bmalloc.h:

Canonical link: <a href="https://commits.webkit.org/291612@main">https://commits.webkit.org/291612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5808d65f8c40a557b18f2f0f958cd65eaef6bf18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93418 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/12978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13270 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21434 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71367 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28754 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51701 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9614 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2114 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43258 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100450 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92084 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14974 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80383 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20722 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79710 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13596 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20454 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25632 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114734 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20141 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23601 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21882 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->