### PR TITLE
Adopt smart pointers in YouTubePluginReplacement.cpp

### DIFF
--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -73,7 +73,8 @@ RenderPtr<RenderElement> YouTubePluginReplacement::createElementRenderer(HTMLPlu
 {
     ASSERT_UNUSED(plugin, m_parentElement == &plugin);
 
-    if (!m_embedShadowElement)
+    RefPtr embedShadowElement = m_embedShadowElement;
+    if (!embedShadowElement)
         return nullptr;
     
     return m_embedShadowElement->createElementRenderer(WTFMove(style), insertionPosition);
@@ -81,11 +82,14 @@ RenderPtr<RenderElement> YouTubePluginReplacement::createElementRenderer(HTMLPlu
 
 void YouTubePluginReplacement::installReplacement(ShadowRoot& root)
 {
-    m_embedShadowElement = YouTubeEmbedShadowElement::create(m_parentElement->document());
+    Ref document = m_parentElement->document();
+    Ref embedShadowElement = YouTubeEmbedShadowElement::create(document);
 
-    root.appendChild(*m_embedShadowElement);
+    m_embedShadowElement = embedShadowElement.copyRef();
 
-    auto iframeElement = HTMLIFrameElement::create(HTMLNames::iframeTag, m_parentElement->document());
+    root.appendChild(embedShadowElement);
+
+    Ref iframeElement = HTMLIFrameElement::create(HTMLNames::iframeTag, document);
     if (m_attributes.contains<HashTranslatorASCIILiteral>("width"_s))
         iframeElement->setAttributeWithoutSynchronization(HTMLNames::widthAttr, "100%"_s);
 
@@ -100,7 +104,7 @@ void YouTubePluginReplacement::installReplacement(ShadowRoot& root)
     
     // Disable frame flattening for this iframe.
     iframeElement->setAttributeWithoutSynchronization(HTMLNames::scrollingAttr, "no"_s);
-    m_embedShadowElement->appendChild(iframeElement);
+    embedShadowElement->appendChild(iframeElement);
 }
     
 static URL createYouTubeURL(StringView videoID, StringView timeID)
@@ -279,7 +283,7 @@ static URL processAndCreateYouTubeURL(const URL& url, bool& isYouTubeShortenedUR
 
 AtomString YouTubePluginReplacement::youTubeURL(const AtomString& srcString)
 {
-    URL srcURL = m_parentElement->document().completeURL(srcString);
+    URL srcURL = m_parentElement->protectedDocument()->completeURL(srcString);
     return youTubeURLFromAbsoluteURL(srcURL, srcString);
 }
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -154,7 +154,6 @@ Modules/paymentrequest/PaymentResponse.cpp
 Modules/permissions/MainThreadPermissionObserver.cpp
 Modules/permissions/Permissions.cpp
 Modules/pictureinpicture/HTMLVideoElementPictureInPicture.cpp
-Modules/plugins/YouTubePluginReplacement.cpp
 Modules/push-api/PushDatabase.cpp
 Modules/push-api/PushManager.cpp
 Modules/push-api/PushSubscription.cpp


### PR DESCRIPTION
#### f10dadb6dc09b0315e6338c54a4455010ea25e83
<pre>
Adopt smart pointers in YouTubePluginReplacement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=289123">https://bugs.webkit.org/show_bug.cgi?id=289123</a>
<a href="https://rdar.apple.com/146160787">rdar://146160787</a>

Reviewed by Eric Carlson.

Static analysis told me to.

* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
(WebCore::YouTubePluginReplacement::createElementRenderer):
(WebCore::YouTubePluginReplacement::installReplacement):
(WebCore::YouTubePluginReplacement::youTubeURL):

Canonical link: <a href="https://commits.webkit.org/291653@main">https://commits.webkit.org/291653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b945162ddbb4f948caa95277410a2a9ae24454d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93542 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98545 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44068 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71464 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28844 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10026 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84590 "Found 1 new API test failure: TestWebKitAPI.ServiceWorker.ServiceWorkerWindowClientFocus (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51799 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2214 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43382 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79985 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100577 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20594 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15060 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80478 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20846 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79809 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24350 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13742 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15008 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20578 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25756 "Found 0 new failure in Modules/plugins/YouTubePluginReplacement.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20265 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23725 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22006 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->