### PR TITLE
AX: [AX Thread Text APIs] Downgrade release asserts in AXTextMarker

### DIFF
--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -27,17 +27,31 @@
 #include "AccessibilityObject.h"
 #include <wtf/StdLibExtras.h>
 
-#define TEXT_MARKER_ASSERT(assertion) do { \
+#define TEXT_MARKER_LOG(methodName) do { \
+    RELEASE_LOG(Accessibility, "[AX Thread Text Marker] hit assertion in %" PUBLIC_LOG_STRING, methodName); \
+} while (0)
+
+#define TEXT_MARKER_ASSERT(assertion, methodName) do { \
+    if (!(assertion)) \
+        TEXT_MARKER_LOG(methodName); \
     std::string debugString = "Text marker origin: " + originToString(origin()).utf8().toStdString(); \
-    RELEASE_ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+    ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
 } while (0)
-#define TEXT_MARKER_ASSERT_SINGLE(assertion, marker) do { \
+#define TEXT_MARKER_ASSERT_SINGLE(assertion, methodName, marker) do { \
+    if (!(assertion)) \
+        TEXT_MARKER_LOG(methodName); \
     std::string debugString = "Text marker origin: " + originToString(marker.origin()).utf8().toStdString(); \
-    RELEASE_ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+    ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
 } while (0)
-#define TEXT_MARKER_ASSERT_DOBULE(assertion, marker1, marker2) do { \
+#define TEXT_MARKER_ASSERT_DOUBLE(assertion, methodName, marker1, marker2) do { \
+    if (!(assertion)) \
+        TEXT_MARKER_LOG(methodName); \
     std::string debugString = "Text marker origins: " + originToString(marker1.origin()).utf8().toStdString() + ", " + originToString(marker2.origin()).utf8().data(); \
-    RELEASE_ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+    ASSERT_WITH_MESSAGE(assertion, "%s", debugString.c_str()); \
+} while (0)
+#define TEXT_MARKER_ASSERT_NOT_REACHED(methodName) do { \
+    TEXT_MARKER_LOG(methodName); \
+    ASSERT_NOT_REACHED(); \
 } while (0)
 
 namespace WebCore {


### PR DESCRIPTION
#### 2f017d5b2c03fba704bb135506d9c2fbe78b9c9f
<pre>
AX: [AX Thread Text APIs] Downgrade release asserts in AXTextMarker
<a href="https://bugs.webkit.org/show_bug.cgi?id=289118">https://bugs.webkit.org/show_bug.cgi?id=289118</a>
<a href="https://rdar.apple.com/146146886">rdar://146146886</a>

Reviewed by Tyler Wilcock.

This PR downgrades the release asserts in AXTextMarker to debug, adds appropriate
fallbacks when these conditions fail, and adds new logging to help diagnose issues
when we hit them.

`accessibility/ax-thread-text-apis` and `accessibility/isolated-tree` do not change
their pass rate with this change.

* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::characterRange const):
(WebCore::AXTextMarker::lineIndex const):
(WebCore::AXTextMarker::characterRangeForLine const):
(WebCore::AXTextMarker::markerRangeForLineIndex const):
(WebCore::AXTextMarker::atLineBoundaryForDirection const):
(WebCore::AXTextMarker::offsetFromRoot const):
(WebCore::AXTextMarker::findMarker const):
(WebCore::AXTextMarker::findLine const):
(WebCore::AXTextMarker::findParagraph const):
(WebCore::AXTextMarker::toTextRunMarker const):
(WebCore::AXTextMarker::partialOrderByTraversal const):
* Source/WebCore/accessibility/AXTextMarker.h:

Canonical link: <a href="https://commits.webkit.org/291629@main">https://commits.webkit.org/291629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14b2dbc2fc4782e8083a845d3dfb5eaa672124b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43973 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71386 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28770 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51720 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2135 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100479 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92113 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14993 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80402 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79731 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24272 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25661 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21911 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->