### PR TITLE
Revert 285421@main (Provisional history item tracking in the UI process)

### DIFF
--- a/Source/WebCore/history/BackForwardClient.h
+++ b/Source/WebCore/history/BackForwardClient.h
@@ -47,8 +47,6 @@ public:
     virtual void setChildItem(BackForwardFrameItemIdentifier, Ref<HistoryItem>&&) = 0;
 
     virtual void goToItem(HistoryItem&) = 0;
-    virtual void goToProvisionalItem(const HistoryItem&) = 0;
-    virtual void clearProvisionalItem(const HistoryItem&) = 0;
 
     virtual RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) = 0;
     virtual unsigned backListCount() const = 0;

--- a/Source/WebCore/history/BackForwardController.cpp
+++ b/Source/WebCore/history/BackForwardController.cpp
@@ -152,16 +152,6 @@ void BackForwardController::setCurrentItem(HistoryItem& item)
     protectedClient()->goToItem(item);
 }
 
-void BackForwardController::setProvisionalItem(const HistoryItem& item)
-{
-    protectedClient()->goToProvisionalItem(item);
-}
-
-void BackForwardController::clearProvisionalItem(const HistoryItem& item)
-{
-    protectedClient()->clearProvisionalItem(item);
-}
-
 bool BackForwardController::containsItem(const HistoryItem& item) const
 {
     return protectedClient()->containsItem(item);

--- a/Source/WebCore/history/BackForwardController.h
+++ b/Source/WebCore/history/BackForwardController.h
@@ -60,8 +60,6 @@ public:
     void addItem(Ref<HistoryItem>&&);
     void setChildItem(BackForwardFrameItemIdentifier, Ref<HistoryItem>&&);
     void setCurrentItem(HistoryItem&);
-    void setProvisionalItem(const HistoryItem&);
-    void clearProvisionalItem(const HistoryItem&);
 
     unsigned count() const;
     WEBCORE_EXPORT unsigned backCount() const;

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -312,6 +312,7 @@ void HistoryItem::addChildItem(Ref<HistoryItem>&& child)
 
 void HistoryItem::setChildItem(Ref<HistoryItem>&& child)
 {
+    ASSERT(!child->isTargetItem());
     unsigned size = m_children.size();
     for (unsigned i = 0; i < size; ++i)  {
         if (m_children[i]->target() == child->target()) {

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -122,8 +122,6 @@ class EmptyBackForwardClient final : public BackForwardClient {
     void addItem(Ref<HistoryItem>&&) final { }
     void setChildItem(BackForwardFrameItemIdentifier, Ref<HistoryItem>&&) final { }
     void goToItem(HistoryItem&) final { }
-    void goToProvisionalItem(const HistoryItem&) final { }
-    void clearProvisionalItem(const HistoryItem&) final { }
     RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) final { return nullptr; }
     unsigned backListCount() const final { return 0; }
     unsigned forwardListCount() const final { return 0; }

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -341,7 +341,7 @@ void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType frameLoa
         // as opposed to happening for some/one of the page commits that might happen soon.
         CheckedRef backForward = page->backForward();
         RefPtr currentItem = backForward->currentItem(protectedThis->m_frame->frameID());
-        backForward->setProvisionalItem(targetItem);
+        backForward->setCurrentItem(targetItem);
 
         // First set the provisional item of any frames that are not actually navigating.
         // This must be done before trying to navigate the desired frame, because some
@@ -400,7 +400,7 @@ void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameL
         // as opposed to happening for some/one of the page commits that might happen soon
         CheckedRef backForward = page->backForward();
         RefPtr currentItem = backForward->currentItem(frame->frameID());
-        backForward->setProvisionalItem(targetItem);
+        backForward->setCurrentItem(targetItem);
 
         // First set the provisional item of any frames that are not actually navigating.
         // This must be done before trying to navigate the desired frame, because some
@@ -806,16 +806,6 @@ void HistoryController::setProvisionalItem(RefPtr<HistoryItem>&& item)
     m_provisionalItem = WTFMove(item);
 }
 
-void HistoryController::clearProvisionalItem()
-{
-    RefPtr provisionalItem = m_provisionalItem;
-    if (!provisionalItem)
-        return;
-
-    if (RefPtr page = m_frame->page())
-        page->checkedBackForward()->clearProvisionalItem(*provisionalItem);
-}
-
 void HistoryController::initializeItem(HistoryItem& item, RefPtr<DocumentLoader> documentLoader)
 {
     ASSERT(documentLoader);
@@ -911,6 +901,8 @@ Ref<HistoryItem> HistoryController::createItemTree(HistoryItemClient& client, Lo
         for (RefPtr child = m_frame->tree().firstLocalDescendant(); child; child = child->tree().nextLocalSibling())
             item->addChildItem(child->loader().protectedHistory()->createItemTree(client, targetFrame, clipAtTarget, itemID));
     }
+
+    // FIXME: Eliminate the isTargetItem flag in favor of itemSequenceNumber.
     if (m_frame.ptr() == &targetFrame)
         item->setIsTargetItem(true);
     return item;
@@ -1013,6 +1005,10 @@ void HistoryController::updateCurrentItem()
         return;
 
     if (currentItem->url() != documentLoader->url()) {
+        // We ended up on a completely different URL this time, so the HistoryItem
+        // needs to be re-initialized. Preserve the isTargetItem flag as it is a
+        // property of how this HistoryItem was originally created and is not
+        // dependent on the document.
         bool isTargetItem = currentItem->isTargetItem();
         auto uuidIdentifier = currentItem->uuidIdentifier();
         bool sameOrigin = SecurityOrigin::create(currentItem->url())->isSameOriginAs(SecurityOrigin::create(documentLoader->url()));

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -91,7 +91,6 @@ public:
     HistoryItem* provisionalItem() const { return m_provisionalItem.get(); }
     RefPtr<HistoryItem> protectedProvisionalItem() const;
     void setProvisionalItem(RefPtr<HistoryItem>&&);
-    void clearProvisionalItem();
 
     void pushState(RefPtr<SerializedScriptValue>&&, const String& url);
     void replaceState(RefPtr<SerializedScriptValue>&&, const String& url);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -60,7 +60,7 @@ WebBackForwardList::~WebBackForwardList()
     LOG(BackForward, "(Back/Forward) Destroying WebBackForwardList %p", this);
 
     // A WebBackForwardList should never be destroyed unless it's associated page has been closed or is invalid.
-    ASSERT((!m_page && !provisionalOrCurrentIndex()) || !m_page->hasRunningProcess());
+    ASSERT((!m_page && !m_currentIndex) || !m_page->hasRunningProcess());
 }
 
 WebBackForwardListItem* WebBackForwardList::itemForID(BackForwardItemIdentifier identifier)
@@ -92,12 +92,11 @@ void WebBackForwardList::pageClosed()
     m_page.clear();
     m_entries.clear();
     m_currentIndex = std::nullopt;
-    m_provisionalIndex = std::nullopt;
 }
 
 void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     RefPtr page = m_page.get();
     if (!page)
@@ -105,11 +104,11 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
 
     Vector<Ref<WebBackForwardListItem>> removedItems;
     
-    if (provisionalOrCurrentIndex()) {
+    if (m_currentIndex) {
         page->recordAutomaticNavigationSnapshot();
 
         // Toss everything in the forward list.
-        unsigned targetSize = *provisionalOrCurrentIndex() + 1;
+        unsigned targetSize = *m_currentIndex + 1;
         removedItems.reserveInitialCapacity(m_entries.size() - targetSize);
         while (m_entries.size() > targetSize) {
             didRemoveItem(m_entries.last());
@@ -127,23 +126,21 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
 
             if (m_entries.isEmpty()) {
                 m_currentIndex = std::nullopt;
-                m_provisionalIndex = std::nullopt;
             } else
-                setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
+                m_currentIndex = *m_currentIndex - 1;
         }
 
         // Toss the first item if the list is getting too big, as long as we're not using it
         // (or even if we are, if we only want 1 entry).
-        if (m_entries.size() >= DefaultCapacity && (*provisionalOrCurrentIndex())) {
+        if (m_entries.size() >= DefaultCapacity && (*m_currentIndex)) {
             didRemoveItem(m_entries[0]);
             removedItems.append(WTFMove(m_entries[0]));
             m_entries.remove(0);
 
-            if (m_entries.isEmpty()) {
+            if (m_entries.isEmpty())
                 m_currentIndex = std::nullopt;
-                m_provisionalIndex = std::nullopt;
-            } else
-                setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() - 1);
+            else
+                --*m_currentIndex;
         }
     } else {
         // If we have no current item index we should also not have any entries.
@@ -160,33 +157,33 @@ void WebBackForwardList::addItem(Ref<WebBackForwardListItem>&& newItem)
 
     bool shouldKeepCurrentItem = true;
 
-    if (!provisionalOrCurrentIndex()) {
+    if (!m_currentIndex) {
         ASSERT(m_entries.isEmpty());
         m_currentIndex = 0;
     } else {
-        shouldKeepCurrentItem = page->shouldKeepCurrentBackForwardListItemInList(m_entries[*provisionalOrCurrentIndex()]);
+        shouldKeepCurrentItem = page->shouldKeepCurrentBackForwardListItemInList(m_entries[*m_currentIndex]);
         if (shouldKeepCurrentItem)
-            setProvisionalOrCurrentIndex(*provisionalOrCurrentIndex() + 1);
+            ++*m_currentIndex;
     }
 
     auto* newItemPtr = newItem.ptr();
     if (!shouldKeepCurrentItem) {
         // m_current should never be pointing past the end of the entries Vector.
         // If it is, something has gone wrong and we should not try to swap in the new item.
-        ASSERT(*provisionalOrCurrentIndex() < m_entries.size());
+        ASSERT(*m_currentIndex < m_entries.size());
 
-        removedItems.append(m_entries[*provisionalOrCurrentIndex()].copyRef());
-        m_entries[*provisionalOrCurrentIndex()] = WTFMove(newItem);
+        removedItems.append(m_entries[*m_currentIndex].copyRef());
+        m_entries[*m_currentIndex] = WTFMove(newItem);
     } else {
         // m_current should never be pointing more than 1 past the end of the entries Vector.
         // If it is, something has gone wrong and we should not try to insert the new item.
-        ASSERT(*provisionalOrCurrentIndex() <= m_entries.size());
+        ASSERT(*m_currentIndex <= m_entries.size());
 
-        if (*provisionalOrCurrentIndex() <= m_entries.size())
-            m_entries.insert(*provisionalOrCurrentIndex(), WTFMove(newItem));
+        if (*m_currentIndex <= m_entries.size())
+            m_entries.insert(*m_currentIndex, WTFMove(newItem));
     }
 
-    LOG(BackForward, "(Back/Forward) WebBackForwardList %p added an item. Current size %zu, current index %zu, threw away %zu items", this, m_entries.size(), *provisionalOrCurrentIndex(), removedItems.size());
+    LOG(BackForward, "(Back/Forward) WebBackForwardList %p added an item. Current size %zu, current index %zu, threw away %zu items", this, m_entries.size(), *m_currentIndex, removedItems.size());
     page->didChangeBackForwardList(newItemPtr, WTFMove(removedItems));
 }
 
@@ -205,21 +202,10 @@ void WebBackForwardList::addChildItem(FrameIdentifier parentFrameID, Ref<FrameSt
 
 void WebBackForwardList::goToItem(WebBackForwardListItem& item)
 {
-    commitProvisionalItem();
-    goToItemInternal(item, m_currentIndex);
-}
-
-void WebBackForwardList::goToProvisionalItem(WebBackForwardListItem& item)
-{
-    goToItemInternal(item, m_provisionalIndex);
-}
-
-void WebBackForwardList::goToItemInternal(WebBackForwardListItem& item, std::optional<size_t>& indexToUpdate)
-{
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     RefPtr page = m_page.get();
-    if (!m_entries.size() || !page || !provisionalOrCurrentIndex())
+    if (!m_entries.size() || !page || !m_currentIndex)
         return;
 
     size_t targetIndex = notFound;
@@ -236,7 +222,7 @@ void WebBackForwardList::goToItemInternal(WebBackForwardListItem& item, std::opt
         return;
     }
 
-    if (targetIndex < *provisionalOrCurrentIndex()) {
+    if (targetIndex < *m_currentIndex) {
         unsigned delta = m_entries.size() - targetIndex - 1;
         String deltaValue = delta > 10 ? "over10"_s : String::number(delta);
         page->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::backNavigationDeltaKey(), deltaValue, ShouldSample::No);
@@ -244,18 +230,18 @@ void WebBackForwardList::goToItemInternal(WebBackForwardListItem& item, std::opt
 
     // If we're going to an item different from the current item, ask the client if the current
     // item should remain in the list.
-    auto& currentItem = m_entries[*provisionalOrCurrentIndex()];
+    auto& currentItem = m_entries[*m_currentIndex];
     bool shouldKeepCurrentItem = true;
     if (currentItem.ptr() != &item) {
         page->recordAutomaticNavigationSnapshot();
-        shouldKeepCurrentItem = page->shouldKeepCurrentBackForwardListItemInList(m_entries[*provisionalOrCurrentIndex()]);
+        shouldKeepCurrentItem = page->shouldKeepCurrentBackForwardListItemInList(m_entries[*m_currentIndex]);
     }
 
     // If the client said to remove the current item, remove it and then update the target index.
     Vector<Ref<WebBackForwardListItem>> removedItems;
     if (!shouldKeepCurrentItem) {
         removedItems.append(currentItem.copyRef());
-        m_entries.remove(*provisionalOrCurrentIndex());
+        m_entries.remove(*m_currentIndex);
         targetIndex = notFound;
         for (size_t i = 0; i < m_entries.size(); ++i) {
             if (m_entries[i].ptr() == &item) {
@@ -266,42 +252,17 @@ void WebBackForwardList::goToItemInternal(WebBackForwardListItem& item, std::opt
         ASSERT(targetIndex != notFound);
     }
 
-    indexToUpdate = targetIndex;
+    m_currentIndex = targetIndex;
 
     LOG(BackForward, "(Back/Forward) WebBackForwardList %p going to item %s, is now at index %zu", this, item.identifier().toString().utf8().data(), targetIndex);
     page->didChangeBackForwardList(nullptr, WTFMove(removedItems));
 }
 
-void WebBackForwardList::clearProvisionalItem(WebBackForwardListFrameItem& frameItem)
-{
-    RefPtr item = frameItem.backForwardListItem();
-    if (!item)
-        return;
-
-    if ((frameItem.parent() || item->isRemoteFrameNavigation()) && frameItem.frameID() != item->navigatedFrameID())
-        return;
-
-    m_provisionalIndex = std::nullopt;
-}
-
-void WebBackForwardList::commitProvisionalItem()
-{
-    if (!m_provisionalIndex)
-        return;
-
-    if (*m_provisionalIndex >= m_entries.size()) {
-        ASSERT_NOT_REACHED();
-        return;
-    }
-
-    m_currentIndex = std::exchange(m_provisionalIndex, std::nullopt);
-}
-
 WebBackForwardListItem* WebBackForwardList::currentItem() const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    return m_page && provisionalOrCurrentIndex() ? m_entries[*provisionalOrCurrentIndex()].ptr() : nullptr;
+    return m_page && m_currentIndex ? m_entries[*m_currentIndex].ptr() : nullptr;
 }
 
 RefPtr<WebBackForwardListItem> WebBackForwardList::protectedCurrentItem() const
@@ -309,38 +270,25 @@ RefPtr<WebBackForwardListItem> WebBackForwardList::protectedCurrentItem() const
     return currentItem();
 }
 
-WebBackForwardListItem* WebBackForwardList::provisionalItem() const
-{
-    if (!m_provisionalIndex)
-        return nullptr;
-
-    if (*m_provisionalIndex >= m_entries.size()) {
-        ASSERT_NOT_REACHED();
-        return nullptr;
-    }
-
-    return m_entries[*m_provisionalIndex].ptr();
-}
-
 WebBackForwardListItem* WebBackForwardList::backItem() const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    return m_page && provisionalOrCurrentIndex() && *provisionalOrCurrentIndex() ? m_entries[*provisionalOrCurrentIndex() - 1].ptr() : nullptr;
+    return m_page && m_currentIndex && *m_currentIndex ? m_entries[*m_currentIndex - 1].ptr() : nullptr;
 }
 
 WebBackForwardListItem* WebBackForwardList::forwardItem() const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    return m_page && provisionalOrCurrentIndex() && m_entries.size() && *provisionalOrCurrentIndex() < m_entries.size() - 1 ? m_entries[*provisionalOrCurrentIndex() + 1].ptr() : nullptr;
+    return m_page && m_currentIndex && m_entries.size() && *m_currentIndex < m_entries.size() - 1 ? m_entries[*m_currentIndex + 1].ptr() : nullptr;
 }
 
 WebBackForwardListItem* WebBackForwardList::itemAtIndex(int index) const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    if (!provisionalOrCurrentIndex() || !m_page)
+    if (!m_currentIndex || !m_page)
         return nullptr;
     
     // Do range checks without doing math on index to avoid overflow.
@@ -350,21 +298,21 @@ WebBackForwardListItem* WebBackForwardList::itemAtIndex(int index) const
     if (index > 0 && static_cast<unsigned>(index) > forwardListCount())
         return nullptr;
 
-    return m_entries[index + *provisionalOrCurrentIndex()].ptr();
+    return m_entries[index + *m_currentIndex].ptr();
 }
 
 unsigned WebBackForwardList::backListCount() const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    return m_page && provisionalOrCurrentIndex() ? *provisionalOrCurrentIndex() : 0;
+    return m_page && m_currentIndex ? *m_currentIndex : 0;
 }
 
 unsigned WebBackForwardList::forwardListCount() const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    return m_page && provisionalOrCurrentIndex() ? m_entries.size() - (*provisionalOrCurrentIndex() + 1) : 0;
+    return m_page && m_currentIndex ? m_entries.size() - (*m_currentIndex + 1) : 0;
 }
 
 WebBackForwardListCounts WebBackForwardList::counts() const
@@ -384,9 +332,9 @@ Ref<API::Array> WebBackForwardList::forwardList() const
 
 Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    if (!m_page || !provisionalOrCurrentIndex())
+    if (!m_page || !m_currentIndex)
         return API::Array::create();
 
     unsigned backListSize = static_cast<unsigned>(backListCount());
@@ -407,16 +355,16 @@ Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) 
 
 Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limit) const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
-    if (!m_page || !provisionalOrCurrentIndex())
+    if (!m_page || !m_currentIndex)
         return API::Array::create();
 
     unsigned size = std::min(static_cast<unsigned>(forwardListCount()), limit);
     if (!size)
         return API::Array::create();
 
-    size_t startIndex = *provisionalOrCurrentIndex() + 1;
+    size_t startIndex = *m_currentIndex + 1;
     Vector<RefPtr<API::Object>> vector(size, [&](size_t i) -> RefPtr<API::Object> {
         return m_entries[startIndex + i].ptr();
     });
@@ -426,7 +374,7 @@ Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limi
 
 void WebBackForwardList::removeAllItems()
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     LOG(BackForward, "(Back/Forward) WebBackForwardList %p removeAllItems (has %zu of them)", this, m_entries.size());
 
@@ -434,13 +382,12 @@ void WebBackForwardList::removeAllItems()
         didRemoveItem(entry);
 
     m_currentIndex = std::nullopt;
-    m_provisionalIndex = std::nullopt;
     protectedPage()->didChangeBackForwardList(nullptr, std::exchange(m_entries, { }));
 }
 
 void WebBackForwardList::clear()
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     LOG(BackForward, "(Back/Forward) WebBackForwardList %p clear (has %zu of them)", this, m_entries.size());
 
@@ -453,14 +400,13 @@ void WebBackForwardList::clear()
 
     if (!currentItem) {
         // We should only ever have no current item if we also have no current item index.
-        ASSERT(!provisionalOrCurrentIndex());
+        ASSERT(!m_currentIndex);
 
         // But just in case it does happen in practice we should get back into a consistent state now.
         for (auto& entry : m_entries)
             didRemoveItem(entry);
 
         m_currentIndex = std::nullopt;
-        m_provisionalIndex = std::nullopt;
         page->didChangeBackForwardList(nullptr, std::exchange(m_entries, { }));
 
         return;
@@ -474,30 +420,27 @@ void WebBackForwardList::clear()
     Vector<Ref<WebBackForwardListItem>> removedItems;
     removedItems.reserveInitialCapacity(size - 1);
     for (size_t i = 0; i < size; ++i) {
-        if (provisionalOrCurrentIndex() && i != *provisionalOrCurrentIndex())
+        if (m_currentIndex && i != *m_currentIndex)
             removedItems.append(WTFMove(m_entries[i]));
     }
 
     m_currentIndex = 0;
-    m_provisionalIndex = std::nullopt;
 
     m_entries.clear();
     if (currentItem)
         m_entries.append(currentItem.releaseNonNull());
-    else {
+    else
         m_currentIndex = std::nullopt;
-        m_provisionalIndex = std::nullopt;
-    }
     page->didChangeBackForwardList(nullptr, WTFMove(removedItems));
 }
 
 BackForwardListState WebBackForwardList::backForwardListState(WTF::Function<bool (WebBackForwardListItem&)>&& filter) const
 {
-    ASSERT(!provisionalOrCurrentIndex() || *provisionalOrCurrentIndex() < m_entries.size());
+    ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     BackForwardListState backForwardListState;
-    if (provisionalOrCurrentIndex())
-        backForwardListState.currentIndex = *provisionalOrCurrentIndex();
+    if (m_currentIndex)
+        backForwardListState.currentIndex = *m_currentIndex;
 
     for (size_t i = 0; i < m_entries.size(); ++i) {
         auto& entry = m_entries[i];
@@ -533,8 +476,6 @@ void WebBackForwardList::restoreFromState(BackForwardListState backForwardListSt
 {
     if (!m_page)
         return;
-
-    m_provisionalIndex = std::nullopt;
 
     // FIXME: Enable restoring resourceDirectoryURL.
     m_entries = WTF::map(WTFMove(backForwardListState.items), [this](auto&& state) {
@@ -646,15 +587,6 @@ RefPtr<WebPageProxy> WebBackForwardList::protectedPage()
     return m_page.get();
 }
 
-void WebBackForwardList::setProvisionalOrCurrentIndex(size_t index)
-{
-    if (m_provisionalIndex) {
-        m_provisionalIndex = index;
-        return;
-    }
-    m_currentIndex = index;
-}
-
 static inline void setBackForwardItemIdentifier(FrameState& frameState, BackForwardItemIdentifier itemID)
 {
     frameState.itemID = itemID;
@@ -691,11 +623,11 @@ String WebBackForwardList::loggingString()
 {
     StringBuilder builder;
 
-    builder.append("\nWebBackForwardList 0x"_s, hex(reinterpret_cast<uintptr_t>(this)), " - "_s, m_entries.size(), " entries, has current index "_s, provisionalOrCurrentIndex() ? "YES"_s : "NO"_s, " ("_s, provisionalOrCurrentIndex() ? *provisionalOrCurrentIndex() : 0, ')');
+    builder.append("\nWebBackForwardList 0x"_s, hex(reinterpret_cast<uintptr_t>(this)), " - "_s, m_entries.size(), " entries, has current index "_s, m_currentIndex ? "YES"_s : "NO"_s, " ("_s, m_currentIndex ? *m_currentIndex : 0, ')');
 
     for (size_t i = 0; i < m_entries.size(); ++i) {
         ASCIILiteral prefix;
-        if (provisionalOrCurrentIndex() && *provisionalOrCurrentIndex() == i)
+        if (m_currentIndex && *m_currentIndex == i)
             prefix = " * "_s;
         else
             prefix = " - "_s;

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -63,7 +63,6 @@ public:
 
     WebBackForwardListItem* currentItem() const;
     RefPtr<WebBackForwardListItem> protectedCurrentItem() const;
-    WebBackForwardListItem* provisionalItem() const;
     WebBackForwardListItem* backItem() const;
     WebBackForwardListItem* forwardItem() const;
     WebBackForwardListItem* itemAtIndex(int) const;
@@ -89,10 +88,6 @@ public:
     void setItemsAsRestoredFromSession();
     void setItemsAsRestoredFromSessionIf(NOESCAPE Function<bool(WebBackForwardListItem&)>&&);
 
-    void goToProvisionalItem(WebBackForwardListItem&);
-    void clearProvisionalItem(WebBackForwardListFrameItem&);
-    void commitProvisionalItem();
-
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
 
 #if !LOG_DISABLED
@@ -104,17 +99,11 @@ private:
 
     void didRemoveItem(WebBackForwardListItem&);
 
-    void goToItemInternal(WebBackForwardListItem&, std::optional<size_t>& indexToUpdate);
-
-    std::optional<size_t> provisionalOrCurrentIndex() const { return m_provisionalIndex ? m_provisionalIndex : m_currentIndex; }
-    void setProvisionalOrCurrentIndex(size_t);
-
     RefPtr<WebPageProxy> protectedPage();
 
     WeakPtr<WebPageProxy> m_page;
     BackForwardListItemVector m_entries;
     std::optional<size_t> m_currentIndex;
-    std::optional<size_t> m_provisionalIndex;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7197,11 +7197,6 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
     if (frame->isMainFrame() && preferences->textExtractionEnabled())
         prepareTextExtractionSupportIfNeeded();
 #endif
-
-    if (isBackForwardLoadType(frameLoadType)) {
-        if (RefPtr provisionalItem = m_backForwardList->provisionalItem(); provisionalItem && provisionalItem->navigatedFrameID() == frameID)
-            m_backForwardList->commitProvisionalItem();
-    }
 }
 
 void WebPageProxy::didFinishDocumentLoadForFrame(IPC::Connection& connection, FrameIdentifier frameID, std::optional<WebCore::NavigationIdentifier> navigationID, const UserData& userData, WallTime timestamp)
@@ -9740,29 +9735,6 @@ void WebPageProxy::backForwardGoToItemShared(BackForwardItemIdentifier itemID, C
         return completionHandler(m_backForwardList->counts());
 
     m_backForwardList->goToItem(*item);
-    completionHandler(m_backForwardList->counts());
-}
-
-void WebPageProxy::backForwardGoToProvisionalItem(IPC::Connection& connection, BackForwardItemIdentifier itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
-{
-    MESSAGE_CHECK_COMPLETION_BASE(!WebKit::isInspectorPage(*this), connection, completionHandler(m_backForwardList->counts()));
-
-    if (m_provisionalPage)
-        return completionHandler(m_backForwardList->counts());
-
-    RefPtr item = m_backForwardList->itemForID(itemID);
-    if (!item)
-        return completionHandler(m_backForwardList->counts());
-
-    m_backForwardList->goToProvisionalItem(*item);
-    completionHandler(m_backForwardList->counts());
-}
-
-void WebPageProxy::backForwardClearProvisionalItem(IPC::Connection& connection, BackForwardItemIdentifier itemID, BackForwardFrameItemIdentifier frameItemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
-{
-    MESSAGE_CHECK_BASE(!WebKit::isInspectorPage(*this), connection);
-    if (RefPtr frameItem = WebBackForwardListFrameItem::itemForID(itemID, frameItemID))
-        m_backForwardList->clearProvisionalItem(*frameItem);
     completionHandler(m_backForwardList->counts());
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2952,8 +2952,6 @@ private:
     void backForwardListContainsItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(bool)>&&);
     void backForwardItemAtIndex(int32_t index, WebCore::FrameIdentifier, CompletionHandler<void(RefPtr<FrameState>&&)>&&);
     void backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&&);
-    void backForwardGoToProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
-    void backForwardClearProvisionalItem(IPC::Connection&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
     void backForwardUpdateItem(IPC::Connection&, Ref<FrameState>&&);
 
     // Undo management

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -222,8 +222,6 @@ messages -> WebPageProxy {
     BackForwardListCounts() -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
     ShouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem)
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem) Synchronous
-    BackForwardGoToProvisionalItem(WebCore::BackForwardItemIdentifier itemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
-    BackForwardClearProvisionalItem(WebCore::BackForwardItemIdentifier itemID, WebCore::BackForwardFrameItemIdentifier frameItemID) -> (struct WebKit::WebBackForwardListCounts counts) Synchronous
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(uint64_t commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp
@@ -85,28 +85,6 @@ void WebBackForwardListProxy::goToItem(HistoryItem& item)
     m_cachedBackForwardListCounts = backForwardListCounts;
 }
 
-void WebBackForwardListProxy::goToProvisionalItem(const HistoryItem& item)
-{
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    auto sendResult = page->sendSync(Messages::WebPageProxy::BackForwardGoToProvisionalItem(item.itemID()));
-    auto [backForwardListCounts] = sendResult.takeReplyOr(WebBackForwardListCounts { });
-    m_cachedBackForwardListCounts = backForwardListCounts;
-}
-
-void WebBackForwardListProxy::clearProvisionalItem(const HistoryItem& item)
-{
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    auto sendResult = page->sendSync(Messages::WebPageProxy::BackForwardClearProvisionalItem(item.itemID(), item.frameItemID()));
-    auto [backForwardListCounts] = sendResult.takeReplyOr(WebBackForwardListCounts { });
-    m_cachedBackForwardListCounts = backForwardListCounts;
-}
-
 RefPtr<HistoryItem> WebBackForwardListProxy::itemAtIndex(int itemIndex, FrameIdentifier frameID)
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -50,8 +50,6 @@ private:
     void setChildItem(WebCore::BackForwardFrameItemIdentifier, Ref<WebCore::HistoryItem>&&) final;
 
     void goToItem(WebCore::HistoryItem&) override;
-    void goToProvisionalItem(const WebCore::HistoryItem&) final;
-    void clearProvisionalItem(const WebCore::HistoryItem&) final;
 
     RefPtr<WebCore::HistoryItem> itemAtIndex(int, WebCore::FrameIdentifier) override;
     unsigned backListCount() const override;

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -51,8 +51,6 @@ public:
     void goBack();
     void goForward();
     void goToItem(WebCore::HistoryItem&) override;
-    void goToProvisionalItem(const WebCore::HistoryItem&) final;
-    void clearProvisionalItem(const WebCore::HistoryItem&) final;
 
     RefPtr<WebCore::HistoryItem> backItem();
     RefPtr<WebCore::HistoryItem> currentItem();
@@ -88,7 +86,6 @@ private:
     Vector<Ref<WebCore::HistoryItem>> m_entries;
     HistoryItemHashSet m_entryHash;
     unsigned m_current;
-    unsigned m_provisional;
     unsigned m_capacity;
     bool m_closed;
     bool m_enabled;

--- a/Source/WebKitLegacy/mac/History/BackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.mm
@@ -36,7 +36,6 @@ static const unsigned NoCurrentItemIndex = UINT_MAX;
 BackForwardList::BackForwardList(WebView *webView)
     : m_webView(webView)
     , m_current(NoCurrentItemIndex)
-    , m_provisional(NoCurrentItemIndex)
     , m_capacity(DefaultCapacity)
     , m_closed(true)
     , m_enabled(true)
@@ -105,18 +104,6 @@ void BackForwardList::goToItem(HistoryItem& item)
 
     if (index < m_entries.size())
         m_current = index;
-}
-
-void BackForwardList::goToProvisionalItem(const HistoryItem& item)
-{
-    m_provisional = m_current;
-    goToItem(const_cast<HistoryItem&>(item));
-}
-
-void BackForwardList::clearProvisionalItem(const HistoryItem&)
-{
-    if (m_provisional != NoCurrentItemIndex)
-        m_current = std::exchange(m_provisional, NoCurrentItemIndex);
 }
 
 RefPtr<HistoryItem> BackForwardList::backItem()

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -233,6 +233,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         NSString *target = coreItem->target();
         [result appendFormat:@" in \"%@\"", target];
     }
+    if (coreItem->isTargetItem())
+        [result appendString:@" *target*"];
     if (coreItem->formData()) {
         [result appendString:@" *POST*"];
     }
@@ -445,6 +447,11 @@ WebHistoryItem *kit(HistoryItem* item)
 - (NSString *)target
 {
     return nsStringNilIfEmpty(core(_private)->target());
+}
+
+- (BOOL)isTargetItem
+{
+    return core(_private)->isTargetItem();
 }
 
 - (NSString *)RSSFeedReferrer

--- a/Source/WebKitLegacy/mac/History/WebHistoryItemPrivate.h
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItemPrivate.h
@@ -61,6 +61,7 @@ extern NSString *WebViewportFitCoverValue;
 - (NSArray *)_redirectURLs;
 
 - (NSString *)target;
+- (BOOL)isTargetItem;
 - (NSArray *)children;
 - (NSDictionary *)dictionaryRepresentation;
 #if TARGET_OS_IPHONE


### PR DESCRIPTION
#### caeafa80a8b6925ed85cfae487580e47826ade80
<pre>
Revert 285421@main (Provisional history item tracking in the UI process)
<a href="https://bugs.webkit.org/show_bug.cgi?id=289136">https://bugs.webkit.org/show_bug.cgi?id=289136</a>
<a href="https://rdar.apple.com/146179703">rdar://146179703</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

Tracking provisional history items in the UI process has led to several bugs where the provisional index
could become stale and then be cleared, resulting in an out-of-bounds crash when accessing the current
back/forward item in WebBackForwardList. Identifying all cases where a provisional history item might not
be committed has been difficult, so let&apos;s revert this change for now. I’ve also added a test that exposes
another crash that occurs without this fix.

* Source/WebCore/history/BackForwardClient.h:
* Source/WebCore/history/BackForwardController.cpp:
(WebCore::BackForwardController::setProvisionalItem): Deleted.
(WebCore::BackForwardController::clearProvisionalItem): Deleted.
* Source/WebCore/history/BackForwardController.h:
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::setChildItem):
* Source/WebCore/loader/EmptyClients.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::goToItemForNavigationAPI):
(WebCore::HistoryController::createItemTree):
(WebCore::HistoryController::updateCurrentItem):
(WebCore::HistoryController::clearProvisionalItem): Deleted.
* Source/WebCore/loader/HistoryController.h:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::~WebBackForwardList):
(WebKit::WebBackForwardList::pageClosed):
(WebKit::WebBackForwardList::addItem):
(WebKit::WebBackForwardList::goToItem):
(WebKit::WebBackForwardList::currentItem const):
(WebKit::WebBackForwardList::backItem const):
(WebKit::WebBackForwardList::forwardItem const):
(WebKit::WebBackForwardList::itemAtIndex const):
(WebKit::WebBackForwardList::backListCount const):
(WebKit::WebBackForwardList::forwardListCount const):
(WebKit::WebBackForwardList::backListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardList::forwardListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardList::removeAllItems):
(WebKit::WebBackForwardList::clear):
(WebKit::WebBackForwardList::backForwardListState const):
(WebKit::WebBackForwardList::restoreFromState):
(WebKit::WebBackForwardList::loggingString):
(WebKit::WebBackForwardList::goToProvisionalItem): Deleted.
(WebKit::WebBackForwardList::goToItemInternal): Deleted.
(WebKit::WebBackForwardList::clearProvisionalItem): Deleted.
(WebKit::WebBackForwardList::commitProvisionalItem): Deleted.
(WebKit::WebBackForwardList::provisionalItem const): Deleted.
(WebKit::WebBackForwardList::setProvisionalOrCurrentIndex): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:
(WebKit::WebBackForwardList::provisionalOrCurrentIndex const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::backForwardGoToProvisionalItem): Deleted.
(WebKit::WebPageProxy::backForwardClearProvisionalItem): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.cpp:
(WebKit::WebBackForwardListProxy::goToItem):
(WebKit::WebBackForwardListProxy::goToProvisionalItem): Deleted.
(WebKit::WebBackForwardListProxy::clearProvisionalItem): Deleted.
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/BackForwardList.mm:
(BackForwardList::BackForwardList):
(BackForwardList::goToProvisionalItem): Deleted.
(BackForwardList::clearProvisionalItem): Deleted.
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(-[WebHistoryItem description]):
* Source/WebKitLegacy/mac/History/WebHistoryItemPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DecidePolicyForNavigationAction.mm:
(TEST(WebKit, DecidePolicyForNavigationActionCancelAfterDiscardingForwardItemsWithPSONAndSessionRestore)):

Canonical link: <a href="https://commits.webkit.org/291628@main">https://commits.webkit.org/291628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b813235aa914f483f0ac9686091bbae73c78225f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43972 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28769 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96448 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9959 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51721 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2130 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43286 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79914 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100478 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/14994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80403 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79732 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13624 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14988 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20482 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25660 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20169 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->