### PR TITLE
AX: Add a fast path for assistive technologies that search for all live regions and all non-root web areas on macOS

### DIFF
--- a/LayoutTests/accessibility/mac/live-region-search-expected.txt
+++ b/LayoutTests/accessibility/mac/live-region-search-expected.txt
@@ -1,0 +1,17 @@
+This test ensures that live region searches work correctly after dynamic page changes.
+
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 0
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 0
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 0
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 2
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 3
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 2
+PASS: webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false) === 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Hello

--- a/LayoutTests/accessibility/mac/live-region-search.html
+++ b/LayoutTests/accessibility/mac/live-region-search.html
@@ -1,0 +1,59 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container">
+</div>
+
+<script>
+var output = "This test ensures that live region searches work correctly after dynamic page changes.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var container = document.getElementById("container");
+    var webArea = accessibilityController.rootElement.childAtIndex(0);
+    output += expect("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "0");
+
+    var dynamicStatus = document.createElement("div");
+    dynamicStatus.id = "dynamic-status";
+    dynamicStatus.role = "status";
+    dynamicStatus.innerText = "Hello";
+
+    var dynamicStatus2 = document.createElement("div");
+    dynamicStatus2.id = "dynamic-status2";
+    dynamicStatus2.role = "status";
+    dynamicStatus2.innerText = "Hello2";
+
+    container.appendChild(dynamicStatus);
+    setTimeout(async function() {
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+        dynamicStatus = document.getElementById("container").removeChild(dynamicStatus);
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "0");
+        container.appendChild(dynamicStatus);
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+        dynamicStatus.role = "group";
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "0");
+        dynamicStatus.setAttribute("aria-live", "polite");
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+        container.setAttribute("aria-live", "polite");
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "2");
+        container.appendChild(dynamicStatus2);
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "3");
+        container.removeAttribute("aria-live");
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "2");
+        dynamicStatus2.remove();
+        output += await expectAsync("webArea.uiElementCountForSearchPredicate(null, true, 'AXLiveRegionSearchKey', '', false, false)", "1");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -107,6 +107,8 @@ enum class ClickHandlerFilter : bool {
     IncludeBody,
 };
 
+enum class PreSortedObjectType : bool { LiveRegion, WebArea };
+
 enum class DateComponentsType : uint8_t;
 
 enum class AXIDType { };
@@ -1366,6 +1368,11 @@ public:
     // ARIA live-region features.
     static bool liveRegionStatusIsEnabled(const AtomString&);
     bool supportsLiveRegion(bool excludeIfOff = true) const;
+#if PLATFORM(MAC)
+    virtual AccessibilityChildrenVector allSortedLiveRegions() const = 0;
+    virtual AccessibilityChildrenVector allSortedNonRootWebAreas() const = 0;
+    AccessibilityChildrenVector sortedDescendants(size_t limit, PreSortedObjectType) const;
+#endif // PLATFORM(MAC)
     virtual AXCoreObject* liveRegionAncestor(bool excludeIfOff = true) const = 0;
     virtual const String liveRegionStatus() const = 0;
     virtual const String liveRegionRelevant() const = 0;

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -87,11 +87,16 @@ struct AccessibilitySearchCriteria {
     unsigned resultsLimit { 0 };
     bool visibleOnly { false };
     bool immediateDescendantsOnly { false };
+    // For some types of common searches (e.g. all the live regions on the page), we eagerly
+    // compute results. This flag determines whether to use these precached results or not.
+    bool usePreCachedResults { true };
 };
 
 class AXSearchManager {
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(AXSearchManager);
 public:
+    AXCoreObject* findNextStartingFrom(AccessibilitySearchKey, AXCoreObject* start, AXCoreObject& anchor);
+    AXCoreObject::AccessibilityChildrenVector findAllMatchingObjectsIgnoringCache(Vector<AccessibilitySearchKey>&&, AXCoreObject& anchor);
     AXCoreObject::AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&);
     std::optional<AXTextMarkerRange> findMatchingRange(AccessibilitySearchCriteria&&);
 private:

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -2845,7 +2845,7 @@ void AccessibilityObject::updateRole()
     m_role = determineAccessibilityRole();
     if (previousRole != m_role) {
         if (auto* cache = axObjectCache())
-            cache->handleRoleChanged(*this);
+            cache->handleRoleChanged(*this, previousRole);
     }
 }
 

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -756,7 +756,10 @@ public:
 #if PLATFORM(MAC)
     bool caretBrowsingEnabled() const final;
     void setCaretBrowsingEnabled(bool) final;
-#endif
+
+    AccessibilityChildrenVector allSortedLiveRegions() const final;
+    AccessibilityChildrenVector allSortedNonRootWebAreas() const final;
+#endif // PLATFORM(MAC)
 
     bool hasClickHandler() const override { return false; }
     AccessibilityObject* clickableSelfOrAncestor(ClickHandlerFilter filter = ClickHandlerFilter::ExcludeBody) const final { return Accessibility::clickableSelfOrAncestor(*this, filter); };

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2544,7 +2544,7 @@ void AccessibilityRenderObject::updateRoleAfterChildrenCreation()
 
     if (role != m_role) {
         if (auto* cache = axObjectCache())
-            cache->handleRoleChanged(*this);
+            cache->handleRoleChanged(*this, role);
     }
 }
     

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -296,6 +296,20 @@ bool AXCoreObject::isEmptyGroup()
         && ![renderWidgetChildren(*this) count];
 }
 
+AXCoreObject::AccessibilityChildrenVector AXCoreObject::sortedDescendants(size_t limit, PreSortedObjectType type) const
+{
+    ASSERT(type == PreSortedObjectType::LiveRegion || type == PreSortedObjectType::WebArea);
+    auto sortedObjects = type == PreSortedObjectType::LiveRegion ? allSortedLiveRegions() : allSortedNonRootWebAreas();
+    AXCoreObject::AccessibilityChildrenVector results;
+    for (const Ref<AXCoreObject>& object : sortedObjects) {
+        if (isAncestorOfObject(object)) {
+            results.append(object);
+            if (results.size() >= limit)
+                break;
+        }
+    }
+    return results;
+}
 #endif // PLATFORM(MAC)
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -339,6 +339,8 @@ private:
     bool fileUploadButtonReturnsValueInTitle() const final;
 #if PLATFORM(MAC)
     bool caretBrowsingEnabled() const final { return boolAttributeValue(AXProperty::CaretBrowsingEnabled); }
+    AccessibilityChildrenVector allSortedLiveRegions() const final;
+    AccessibilityChildrenVector allSortedNonRootWebAreas() const final;
 #endif
     AXIsolatedObject* focusableAncestor() final { return Accessibility::focusableAncestor(*this); }
     AXIsolatedObject* highestEditableAncestor() final { return Accessibility::highestEditableAncestor(*this); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -468,6 +468,9 @@ public:
     void relationsNeedUpdate(bool needUpdate) { m_relationsNeedUpdate = needUpdate; }
     void updateRelations(const UncheckedKeyHashMap<AXID, AXRelations>&);
 
+    AXCoreObject::AccessibilityChildrenVector sortedLiveRegions();
+    AXCoreObject::AccessibilityChildrenVector sortedNonRootWebAreas();
+
     // Called on AX thread from WebAccessibilityObjectWrapper methods.
     // During layout tests, it is called on the main thread.
     void applyPendingChanges();
@@ -482,6 +485,8 @@ public:
     AXTextMarkerRange selectedTextMarkerRange();
     void setSelectedTextMarkerRange(AXTextMarkerRange&&);
 
+    void sortedLiveRegionsDidChange(Vector<AXID>);
+    void sortedNonRootWebAreasDidChange(Vector<AXID>);
     void queueNodeUpdate(AXID, const NodeUpdateOptions&);
     void queueNodeRemoval(const AccessibilityObject&);
     void processQueuedNodeUpdates();
@@ -590,9 +595,15 @@ private:
     UncheckedKeyHashMap<AXID, AXID> m_pendingParentUpdates WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Markable<AXID> m_pendingFocusedNodeID WTF_GUARDED_BY_LOCK(m_changeLogLock);
     bool m_queuedForDestruction WTF_GUARDED_BY_LOCK(m_changeLogLock) { false };
+    std::optional<Vector<AXID>> m_pendingSortedLiveRegionIDs WTF_GUARDED_BY_LOCK(m_changeLogLock);
+    std::optional<Vector<AXID>> m_pendingSortedNonRootWebAreaIDs WTF_GUARDED_BY_LOCK(m_changeLogLock);
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };
     std::atomic<double> m_processingProgress { 1 };
+
+    // Only accessed on the accessibility thread.
+    Vector<AXID> m_sortedLiveRegionIDs;
+    Vector<AXID> m_sortedNonRootWebAreaIDs;
 
     // Relationships between objects.
     UncheckedKeyHashMap<AXID, AXRelations> m_relations WTF_GUARDED_BY_LOCK(m_changeLogLock);

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -174,6 +174,22 @@ void AXIsolatedObject::detachPlatformWrapper(AccessibilityDetachmentType detachm
     [wrapper() detachIsolatedObject:detachmentType];
 }
 
+AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::allSortedLiveRegions() const
+{
+    RefPtr tree = this->tree();
+    if (!tree)
+        return { };
+    return tree->sortedLiveRegions();
+}
+
+AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::allSortedNonRootWebAreas() const
+{
+    RefPtr tree = this->tree();
+    if (!tree)
+        return { };
+    return tree->sortedNonRootWebAreas();
+}
+
 std::optional<String> AXIsolatedObject::textContent() const
 {
 #if ENABLE(AX_THREAD_TEXT_APIS)

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -205,6 +205,22 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return Accessibility::roleToPlatformString(role);
 }
 
+AXCoreObject::AccessibilityChildrenVector AccessibilityObject::allSortedLiveRegions() const
+{
+    CheckedPtr cache = axObjectCache();
+    if (!cache)
+        return { };
+    return cache->sortedLiveRegions();
+}
+
+AXCoreObject::AccessibilityChildrenVector AccessibilityObject::allSortedNonRootWebAreas() const
+{
+    CheckedPtr cache = axObjectCache();
+    if (!cache)
+        return { };
+    return cache->sortedNonRootWebAreas();
+}
+
 String AccessibilityObject::subrolePlatformString() const
 {
     if (isSecureField())

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3258,6 +3258,11 @@ void Document::createRenderTree()
     renderView->setIsInWindow(true);
 
     resolveStyle(ResolveStyleType::Rebuild);
+
+#if PLATFORM(MAC)
+    if (CheckedPtr cache = existingAXObjectCache())
+        cache->onDocumentRenderTreeCreation(*this);
+#endif // PLATFORM(MAC)
 }
 
 void Document::didBecomeCurrentDocumentInFrame()


### PR DESCRIPTION
#### 0420ca016995d73138f1b7311c9efbca90924e75
<pre>
AX: Add a fast path for assistive technologies that search for all live regions and all non-root web areas on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=289137">https://bugs.webkit.org/show_bug.cgi?id=289137</a>
<a href="https://rdar.apple.com/146185640">rdar://146185640</a>

Reviewed by Chris Fleizach.

VoiceOver commonly sends remote search requests for all the live regions, and all the non-woot web areas on the page.
Prior to this commit, this always required a full tree traversal. With this commit, we eagerly maintain a pre-sorted
list of these objects, allowing us to answer these queries immediately. There are generally very few of these objects
on a page, so it&apos;s cheap to keep this list up-to-date.

To avoid confusion, the existing AXObjectCache::m_liveRegionObjects list is renamed to AXObjectCache::m_changedLiveRegions,
as that is what it actually holds (live regions that have changed and are waiting for notifications to be sent for them).

* LayoutTests/accessibility/mac/live-region-search-expected.txt: Added.
* LayoutTests/accessibility/mac/live-region-search.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::remove):
(WebCore::AXObjectCache::handleLiveRegionCreated):
(WebCore::AXObjectCache::postLiveRegionChangeNotification):
(WebCore::AXObjectCache::liveRegionChangedNotificationPostTimerFired):
(WebCore::AXObjectCache::handleRoleChanged):
(WebCore::AXObjectCache::handleAttributeChange):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::findMatchingObjectsInternal):
(WebCore::AXSearchManager::findMatchingRange):
(WebCore::AXSearchManager::findNextStartingFrom):
(WebCore::AXSearchManager::findAllMatchingObjectsIgnoringCache):
* Source/WebCore/accessibility/AXSearchManager.h:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::updateRole):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::updateRoleAfterChildrenCreation):
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::AXCoreObject::sortedDescendants const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::sortedLiveRegions):
(WebCore::AXIsolatedTree::sortedNonRootWebAreas):
(WebCore::AXIsolatedTree::applyPendingChanges):
(WebCore::AXIsolatedTree::sortedLiveRegionsDidChange):
(WebCore::AXIsolatedTree::sortedNonRootWebAreasDidChange):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::AXIsolatedObject::allSortedLiveRegions const):
(WebCore::AXIsolatedObject::allSortedNonRootWebAreas const):
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::onDocumentRenderTreeCreation):
(WebCore::AXObjectCache::platformPerformDeferredCacheUpdate):
(WebCore::AXObjectCache::sortedLiveRegions const):
(WebCore::AXObjectCache::sortedNonRootWebAreas const):
(WebCore::AXObjectCache::addSortedObject):
(WebCore::AXObjectCache::removeLiveRegion):
(WebCore::AXObjectCache::initializeSortedIDLists):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::allSortedLiveRegions const):
(WebCore::AccessibilityObject::allSortedNonRootWebAreas const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createRenderTree):

Canonical link: <a href="https://commits.webkit.org/291652@main">https://commits.webkit.org/291652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b19294766b87c8e376e523f4bcc04bfa8c9054b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44062 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28839 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84591 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51795 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2215 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43376 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79981 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100571 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80476 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20840 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13736 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20572 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25750 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20259 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23719 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22000 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->