### PR TITLE
Skip unnecessary checks for control styling when devolvable widgets are enabled

### DIFF
--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -181,9 +181,6 @@ bool RenderThemeIOS::isControlStyled(const RenderStyle& style, const RenderStyle
     if (style.usedAppearance() == StyleAppearance::TextField || style.usedAppearance() == StyleAppearance::TextArea || style.usedAppearance() == StyleAppearance::SearchField)
         return !style.borderAndBackgroundEqual(userAgentStyle);
 
-    if (style.usedAppearance() == StyleAppearance::ListButton)
-        return style.hasContent() || style.hasUsedContentNone();
-
     return RenderTheme::isControlStyled(style, userAgentStyle);
 }
 
@@ -1718,10 +1715,12 @@ bool RenderThemeIOS::paintListButton(const RenderObject& box, const PaintInfo& p
         return RenderThemeCocoa::paintListButton(box, paintInfo, rect);
 #endif
 
+    auto& style = box.style();
+    if (style.hasContent() || style.hasUsedContentNone())
+        return false;
+
     auto& context = paintInfo.context();
     GraphicsContextStateSaver stateSaver(context);
-
-    auto& style = box.style();
 
     float paddingTop = floatValueForLength(style.paddingTop(), rect.height());
     float paddingRight = floatValueForLength(style.paddingRight(), rect.width());


### PR DESCRIPTION
#### 04d7deac7dec7497cc16c0a4de96d45a6e1c7a6b
<pre>
Skip unnecessary checks for control styling when devolvable widgets are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=289139">https://bugs.webkit.org/show_bug.cgi?id=289139</a>
<a href="https://rdar.apple.com/146145732">rdar://146145732</a>

Reviewed by Aditya Keerthi and Wenson Hsieh.

For platforms besides Mac &amp; iOS, all of the checks in `isControlStyled(...)`
are for border and background styling which would cause the
RenderStyle&apos;s `nativeAppearanceDisabled` flag to be set anyways. Thus,
it is not necessary to check `isControlStyled` on non-Mac &amp; non-iOS
platforms when the devolvable widgets feature is enabled.

On Mac, `isControlStyled` contains an additional check for zoom
styling and writing mode styling for menu lists due to an issue
which prevents the control from being scaled. This issue does not
occur when vector-based controls are enabled. Thus, it is not
necessary to check `isControlStyled` on Mac when both vector-based
controls and devolvable widgets are enabled.

On iOS, `isControlStyled` contains an additional check for list
buttons, disabling native appearance if the style has content set
or content:none in order to hide the button. These change move
this logic to the control&apos;s paint method, which simply draws
nothing if these styles are set. With this logic moved, it is
no longer necessary to check `isControlStyled` on iOS when the
devolvable widgets feature is enabled.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::shouldCheckLegacyStylesForNativeAppearance):
(WebCore::RenderTheme::adjustStyle):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::isControlStyled const):
(WebCore::RenderThemeIOS::paintListButton):

Canonical link: <a href="https://commits.webkit.org/291667@main">https://commits.webkit.org/291667@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6db466b46907c7d866a6f349a8a2492ebaea300d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93481 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21497 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71417 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28796 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96483 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9974 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51751 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2160 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43321 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79935 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100515 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20533 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80431 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20785 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80467 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79761 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/19852 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1641 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13668 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15018 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20517 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25695 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23664 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21945 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->