### PR TITLE
REGRESSION(288409@main): Session restore may treat a child frame’s state as the main frame

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -453,7 +453,7 @@ BackForwardListState WebBackForwardList::backForwardListState(WTF::Function<bool
             continue;
         }
 
-        backForwardListState.items.append(entry->navigatedFrameState());
+        backForwardListState.items.append(entry->mainFrameState());
     }
 
     if (backForwardListState.items.isEmpty())
@@ -482,8 +482,9 @@ void WebBackForwardList::restoreFromState(BackForwardListState backForwardListSt
         Ref stateCopy = state->copy();
         setBackForwardItemIdentifiers(stateCopy, BackForwardItemIdentifier::generate());
         m_currentIndex = m_entries.isEmpty() ? std::nullopt : std::optional(m_entries.size() - 1);
+        // FIXME: navigatedFrameID will always be the main frame ID, causing the restored session state to be sent to an incorrect process when going back or forward with site isolation enabled.
         auto navigatedFrameID = stateCopy->frameID;
-        return WebBackForwardListItem::create(completeFrameStateForNavigation(WTFMove(stateCopy)), m_page->identifier(), navigatedFrameID);
+        return WebBackForwardListItem::create(WTFMove(stateCopy), m_page->identifier(), navigatedFrameID);
     });
     m_currentIndex = backForwardListState.currentIndex ? std::optional<size_t>(*backForwardListState.currentIndex) : std::nullopt;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3131,7 +3131,7 @@ TEST(SiteIsolation, NavigateIframeSameOriginBackForward)
     testNavigateIframeBackForward(@"https://webkit.org/destination", false);
 }
 
-TEST(SiteIsolation, NavigateIframeSameOriginBackForwardAfterSessionRestore)
+TEST(SiteIsolation, DISABLED_NavigateIframeSameOriginBackForwardAfterSessionRestore)
 {
     testNavigateIframeBackForward(@"https://webkit.org/destination", true);
 }
@@ -3141,7 +3141,7 @@ TEST(SiteIsolation, NavigateIframeCrossOriginBackForward)
     testNavigateIframeBackForward(@"https://apple.com/destination", false);
 }
 
-TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestore)
+TEST(SiteIsolation, DISABLED_NavigateIframeCrossOriginBackForwardAfterSessionRestore)
 {
     testNavigateIframeBackForward(@"https://apple.com/destination", true);
 }


### PR DESCRIPTION
#### 31cf39eea5b44aaacf7a745ca14eb2703d2e8799
<pre>
REGRESSION(288409@main): Session restore may treat a child frame’s state as the main frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=289142">https://bugs.webkit.org/show_bug.cgi?id=289142</a>
<a href="https://rdar.apple.com/146207266">rdar://146207266</a>

Reviewed by Pascoe.

After 288409@main, history state is only constructed for navigating frames. If a navigation occurs in a
child frame, the UI process reconstructs the history state for the entire frame tree. However, when
retrieving and restoring session state, this reconstruction can fail for child frame navigations because
frame IDs will have changed after session restoration.

For now, when outputting session state, we should include the entire frame tree for each navigation. This
should restore the previous session restore behavior from before 288409@main.

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardListState const):
(WebKit::WebBackForwardList::restoreFromState):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, GoBackToPageAfterNavigatingIframeAndRestoringSession)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, DISABLED_NavigateIframeSameOriginBackForwardAfterSessionRestore)):
(TestWebKitAPI::TEST(SiteIsolation, DISABLED_NavigateIframeCrossOriginBackForwardAfterSessionRestore)):
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeSameOriginBackForwardAfterSessionRestore)): Deleted.
(TestWebKitAPI::TEST(SiteIsolation, NavigateIframeCrossOriginBackForwardAfterSessionRestore)): Deleted.

Canonical link: <a href="https://commits.webkit.org/291633@main">https://commits.webkit.org/291633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53de46f0d1d7943629d43d19aa3ef81cc04739d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98467 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95512 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71405 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28782 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9958 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2145 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43302 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79922 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100495 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15004 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80415 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79746 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13645 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14992 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20498 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25676 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20185 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23645 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->