### PR TITLE
[ macOS wk2 Debug arm64 ] http/tests/eventsource/eventsource-reconnect.html is a flaky failure.

### DIFF
--- a/LayoutTests/http/tests/eventsource/eventsource-reconnect.html
+++ b/LayoutTests/http/tests/eventsource/eventsource-reconnect.html
@@ -54,7 +54,7 @@ es.onerror = function () {
     errCount++;
     if (errCount < 2) {
         checkReadyState(es, CONNECTING);
-        retryTimeout = setTimeout(end, 1000);
+        retryTimeout = setTimeout(end, 10000);
         return;
     }
     clearTimeout(retryTimeout);

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2066,4 +2066,3 @@ webkit.org/b/289098 [ Debug ] ipc/serialized-type-info.html [ Failure ]
 
 webkit.org/b/289121 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-mandatory-getStats.https.html [ Pass Failure ]
 
-webkit.org/b/289127 [ Debug arm64 ] http/tests/eventsource/eventsource-reconnect.html [ Pass Failure ]


### PR DESCRIPTION
#### 4b9535a452d28848b17d5840e81d2eb51f3366f5
<pre>
[ macOS wk2 Debug arm64 ] http/tests/eventsource/eventsource-reconnect.html is a flaky failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=289127">https://bugs.webkit.org/show_bug.cgi?id=289127</a>
<a href="https://rdar.apple.com/146165288">rdar://146165288</a>

Reviewed by Sihui Liu.

Increase the delay of the reconnect timeout timer from 1 second to 10 seconds. 1 second is short
enough that it can happen on a slow configuration / machine and there is no good reason for a
very short timeout here. The timer is only useful to print out a useful error message in case
of timeout (rather than having the whole test time out after 30 seconds with a generic timeout
message).

* LayoutTests/http/tests/eventsource/eventsource-reconnect.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/291621@main">https://commits.webkit.org/291621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/415baa4b44c93ff3fc517a4ff4307e35b830d022

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/43990 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71403 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28784 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96466 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51737 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2146 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79923 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100497 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80417 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79748 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13648 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14981 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20500 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20187 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->