### PR TITLE
Percentage height becomes auto if containing block height is auto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="author" title="Morten Stenshorne" href="mstensho@chromium.org">
+<link rel="help" href="https://www.w3.org/TR/CSS22/box.html#collapsing-margins" title="8.3.1 Collapsing margins">
+<link rel="help" href="http://crbug.com/962175">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="A percentage height is unresolvable (i.e. gets treated as auto) if the containing block is auto.">
+<p>Test passes if there is a filled green square.</p>
+<div style="height:200px;">
+  <div style="overflow:hidden; width:100px; background:green;">
+    <div style="margin-bottom:100px;"></div>
+    <div style="height:30%;"></div>
+    <div style="margin-top:100px;"></div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -483,8 +483,8 @@ bool RenderBlock::isSelfCollapsingBlock() const
     bool hasAutoHeight = logicalHeightLength.isAuto();
     if (logicalHeightLength.isPercentOrCalculated() && !document().inQuirksMode()) {
         hasAutoHeight = true;
-        for (RenderBlock* cb = containingBlock(); cb && !is<RenderView>(*cb); cb = cb->containingBlock()) {
-            if (cb->style().logicalHeight().isFixed() || cb->isRenderTableCell())
+        if (RenderBlock* cb = containingBlock()) {
+            if (!is<RenderView>(*cb) && (cb->style().logicalHeight().isFixed() || cb->isRenderTableCell()))
                 hasAutoHeight = false;
         }
     }


### PR DESCRIPTION
#### a9db377af6d741b5358ab9bfd6313ef28bcd0113
<pre>
Percentage height becomes auto if containing block height is auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=289143">https://bugs.webkit.org/show_bug.cgi?id=289143</a>
<a href="https://rdar.apple.com/146207504">rdar://146207504</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1617833">https://chromium-review.googlesource.com/c/chromium/src/+/1617833</a>

It&apos;s wrong to walk all the way to the root and look for something with a
fixed block size just to determine whether we can collapse through the
block or not. It only matters what the actual block size of the
containing block is.

This bug triggered because the cached state of self-collapsing got out of sync
with reality, because some ancestor went from auto-height to fixed-height, a change
that shouldn&apos;t affect the descendant at all.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::isSelfCollapsingBlock const):
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block.html:
* LayoutTests/imported/w3c/web-platform-tests/css/CSS2/normal-flow/margin-collapse-through-percentage-height-block-expected.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9db377af6d741b5358ab9bfd6313ef28bcd0113

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2775 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98477 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44001 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71414 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28793 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51748 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2154 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43315 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100508 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15010 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79756 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24286 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13662 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25689 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20198 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23658 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->