### PR TITLE
Merge macOS suppress-HDR notification handlers

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -918,20 +918,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
 #endif
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-#if PLATFORM(MAC)
-    NSNotificationName const NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification = @"NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification";
-    NSNotificationName const NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification = @"NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification";
-    m_beginSuppressingHDRObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldBeginSuppressingHighDynamicRangeContentNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        sendToAllProcesses(Messages::WebProcess::SetShouldSuppressHDR(true));
-    }];
-
-    m_endSuppressingHDRObserver = [[NSNotificationCenter defaultCenter] addObserverForName:NSApplicationShouldEndSuppressingHighDynamicRangeContentNotification object:NSApp queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
-        sendToAllProcesses(Messages::WebProcess::SetShouldSuppressHDR(false));
-    }];
-#endif // PLATFORM(MAC)
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-
     m_finishedMobileAssetFontDownloadObserver = [[NSNotificationCenter defaultCenter] addObserverForName:@"FontActivateNotification" object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *notification) {
         NSString *fontFamily = notification.userInfo[@"FontActivateNotificationFontFamilyKey"];
         if ([fontFamily isKindOfClass:[NSString class]]) {
@@ -1020,13 +1006,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     auto notificationName = adoptNS([[NSString alloc] initWithCString:kGSEventHardwareKeyboardAvailabilityChangedNotification encoding:NSUTF8StringEncoding]);
     removeCFNotificationObserver((__bridge CFStringRef)notificationName.get());
 #endif
-
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-#if PLATFORM(MAC)
-    [[NSNotificationCenter defaultCenter] removeObserver:m_beginSuppressingHDRObserver.get()];
-    [[NSNotificationCenter defaultCenter] removeObserver:m_endSuppressingHDRObserver.get()];
-#endif // PLATFORM(MAC)
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
 
     [[NSNotificationCenter defaultCenter] removeObserver:m_activationObserver.get()];
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -839,13 +839,6 @@ private:
     RetainPtr<WKProcessPoolWeakObserver> m_weakObserver;
 #endif
 
-#if HAVE(SUPPORT_HDR_DISPLAY_APIS)
-#if PLATFORM(MAC)
-    RetainPtr<NSObject> m_beginSuppressingHDRObserver;
-    RetainPtr<NSObject> m_endSuppressingHDRObserver;
-#endif // PLATFORM(MAC)
-#endif // HAVE(SUPPORT_HDR_DISPLAY_APIS)
-
     bool m_processTerminationEnabled { true };
 
     bool m_memoryCacheDisabled { false };

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1076,7 +1076,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     bool m_inlinePredictionsEnabled { false };
 #endif
-    OptionSet<HDRConstrainingReason> m_hdrConstrainingReason;
+    OptionSet<HDRConstrainingReason> m_hdrConstrainingReason { HDRConstrainingReason::WindowIsNotActive };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2187,15 +2187,18 @@ void WebViewImpl::screenDidChangeColorSpace()
 
 void WebViewImpl::updateHDRState(HDRConstrainingReasonAction action, HDRConstrainingReason reason)
 {
-    auto wasEmpty = m_hdrConstrainingReason.isEmpty();
+    auto didHaveReasonToConstrain = !m_hdrConstrainingReason.isEmpty();
 
     if (action == HDRConstrainingReasonAction::Add)
         m_hdrConstrainingReason.add(reason);
     else
         m_hdrConstrainingReason.remove(reason);
 
-    if (m_hdrConstrainingReason.isEmpty() != wasEmpty)
-        setDynamicRangeLimit(m_rootLayer.get(), m_hdrConstrainingReason.isEmpty() ? PlatformDynamicRangeLimit::noLimit() : PlatformDynamicRangeLimit::defaultWhenSuppressingHDR(), true);
+    auto haveReasonToConstrain = !m_hdrConstrainingReason.isEmpty();
+    if (haveReasonToConstrain != didHaveReasonToConstrain) {
+        m_page->setShouldSuppressHDR(haveReasonToConstrain);
+        setDynamicRangeLimit(m_rootLayer.get(), haveReasonToConstrain ? PlatformDynamicRangeLimit::defaultWhenSuppressingHDR() : PlatformDynamicRangeLimit::noLimit(), true);
+    }
 }
 
 void WebViewImpl::applicationShouldSuppressHDR()

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -965,9 +965,6 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
         accessibilityRelayProcessSuspended(false);
     }
     ASSERT(result.iterator->value);
-
-    if (m_shouldSuppressHDR)
-        RefPtr { result.iterator->value }->setShouldSuppressHDR(m_shouldSuppressHDR);
 }
 
 void WebProcess::removeWebPage(PageIdentifier pageID)
@@ -1567,16 +1564,6 @@ void WebProcess::setTextCheckerState(OptionSet<TextCheckerState> textCheckerStat
         if (grammarCheckingTurnedOff)
             page->unmarkAllBadGrammar();
     }
-}
-
-void WebProcess::setShouldSuppressHDR(bool shouldSuppressHDR)
-{
-    m_shouldSuppressHDR = shouldSuppressHDR;
-
-#if ENABLE(VIDEO)
-    for (auto& page : m_pageMap.values())
-        page->setShouldSuppressHDR(shouldSuppressHDR);
-#endif // ENABLE(VIDEO)
 }
 
 void WebProcess::fetchWebsiteData(OptionSet<WebsiteDataType> websiteDataTypes, CompletionHandler<void(WebsiteData&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -257,9 +257,6 @@ public:
     OptionSet<TextCheckerState> textCheckerState() const { return m_textCheckerState; }
     void setTextCheckerState(OptionSet<TextCheckerState>);
 
-    bool shouldSuppressHDR() const { return m_shouldSuppressHDR; }
-    void setShouldSuppressHDR(bool);
-
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
     Ref<EventDispatcher> protectedEventDispatcher() { return m_eventDispatcher; }
     Ref<WebInspectorInterruptDispatcher> protectedWebInspectorInterruptDispatcher() { return m_webInspectorInterruptDispatcher; }
@@ -766,8 +763,6 @@ private:
     WebProcessSupplementMap m_supplements;
 
     OptionSet<TextCheckerState> m_textCheckerState;
-
-    bool m_shouldSuppressHDR { false };
 
     String m_uiProcessBundleIdentifier;
     RefPtr<NetworkProcessConnection> m_networkProcessConnection;

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -75,8 +75,6 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
     SetTextCheckerState(OptionSet<WebKit::TextCheckerState> textCheckerState)
 
-    SetShouldSuppressHDR(bool shouldSuppressHDR)
-
     SetEnhancedAccessibility(bool flag)
     BindAccessibilityFrameWithData(WebCore::FrameIdentifier frameID, std::span<const uint8_t> data);
 


### PR DESCRIPTION
#### c0f7f82bf6f1f2a32e52806d3bd24f6e6a4a7b11
<pre>
Merge macOS suppress-HDR notification handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=289151">https://bugs.webkit.org/show_bug.cgi?id=289151</a>
<a href="https://rdar.apple.com/146236713">rdar://146236713</a>

Reviewed by Mike Wyrzykowski.

Follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=288690">https://bugs.webkit.org/show_bug.cgi?id=288690</a> :
Instead of observing suppress-HDR notifications in the web process
pool, observe from the web view, which was already present thanks to
<a href="https://bugs.webkit.org/show_bug.cgi?id=283314">https://bugs.webkit.org/show_bug.cgi?id=283314</a> , and notify the
WebPage about it.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::registerNotificationObservers):
(WebKit::WebProcessPool::unregisterNotificationObservers):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::updateHDRState):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::setShouldSuppressHDR): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/292115@main">https://commits.webkit.org/292115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66d73d0d58f8ac84b68d73058ba37cb7257f93f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14497 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72393 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29683 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85693 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52724 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10722 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44736 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101966 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81393 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22185 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81717 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80784 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20204 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25341 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2737 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15176 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21914 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27031 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21573 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25045 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->