### PR TITLE
Refactor dynamic-range-limit layer-setting code after suppress-HDR notifications

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7912,14 +7912,16 @@ void HTMLMediaElement::markCaptionAndSubtitleTracksAsUnconfigured(ReconfigureMod
 
 PlatformDynamicRangeLimit HTMLMediaElement::computePlayerDynamicRangeLimit() const
 {
+    constexpr auto maxLimitWhenSuppressingHDR = PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos();
+    if (m_platformDynamicRangeLimit <= maxLimitWhenSuppressingHDR)
+        return m_platformDynamicRangeLimit;
+
     bool shouldSuppressHDR = [this]() {
         if (Page* page = document().page())
             return page->shouldSuppressHDR();
         return false;
     }();
-    if (!shouldSuppressHDR)
-        return m_platformDynamicRangeLimit;
-    return std::min(m_platformDynamicRangeLimit, PlatformDynamicRangeLimit::constrainedHigh());
+    return shouldSuppressHDR ? maxLimitWhenSuppressingHDR : m_platformDynamicRangeLimit;
 }
 
 // Use WTF_IGNORES_THREAD_SAFETY_ANALYSIS because this function does conditional locking of m_audioSourceNode->processLock()

--- a/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
+++ b/Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h
@@ -46,6 +46,9 @@ public:
     static constexpr PlatformDynamicRangeLimit constrainedHigh() { return PlatformDynamicRangeLimit(constrainedHighValue); }
     static constexpr PlatformDynamicRangeLimit noLimit() { return PlatformDynamicRangeLimit(noLimitValue); }
 
+    static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDR() { return standard(); }
+    static constexpr PlatformDynamicRangeLimit defaultWhenSuppressingHDRInVideos() { return constrainedHigh(); }
+
     // `dynamic-range-limit` mapped to PlatformDynamicRangeLimit.value():
     // ["standard", "constrainedHigh"] -> [standard().value(), constrainedHigh().value()],
     // ["constrainedHigh", "noLimit"] -> [constrainedHigh().value(), noLimit().value()]

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -329,7 +329,13 @@ public:
     bool windowResizeMouseLocationIsInVisibleScrollerThumb(CGPoint);
     void applicationShouldSuppressHDR();
     void applicationShouldAllowHDR();
-    void updateHDRState();
+
+    enum class HDRConstrainingReasonAction : bool { Remove, Add };
+    enum class HDRConstrainingReason : uint8_t {
+        WindowIsNotActive = 1 << 0,
+        ShouldSuppressHDR = 1 << 1,
+    };
+    void updateHDRState(HDRConstrainingReasonAction, HDRConstrainingReason);
 
     void accessibilitySettingsDidChange();
 
@@ -1070,9 +1076,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if HAVE(INLINE_PREDICTIONS)
     bool m_inlinePredictionsEnabled { false };
 #endif
-    bool m_hdrAllowed { true };
+    OptionSet<HDRConstrainingReason> m_hdrConstrainingReason;
 };
-    
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### dfab897cb22d7f3f0e49f950ecc85186b7d010a0
<pre>
Refactor dynamic-range-limit layer-setting code after suppress-HDR notifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=289152">https://bugs.webkit.org/show_bug.cgi?id=289152</a>
<a href="https://rdar.apple.com/146238622">rdar://146238622</a>

Reviewed by Mike Wyrzykowski.

Centralize the dynamic-range-limit to be used when suppressing HDR in
videos and other elements.

Also directly use the window-did-become/resign-key notification to use
as window activity state -- `m_page-&gt;isViewWindowActive()` was not
actually correct yet.
And only update layer properties when the target dynamic range limit has
actually changed.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::computePlayerDynamicRangeLimit const):
* Source/WebCore/platform/graphics/PlatformDynamicRangeLimit.h:
(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDR):
(WebCore::PlatformDynamicRangeLimit::defaultWhenSuppressingHDRInVideos):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::windowDidBecomeKey):
(WebKit::WebViewImpl::windowDidResignKey):
(WebKit::WebViewImpl::updateHDRState):
(WebKit::WebViewImpl::applicationShouldSuppressHDR):
(WebKit::WebViewImpl::applicationShouldAllowHDR):

Canonical link: <a href="https://commits.webkit.org/292044@main">https://commits.webkit.org/292044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a479e903c7bd76d1f59cecbbc9a9b8d5f4c8b4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45188 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96746 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72234 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29536 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97698 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10843 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85480 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52570 "Passed tests") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10536 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3191 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101758 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21724 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81233 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80614 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25168 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14946 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26816 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21365 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->