### PR TITLE
[Damage] Avoid using Region for propagation

### DIFF
--- a/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in
@@ -25,5 +25,5 @@ messages -> AcceleratedBackingStoreDMABuf {
     DidCreateBuffer(uint64_t id, WebCore::IntSize size, uint32_t format, Vector<UnixFileDescriptor> fds, Vector<uint32_t> offsets, Vector<uint32_t> strides, uint64_t modifier, WebKit::DMABufRendererBufferFormat::Usage usage)
     DidCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle handle)
     DidDestroyBuffer(uint64_t id)
-    Frame(uint64_t id, WebCore::Region damage, UnixFileDescriptor syncFD)
+    Frame(uint64_t id, Vector<WebCore::IntRect, 1> damage, UnixFileDescriptor syncFD)
 }

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -30,9 +30,9 @@
 #include "FenceMonitor.h"
 #include "MessageReceiver.h"
 #include "RendererBufferFormat.h"
+#include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
 #include <WebCore/RefPtrCairo.h>
-#include <WebCore/Region.h>
 #include <gtk/gtk.h>
 #include <wtf/OptionSet.h>
 #include <wtf/RefCounted.h>
@@ -48,8 +48,6 @@ struct gbm_bo;
 #endif
 
 namespace WebCore {
-class IntRect;
-class Region;
 class ShareableBitmap;
 class ShareableBitmapHandle;
 }
@@ -68,6 +66,8 @@ class AcceleratedBackingStoreDMABuf final : public AcceleratedBackingStore, publ
     WTF_MAKE_TZONE_ALLOCATED(AcceleratedBackingStoreDMABuf);
     WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf);
 public:
+    using Rects = Vector<WebCore::IntRect, 1>;
+
     static OptionSet<RendererBufferTransportMode> rendererBufferTransportMode();
     static bool checkRequirements();
 #if USE(GBM)
@@ -88,7 +88,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t id, WebCore::Region&&, WTF::UnixFileDescriptor&&);
+    void frame(uint64_t id, Rects&&, WTF::UnixFileDescriptor&&);
     void frameDone();
     void ensureGLContext();
     bool swapBuffersIfNeeded();
@@ -119,7 +119,7 @@ private:
         };
 
         virtual Type type() const = 0;
-        virtual void didUpdateContents(Buffer*, const WebCore::Region&) = 0;
+        virtual void didUpdateContents(Buffer*, const Rects&) = 0;
 #if USE(GTK4)
         virtual GdkTexture* texture() const { return nullptr; }
 #else
@@ -161,7 +161,7 @@ private:
         BufferDMABuf(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, DMABufRendererBufferFormat::Usage, Vector<WTF::UnixFileDescriptor>&&, GRefPtr<GdkDmabufTextureBuilder>&&);
 
         Buffer::Type type() const override { return Buffer::Type::DmaBuf; }
-        void didUpdateContents(Buffer*, const WebCore::Region&) override;
+        void didUpdateContents(Buffer*, const Rects&) override;
         GdkTexture* texture() const override { return m_texture.get(); }
         RendererBufferFormat format() const override;
         RefPtr<WebCore::NativeImage> asNativeImageForTesting() const override;
@@ -182,7 +182,7 @@ private:
         BufferEGLImage(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, DMABufRendererBufferFormat::Usage, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, uint64_t modifier, EGLImage);
 
         Buffer::Type type() const override { return Buffer::Type::EglImage; }
-        void didUpdateContents(Buffer*, const WebCore::Region&) override;
+        void didUpdateContents(Buffer*, const Rects&) override;
 #if USE(GTK4)
         GdkTexture* texture() const override { return m_texture.get(); }
 #else
@@ -213,7 +213,7 @@ private:
         BufferGBM(WebPageProxy&, uint64_t id, uint64_t surfaceID, const WebCore::IntSize&, DMABufRendererBufferFormat::Usage, WTF::UnixFileDescriptor&&, struct gbm_bo*);
 
         Buffer::Type type() const override { return Buffer::Type::Gbm; }
-        void didUpdateContents(Buffer*, const WebCore::Region&) override;
+        void didUpdateContents(Buffer*, const Rects&) override;
         cairo_surface_t* surface() const override { return m_surface.get(); }
         RendererBufferFormat format() const override;
         RefPtr<WebCore::NativeImage> asNativeImageForTesting() const override;
@@ -234,7 +234,7 @@ private:
         BufferSHM(WebPageProxy&, uint64_t id, uint64_t surfaceID, RefPtr<WebCore::ShareableBitmap>&&);
 
         Buffer::Type type() const override { return Buffer::Type::SharedMemory; }
-        void didUpdateContents(Buffer*, const WebCore::Region&) override;
+        void didUpdateContents(Buffer*, const Rects&) override;
         cairo_surface_t* surface() const override { return m_surface.get(); }
         RendererBufferFormat format() const override;
         RefPtr<WebCore::NativeImage> asNativeImageForTesting() const override;
@@ -251,7 +251,7 @@ private:
     WeakPtr<WebProcessProxy> m_legacyMainFrameProcess;
     RefPtr<Buffer> m_pendingBuffer;
     RefPtr<Buffer> m_committedBuffer;
-    WebCore::Region m_pendingDamageRegion;
+    Rects m_pendingDamageRects;
     HashMap<uint64_t, RefPtr<Buffer>> m_buffers;
 };
 

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp
@@ -79,7 +79,7 @@ void AcceleratedBackingStoreDMABuf::updateSurfaceID(uint64_t surfaceID)
         if (m_pendingBuffer) {
             frameDone();
             m_pendingBuffer = nullptr;
-            m_pendingDamageRegion = { };
+            m_pendingDamageRects = { };
         }
         m_buffers.clear();
         m_bufferIDs.clear();
@@ -130,7 +130,7 @@ void AcceleratedBackingStoreDMABuf::didDestroyBuffer(uint64_t id)
         m_bufferIDs.remove(buffer.get());
 }
 
-void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, WebCore::Region&& damageRegion, WTF::UnixFileDescriptor&& renderingFenceFD)
+void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, Rects&& damageRects, WTF::UnixFileDescriptor&& renderingFenceFD)
 {
     ASSERT(!m_pendingBuffer);
     auto* buffer = m_buffers.get(bufferID);
@@ -140,7 +140,7 @@ void AcceleratedBackingStoreDMABuf::frame(uint64_t bufferID, WebCore::Region&& d
     }
 
     m_pendingBuffer = buffer;
-    m_pendingDamageRegion = WTFMove(damageRegion);
+    m_pendingDamageRects = WTFMove(damageRects);
     if (wpe_display_use_explicit_sync(wpe_view_get_display(m_wpeView.get()))) {
         if (WPE_IS_BUFFER_DMA_BUF(m_pendingBuffer.get()))
             wpe_buffer_dma_buf_set_rendering_fence(WPE_BUFFER_DMA_BUF(m_pendingBuffer.get()), renderingFenceFD.release());
@@ -155,17 +155,16 @@ void AcceleratedBackingStoreDMABuf::renderPendingBuffer()
     // to pass directly a pointer below instead of using copies.
     static_assert(sizeof(WebCore::IntRect) == sizeof(WPERectangle));
 
-    auto damageRects = m_pendingDamageRegion.rects();
-    ASSERT(damageRects.size() <= std::numeric_limits<guint>::max());
-    const auto* rects = !damageRects.isEmpty() ? reinterpret_cast<const WPERectangle*>(damageRects.data()) : nullptr;
+    ASSERT(m_pendingDamageRects.size() <= std::numeric_limits<guint>::max());
+    const auto* rects = !m_pendingDamageRects.isEmpty() ? reinterpret_cast<const WPERectangle*>(m_pendingDamageRects.data()) : nullptr;
 
     GUniqueOutPtr<GError> error;
-    if (!wpe_view_render_buffer(m_wpeView.get(), m_pendingBuffer.get(), rects, damageRects.size(), &error.outPtr())) {
+    if (!wpe_view_render_buffer(m_wpeView.get(), m_pendingBuffer.get(), rects, m_pendingDamageRects.size(), &error.outPtr())) {
         g_warning("Failed to render frame: %s", error->message);
         frameDone();
         m_pendingBuffer = nullptr;
     }
-    m_pendingDamageRegion = { };
+    m_pendingDamageRects = { };
 }
 
 void AcceleratedBackingStoreDMABuf::frameDone()

--- a/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h
@@ -29,8 +29,8 @@
 #include "FenceMonitor.h"
 #include "MessageReceiver.h"
 #include "RendererBufferFormat.h"
+#include <WebCore/IntRect.h>
 #include <WebCore/IntSize.h>
-#include <WebCore/Region.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
@@ -41,7 +41,6 @@ typedef struct _WPEBuffer WPEBuffer;
 typedef struct _WPEView WPEView;
 
 namespace WebCore {
-class Region;
 class ShareableBitmapHandle;
 }
 
@@ -58,6 +57,8 @@ class AcceleratedBackingStoreDMABuf final : public IPC::MessageReceiver, public 
     WTF_MAKE_TZONE_ALLOCATED(AcceleratedBackingStoreDMABuf);
     WTF_MAKE_NONCOPYABLE(AcceleratedBackingStoreDMABuf);
 public:
+    using Rects = Vector<WebCore::IntRect, 1>;
+
     static Ref<AcceleratedBackingStoreDMABuf> create(WebPageProxy&, WPEView*);
     ~AcceleratedBackingStoreDMABuf();
 
@@ -77,7 +78,7 @@ private:
     void didCreateBuffer(uint64_t id, const WebCore::IntSize&, uint32_t format, Vector<WTF::UnixFileDescriptor>&&, Vector<uint32_t>&& offsets, Vector<uint32_t>&& strides, uint64_t modifier, DMABufRendererBufferFormat::Usage);
     void didCreateBufferSHM(uint64_t id, WebCore::ShareableBitmapHandle&&);
     void didDestroyBuffer(uint64_t id);
-    void frame(uint64_t bufferID, WebCore::Region&&, WTF::UnixFileDescriptor&&);
+    void frame(uint64_t bufferID, Rects&&, WTF::UnixFileDescriptor&&);
     void frameDone();
     void renderPendingBuffer();
     void bufferRendered();
@@ -90,7 +91,7 @@ private:
     WeakPtr<WebProcessProxy> m_legacyMainFrameProcess;
     GRefPtr<WPEBuffer> m_pendingBuffer;
     GRefPtr<WPEBuffer> m_committedBuffer;
-    WebCore::Region m_pendingDamageRegion;
+    Rects m_pendingDamageRects;
     HashMap<uint64_t, GRefPtr<WPEBuffer>> m_buffers;
     HashMap<WPEBuffer*, uint64_t> m_bufferIDs;
 };

--- a/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp
@@ -679,15 +679,15 @@ void AcceleratedSurfaceDMABuf::didRenderFrame()
 
     m_target->didRenderFrame();
 
-    const auto& damageRegion = [this]() -> WebCore::Region {
+    const auto& damageRects = [this]() -> Vector<WebCore::IntRect, 1> {
 #if ENABLE(DAMAGE_TRACKING)
-        return m_frameDamage.region();
+        return m_frameDamage.rects();
 #else
-        return Region { };
+        return { };
 #endif
     }();
 
-    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id(), damageRegion, WTFMove(renderingFence)), m_id);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::AcceleratedBackingStoreDMABuf::Frame(m_target->id(), damageRects, WTFMove(renderingFence)), m_id);
 
 #if ENABLE(DAMAGE_TRACKING)
     m_frameDamage = WebCore::Damage();


### PR DESCRIPTION
#### 18ae4afd6eac218bfe55a843aa5d84c30784504e
<pre>
[Damage] Avoid using Region for propagation
<a href="https://bugs.webkit.org/show_bug.cgi?id=289150">https://bugs.webkit.org/show_bug.cgi?id=289150</a>

Reviewed by Carlos Garcia Campos.

With this change, the damage rectangles are transferred from WebProcess to UIProcess
as a vector of rectangles instead of Region.

Region is a pretty compact data structure in terms of storing rectangles, but it quickly
becomes very slow to construct as the number of rects it stores grow. Moreover, due to the
way the data structure is organized, Region suffers from the problem such that in the worst case
(and usually in the average case) inserting N rectangles into Region results in pulling
N^2 rects out from the data structure when calling `.rects()`.

This change is possible since:
- both GTK and WPE ports accept the damage to include empty or overlapping rectangles
- in the new (recently updated) version of Damage the number of rects stored is bounded
  by the artificial grid size - so it&apos;s small anyway

* Source/WebKit/UIProcess/dmabuf/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::BufferDMABuf::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferEGLImage::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferGBM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::BufferSHM::didUpdateContents):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::update):
(WebKit::AcceleratedBackingStoreDMABuf::swapBuffersIfNeeded):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::updateSurfaceID):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::renderPendingBuffer):
* Source/WebKit/UIProcess/wpe/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):

Canonical link: <a href="https://commits.webkit.org/291619@main">https://commits.webkit.org/291619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/413e2746bfaa8e7d956938f469f97ce3ea2ea90e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13057 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98493 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44017 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71424 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28803 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/9981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51758 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9663 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43331 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79942 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100525 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80437 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79767 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19826 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13678 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20527 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25705 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->