### PR TITLE
[svg] document settings don't get propagated to SVGImage and animating `d` property in SVG using CSS is broken in background images

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<style>
+
+div {
+    display: inline-block;
+    width: 96px;
+    height: 96px;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cstyle%3E path { fill: none; stroke-width: 2; stroke: black; } %3C/style%3E%3Cpath d='M2 2l20 0' /%3E%3C/svg%3E");
+}
+
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image-ref.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<style>
+
+div {
+    display: inline-block;
+    width: 96px;
+    height: 96px;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cstyle%3E path { fill: none; stroke-width: 2; stroke: black; } %3C/style%3E%3Cpath d='M2 2l20 0' /%3E%3C/svg%3E");
+}
+
+</style>
+<div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Test the d property animates within a document loaded via "background-image: url()"</title>
+<meta charset=utf-8>
+<style>
+
+div {
+    display: inline-block;
+    width: 96px;
+    height: 96px;
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cstyle%3E path { fill: none; stroke-width: 2; stroke: black; animation: path 1s linear forwards paused; } @keyframes path { 0%25 { d: path('M2 2l20 0'); } 100%25 { stroke: green; d: path('M2 2l20 0'); } } %3C/style%3E%3Cpath d='M2 2l2 0' /%3E%3C/svg%3E");
+}
+
+</style>
+<div></div>

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -481,6 +481,7 @@ EncodedDataStatus SVGImage::dataChanged(bool allDataReceived)
             if (RefPtr parentSettings = observer->settings()) {
                 m_page->settings().setLayerBasedSVGEngineEnabled(parentSettings->layerBasedSVGEngineEnabled());
                 m_page->settings().fontGenericFamilies() = parentSettings->fontGenericFamilies();
+                m_page->settings().setCSSDPropertyEnabled(parentSettings->cssDPropertyEnabled());
             }
         }
 


### PR DESCRIPTION
#### f6dba489e483c9aed714a867f9b25a7499e93cc3
<pre>
[svg] document settings don&apos;t get propagated to SVGImage and animating `d` property in SVG using CSS is broken in background images
<a href="https://bugs.webkit.org/show_bug.cgi?id=288510">https://bugs.webkit.org/show_bug.cgi?id=288510</a>

Reviewed by Anne van Kesteren.

Propagate the `d` CSS property setting down to SVGImage.

* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/path/property/d-interpolation-within-document-referenced-via-background-image.html: Added.
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::dataChanged):

Canonical link: <a href="https://commits.webkit.org/291623@main">https://commits.webkit.org/291623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/669e0428f10d65de8a397476f6c7bdb6b1fc51ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44024 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71429 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28806 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96500 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WK2-Tests-EWS "Waiting to run tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84547 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51763 "Passed tests") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-18-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2171 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43338 "Built successfully") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100532 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20550 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15022 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80441 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79771 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24310 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13685 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14984 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25712 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20221 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->