### PR TITLE
[scroll-animations] CSS Animations targeting slotted elements fail to find timeline established by parent in `<template>`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt
@@ -2,5 +2,5 @@
 PASS Outer animation can see scroll timeline defined by :host
 PASS Outer animation can see scroll timeline defined by ::slotted
 PASS Inner animation can see scroll timeline defined by ::part
-FAIL Slotted element can see scroll timeline within the shadow assert_equals: expected "y" but got "x"
+PASS Slotted element can see scroll timeline within the shadow
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt
@@ -2,5 +2,5 @@
 PASS Outer animation can see view timeline defined by :host
 PASS Outer animation can see view timeline defined by ::slotted
 PASS Inner animation can see view timeline defined by ::part
-FAIL Slotted element can see view timeline within the shadow assert_equals: expected "y" but got "x"
+PASS Slotted element can see view timeline within the shadow
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -126,7 +126,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTreeOrder(const Vec
         // Has blocking timeline scope element
         if (containsElement(timelineScopeElements, element.get()))
             return nullptr;
-        element = element->parentElement();
+        element = element->parentElementInComposedTree();
     }
 
     ASSERT_NOT_REACHED();
@@ -148,7 +148,7 @@ ScrollTimeline* StyleOriginatedTimelinesController::determineTimelineForElement(
         if (!styleableForTimeline)
             continue;
         Ref protectedElementForTimeline { styleableForTimeline->element };
-        if (&styleableForTimeline->element == &styleable.element || Ref { styleable.element }->isDescendantOrShadowDescendantOf(protectedElementForTimeline.get()))
+        if (&styleableForTimeline->element == &styleable.element || Ref { styleable.element }->isComposedTreeDescendantOf(protectedElementForTimeline.get()))
             matchedTimelines.append(timeline);
     }
     if (matchedTimelines.isEmpty())
@@ -173,7 +173,7 @@ void StyleOriginatedTimelinesController::updateTimelineForTimelineScope(const Re
     for (auto& entry : m_timelineScopeEntries) {
         if (auto entryElement = entry.second.styleable()) {
             Ref protectedEntryElement { entryElement->element };
-            if (Ref { timelineElement->element }->isDescendantOrShadowDescendantOf(protectedEntryElement.get()) && (entry.first.type == NameScope::Type::All ||  entry.first.names.contains(name)))
+            if (Ref { timelineElement->element }->isComposedTreeDescendantOf(protectedEntryElement.get()) && (entry.first.type == NameScope::Type::All ||  entry.first.names.contains(name)))
                 matchedTimelineScopeElements.appendIfNotContains(*entryElement);
         }
     }
@@ -370,7 +370,7 @@ void StyleOriginatedTimelinesController::attachAnimation(CSSAnimation& animation
             for (auto timelineScopeElement : timelineScopeElements) {
                 ASSERT(timelineScopeElement.element());
                 Ref protectedTimelineScopeElement { *timelineScopeElement.element() };
-                if (*target == timelineScopeElement.styleable() || Ref { target->element }->isDescendantOrShadowDescendantOf(protectedTimelineScopeElement.get()))
+                if (*target == timelineScopeElement.styleable() || Ref { target->element }->isComposedTreeDescendantOf(protectedTimelineScopeElement.get()))
                     return true;
             }
             return false;
@@ -411,7 +411,7 @@ static void updateTimelinesForTimelineScope(Vector<Ref<ScrollTimeline>> entries,
     for (auto& entry : entries) {
         if (auto entryElement = originatingElementExcludingTimelineScope(entry).styleable()) {
             Ref protectedElement { styleable.element };
-            if (Ref { entryElement->element }->isDescendantOrShadowDescendantOf(protectedElement.get()))
+            if (Ref { entryElement->element }->isComposedTreeDescendantOf(protectedElement.get()))
                 entry->setTimelineScopeElement(protectedElement.get());
         }
     }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1209,6 +1209,15 @@ bool Node::containsIncludingShadowDOM(const Node* node) const
     return false;
 }
 
+bool Node::isComposedTreeDescendantOf(const Node& node) const
+{
+    for (CheckedPtr currentAncestor = parentElementInComposedTree(); currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
+        if (currentAncestor.get() == &node)
+            return true;
+    }
+    return false;
+}
+
 Node* Node::pseudoAwarePreviousSibling() const
 {
     auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -450,6 +450,7 @@ public:
     WEBCORE_EXPORT bool isDescendantOrShadowDescendantOf(const Node&) const;
     bool isDescendantOrShadowDescendantOf(const Node* other) const { return other && isDescendantOrShadowDescendantOf(*other); } 
     WEBCORE_EXPORT bool containsIncludingShadowDOM(const Node*) const;
+    bool isComposedTreeDescendantOf(const Node&) const;
 
     // Whether or not a selection can be started in this object
     virtual bool canStartSelection() const;

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -782,17 +782,6 @@ static CheckedPtr<Element> anchorScopeForAnchorElement(const Element& anchorElem
     return nullptr;
 }
 
-// Checks if `parent` is the parent of `descendant` within the composed tree.
-static bool elementIsParentOfElementInComposedTree(const Element& parent, const Element& descendant)
-{
-    for (CheckedPtr currentAncestor = descendant.parentElementInComposedTree(); currentAncestor; currentAncestor = currentAncestor->parentElementInComposedTree()) {
-        if (currentAncestor.get() == &parent)
-            return true;
-    }
-
-    return false;
-}
-
 // See: https://drafts.csswg.org/css-anchor-position-1/#acceptable-anchor-element
 static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer, Ref<const Element> anchorPositionedElement)
 {
@@ -805,7 +794,7 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
 
     if (auto anchorScopeElement = anchorScopeForAnchorElement(*anchorElement, anchorRenderer.style().anchorNames())) {
         // If the anchor is scoped, the anchor-positioned element must also be in the same scope.
-        if (!elementIsParentOfElementInComposedTree(*anchorScopeElement, anchorPositionedElement))
+        if (!anchorPositionedElement->isComposedTreeDescendantOf(*anchorScopeElement))
             return false;
     }
 


### PR DESCRIPTION
#### ddcd5d2091e2312d59d91c63a1f4c637d7e474a4
<pre>
[scroll-animations] CSS Animations targeting slotted elements fail to find timeline established by parent in `&lt;template&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289158">https://bugs.webkit.org/show_bug.cgi?id=289158</a>

Reviewed by Antti Koivisto and Anne van Kesteren.

Make sure we only ever use the composed tree to establish the relationship between
elements when looking for a parent element establishing a timeline. Indeed, our previous
use of `Node::parentElement()` and `Node::isDescendantOrShadowDescendantOf()` would not
deal with slotted elements. We now use the new `Node::isComposedTreeDescendantOf()`
which was promoted from a static function in `AnchorPositionEvaluator.cpp` to `Node`.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-name-shadow-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-name-shadow-expected.txt:
* Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
(WebCore::StyleOriginatedTimelinesController::determineTreeOrder):
(WebCore::StyleOriginatedTimelinesController::determineTimelineForElement):
(WebCore::StyleOriginatedTimelinesController::updateTimelineForTimelineScope):
(WebCore::StyleOriginatedTimelinesController::attachAnimation):
(WebCore::updateTimelinesForTimelineScope):
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::isComposedTreeDescendantOf const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::isAcceptableAnchorElement):
(WebCore::Style::elementIsParentOfElementInComposedTree): Deleted.

Canonical link: <a href="https://commits.webkit.org/291646@main">https://commits.webkit.org/291646@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75d74297d323770fe595005231847a2884f1b322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44049 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71449 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28828 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51783 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9693 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2202 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100558 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80470 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20827 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80508 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79800 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24333 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1677 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13723 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14998 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25737 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20246 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23706 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21987 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->