### PR TITLE
`will-change: view-transition-name` should create a stacking context and a backdrop root

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-view-transition-name-1-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-view-transition-name-1-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS will-change reference</title>
+<link rel="author" title="L. David Baron" href="https://dbaron.org/">
+<link rel="author" title="Mozilla" href="http://www.mozilla.org/">
+<style>
+html, body { margin: 0; padding: 0; }
+div { width: 100px; height: 100px; background: green }
+</style>
+<body>
+  <div></div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-view-transition-name-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-view-transition-name-1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS will-change: 'will-change: view-transition-name' creates a stacking context</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-will-change-1/#will-change">
+<link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/#named-and-transitioning">
+<link rel="match" href="green-square-100-by-100-ref.html">
+<meta name="assert" content="If any non-initial value of a property would create a stacking context on the element, specifying that property in will-change must create a stacking context on the element.">
+<style>
+html, body { margin: 0; padding: 0; }
+div { width: 100px; height: 100px }
+#wc { will-change: view-transition-name; background: red }
+#child { position: absolute; top: 0; left: 0; z-index: -1; background: green }
+</style>
+<body>
+  <div id="wc">
+    <div id="child">
+    </div>
+  </div>
+</body>

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -96,7 +96,8 @@ bool WillChangeData::canBeBackdropRoot() const
         || containsProperty(CSSPropertyClipPath)
         || containsProperty(CSSPropertyFilter)
         || containsProperty(CSSPropertyMixBlendMode)
-        || containsProperty(CSSPropertyMask);
+        || containsProperty(CSSPropertyMask)
+        || containsProperty(CSSPropertyViewTransitionName);
 }
 
 // "If any non-initial value of a property would create a stacking context on the element,
@@ -130,6 +131,7 @@ bool WillChangeData::propertyCreatesStackingContext(CSSPropertyID property)
 #if ENABLE(OVERFLOW_SCROLLING_TOUCH)
     case CSSPropertyWebkitOverflowScrolling:
 #endif
+    case CSSPropertyViewTransitionName:
     case CSSPropertyContain:
         return true;
     default:


### PR DESCRIPTION
#### ee2ee8440135510b724228166c688c4b9b9c3f30
<pre>
`will-change: view-transition-name` should create a stacking context and a backdrop root
<a href="https://bugs.webkit.org/show_bug.cgi?id=289164">https://bugs.webkit.org/show_bug.cgi?id=289164</a>
<a href="https://rdar.apple.com/146281670">rdar://146281670</a>

Reviewed by Simon Fraser.

<a href="https://drafts.csswg.org/css-will-change/#valdef-will-change-custom-ident">https://drafts.csswg.org/css-will-change/#valdef-will-change-custom-ident</a>

&gt; If any non-initial value of a property would create a stacking context on the element, specifying that property in will-change must create a stacking context on the element.

<a href="https://drafts.csswg.org/css-view-transitions-1/#named-and-transitioning">https://drafts.csswg.org/css-view-transitions-1/#named-and-transitioning</a>

&gt; Elements captured in a view transition during a view transition or whose view-transition-name computed value is not none (at any time):
&gt; * Form a stacking context.
&gt; * Are flattened in 3D transforms.
&gt; * Form a backdrop root.

* LayoutTests/imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-view-transition-name-1-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-view-transition-name-1.html: Added.
* Source/WebCore/rendering/style/WillChangeData.cpp:
(WebCore::WillChangeData::canBeBackdropRoot const):
(WebCore::WillChangeData::propertyCreatesStackingContext):

Canonical link: <a href="https://commits.webkit.org/291636@main">https://commits.webkit.org/291636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9112699add32d1bdc2e139792d90b599feae3ecd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93519 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13088 "Hash 9112699a for PR 41920 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98521 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28822 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51778 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9688 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2189 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43359 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100554 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20571 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15040 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80460 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79790 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1665 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13715 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14994 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25733 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20242 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21983 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->