### PR TITLE
`will-change: offset-path` should create a stacking context and a containing block

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5698,11 +5698,6 @@ webkit.org/b/225035 imported/w3c/web-platform-tests/css/css-will-change/will-cha
 webkit.org/b/225034 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixpos-cb-webkit-perspective-1.html [ ImageOnlyFailure ]
 webkit.org/b/224902 [ Debug ] imported/w3c/web-platform-tests/css/css-will-change/parsing/will-change-invalid.html [ Skip ]
-
-# Implement offset-* properties
-webkit.org/b/139128 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixpos-cb-offset-path-1.html [ ImageOnlyFailure ]
-webkit.org/b/139128 imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-offset-path-1.html [ ImageOnlyFailure ]
-
 webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-005.html [ ImageOnlyFailure ]
 
 # Needs display box support.

--- a/Source/WebCore/rendering/style/WillChangeData.cpp
+++ b/Source/WebCore/rendering/style/WillChangeData.cpp
@@ -78,6 +78,8 @@ bool WillChangeData::createsContainingBlockForOutOfFlowPositioned(bool isRootEle
         || containsProperty(CSSPropertyTranslate)
         || containsProperty(CSSPropertyRotate)
         || containsProperty(CSSPropertyScale)
+        || containsProperty(CSSPropertyOffsetPath)
+        // CSS containment
         || containsProperty(CSSPropertyContain)
         // CSS filter & backdrop-filter
         // FIXME: exclude root element for those properties (bug 225034)
@@ -109,6 +111,7 @@ bool WillChangeData::propertyCreatesStackingContext(CSSPropertyID property)
     case CSSPropertyTranslate:
     case CSSPropertyTransform:
     case CSSPropertyTransformStyle:
+    case CSSPropertyOffsetPath:
     case CSSPropertyClipPath:
     case CSSPropertyMask:
     case CSSPropertyWebkitMask:
@@ -159,6 +162,7 @@ static bool propertyTriggersCompositingOnBoxesOnly(CSSPropertyID property)
     case CSSPropertyRotate:
     case CSSPropertyTranslate:
     case CSSPropertyTransform:
+    case CSSPropertyOffsetPath:
         return true;
     default:
         return false;


### PR DESCRIPTION
#### 1bceed1cdf972deb4854794d43034df2c9f5e0d6
<pre>
`will-change: offset-path` should create a stacking context and a containing block
<a href="https://bugs.webkit.org/show_bug.cgi?id=289162">https://bugs.webkit.org/show_bug.cgi?id=289162</a>
<a href="https://rdar.apple.com/146292698">rdar://146292698</a>

Reviewed by Oriol Brufau and Simon Fraser.

From the css-will-change spec:

&gt; If any non-initial value of a property would cause the element to generate a containing block for fixed-position elements, specifying that property in will-change must cause the element to generate a containing block for fixed-position elements.

&gt; If any non-initial value of a property would create a stacking context on the element, specifying that property in will-change must create a stacking context on the element.

`offset-path` is just another type of `transform`.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/style/WillChangeData.cpp:
(WebCore::WillChangeData::createsContainingBlockForOutOfFlowPositioned const):
(WebCore::WillChangeData::propertyCreatesStackingContext):
(WebCore::propertyTriggersCompositingOnBoxesOnly):

Canonical link: <a href="https://commits.webkit.org/291635@main">https://commits.webkit.org/291635@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28709c8d12c9d1d0163f6ae2baa49e1d5602f5db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44044 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71446 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28823 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84573 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9690 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2197 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43358 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/79967 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100553 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15038 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80459 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80504 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79789 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24325 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13714 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/14993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25732 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20241 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23701 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/21982 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->