### PR TITLE
[WPE] WPEPlatform-based implementation of Interaction Media Features

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -160,7 +160,7 @@ WEBCORE_EXPORT float screenScaleFactor(UIScreen * = nullptr);
 #endif
 
 #if ENABLE(TOUCH_EVENTS)
-#if PLATFORM(GTK) || PLATFORM(WPE)
+#if PLATFORM(GTK)
 WEBCORE_EXPORT bool screenHasTouchDevice();
 WEBCORE_EXPORT bool screenIsTouchPrimaryInputDevice();
 #else

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -150,16 +150,4 @@ bool screenSupportsExtendedColor(Widget*)
     return false;
 }
 
-#if ENABLE(TOUCH_EVENTS)
-bool screenHasTouchDevice()
-{
-    return true;
-}
-
-bool screenIsTouchPrimaryInputDevice()
-{
-    return true;
-}
-#endif
-
 } // namespace WebCore

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -114,6 +114,7 @@ if (USE_GBM)
 endif ()
 
 list(APPEND WebKit_SERIALIZATION_IN_FILES
+    Shared/glib/AvailableInputDevices.serialization.in
     Shared/glib/InputMethodState.serialization.in
     Shared/glib/RendererBufferTransportMode.serialization.in
     Shared/glib/SystemSettings.serialization.in

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -558,6 +558,7 @@ def types_that_cannot_be_forward_declared():
 
 def conditions_for_header(header):
     conditions = {
+        '"AvailableInputDevices.h"': ["PLATFORM(WPE)"],
         '"CoreIPCAuditToken.h"': ["HAVE(AUDIT_TOKEN)"],
         '"DMABufRendererBufferFormat.h"': ["PLATFORM(GTK)", "PLATFORM(WPE)"],
         '"GestureTypes.h"': ["PLATFORM(IOS_FAMILY)"],

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -64,6 +64,10 @@
 #include <wtf/MemoryPressureHandler.h>
 #endif
 
+#if PLATFORM(WPE)
+#include "AvailableInputDevices.h"
+#endif
+
 namespace API {
 class Data;
 }
@@ -263,6 +267,10 @@ struct WebProcessCreationParameters {
 #if ENABLE(REMOTE_INSPECTOR)
     CString inspectorServerAddress;
 #endif
+#endif
+
+#if PLATFORM(WPE)
+    OptionSet<AvailableInputDevices> availableInputDevices;
 #endif
 
 #if USE(ATSPI)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.serialization.in
@@ -214,6 +214,10 @@
     CString inspectorServerAddress;
 #endif
 
+#if PLATFORM(WPE)
+    OptionSet<WebKit::AvailableInputDevices> availableInputDevices;
+#endif
+
 #if USE(ATSPI)
     String accessibilityBusAddress;
     String accessibilityBusName;

--- a/Source/WebKit/Shared/glib/AvailableInputDevices.h
+++ b/Source/WebKit/Shared/glib/AvailableInputDevices.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(WPE)
+
+namespace WebKit {
+
+enum class AvailableInputDevices : uint8_t {
+    Mouse       = (1 << 0),
+    Keyboard    = (1 << 1),
+    Touchscreen = (1 << 2),
+};
+
+} // namespace WebKit
+
+#endif // PLATFORM(WPE)

--- a/Source/WebKit/Shared/glib/AvailableInputDevices.serialization.in
+++ b/Source/WebKit/Shared/glib/AvailableInputDevices.serialization.in
@@ -1,0 +1,33 @@
+# Copyright (C) 2025 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+#if PLATFORM(WPE)
+
+[OptionSet] enum class WebKit::AvailableInputDevices : uint8_t {
+    Mouse,
+    Keyboard,
+    Touchscreen,
+};
+
+#endif // PLATFORM(WPE)

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -46,6 +46,13 @@ G_BEGIN_DECLS
 #define WPE_TYPE_DISPLAY (wpe_display_get_type())
 WPE_DECLARE_DERIVABLE_TYPE (WPEDisplay, wpe_display, WPE, DISPLAY, GObject)
 
+typedef enum {
+    WPE_AVAILABLE_INPUT_DEVICE_NONE        = 0,
+    WPE_AVAILABLE_INPUT_DEVICE_MOUSE       = (1 << 0),
+    WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD    = (1 << 1),
+    WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN = (1 << 2)
+} WPEAvailableInputDevices;
+
 struct _WPEDisplayClass
 {
     GObjectClass parent_class;
@@ -85,29 +92,32 @@ typedef enum {
     WPE_DISPLAY_ERROR_CONNECTION_FAILED
 } WPEDisplayError;
 
-WPE_API GQuark                  wpe_display_error_quark                   (void);
-WPE_API WPEDisplay             *wpe_display_get_default                   (void);
-WPE_API WPEDisplay             *wpe_display_get_primary                   (void);
-WPE_API void                    wpe_display_set_primary                   (WPEDisplay *display);
-WPE_API gboolean                wpe_display_connect                       (WPEDisplay *display,
-                                                                           GError    **error);
-WPE_API gpointer                wpe_display_get_egl_display               (WPEDisplay *display,
-                                                                           GError    **error);
-WPE_API WPEKeymap              *wpe_display_get_keymap                    (WPEDisplay *display,
-                                                                           GError    **error);
-WPE_API WPEBufferDMABufFormats *wpe_display_get_preferred_dma_buf_formats (WPEDisplay *display);
-WPE_API guint                   wpe_display_get_n_screens                 (WPEDisplay *display);
-WPE_API WPEScreen              *wpe_display_get_screen                    (WPEDisplay *display,
-                                                                           guint       index);
-WPE_API void                    wpe_display_screen_added                  (WPEDisplay *display,
-                                                                           WPEScreen *screen);
-WPE_API void                    wpe_display_screen_removed                (WPEDisplay *display,
-                                                                           WPEScreen *screen);
-WPE_API const char             *wpe_display_get_drm_device                (WPEDisplay *display);
-WPE_API const char             *wpe_display_get_drm_render_node           (WPEDisplay *display);
-WPE_API gboolean                wpe_display_use_explicit_sync             (WPEDisplay *display);
+WPE_API GQuark                   wpe_display_error_quark                   (void);
+WPE_API WPEDisplay              *wpe_display_get_default                   (void);
+WPE_API WPEDisplay              *wpe_display_get_primary                   (void);
+WPE_API void                     wpe_display_set_primary                   (WPEDisplay *display);
+WPE_API gboolean                 wpe_display_connect                       (WPEDisplay *display,
+                                                                            GError    **error);
+WPE_API gpointer                 wpe_display_get_egl_display               (WPEDisplay *display,
+                                                                            GError    **error);
+WPE_API WPEKeymap               *wpe_display_get_keymap                    (WPEDisplay *display,
+                                                                            GError    **error);
+WPE_API WPEBufferDMABufFormats  *wpe_display_get_preferred_dma_buf_formats (WPEDisplay *display);
+WPE_API guint                    wpe_display_get_n_screens                 (WPEDisplay *display);
+WPE_API WPEScreen               *wpe_display_get_screen                    (WPEDisplay *display,
+                                                                            guint       index);
+WPE_API void                     wpe_display_screen_added                  (WPEDisplay *display,
+                                                                            WPEScreen *screen);
+WPE_API void                     wpe_display_screen_removed                (WPEDisplay *display,
+                                                                            WPEScreen *screen);
+WPE_API const char              *wpe_display_get_drm_device                (WPEDisplay *display);
+WPE_API const char              *wpe_display_get_drm_render_node           (WPEDisplay *display);
+WPE_API gboolean                 wpe_display_use_explicit_sync             (WPEDisplay *display);
 
-WPE_API WPESettings            *wpe_display_get_settings                  (WPEDisplay *display);
+WPE_API WPESettings             *wpe_display_get_settings                  (WPEDisplay *display);
+WPE_API WPEAvailableInputDevices wpe_display_get_available_input_devices   (WPEDisplay *display);
+WPE_API void                     wpe_display_set_available_input_devices   (WPEDisplay *display,
+                                                                            WPEAvailableInputDevices devices);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp
@@ -375,6 +375,12 @@ static gboolean wpeDisplayWaylandSetup(WPEDisplayWayland* display, GError** erro
         xdg_wm_base_add_listener(priv->xdgWMBase, &xdgWMBaseListener, nullptr);
     if (priv->wlSeat) {
         priv->wlCursor = makeUnique<WPE::WaylandCursor>(display);
+        priv->wlSeat->setAvailableInputDevicesChangedCallback([weakDisplay = GWeakPtr { display }](WPEAvailableInputDevices devices) {
+            if (!weakDisplay)
+                return;
+
+            wpe_display_set_available_input_devices(WPE_DISPLAY(weakDisplay.get()), devices);
+        });
         priv->wlSeat->startListening();
     }
 

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp
@@ -523,6 +523,9 @@ const struct wl_seat_listener WaylandSeat::s_listener = {
             wl_touch_release(seat.m_touch.object);
             seat.m_touch = { };
         }
+
+        if (seat.m_capabilitiesChangedCallback)
+            seat.m_capabilitiesChangedCallback(seat.availableInputDevices());
     },
     // name
     [](void*, struct wl_seat*, const char*) { }
@@ -742,6 +745,18 @@ bool WaylandSeat::keyRepeat(Seconds& delay, Seconds& interval)
     // rate is the number of characters per second.
     interval = Seconds(1. / m_keyboard.repeat.rate.value());
     return true;
+}
+
+WPEAvailableInputDevices WaylandSeat::availableInputDevices() const
+{
+    WPEAvailableInputDevices source = WPE_AVAILABLE_INPUT_DEVICE_NONE;
+    if (m_pointer.object)
+        source = WPE_AVAILABLE_INPUT_DEVICE_MOUSE;
+    if (m_keyboard.object)
+        source = static_cast<WPEAvailableInputDevices>(source | WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD);
+    if (m_touch.object)
+        source = static_cast<WPEAvailableInputDevices>(source | WPE_AVAILABLE_INPUT_DEVICE_TOUCHSCREEN);
+    return source;
 }
 
 } // namespace WPE

--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h
@@ -29,6 +29,7 @@
 #include "WPEKeymap.h"
 #include "WPEToplevelWayland.h"
 #include <wayland-client.h>
+#include <wtf/Function.h>
 #include <wtf/HashMap.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMalloc.h>
@@ -47,6 +48,7 @@ public:
     WPEKeymap* keymap() const { return m_keymap.get(); }
     uint32_t pointerModifiers() const { return m_pointer.modifiers; }
     std::pair<double, double> pointerCoords() const { return std::pair<double, double>(m_pointer.x, m_pointer.y); }
+    WPEAvailableInputDevices availableInputDevices() const;
 
     void startListening();
 
@@ -54,6 +56,8 @@ public:
 
     void emitPointerEnter(WPEView*) const;
     void emitPointerLeave(WPEView*) const;
+
+    void setAvailableInputDevicesChangedCallback(Function<void(WPEAvailableInputDevices)>&& callback) { m_capabilitiesChangedCallback = WTFMove(callback); }
 
 private:
     static const struct wl_seat_listener s_listener;
@@ -119,6 +123,7 @@ private:
         GWeakPtr<WPEToplevelWayland> toplevel;
         HashMap<int32_t, std::pair<double, double>, IntHash<int32_t>, WTF::SignedWithZeroKeyHashTraits<int32_t>> points;
     } m_touch;
+    Function<void(WPEAvailableInputDevices)> m_capabilitiesChangedCallback;
 };
 
 } // namespace WPE

--- a/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp
@@ -48,38 +48,33 @@ bool WebPage::platformCanHandleRequest(const ResourceRequest&)
 
 bool WebPage::hoverSupportedByPrimaryPointingDevice() const
 {
-#if ENABLE(TOUCH_EVENTS)
-    return !screenIsTouchPrimaryInputDevice();
-#else
-    return true;
-#endif
+    return WebProcess::singleton().primaryPointingDevice() == AvailableInputDevices::Mouse;
 }
 
 bool WebPage::hoverSupportedByAnyAvailablePointingDevice() const
 {
-#if ENABLE(TOUCH_EVENTS)
-    return !screenHasTouchDevice();
-#else
-    return true;
-#endif
+    return WebProcess::singleton().availableInputDevices().contains(AvailableInputDevices::Mouse);
 }
 
 std::optional<PointerCharacteristics> WebPage::pointerCharacteristicsOfPrimaryPointingDevice() const
 {
-#if ENABLE(TOUCH_EVENTS)
-    if (screenIsTouchPrimaryInputDevice())
+    const auto& primaryPointingDevice = WebProcess::singleton().primaryPointingDevice();
+    if (primaryPointingDevice == AvailableInputDevices::Mouse)
+        return PointerCharacteristics::Fine;
+    if (primaryPointingDevice == AvailableInputDevices::Touchscreen)
         return PointerCharacteristics::Coarse;
-#endif
-    return PointerCharacteristics::Fine;
+    return std::nullopt;
 }
 
 OptionSet<PointerCharacteristics> WebPage::pointerCharacteristicsOfAllAvailablePointingDevices() const
 {
-#if ENABLE(TOUCH_EVENTS)
-    if (screenHasTouchDevice())
-        return PointerCharacteristics::Coarse;
-#endif
-    return PointerCharacteristics::Fine;
+    OptionSet<PointerCharacteristics> pointerCharacteristics;
+    const auto& availableInputs = WebProcess::singleton().availableInputDevices();
+    if (availableInputs.contains(AvailableInputDevices::Mouse))
+        pointerCharacteristics.add(PointerCharacteristics::Fine);
+    if (availableInputs.contains(AvailableInputDevices::Touchscreen))
+        pointerCharacteristics.add(PointerCharacteristics::Coarse);
+    return pointerCharacteristics;
 }
 
 #if USE(GBM) && ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -77,6 +77,10 @@ OBJC_CLASS NSMutableDictionary;
 #include "RendererBufferTransportMode.h"
 #endif
 
+#if PLATFORM(WPE)
+#include "AvailableInputDevices.h"
+#endif
+
 #if PLATFORM(IOS_FAMILY)
 #include "ViewUpdateDispatcher.h"
 #endif
@@ -478,6 +482,14 @@ public:
     void initializePlatformDisplayIfNeeded() const;
 #endif
 
+#if PLATFORM(WPE)
+    const OptionSet<AvailableInputDevices>& availableInputDevices() const { return m_availableInputDevices; }
+    std::optional<AvailableInputDevices> primaryPointingDevice() const;
+#if ENABLE(WPE_PLATFORM)
+    void setAvailableInputDevices(OptionSet<AvailableInputDevices>);
+#endif // ENABLE(WPE_PLATFORM)
+#endif // PLATFORM(WPE)
+
     String mediaKeysStorageDirectory() const { return m_mediaKeysStorageDirectory; }
     FileSystem::Salt mediaKeysStorageSalt() const { return m_mediaKeysStorageSalt; }
 
@@ -836,6 +848,10 @@ private:
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
     OptionSet<RendererBufferTransportMode> m_rendererBufferTransportMode;
+#endif
+
+#if PLATFORM(WPE)
+    OptionSet<AvailableInputDevices> m_availableInputDevices;
 #endif
 
     bool m_hasSuspendedPageProxy { false };

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -126,6 +126,9 @@ messages -> WebProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     SetScreenProperties(struct WebCore::ScreenProperties screenProperties)
 #endif
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
+    SetAvailableInputDevices(OptionSet<WebKit::AvailableInputDevices> availableInputDevices)
+#endif
 #if PLATFORM(MAC)
     ScrollerStylePreferenceChanged(bool useOvelayScrollbars)
 #endif

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -196,6 +196,8 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         } else
             initializePlatformDisplayIfNeeded();
     }
+
+    m_availableInputDevices = parameters.availableInputDevices;
 #endif
 
 #if USE(GSTREAMER)
@@ -296,6 +298,24 @@ void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties
         page->screenPropertiesDidChange();
 }
 #endif
+
+#if PLATFORM(WPE)
+std::optional<AvailableInputDevices> WebProcess::primaryPointingDevice() const
+{
+    if (m_availableInputDevices.contains(AvailableInputDevices::Mouse))
+        return AvailableInputDevices::Mouse;
+    if (m_availableInputDevices.contains(AvailableInputDevices::Touchscreen))
+        return AvailableInputDevices::Touchscreen;
+    return std::nullopt;
+}
+
+#if ENABLE(WPE_PLATFORM)
+void WebProcess::setAvailableInputDevices(OptionSet<AvailableInputDevices> availableInputDevices)
+{
+    m_availableInputDevices = availableInputDevices;
+}
+#endif // ENABLE(WPE_PLATFORM)
+#endif // PLATFORM(WPE)
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 2e472a4b1063f7eb10f34fe875cfab1aa7c83cd5
<pre>
[WPE] WPEPlatform-based implementation of Interaction Media Features
<a href="https://bugs.webkit.org/show_bug.cgi?id=289166">https://bugs.webkit.org/show_bug.cgi?id=289166</a>

Reviewed by Carlos Garcia Campos.

This updates the WebPageWPE behaviour so that it queries
interaction-related information (i.e. mouse or touch capabilities) from
the WebProcess singleton. The WebProcess retrieves this information
throug the WebProcessCreationParameters, which themselves are fetched by
means of WPEPlatform.

This initial changeset includes the Wayland implementation where seat
capabilities are queried, then stored as properties. When a change is
received by the seat, it is propagated to the WebProcesses.

The old implementation has been kept as a fallback: when not using
WPE_PLATFORM and using TOUCH_EVENTS, Touch is assumed. Otherwise we
fallback to Mouse.

* Source/WebCore/platform/PlatformScreen.h:
* Source/WebCore/platform/wpe/PlatformScreenWPE.cpp:
(WebCore::screenHasTouchDevice): Deleted.
(WebCore::screenIsTouchPrimaryInputDevice): Deleted.
* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/Scripts/webkit/messages.py:
(conditions_for_header):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.serialization.in:
* Source/WebKit/Shared/glib/AvailableInputDevices.h: Added.
* Source/WebKit/Shared/glib/AvailableInputDevices.serialization.in: Added.
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::toAvailableInputDevices):
(WebKit::WebProcessPool::availableInputDevices):
(WebKit::WebProcessPool::platformInitialize):
(WebKit::WebProcessPool::platformInitializeWebProcess):
(WebKit::WebProcessPool::platformInvalidateContext):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.cpp:
(wpeDisplaySetProperty):
(wpeDisplayGetProperty):
(wpe_display_class_init):
(wpe_display_get_available_input_devices):
(wpe_display_set_available_input_devices):
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/wayland/WPEDisplayWayland.cpp:
(wpeDisplayWaylandSetup):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.cpp:
(WPE::WaylandSeat::availableInputDevices const):
* Source/WebKit/WPEPlatform/wpe/wayland/WPEWaylandSeat.h:
(WPE::WaylandSeat::setAvailableInputDevicesChangedCallback):
* Source/WebKit/WebProcess/WebPage/wpe/WebPageWPE.cpp:
(WebKit::WebPage::hoverSupportedByPrimaryPointingDevice const):
(WebKit::WebPage::hoverSupportedByAnyAvailablePointingDevice const):
(WebKit::WebPage::pointerCharacteristicsOfPrimaryPointingDevice const):
(WebKit::WebPage::pointerCharacteristicsOfAllAvailablePointingDevices const):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
(WebKit::WebProcess::primaryPointingDevice const):
(WebKit::WebProcess::setAvailableInputDevices):

Canonical link: <a href="https://commits.webkit.org/293276@main">https://commits.webkit.org/293276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add3ff824b54dca9c7fbc217a58ca5e0e187c5dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/98327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/17958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/8186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/103447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/48856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/100372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/18250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/26409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/74845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/32011 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/101331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/13823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/88804 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/55205 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/97813 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/13606 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/6765 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/48298 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/83586 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/6839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/105821 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/25414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/18494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/83826 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/25787 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/85006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/83296 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/21057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27938 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/5610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/19058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/25372 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/30553 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/25192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/28508 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/26767 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->