### PR TITLE
Add support for generating a consumer for CSS property's that require arbitrary numeric ranges

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/at-position-try-cssom-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL CSSPositionTryRule attribute values Can't find variable: CSSPositionTryDescriptors
-FAIL CSSPositionTryRule.style.setProperty setting allowed and disallowed properties assert_equals: expected 100 but got 8
+PASS CSSPositionTryRule.style.setProperty setting allowed and disallowed properties
 PASS CSSPositionTryDescriptors.item
 PASS CSSPositionTryDescriptors.cssText
 PASS CSSPositionTryDescriptors.getPropertyValue(margin)

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -737,10 +737,8 @@
                 "font-property": true,
                 "high-priority": true,
                 "style-builder-converter": "FontWeight",
-                "parser-function": "consumeFontWeight",
-                "parser-function-allows-number-or-integer-input": true,
-                "parser-grammar-unused": "<font-weight-absolute> | bolder | lighter",
-                "parser-grammar-unused-reason": "Needs support for arbitrary ranges on <number>."
+                "parser-grammar": "<font-weight-absolute> | bolder | lighter",
+                "parser-exported": true
             },
             "specification": {
                 "category": "css-fonts-4",

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -763,6 +763,10 @@ static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID propertyId, StringView s
     // FIXME: The "!context.enclosingRuleType" is suspicious.
     ASSERT(!CSSProperty::isDescriptorOnly(propertyId) || parsingDescriptor || !context.enclosingRuleType);
 
+    // Fast path keyword parsing is currently only supported for style properties.
+    if (parsingDescriptor)
+        return nullptr;
+
     if (!CSSParserFastPaths::isKeywordFastPathEligibleStyleProperty(propertyId)) {
         // All properties, including non-keyword properties, accept the CSS-wide keywords.
         if (!isUniversalKeyword(string))
@@ -771,10 +775,6 @@ static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID propertyId, StringView s
         // Leave shorthands to parse CSS-wide keywords using CSSPropertyParser.
         if (shorthandForProperty(propertyId).length())
             return nullptr;
-
-        // Descriptors do not support the CSS-wide keywords.
-        if (parsingDescriptor)
-            return nullptr;
     }
 
     CSSValueID valueID = cssValueKeywordID(string);
@@ -782,7 +782,7 @@ static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID propertyId, StringView s
     if (!valueID)
         return nullptr;
 
-    if (!parsingDescriptor && isCSSWideKeyword(valueID))
+    if (isCSSWideKeyword(valueID))
         return CSSPrimitiveValue::create(valueID);
 
     if (CSSParserFastPaths::isKeywordValidForStyleProperty(propertyId, valueID, context))

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -735,7 +735,7 @@ bool CSSPropertyParser::consumeFont(bool important)
             continue;
         if (!fontVariantCaps && (fontVariantCaps = consumeIdent<CSSValueSmallCaps>(range)))
             continue;
-        if (!fontWeight && (fontWeight = consumeFontWeight(range, m_context)))
+        if (!fontWeight && (fontWeight = CSSPropertyParsing::consumeFontWeight(range, m_context)))
             continue;
         if (!fontWidth && (fontWidth = CSSPropertyParsing::consumeFontWidthAbsolute(range)))
             continue;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -168,15 +168,6 @@ static std::optional<UnresolvedFontWeight> consumeFontWeightUnresolved(CSSParser
     return std::nullopt;
 }
 
-RefPtr<CSSValue> consumeFontWeight(CSSParserTokenRange& range, const CSSParserContext& context)
-{
-    if (auto keyword = consumeIdentRaw<CSSValueNormal, CSSValueBold, CSSValueBolder, CSSValueLighter>(range))
-        return CSSPrimitiveValue::create(*keyword);
-    if (auto fontWeightNumber = consumeFontWeightNumberUnresolved(range, context))
-        return resolveToCSSPrimitiveValue(WTFMove(*fontWeightNumber));
-    return nullptr;
-}
-
 // MARK: - 'font-style'
 
 #if ENABLE(VARIATION_FONTS)

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -97,10 +97,6 @@ struct UnresolvedFont {
 // https://drafts.csswg.org/css-fonts-4/#font-prop
 std::optional<UnresolvedFont> parseUnresolvedFont(const String&, const CSSParserContext&);
 
-// MARK: 'font-weight'
-// https://drafts.csswg.org/css-fonts-4/#font-weight-prop
-RefPtr<CSSValue> consumeFontWeight(CSSParserTokenRange&, const CSSParserContext&);
-
 // MARK: 'font-style'
 // https://drafts.csswg.org/css-fonts-4/#font-style-prop
 RefPtr<CSSValue> consumeFontStyle(CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/css/scripts/test/TestCSSProperties.json
+++ b/Source/WebCore/css/scripts/test/TestCSSProperties.json
@@ -41,7 +41,13 @@
                 "parser-grammar": "<number>"
             }
         },
-
+        "test-numeric-value-range": {
+            "animation-type": "discrete",
+            "initial": "0",
+            "codegen-properties": {
+                "parser-grammar": "<number [-inf, -10]> | <length [0, inf]> | <angle [-90,90]> | <percentage [1,100]>"
+            }
+        },
         "test-settings-one": {
             "animation-type": "discrete",
             "initial": "0",

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf
@@ -24,7 +24,7 @@ namespace WebCore {
 
 static_assert(cssPropertyIDEnumValueCount <= (std::numeric_limits<uint16_t>::max() + 1), "CSSPropertyID should fit into uint16_t.");
 
-const std::array<CSSPropertyID, 13> computedPropertyIDs {
+const std::array<CSSPropertyID, 14> computedPropertyIDs {
     CSSPropertyID::CSSPropertyTestAnimationWrapper,
     CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationAlways,
     CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationThreadedOnly,
@@ -33,6 +33,7 @@ const std::array<CSSPropertyID, 13> computedPropertyIDs {
     CSSPropertyID::CSSPropertyTestLogicalPropertyGroupLogicalInline,
     CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal,
     CSSPropertyID::CSSPropertyTestLogicalPropertyGroupPhysicalVertical,
+    CSSPropertyID::CSSPropertyTestNumericValueRange,
     CSSPropertyID::CSSPropertyTestProperty,
     CSSPropertyID::CSSPropertyTestSettingsOne,
     CSSPropertyID::CSSPropertyTestSinkPriority,
@@ -48,6 +49,7 @@ constexpr ASCIILiteral propertyNameStrings[numCSSProperties] = {
     "test-animation-wrapper"_s,
     "test-animation-wrapper-acceleration-always"_s,
     "test-animation-wrapper-acceleration-threaded-only"_s,
+    "test-numeric-value-range"_s,
     "test-property"_s,
     "test-settings-one"_s,
     "test-using-shared-rule"_s,
@@ -83,6 +85,7 @@ first-test-descriptor-for-second-descriptor, CSSPropertyID::CSSPropertyFirstTest
 test-animation-wrapper, CSSPropertyID::CSSPropertyTestAnimationWrapper
 test-animation-wrapper-acceleration-always, CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationAlways
 test-animation-wrapper-acceleration-threaded-only, CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationThreadedOnly
+test-numeric-value-range, CSSPropertyID::CSSPropertyTestNumericValueRange
 test-property, CSSPropertyID::CSSPropertyTestProperty
 test-settings-one, CSSPropertyID::CSSPropertyTestSettingsOne
 test-using-shared-rule, CSSPropertyID::CSSPropertyTestUsingSharedRule
@@ -224,6 +227,7 @@ constexpr bool isInheritedPropertyTable[cssPropertyIDEnumValueCount] = {
     false, // CSSPropertyID::CSSPropertyTestAnimationWrapper
     false, // CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationAlways
     false, // CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationThreadedOnly
+    false, // CSSPropertyID::CSSPropertyTestNumericValueRange
     false, // CSSPropertyID::CSSPropertyTestProperty
     false, // CSSPropertyID::CSSPropertyTestSettingsOne
     false, // CSSPropertyID::CSSPropertyTestUsingSharedRule
@@ -289,6 +293,7 @@ bool CSSProperty::allowsNumberOrIntegerInput(CSSPropertyID id)
     case CSSPropertyID::CSSPropertyTestAnimationWrapper:
     case CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationAlways:
     case CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationThreadedOnly:
+    case CSSPropertyID::CSSPropertyTestNumericValueRange:
     case CSSPropertyID::CSSPropertyTestProperty:
     case CSSPropertyID::CSSPropertyTestSettingsOne:
     case CSSPropertyID::CSSPropertyTestUsingSharedRule:

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h
@@ -20,17 +20,18 @@ enum CSSPropertyID : uint16_t {
     CSSPropertyTestAnimationWrapper = 6,
     CSSPropertyTestAnimationWrapperAccelerationAlways = 7,
     CSSPropertyTestAnimationWrapperAccelerationThreadedOnly = 8,
-    CSSPropertyTestProperty = 9,
-    CSSPropertyTestSettingsOne = 10,
-    CSSPropertyTestUsingSharedRule = 11,
-    CSSPropertyTestSinkPriority = 12,
-    CSSPropertyTestLogicalPropertyGroupLogicalBlock = 13,
-    CSSPropertyTestLogicalPropertyGroupLogicalInline = 14,
-    CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal = 15,
-    CSSPropertyTestLogicalPropertyGroupPhysicalVertical = 16,
-    CSSPropertyFont = 17,
-    CSSPropertyTestShorthandOne = 18,
-    CSSPropertyTestShorthandTwo = 19,
+    CSSPropertyTestNumericValueRange = 9,
+    CSSPropertyTestProperty = 10,
+    CSSPropertyTestSettingsOne = 11,
+    CSSPropertyTestUsingSharedRule = 12,
+    CSSPropertyTestSinkPriority = 13,
+    CSSPropertyTestLogicalPropertyGroupLogicalBlock = 14,
+    CSSPropertyTestLogicalPropertyGroupLogicalInline = 15,
+    CSSPropertyTestLogicalPropertyGroupPhysicalHorizontal = 16,
+    CSSPropertyTestLogicalPropertyGroupPhysicalVertical = 17,
+    CSSPropertyFont = 18,
+    CSSPropertyTestShorthandOne = 19,
+    CSSPropertyTestShorthandTwo = 20,
 };
 
 // Enum value of the first "real" CSS property, which excludes
@@ -38,10 +39,10 @@ enum CSSPropertyID : uint16_t {
 constexpr uint16_t firstCSSProperty = 2;
 // Total number of enum values in the CSSPropertyID enum. If making an array
 // that can be indexed into using the enum value, use this as the size.
-constexpr uint16_t cssPropertyIDEnumValueCount = 20;
+constexpr uint16_t cssPropertyIDEnumValueCount = 21;
 // Number of "real" CSS properties. This differs from cssPropertyIDEnumValueCount,
 // as this doesn't consider CSSPropertyInvalid and CSSPropertyCustom.
-constexpr uint16_t numCSSProperties = 18;
+constexpr uint16_t numCSSProperties = 19;
 constexpr unsigned maxCSSPropertyNameLength = 49;
 constexpr auto firstTopPriorityProperty = CSSPropertyID::CSSPropertyTestTopPriority;
 constexpr auto lastTopPriorityProperty = CSSPropertyID::CSSPropertyTestTopPriority;
@@ -54,7 +55,7 @@ constexpr auto lastLogicalGroupProperty = CSSPropertyID::CSSPropertyTestLogicalP
 constexpr auto firstShorthandProperty = CSSPropertyID::CSSPropertyFont;
 constexpr auto lastShorthandProperty = CSSPropertyID::CSSPropertyTestShorthandTwo;
 constexpr uint16_t numCSSPropertyLonghands = firstShorthandProperty - firstCSSProperty;
-extern const std::array<CSSPropertyID, 13> computedPropertyIDs;
+extern const std::array<CSSPropertyID, 14> computedPropertyIDs;
 
 struct CSSPropertySettings {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSStyleDeclaration+PropertyNames.idl
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSStyleDeclaration+PropertyNames.idl
@@ -21,6 +21,7 @@ partial interface CSSStyleDeclaration {
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString testLogicalPropertyGroupLogicalInline;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString testLogicalPropertyGroupPhysicalHorizontal;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString testLogicalPropertyGroupPhysicalVertical;
+    [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString testNumericValueRange;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString testProperty;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName, EnabledBySetting=cssSettingsOneEnabled] attribute [LegacyNullToEmptyString] CSSOMString testSettingsOne;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForCamelCasedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString testShorthandOne;
@@ -54,6 +55,7 @@ partial interface CSSStyleDeclaration {
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString test-logical-property-group-logical-inline;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString test-logical-property-group-physical-horizontal;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString test-logical-property-group-physical-vertical;
+    [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString test-numeric-value-range;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString test-property;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName, EnabledBySetting=cssSettingsOneEnabled] attribute [LegacyNullToEmptyString] CSSOMString test-settings-one;
     [CEReactions=Needed, DelegateToSharedSyntheticAttribute=propertyValueForDashedIDLAttribute, CallWith=PropertyName] attribute [LegacyNullToEmptyString] CSSOMString test-shorthand-one;

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp
@@ -80,6 +80,18 @@ public:
     {
         builderState.style().setTestAnimationWrapperAccelerationThreadedOnly(fromCSSValueDeducingType(builderState, value));
     }
+    static void applyInitialTestNumericValueRange(BuilderState& builderState)
+    {
+        builderState.style().setTestNumericValueRange(RenderStyle::initialTestNumericValueRange());
+    }
+    static void applyInheritTestNumericValueRange(BuilderState& builderState)
+    {
+        builderState.style().setTestNumericValueRange(forwardInheritedValue(builderState.parentStyle().testNumericValueRange()));
+    }
+    static void applyValueTestNumericValueRange(BuilderState& builderState, CSSValue& value)
+    {
+        builderState.style().setTestNumericValueRange(fromCSSValueDeducingType(builderState, value));
+    }
     static void applyInitialTestProperty(BuilderState& builderState)
     {
         builderState.style().setTestProperty(RenderStyle::initialTestProperty());
@@ -232,6 +244,19 @@ void BuilderGenerated::applyProperty(CSSPropertyID id, BuilderState& builderStat
             break;
         case ApplyValueType::Value:
             BuilderFunctions::applyValueTestAnimationWrapperAccelerationThreadedOnly(builderState, value);
+            break;
+        }
+        break;
+    case CSSPropertyID::CSSPropertyTestNumericValueRange:
+        switch (valueType) {
+        case ApplyValueType::Initial:
+            BuilderFunctions::applyInitialTestNumericValueRange(builderState);
+            break;
+        case ApplyValueType::Inherit:
+            BuilderFunctions::applyInheritTestNumericValueRange(builderState);
+            break;
+        case ApplyValueType::Value:
+            BuilderFunctions::applyValueTestNumericValueRange(builderState, value);
             break;
         }
         break;

--- a/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleInterpolationWrapperMap.cpp
+++ b/Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleInterpolationWrapperMap.cpp
@@ -38,6 +38,7 @@ WrapperMap::WrapperMap()
         new Wrapper<float>(CSSPropertyID::CSSPropertyTestAnimationWrapper, &RenderStyle::testAnimationWrapper, &RenderStyle::setTestAnimationWrapper), // CSSPropertyID::CSSPropertyTestAnimationWrapper
         new Wrapper<float>(CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationAlways, &RenderStyle::testAnimationWrapperAccelerationAlways, &RenderStyle::setTestAnimationWrapperAccelerationAlways), // CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationAlways
         new Wrapper<float>(CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationThreadedOnly, &RenderStyle::testAnimationWrapperAccelerationThreadedOnly, &RenderStyle::setTestAnimationWrapperAccelerationThreadedOnly), // CSSPropertyID::CSSPropertyTestAnimationWrapperAccelerationThreadedOnly
+        new DiscreteWrapper(CSSPropertyID::CSSPropertyTestNumericValueRange, &RenderStyle::testNumericValueRange, &RenderStyle::setTestNumericValueRange), // CSSPropertyID::CSSPropertyTestNumericValueRange
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestProperty, &RenderStyle::testProperty, &RenderStyle::setTestProperty), // CSSPropertyID::CSSPropertyTestProperty
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestSettingsOne, &RenderStyle::testSettingsOne, &RenderStyle::setTestSettingsOne), // CSSPropertyID::CSSPropertyTestSettingsOne
         new DiscreteWrapper(CSSPropertyID::CSSPropertyTestUsingSharedRule, &RenderStyle::testUsingSharedRule, &RenderStyle::setTestUsingSharedRule), // CSSPropertyID::CSSPropertyTestUsingSharedRule


### PR DESCRIPTION
#### 27fa2a20b2901866b273cc5b2cbbca23637483a1
<pre>
Add support for generating a consumer for CSS property&apos;s that require arbitrary numeric ranges
<a href="https://bugs.webkit.org/show_bug.cgi?id=289170">https://bugs.webkit.org/show_bug.cgi?id=289170</a>

Reviewed by Darin Adler.

To support CSS properties like font-weight, which contains the production
&lt;number [1,1000]&gt;, support for arbitrary numeric ranges is required in the
code generator. This is done by replacing calls to dedicated consume{numeric type}(...)
functions with direct use of CSSPrimitiveValueResolver. CSSPrimitiveValueResolver
allows specifying an arbitrary strongly typed CSS value including any numeric
range it specifies.

* Source/WebCore/css/CSSProperties.json:
    - Make &apos;font-weight&apos; use the code generator and export it for use
      in the font shorthand.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::CSSPropertyParser::consumeFont):
    - Call new generated and exported function.

* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseKeywordValue):
    - Remove unused support for fast path parsing of descriptors. When
      properties and descriptors share the same name (as is true with
      &apos;font-weight&apos;) but have different grammars, the fast path would
      be incorrect.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
(WebCore::CSSPropertyParserHelpers::consumeFontWeight): Deleted.
    - Remove old hand written &apos;font-weight&apos; consumer.

* Source/WebCore/css/process-css-properties.py:
    - Remove mappings for range parameters and instead generate
      appropriate CSS::Range expressions for them.
    - Fix BNFLexer to support negative numeric tokens.

* Source/WebCore/css/scripts/test/TestCSSProperties.json:
    - Add new test case with numeric ranges.

* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.gperf:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyNames.h:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSPropertyParsing.cpp:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/CSSStyleDeclaration+PropertyNames.idl:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleBuilderGenerated.cpp:
* Source/WebCore/css/scripts/test/TestCSSPropertiesResults/StyleInterpolationWrapperMap.cpp:
    - Update results for new test case.

Canonical link: <a href="https://commits.webkit.org/291734@main">https://commits.webkit.org/291734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/812ac514c72f131b97d6dcc07708706a454b8562

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93829 "30 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/13409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98835 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21845 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71609 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96831 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51944 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2418 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43670 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100871 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20881 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79971 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19910 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24520 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20865 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24012 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/22293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->