### PR TITLE
[css-anchor-position-1] Tighten the state management in AnchorPositionedState

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL Transition when the result of anchor() changes assert_equals: expected 120 but got 130
-FAIL Transition when the result of anchor-size() changes assert_equals: expected 60 but got 70
+PASS Transition when the result of anchor() changes
+PASS Transition when the result of anchor-size() changes
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-position-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-position-area-expected.txt
@@ -8,28 +8,28 @@ PASS normal --right, --left, --bottom, --top | --right
 PASS normal --top, --left, --bottom, --right | --top
 PASS most-block-size --right, --left | --right
 PASS most-height --right, --left | --right
-PASS most-inline-size --right, --left | --left
-PASS most-width --right, --left | --left
+FAIL most-inline-size --right, --left | --left assert_equals: offsetLeft expected 0 but got 300
+FAIL most-width --right, --left | --left assert_equals: offsetLeft expected 0 but got 300
 PASS most-inline-size --bottom, --top | --bottom
 PASS most-width --bottom, --top | --bottom
-PASS most-block-size --bottom, --top | --top
-PASS most-height --bottom, --top | --top
-PASS most-inline-size --right, --left, --bottom, --top | --bottom
-PASS most-inline-size --right, --left, --top, --bottom | --top
-PASS most-block-size --bottom, --top, --right, --left | --right
-PASS most-block-size --bottom, --top, --left, --right | --left
+FAIL most-block-size --bottom, --top | --top assert_equals: offsetTop expected 0 but got 350
+FAIL most-height --bottom, --top | --top assert_equals: offsetTop expected 0 but got 350
+FAIL most-inline-size --right, --left, --bottom, --top | --bottom assert_equals: offsetLeft expected 0 but got 300
+FAIL most-inline-size --right, --left, --top, --bottom | --top assert_equals: offsetLeft expected 0 but got 300
+FAIL most-block-size --bottom, --top, --right, --left | --right assert_equals: offsetLeft expected 300 but got 0
+FAIL most-block-size --bottom, --top, --left, --right | --left assert_equals: offsetTop expected 0 but got 350
 PASS most-inline-size --left-sweep, --bottom-sweep | --left-sweep
 PASS most-inline-size --bottom-sweep, --left-sweep | --bottom-sweep
 PASS most-block-size --left-sweep, --bottom-sweep | --left-sweep
-PASS most-block-size --bottom-sweep, --left-sweep | --left-sweep
-PASS most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep
-PASS most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep
-PASS most-inline-size
+FAIL most-block-size --bottom-sweep, --left-sweep | --left-sweep assert_equals: offsetLeft expected 0 but got 150
+FAIL most-inline-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --left-sweep assert_equals: offsetLeft expected 0 but got 300
+FAIL most-block-size --right-sweep, --left-sweep, --bottom-sweep, --top-sweep | --top-sweep assert_equals: offsetLeft expected 150 but got 300
+FAIL most-inline-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --left-sweep
-PASS most-block-size
+   | --left-sweep assert_equals: offsetLeft expected 0 but got 300
+FAIL most-block-size
   --right-sweep, --left-sweep, --bottom-sweep, --top-sweep,
   --right, --left, --bottom, --top
-   | --right
+   | --right assert_equals: offsetTop expected 0 but got 200
 

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -4508,6 +4508,9 @@ void RenderLayer::setSnapshottedScrollOffsetForAnchorPositioning(LayoutSize offs
     // FIXME: Scroll offset should be adjusted in the scrolling tree so layers stay exactly in sync.
     m_snapshottedScrollOffsetForAnchorPositioning = offset;
     updateTransform();
+
+    if (isComposited())
+        setNeedsCompositingGeometryUpdate();
 }
 
 void RenderLayer::clearSnapshottedScrollOffsetForAnchorPositioning()
@@ -4517,6 +4520,9 @@ void RenderLayer::clearSnapshottedScrollOffsetForAnchorPositioning()
 
     m_snapshottedScrollOffsetForAnchorPositioning = { };
     updateTransform();
+
+    if (isComposited())
+        setNeedsCompositingGeometryUpdate();
 }
 
 // hitTestLocation and hitTestRect are relative to rootLayer.

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -66,7 +66,7 @@ struct AnchorPositionedState {
 public:
     AnchorElements anchorElements;
     UncheckedKeyHashSet<AtomString> anchorNames;
-    AnchorPositionResolutionStage stage { AnchorPositionResolutionStage::FindAnchors };
+    std::optional<AnchorPositionResolutionStage> stage;
     bool hasAnchorFunctions { false };
 };
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -1001,8 +1001,6 @@ bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& conte
     for (auto& anchorRenderer : m_document->renderView()->anchors()) {
         auto rect = anchorRenderer.absoluteBoundingBoxRect();
 
-        m_anchorRectsOnLastUpdate.add(anchorRenderer, rect);
-
         auto it = previousAnchorRects.find(anchorRenderer);
         bool changed = it == previousAnchorRects.end() || it->value != rect;
         if (!changed)
@@ -1011,6 +1009,8 @@ bool Scope::invalidateForAnchorDependencies(LayoutDependencyUpdateContext& conte
         auto anchoredElements = anchorMap.getOptional(anchorRenderer);
         if (!anchoredElements)
             continue;
+
+        m_anchorRectsOnLastUpdate.add(anchorRenderer, rect);
 
         for (auto& anchoredElement : *anchoredElements) {
             if (!context.invalidatedAnchorPositioned.add(anchoredElement.get()).isNewEntry)
@@ -1122,7 +1122,7 @@ void Scope::resetAnchorPositioningStateBeforeStyleResolution()
     // FIXME: Move this transient state to TreeResolver.
     for (auto elementAndState : m_anchorPositionedStates) {
         elementAndState.value->anchorNames.clear();
-        elementAndState.value->stage = AnchorPositionResolutionStage::FindAnchors;
+        elementAndState.value->stage = { };
         elementAndState.value->hasAnchorFunctions = false;
     }
 }
@@ -1133,7 +1133,7 @@ void Scope::updateAnchorPositioningStateAfterStyleResolution()
 
     m_anchorPositionedStates.removeIf([](auto& elementAndState) {
         // Remove if we have no anchors after initial resolution.
-        return elementAndState.value->stage != AnchorPositionResolutionStage::FindAnchors && elementAndState.value->anchorNames.isEmpty();
+        return elementAndState.value->stage && elementAndState.value->anchorNames.isEmpty();
     });
 }
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -148,7 +148,7 @@ private:
     const RenderStyle* parentBoxStyle() const;
     const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
 
-    AnchorPositionedElementAction updateAnchorPositioningState(Element&, const RenderStyle*);
+    AnchorPositionedElementAction updateAnchorPositioningState(Element&, const RenderStyle*, Change);
 
     void generatePositionOptionsIfNeeded(const ResolvedStyle&, const Styleable&, const ResolutionContext&);
     std::unique_ptr<RenderStyle> generatePositionOption(const PositionTryFallback&, const ResolvedStyle&, const Styleable&, const ResolutionContext&);


### PR DESCRIPTION
#### d246b8e72c4fb421054c6ac396c7e79e27537ca9
<pre>
[css-anchor-position-1] Tighten the state management in AnchorPositionedState
<a href="https://bugs.webkit.org/show_bug.cgi?id=289163">https://bugs.webkit.org/show_bug.cgi?id=289163</a>
<a href="https://rdar.apple.com/problem/146313542">rdar://problem/146313542</a>

Reviewed by Sam Weinig.

Currently we do too many style updates for anchor positioned elements because transient state is not properly managed.
This is inefficient and also hides bugs (which this patch fixes).

The patch makes the stage enum an optional paramater that is only initialized if we are actually resolving anchors.
This is a step toward moving the transient state to a TreeResolver scoped struct.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/anchor-transition-eval-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-try-order-position-area-expected.txt:

These were spurious PASSes as try-order evaluation is not implemented.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):

Scope Style::Resolver lifetime so it gets deleted before compositing layer update.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setSnapshottedScrollOffsetForAnchorPositioning):
(WebCore::RenderLayer::clearSnapshottedScrollOffsetForAnchorPositioning):

Ensure we do compositing layer update if offset change.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
(WebCore::Style::AnchorPositionEvaluator::findAnchorForAnchorFunctionAndAttemptResolution):
(WebCore::Style::AnchorPositionEvaluator::updateAnchorPositionedStateForLayoutTimePositioned):

Update if it might be layout time positioned (has position-anchor);

* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::invalidateForAnchorDependencies):

Only save the anchor rect if anchored elements have been found.

(WebCore::Style::Scope::resetAnchorPositioningStateBeforeStyleResolution):

Clear the stage.

(WebCore::Style::Scope::updateAnchorPositioningStateAfterStyleResolution):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolve):

Don&apos;t trigger further style resolution passes if the stage has not progressed.

(WebCore::Style::TreeResolver::updateAnchorPositioningState):

If an anchor changes style we need to do an interleaving round since its position may change.

(WebCore::Style::TreeResolver::generatePositionOptionsIfNeeded):
(WebCore::Style::TreeResolver::tryChoosePositionOption):

Don&apos;t pick an option before it has been positioned.

Canonical link: <a href="https://commits.webkit.org/291656@main">https://commits.webkit.org/291656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b5b37bd1c072981425ec4176a7879adbd760219

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98567 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71479 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28855 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51814 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2232 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43404 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100599 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80492 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79826 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19856 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1708 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13764 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25778 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20287 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23747 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22028 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->