### PR TITLE
Use convertNodesOrStringsIntoNodeVector instead convertNodesOrStringsIntoNode

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -712,19 +712,17 @@ ExceptionOr<void> Node::replaceWith(FixedVector<NodeOrString>&& nodeOrStringVect
     auto nodeSet = nodeSetPreTransformedFromNodeOrStringVector(nodeOrStringVector);
     RefPtr viableNextSibling = firstFollowingSiblingNotInNodeSet(*this, nodeSet);
 
-    auto result = convertNodesOrStringsIntoNode(WTFMove(nodeOrStringVector));
+    auto result = convertNodesOrStringsIntoNodeVector(WTFMove(nodeOrStringVector));
     if (result.hasException())
         return result.releaseException();
 
+    auto child = result.releaseReturnValue();
     if (parentNode() == parent) {
-        if (RefPtr node = result.releaseReturnValue())
-            return parent->replaceChild(*node, *this);
+        return parent->replaceChild(child[0], *this);
         return parent->removeChild(*this);
     }
 
-    if (RefPtr node = result.releaseReturnValue())
-        return parent->insertBefore(*node, WTFMove(viableNextSibling));
-    return { };
+    return parent->insertBefore(child[0], WTFMove(viableNextSibling));
 }
 
 ExceptionOr<void> Node::remove()

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -762,7 +762,6 @@ protected:
     template<typename NodeClass>
     static NodeClass& traverseToRootNodeInternal(const NodeClass&);
 
-    // FIXME: Replace all uses of convertNodesOrStringsIntoNode by convertNodesOrStringsIntoNodeVector.
     ExceptionOr<RefPtr<Node>> convertNodesOrStringsIntoNode(FixedVector<NodeOrString>&&);
     ExceptionOr<NodeVector> convertNodesOrStringsIntoNodeVector(FixedVector<NodeOrString>&&);
 


### PR DESCRIPTION
#### 031747b4931b9648b70af0589523c46804025513
<pre>
Use convertNodesOrStringsIntoNodeVector instead convertNodesOrStringsIntoNode
<a href="https://bugs.webkit.org/show_bug.cgi?id=289179">https://bugs.webkit.org/show_bug.cgi?id=289179</a>

Reviewed by NOBODY (OOPS!).

Use convertNodesOrStringsIntoNodeVector instead convertNodesOrStringsIntoNode in Node.cpp.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::replaceWith):
* Source/WebCore/dom/Node.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/031747b4931b9648b70af0589523c46804025513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44086 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95610 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21576 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71495 "Found 5 new test failures: fast/dom/ChildNode-replaceWith.html imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28851 "Found 4 new test failures: fast/dom/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96562 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10033 "Found 1 new test failure: fast/dom/ChildNode-replaceWith.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84644 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51820 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9715 "Found 4 new test failures: imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2269 "Found 2 new test failures: fast/dom/ChildNode-replaceWith.html imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43400 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/79990 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2337 "Found 5 new test failures: fast/dom/ChildNode-replaceWith.html imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100595 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20612 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15072 "Found 6 new test failures: fast/dom/ChildNode-replaceWith.html fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80491 "Found 5 new test failures: fast/dom/ChildNode-replaceWith.html imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79825 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24359 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1743 "Found 5 new test failures: fast/dom/ChildNode-replaceWith.html imported/w3c/web-platform-tests/dom/nodes/ChildNode-replaceWith.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments-tt-enforced.html imported/w3c/web-platform-tests/trusted-types/Node-multiple-arguments.html imported/w3c/web-platform-tests/trusted-types/legacy-trusted-scripts.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13760 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20596 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25774 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->