### PR TITLE
[Grid][Cleanup] Move m_hasAspectRatioBlockSizeDependentItem  to GridLayoutState

### DIFF
--- a/Source/WebCore/rendering/GridLayoutState.h
+++ b/Source/WebCore/rendering/GridLayoutState.h
@@ -46,9 +46,13 @@ public:
     bool needsSecondTrackSizingPass() const { return m_needsSecondTrackSizingPass; }
     void setNeedsSecondTrackSizingPass() { m_needsSecondTrackSizingPass = true; }
 
+    void setHasAspectRatioBlockSizeDependentItem() { m_hasAspectRatioBlockSizeDependentItem = true; }
+    bool hasAspectRatioBlockSizeDependentItem() const { return m_hasAspectRatioBlockSizeDependentItem; }
+
 private:
     ItemsLayoutRequirements m_itemsLayoutRequirements;
     bool m_needsSecondTrackSizingPass { false };
+    bool m_hasAspectRatioBlockSizeDependentItem { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -270,7 +270,7 @@ private:
 
     bool aspectRatioPrefersInline(const RenderBox& gridItem, bool blockFlowIsColumnAxis);
 
-    Vector<RenderBox*> computeAspectRatioDependentAndBaselineItems();
+    Vector<RenderBox*> computeAspectRatioDependentAndBaselineItems(GridLayoutState&);
 
     GridSpan gridSpanForOutOfFlowGridItem(const RenderBox&, GridTrackSizingDirection) const;
 
@@ -304,7 +304,6 @@ private:
     OutOfFlowPositionsMap m_outOfFlowItemColumn;
     OutOfFlowPositionsMap m_outOfFlowItemRow;
 
-    bool m_hasAspectRatioBlockSizeDependentItem { false };
     bool m_baselineItemsCached {false};
     bool m_hasAnyBaselineAlignmentItem { false };
 


### PR DESCRIPTION
#### 3f2a366bd8d0e9aafe6722b2d4d4cb05ef8eaae0
<pre>
[Grid][Cleanup] Move m_hasAspectRatioBlockSizeDependentItem  to GridLayoutState
<a href="https://rdar.apple.com/146314286">rdar://146314286</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289180">https://bugs.webkit.org/show_bug.cgi?id=289180</a>

Reviewed by Brandon Stewart.

m_hasAspectRatioBlockSizeDependentItem is a member variable which lives
on RenderGrid but is only computed and used during grid layout. This
makes it a prime candidate to be moved to GridLayoutState, which is a
helper class to store information to be used during grid layout.

The logic handling this bool seems to be:

1.) Set the value to false in computeAspectRatioDependentBaselineItems
and potentially set it to true depending on what happens during this
function. This function is one of the first things to happen in
layoutGrid/layoutMasonry.

2.) Check its value during repeatTrackSizingIfNeeded to determine if it
is one of the reasons which forces us to perform the second iteration of
the track sizing algorithm.

Based off of this, we should just be able to initialize it to false in
GridLayoutState, which is created at the beginning of grid/masonry
layout, and set/check the value according to the logic described above.

* Source/WebCore/rendering/GridLayoutState.h:
(WebCore::GridLayoutState::setHasAspectRatioBlockSizeDependentItem):
(WebCore::GridLayoutState::hasAspectRatioBlockSizeDependentItem const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::repeatTracksSizingIfNeeded):
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/291677@main">https://commits.webkit.org/291677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef51e290708f5dabae45b29017b695cd0e36be8e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13165 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2899 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98598 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44120 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71490 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28862 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96596 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10049 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84627 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51825 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2250 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43434 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100630 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20646 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15090 "Found 1 new test failure: js/dom/missing-exception-check-in-convertNumbers.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80503 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80564 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79839 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24382 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1726 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13794 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20630 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25808 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20317 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->