### PR TITLE
Web content processes sometimes crashes under Page::viewportArguments() calls from FrameLoader::commitProvisionalLoad()

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2386,9 +2386,13 @@ void FrameLoader::commitProvisionalLoad()
 
 #if PLATFORM(IOS_FAMILY)
         page->chrome().setDispatchViewportDataDidChangeSuppressed(false);
-        page->chrome().dispatchViewportPropertiesDidChange(frame->page()->viewportArguments());
 #endif
-        page->chrome().dispatchDisabledAdaptationsDidChange(frame->page()->disabledAdaptations());
+        if (RefPtr framePage = frame->page()) {
+#if PLATFORM(IOS_FAMILY)
+            page->chrome().dispatchViewportPropertiesDidChange(framePage->viewportArguments());
+#endif
+            page->chrome().dispatchDisabledAdaptationsDidChange(framePage->disabledAdaptations());
+        }
 
         auto& title = m_documentLoader->title();
         if (!title.string.isNull())


### PR DESCRIPTION
#### 6fdcc035f663730065a10aad9dae8071f82ae93b
<pre>
Web content processes sometimes crashes under Page::viewportArguments() calls from FrameLoader::commitProvisionalLoad()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289182">https://bugs.webkit.org/show_bug.cgi?id=289182</a>
<a href="https://rdar.apple.com/145386222">rdar://145386222</a>

Reviewed by Wenson Hsieh.

Sometimes the WP crashes under WebCore::Page::viewportArguments() with a
backtrace like this:

```
WTF::RawPtrTraits&lt;WebCore::Frame&gt;::unwrap(WebCore::Frame* const&amp;) (WebCore)
  WTF::Ref&lt;WebCore::Frame, WTF::RawPtrTraits&lt;WebCore::Frame&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Frame&gt;&gt;::get() const (WebCore)
     WTF::Ref&lt;WebCore::Frame, WTF::RawPtrTraits&lt;WebCore::Frame&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Frame&gt;&gt;::Ref(WTF::Ref&lt;WebCore::Frame, WTF::RawPtrTraits&lt;WebCore::Frame&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Frame&gt;&gt; const&amp;) (WebCore)
       WTF::Ref&lt;WebCore::Frame, WTF::RawPtrTraits&lt;WebCore::Frame&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Frame&gt;&gt;::Ref(WTF::Ref&lt;WebCore::Frame, WTF::RawPtrTraits&lt;WebCore::Frame&gt;, WTF::DefaultRefDerefTraits&lt;WebCore::Frame&gt;&gt; const&amp;) (WebCore)
         WebCore::Page::protectedMainFrame() const (WebCore)
           WebCore::Page::viewportArguments() const (WebCore)
             WebCore::FrameLoader::commitProvisionalLoad() (WebCore)
```

While the root cause is yet to be determined, we can make the process
less crashy by null checking frame-&gt;page() before querying for viewport
arguments in FrameLoader::commitProvisionalLoad.

Note that this is better than null checking m_mainFrame on the Page
object, because Page holds a strong reference to m_mainFrame, and so if
we&apos;re crashing while dereferencing that object, it indicates all of Page
is null.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad):

Canonical link: <a href="https://commits.webkit.org/291655@main">https://commits.webkit.org/291655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/011635faebc9f4add75cbd7a8ac2ded074b5d6ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98581 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44104 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21594 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28857 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96580 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10044 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51816 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9726 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43418 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80001 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20630 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20882 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79832 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24376 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13778 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20614 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20301 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23761 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22042 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->