### PR TITLE
[Debug] fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html is a flaky crash

### DIFF
--- a/LayoutTests/fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html
+++ b/LayoutTests/fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html
@@ -27,6 +27,7 @@
 
         consoleWrite('Fully exit fullscreen with target1');
         run('document.webkitCancelFullScreen()');
+        await testRunner.updatePresentation();
 
         consoleWrite('Attempt to enter fullscreen with target2');
         internals.withUserGesture(() => { run('target2.requestFullscreen()'); });

--- a/LayoutTests/fullscreen/full-screen-enter-while-exiting-mid-completion-handler-expected.txt
+++ b/LayoutTests/fullscreen/full-screen-enter-while-exiting-mid-completion-handler-expected.txt
@@ -7,7 +7,6 @@ RUN(document.exitFullscreen())
 Attempt to enter fullscreen with target2
 RUN(target2.requestFullscreen())
 EVENT(fullscreenerror)
-EVENT(fullscreenchange)
 RUN(target2.requestFullscreen())
 EVENT(fullscreenchange)
 END OF TEST

--- a/LayoutTests/fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html
+++ b/LayoutTests/fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html
@@ -27,7 +27,6 @@
 
         consoleWrite('Exit fullscreen with target1');
         run('document.exitFullscreen()');
-        changePromise = waitFor(document, 'fullscreenchange')
         await testRunner.updatePresentation();
 
         consoleWrite('Attempt to enter fullscreen with target2');


### PR DESCRIPTION
#### 11110d030a773ba43452128996397dc9b3d84606
<pre>
[Debug] fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=289186">https://bugs.webkit.org/show_bug.cgi?id=289186</a>
<a href="https://rdar.apple.com/146319214">rdar://146319214</a>

Reviewed by Eric Carlson.

Follow the same pattern as full-screen-enter-while-exiting-mid-completion-handler.html of waiting for a presentation update.

Also remove unused changePromise variable from the other test.

* LayoutTests/fullscreen/full-screen-enter-while-exiting-fully-mid-completion-handler.html:
* LayoutTests/fullscreen/full-screen-enter-while-exiting-mid-completion-handler-expected.txt:
* LayoutTests/fullscreen/full-screen-enter-while-exiting-mid-completion-handler.html:

Canonical link: <a href="https://commits.webkit.org/291663@main">https://commits.webkit.org/291663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62098eb5197010232ce0e78ad59e2ce3b9a77eff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98595 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44117 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21607 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28859 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10047 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84621 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51822 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2244 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43431 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100627 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20643 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80500 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79836 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24373 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1720 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13791 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15016 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20314 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->