### PR TITLE
[iOS] [Visual Bidi Selection] Selection should be visually contiguous across soft line breaks in bidi text

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8-expected.txt
@@ -1,0 +1,13 @@
+هذه جملة باللغة الإنجليزية: The quick brown fox jumped over the lazy dog.
+
+Verifies that the selection extends to select the contents of the second line, and the ending selection handle is placed on the left.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS isVisuallyContiguous is true
+PASS lastLineBounds.left - finalEndHandlePoint.x is <= widthOfPeriod + 4
+PASS getSelection().toString().includes('The quick brown fox jumped over the lazy dog') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    font-size: 18px;
+    font-family: system-ui;
+}
+
+div.overlay {
+    position: fixed;
+    background-color: tomato;
+    opacity: 0.15;
+    pointer-events: none;
+}
+
+p[dir="rtl"] {
+    max-width: 350px;
+    border: 1px solid tomato;
+    padding: 12px;
+    line-height: 2;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that the selection extends to select the contents of the second line, and the ending selection handle is placed on the left.");
+
+    function computeLineBounds(firstRunIndex, lastRunIndex) {
+        const range = document.createRange();
+        range.selectNodeContents(document.querySelector("p[dir='rtl']"));
+        const clientRects = range.getClientRects();
+        const firstRect = clientRects[firstRunIndex];
+        const secondRect = clientRects[lastRunIndex];
+        const x = Math.min(firstRect.left, secondRect.left);
+        const y = Math.min(firstRect.top, secondRect.top);
+        const maxX = Math.max(firstRect.left + firstRect.width, secondRect.left + secondRect.width);
+        const maxY = Math.max(firstRect.top + firstRect.height, secondRect.top + secondRect.height);
+        return {
+            top: Math.round(y),
+            left: Math.round(x),
+            width: Math.round(maxX - x),
+            height: Math.round(maxY - y)
+        };
+    }
+
+    firstLineBounds = computeLineBounds(0, 1);
+    lastLineBounds = computeLineBounds(2, 3);
+
+    let overlay = document.querySelector("div.overlay");
+    overlay.style.top = `${firstLineBounds.top}px`;
+    overlay.style.left = `${firstLineBounds.left}px`;
+    overlay.style.width = `${firstLineBounds.width}px`;
+    overlay.style.height = `${firstLineBounds.height}px`;
+
+    await UIHelper.longPressAtPoint(firstLineBounds.left + firstLineBounds.width - 5, firstLineBounds.top + 5);
+    await UIHelper.waitForSelectionToAppear();
+
+    const endHandlePoint = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    const finalOffsetX = endHandlePoint.x - 0.5 * firstLineBounds.width;
+    const finalOffsetY = UIHelper.selectionHitTestOffset() + lastLineBounds.top + lastLineBounds.height / 2;
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(endHandlePoint.x, endHandlePoint.y)
+        .move(finalOffsetX, finalOffsetY, 0.8)
+        .wait(0.2)
+        .end()
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    isVisuallyContiguous = await UIHelper.isSelectionVisuallyContiguous();
+    finalEndHandlePoint = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    shouldBeTrue("isVisuallyContiguous");
+    widthOfPeriod = (() => {
+        const span = document.createElement("span");
+        document.body.appendChild(span);
+        span.textContent = ".";
+        const width = span.getBoundingClientRect().width;
+        span.remove();
+        return width;
+    })();
+    shouldBeLessThanOrEqual("lastLineBounds.left - finalEndHandlePoint.x", "widthOfPeriod + 4");
+    shouldBeTrue("getSelection().toString().includes('The quick brown fox jumped over the lazy dog')");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p dir="rtl">هذه جملة باللغة الإنجليزية: The quick brown fox jumped over the lazy dog.</p>
+    <div class="overlay"></div>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -324,6 +324,11 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static selectionHitTestOffset()
+    {
+        return this.isIOSFamily() ? 40 : 0;
+    }
+
     static zoomByDoubleTappingAt(x, y)
     {
         console.assert(this.isIOSFamily());


### PR DESCRIPTION
#### 6351de524954678c96e152441e7510193b085af6
<pre>
[iOS] [Visual Bidi Selection] Selection should be visually contiguous across soft line breaks in bidi text
<a href="https://bugs.webkit.org/show_bug.cgi?id=289184">https://bugs.webkit.org/show_bug.cgi?id=289184</a>
<a href="https://rdar.apple.com/142811818">rdar://142811818</a>

Reviewed by Abrar Rahman Protyasha.

Make some adjustments to the visual bidi selection mode on iOS. See below for more details.

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8.html: Added.

Add a layout test to exercise this change, by extending a selection handle across a soft line break
containing bidi LTR text in an RTL paragraph, and verify that the selection snaps to select the
entire LTR text run after text interaction ends.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async selectionHitTestOffset):
(window.UIHelper.async zoomByDoubleTappingAt): Deleted.
* Source/WebCore/editing/Editing.cpp:
(WebCore::advanceInDirection):
(WebCore::makeVisuallyContiguousIfNeeded):

Consider the case where, in an RTL paragraph with selected text, the selection end position is in
the second line of an LTR text run that spans two lines with a soft line break in between. Right
now, we treat this scenario as being visually contiguous and don&apos;t attempt to adjust the selection
endpoints because there&apos;s no break in visual continuity in the selection, within the last line.
However, this can lead to unintuitive behaviors, as the selection will visually flip when extended
across the bidi text boundary, to the rest of the RTL text on the second line. To mitigate this, we
detect the following case:

-   The selection spans multiple lines.
-   The visually selected text on the first or last line only spans text which is a different
    direction from the rest of the paragraph (in this case, only LTR text is selected when the rest
    of the paragraph is RTL).

...and automatically expand the selection start or end, so that we select all of the text that&apos;s of
a different direction than the paragraph direction after the soft line break.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::makeBidiSelectionVisuallyContiguousIfNeeded):
(WebCore::adjustTextDirectionForCoalescedGeometries):

Adjust code that makes iOS selection rects visually contiguous, so that it will start the selection
rect from the right visual extent in the scenario detailed above. To achieve this, we compute the
visible extent of the first or last line of the selection, on the opposite end of the caret, and
unify the visual selection bounds with this caret rect in order to compute the final coalesced quad
for the start and end selection geometries.

(WebCore::directionForFirstLine): Deleted.
(WebCore::directionForLastLine): Deleted.

Canonical link: <a href="https://commits.webkit.org/291662@main">https://commits.webkit.org/291662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce153fe1c060935fa956ed3e116824e9e8166c66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44114 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21604 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71486 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28860 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96590 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10048 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84615 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51821 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9730 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2238 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43428 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80006 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100624 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20640 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15087 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80499 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79835 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19860 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13788 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25802 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20311 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23771 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22052 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->