### PR TITLE
Split up release asserts in ContentExtension*

### DIFF
--- a/Source/WebCore/contentextensions/ContentExtension.cpp
+++ b/Source/WebCore/contentextensions/ContentExtension.cpp
@@ -79,7 +79,8 @@ void ContentExtension::compileGlobalDisplayNoneStyleSheet()
     auto serializedActions = m_compiledExtension->serializedActions();
 
     auto inGlobalDisplayNoneStyleSheet = [&](const uint32_t location) {
-        RELEASE_ASSERT(location < serializedActions.size());
+        auto serializedActionSize = serializedActions.size();
+        RELEASE_ASSERT(location < serializedActionSize, location, serializedActionSize);
         return location < firstIgnorePreviousRules && serializedActions[location] == WTF::alternativeIndexV<CSSDisplayNoneSelectorAction, ActionData>;
     };
     

--- a/Source/WebCore/contentextensions/ContentExtensionRule.cpp
+++ b/Source/WebCore/contentextensions/ContentExtensionRule.cpp
@@ -85,13 +85,15 @@ template<typename... Types> struct VariantDeserializer<std::variant<Types...>> {
 
 DeserializedAction DeserializedAction::deserialize(std::span<const uint8_t> serializedActions, uint32_t location)
 {
-    RELEASE_ASSERT(location < serializedActions.size());
+    auto serializedActionSize = serializedActions.size();
+    RELEASE_ASSERT(location < serializedActionSize, location, serializedActionSize);
     return { location, VariantDeserializer<ActionData>::deserialize(serializedActions.subspan(location + 1), serializedActions[location]) };
 }
 
 size_t DeserializedAction::serializedLength(std::span<const uint8_t> serializedActions, uint32_t location)
 {
-    RELEASE_ASSERT(location < serializedActions.size());
+    auto serializedActionSize = serializedActions.size();
+    RELEASE_ASSERT(location < serializedActionSize, location, serializedActionSize);
     return 1 + VariantDeserializer<ActionData>::serializedLength(serializedActions.subspan(location + 1), serializedActions[location]);
 }
 


### PR DESCRIPTION
#### f11eb0dc237d704ee95cb37c690d91cefe7e947b
<pre>
Split up release asserts in ContentExtension*
<a href="https://bugs.webkit.org/show_bug.cgi?id=289188">https://bugs.webkit.org/show_bug.cgi?id=289188</a>
<a href="https://rdar.apple.com/problem/146320785">rdar://problem/146320785</a>

Reviewed by Charlie Wolfe.

This change may be useful for diagnosis purposes.

* Source/WebCore/contentextensions/ContentExtension.cpp:
(WebCore::ContentExtensions::ContentExtension::compileGlobalDisplayNoneStyleSheet):
* Source/WebCore/contentextensions/ContentExtensionRule.cpp:
(WebCore::ContentExtensions::DeserializedAction::deserialize):
(WebCore::ContentExtensions::DeserializedAction::serializedLength):

Canonical link: <a href="https://commits.webkit.org/291651@main">https://commits.webkit.org/291651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/523a83f80475d65a48fb0d450b6ceeed2dd97673

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93592 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/13163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98596 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95642 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13451 "Hash 523a83f8 for PR 41944 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21608 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96594 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/13451 "Hash 523a83f8 for PR 41944 does not build (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51823 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/13451 "Hash 523a83f8 for PR 41944 does not build (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43432 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/13451 "Hash 523a83f8 for PR 41944 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100628 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20644 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80554 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24374 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/13792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20628 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/20315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/23775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/22056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->