### PR TITLE
Validate content extensions whenever loading them in

### DIFF
--- a/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
+++ b/Source/WebCore/contentextensions/DFABytecodeInterpreter.h
@@ -43,7 +43,7 @@ public:
     using Actions = UncheckedKeyHashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>;
 
     WEBCORE_EXPORT Actions interpret(const String&, ResourceFlags);
-    Actions actionsMatchingEverything();
+    WEBCORE_EXPORT Actions actionsMatchingEverything();
 
 private:
     void interpretAppendAction(unsigned& programCounter, Actions&);

--- a/Source/WebKit/Platform/Logging.h
+++ b/Source/WebKit/Platform/Logging.h
@@ -94,6 +94,7 @@ extern "C" {
     M(BackForwardCache) \
     M(CacheStorage) \
     M(ContentObservation) \
+    M(ContentRuleLists) \
     M(ContextMenu) \
     M(DigitalCredentials) \
     M(DisplayLink) \

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -77,6 +77,7 @@ public:
     void synchronousRemoveAllContentRuleLists();
     void invalidateContentRuleListVersion(const WTF::String& identifier);
     void corruptContentRuleListHeader(const WTF::String& identifier, bool usingCurrentVersion);
+    void corruptContentRuleListActionsMatchingEverything(const WTF::String& identifier);
     void invalidateContentRuleListHeader(const WTF::String& identifier);
     void getContentRuleListSource(WTF::String&& identifier, CompletionHandler<void(WTF::String)>);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm
@@ -176,6 +176,13 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 #endif
 }
 
+- (void)_corruptContentRuleListActionsMatchingEverythingForIdentifier:(NSString *)identifier
+{
+#if ENABLE(CONTENT_EXTENSIONS)
+    _contentRuleListStore->corruptContentRuleListActionsMatchingEverything(identifier);
+#endif
+}
+
 - (void)_invalidateContentRuleListHeaderForIdentifier:(NSString *)identifier
 {
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h
@@ -31,6 +31,7 @@
 - (void)_removeAllContentRuleLists;
 - (void)_invalidateContentRuleListVersionForIdentifier:(NSString *)identifier;
 - (void)_corruptContentRuleListHeaderForIdentifier:(NSString *)identifier usingCurrentVersion:(BOOL)usingCurrentVersion;
+- (void)_corruptContentRuleListActionsMatchingEverythingForIdentifier:(NSString *)identifier;
 - (void)_invalidateContentRuleListHeaderForIdentifier:(NSString *)identifier;
 - (void)_getContentRuleListSourceForIdentifier:(NSString *)identifier completionHandler:(void (^)(NSString *))completionHandler;
 


### PR DESCRIPTION
#### 040e877236f583892af4d7d8f9d84318dd1ca7ee
<pre>
Validate content extensions whenever loading them in
<a href="https://bugs.webkit.org/show_bug.cgi?id=289293">https://bugs.webkit.org/show_bug.cgi?id=289293</a>
<a href="https://rdar.apple.com/145703008">rdar://145703008</a>

Reviewed by Alex Christensen.

We should perform some validation when adding extensions instead of
killing the web process if the file got corrupted for whatever reason.

Added API test.

* Source/WebCore/contentextensions/DFABytecodeInterpreter.h:
* Source/WebKit/Platform/Logging.h:
* Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
(API::openAndMapContentRuleList):
(API::ContentRuleListStore::corruptContentRuleListURLFilter):
* Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStore.mm:
(-[WKContentRuleListStore _corruptContentRuleListURLFilterForIdentifier:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentRuleListStorePrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKContentExtensionStore.mm:
(TEST_F(WKContentRuleListStoreTest, CorruptURLFilter)):

Canonical link: <a href="https://commits.webkit.org/291937@main">https://commits.webkit.org/291937@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4646032479cac5458f6997839a0ff628081dd957

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44978 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72081 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29404 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85280 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2972 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44293 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/3073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101514 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21505 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15690 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81082 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21754 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80457 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25003 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14731 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21482 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21166 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->