### PR TITLE
Avoid virtual function call for JS microtasks in WebCore

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1146,6 +1146,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/MemoryStatistics.h
     runtime/Microtask.h
     runtime/MicrotaskQueue.h
+    runtime/MicrotaskQueueInlines.h
     runtime/ModuleProgramExecutable.h
     runtime/NativeCallee.h
     runtime/NativeExecutable.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1897,6 +1897,7 @@
 		DE26E9031CB5DD0500D2BE82 /* BuiltinExecutableCreator.h in Headers */ = {isa = PBXBuildFile; fileRef = DE26E9021CB5DD0500D2BE82 /* BuiltinExecutableCreator.h */; };
 		DEA7E2451BBC677F00D78440 /* JSTypedArrayViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 53917E7C1B791106000EBD33 /* JSTypedArrayViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E124A8F70E555775003091F1 /* OpaqueJSString.h in Headers */ = {isa = PBXBuildFile; fileRef = E124A8F50E555775003091F1 /* OpaqueJSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E306C1BC2D79000D0011D5AC /* MicrotaskQueueInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E306C1BB2D7900050011D5AC /* MicrotaskQueueInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E307178324C7827100DF0644 /* IntlRelativeTimeFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = A3BF885024480BE1001B9F35 /* IntlRelativeTimeFormat.h */; };
 		E307178424C7827700DF0644 /* IntlRelativeTimeFormatConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A3BF884E24480BE0001B9F35 /* IntlRelativeTimeFormatConstructor.h */; };
 		E307178524C7827900DF0644 /* IntlRelativeTimeFormatPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A3BF884C24480BDF001B9F35 /* IntlRelativeTimeFormatPrototype.h */; };
@@ -5566,6 +5567,7 @@
 		E18E3A570DF9278C00D90B34 /* VM.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; lineEnding = 0; path = VM.cpp; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.cpp; };
 		E3060128228F978100FAABDF /* UnlinkedMetadataTable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnlinkedMetadataTable.cpp; sourceTree = "<group>"; };
 		E30677971B8BC6F5003F87F0 /* ModuleLoader.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ModuleLoader.js; sourceTree = "<group>"; };
+		E306C1BB2D7900050011D5AC /* MicrotaskQueueInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskQueueInlines.h; sourceTree = "<group>"; };
 		E307177D24C7824600DF0644 /* IntlSegmenterConstructor.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlSegmenterConstructor.h; sourceTree = "<group>"; };
 		E307177E24C7824600DF0644 /* IntlSegmenterPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntlSegmenterPrototype.cpp; sourceTree = "<group>"; };
 		E307177F24C7824700DF0644 /* IntlSegmenterPrototype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntlSegmenterPrototype.h; sourceTree = "<group>"; };
@@ -8691,6 +8693,7 @@
 				7C008CE5187631B600955C24 /* Microtask.h */,
 				E36965F12D76E96F005BCC77 /* MicrotaskQueue.cpp */,
 				E36965F02D76E96F005BCC77 /* MicrotaskQueue.h */,
+				E306C1BB2D7900050011D5AC /* MicrotaskQueueInlines.h */,
 				FE2A875F1F02381600EB31B2 /* MinimumReservedZoneSize.h */,
 				147341DD1DC2CE9600AA29BA /* ModuleProgramExecutable.cpp */,
 				147341D51DC02EB900AA29BA /* ModuleProgramExecutable.h */,
@@ -11629,6 +11632,7 @@
 				0FB5467B14F5C7E1002C2989 /* MethodOfGettingAValueProfile.h in Headers */,
 				7C008CE7187631B600955C24 /* Microtask.h in Headers */,
 				E36965F32D76E975005BCC77 /* MicrotaskQueue.h in Headers */,
+				E306C1BC2D79000D0011D5AC /* MicrotaskQueueInlines.h in Headers */,
 				FE2A87601F02381600EB31B2 /* MinimumReservedZoneSize.h in Headers */,
 				C4703CD7192844CC0013FBEA /* models.py in Headers */,
 				E3794E761B77EB97005543AE /* ModuleAnalyzer.h in Headers */,

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -72,9 +72,9 @@ public:
         m_dispatcher = WTFMove(dispatcher);
     }
 
-    Result tryRun();
     bool isRunnable() const;
 
+    MicrotaskDispatcher* dispatcher() const { return m_dispatcher.get(); }
     MicrotaskIdentifier identifier() const { return m_identifier; }
     JSGlobalObject* globalObject() const { return m_globalObject; }
     JSValue job() const { return m_job; }
@@ -176,7 +176,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
 
-    JS_EXPORT_PRIVATE void performMicrotaskCheckpoint(VM&);
+    inline void performMicrotaskCheckpoint(VM&, const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor);
 
     bool hasMicrotasksForFullyActiveDocument() const
     {

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -254,7 +254,7 @@ class UserGestureInitiatedMicrotaskDispatcher final : public WebCoreMicrotaskDis
 public:
 
     UserGestureInitiatedMicrotaskDispatcher(EventLoopTaskGroup& group, Ref<UserGestureToken>&& userGestureToken)
-        : WebCoreMicrotaskDispatcher(group)
+        : WebCoreMicrotaskDispatcher(Type::UserGestureIndicator, group)
         , m_userGestureToken(WTFMove(userGestureToken))
     {
     }

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -29,6 +29,7 @@
 #include "JSExecState.h"
 #include "Microtasks.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/MicrotaskQueueInlines.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -410,7 +411,7 @@ class JSMicrotaskDispatcher final : public WebCoreMicrotaskDispatcher {
     WTF_MAKE_TZONE_ALLOCATED(JSMicrotaskDispatcher);
 public:
     JSMicrotaskDispatcher(EventLoopTaskGroup& group)
-        : WebCoreMicrotaskDispatcher(group)
+        : WebCoreMicrotaskDispatcher(Type::JavaScript, group)
     {
     }
 
@@ -536,7 +537,7 @@ class EventLoopFunctionMicrotaskDispatcher final : public WebCoreMicrotaskDispat
     WTF_MAKE_TZONE_ALLOCATED(EventLoopFunctionMicrotaskDispatcher);
 public:
     EventLoopFunctionMicrotaskDispatcher(EventLoopTaskGroup& group, EventLoop::TaskFunction&& function)
-        : WebCoreMicrotaskDispatcher(group)
+        : WebCoreMicrotaskDispatcher(Type::Function, group)
         , m_function(WTFMove(function))
     {
     }

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -37,20 +37,29 @@ namespace WebCore {
 class WebCoreMicrotaskDispatcher : public JSC::MicrotaskDispatcher {
     WTF_MAKE_TZONE_ALLOCATED(WebCoreMicrotaskDispatcher);
 public:
-    WebCoreMicrotaskDispatcher(EventLoopTaskGroup& group)
-        : m_group(group)
+    enum class Type {
+        JavaScript,
+        UserGestureIndicator,
+        Function,
+    };
+
+    WebCoreMicrotaskDispatcher(Type type, EventLoopTaskGroup& group)
+        : m_type(type)
+        , m_group(group)
     {
     }
+
+    Type type() const { return m_type; }
 
     bool isRunnable() const final
     {
         return currentRunnability() == JSC::QueuedTask::Result::Executed;
     }
 
-protected:
     JSC::QueuedTask::Result currentRunnability() const;
 
 private:
+    Type m_type { Type::JavaScript };
     WeakPtr<EventLoopTaskGroup> m_group;
 };
 


### PR DESCRIPTION
#### a70ba5ac0a0b2c7483372f2f1afeb91a52de3e99
<pre>
Avoid virtual function call for JS microtasks in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=289198">https://bugs.webkit.org/show_bug.cgi?id=289198</a>
<a href="https://rdar.apple.com/146334563">rdar://146334563</a>

Reviewed by Keith Miller and Ryosuke Niwa.

JSC::MicrotaskQueue::performMicrotaskCheckpoint will take a lambda which
customizes default dispatching mechanism for microtasks. And then
WebCore offers a lambda and avoid doing virtual function call for JS
microtasks which is by-far most frequently called type of microtasks.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runJSMicrotask):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::QueuedTask::tryRun): Deleted.
(JSC::MicrotaskQueue::performMicrotaskCheckpoint): Deleted.
* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::QueuedTask::dispatcher const):
* Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h: Copied from Source/JavaScriptCore/runtime/JSMicrotask.h.
(JSC::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::drainMicrotasks):
* Source/WebCore/bindings/js/JSDOMWindowBase.cpp:
* Source/WebCore/dom/EventLoop.cpp:
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/Microtasks.h:
(WebCore::WebCoreMicrotaskDispatcher::WebCoreMicrotaskDispatcher):
(WebCore::WebCoreMicrotaskDispatcher::type const):

Canonical link: <a href="https://commits.webkit.org/291671@main">https://commits.webkit.org/291671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6395509641d06269881a20f38eec5dd7f7e83e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98644 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44165 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13504 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21655 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/28879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96641 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2273 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43479 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86349 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100675 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92305 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20691 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79857 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24399 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13839 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15022 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20675 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/25853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/114955 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20362 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23822 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22103 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->