### PR TITLE
[MSE] Fix MediaSource log identifier

### DIFF
--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp
@@ -118,6 +118,11 @@ bool MediaSourceInterfaceMainThread::detachable() const
     return m_mediaSource->detachable();
 }
 
+void MediaSourceInterfaceMainThread::setLogIdentifier(uint64_t identifier)
+{
+    m_mediaSource->setLogIdentifier(identifier);
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE)

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h
@@ -53,6 +53,7 @@ private:
     void setAsSrcObject(bool) final;
     void memoryPressure() final;
     bool detachable() const final;
+    void setLogIdentifier(uint64_t) final;
 
     explicit MediaSourceInterfaceMainThread(Ref<MediaSource>&&);
 

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h
@@ -60,6 +60,7 @@ public:
     virtual void setAsSrcObject(bool) = 0;
     virtual void memoryPressure() = 0;
     virtual bool detachable() const = 0;
+    virtual void setLogIdentifier(uint64_t) = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp
@@ -151,6 +151,13 @@ bool MediaSourceInterfaceWorker::detachable() const
     return m_handle->detachable();
 }
 
+void MediaSourceInterfaceWorker::setLogIdentifier(uint64_t identifier)
+{
+    m_handle->ensureOnDispatcher([identifier](MediaSource& mediaSource) {
+        mediaSource.setLogIdentifier(identifier);
+    });
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_SOURCE_IN_WORKERS)

--- a/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
+++ b/Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h
@@ -53,6 +53,7 @@ private:
     void setAsSrcObject(bool) final;
     void memoryPressure() final;
     bool detachable() const final;
+    void setLogIdentifier(uint64_t) final;
 
     explicit MediaSourceInterfaceWorker(Ref<MediaSourceHandle>&&);
 


### PR DESCRIPTION
#### 794342272241264e8296982e8cfead53c9a63d94
<pre>
[MSE] Fix MediaSource log identifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=289203">https://bugs.webkit.org/show_bug.cgi?id=289203</a>
<a href="https://rdar.apple.com/146337584">rdar://146337584</a>

Reviewed by Jean Yves Avenard.

Pass the HTMLMediaElement log identifier to the MediaSource.

* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.cpp:
(WebCore::MediaSourceInterfaceMainThread::setLogIdentifier):
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceMainThread.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceProxy.h:
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.cpp:
(WebCore::MediaSourceInterfaceWorker::setLogIdentifier):
* Source/WebCore/Modules/mediasource/MediaSourceInterfaceWorker.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource): Drive-by: Pass the `LOGIDENTIFIER` into the
completion handler so logging includes the correct method name.

Canonical link: <a href="https://commits.webkit.org/291708@main">https://commits.webkit.org/291708@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90bf38a35d037ee6a13a34f0ca1a3cf73ee3149c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98739 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44259 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71557 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28928 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51891 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2343 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43574 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15167 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80573 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79911 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24461 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13941 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25947 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20456 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22197 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->