### PR TITLE
AX: [AX Thread Text APIs] Clamp the offset if it is greater than the total length of the runs

### DIFF
--- a/LayoutTests/accessibility/ax-thread-text-apis/stale-offset-no-crash-expected.txt
+++ b/LayoutTests/accessibility/ax-thread-text-apis/stale-offset-no-crash-expected.txt
@@ -1,0 +1,8 @@
+This test ensures when we have a stale offset passed into the word methdods, we don't crash.
+
+PASS: input.stringForTextMarkerRange(finalMarkerRange) === 'Hello world'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/ax-thread-text-apis/stale-offset-no-crash.html
+++ b/LayoutTests/accessibility/ax-thread-text-apis/stale-offset-no-crash.html
@@ -1,0 +1,40 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ runSingly=true AccessibilityThreadTextApisEnabled=true ] -->
+<!-- This is new test added with the accessibilityThreadTextApisEnabled effort. After accessibilityThreadTextApisEnabled is enabled by default, we should move it into LayoutTests/accessibility/mac. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input type="text" id="input" value="Hello world!" />
+
+<script>
+var output = "This test ensures when we have a stale offset passed into the word methdods, we don't crash.\n\n";
+
+var input, finalMarkerRange;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    input = accessibilityController.accessibleElementById("input");
+    const inputMarkerRange = input.textMarkerRangeForElement(input);
+    const startOfInputRange = input.startTextMarkerForTextMarkerRange(inputMarkerRange);
+    const endOfInputRange = input.endTextMarkerForTextMarkerRange(inputMarkerRange);
+
+    setTimeout(async function() {
+        // Remove the '!' from the text.
+        input.replaceTextInRange("", 11, 1);
+
+        await waitFor(() => input.stringValue.length == 20);
+        // We shouldn't crash here.
+        input.previousWordStartTextMarkerForTextMarker(endOfInputRange);
+        finalMarkerRange = input.textMarkerRangeForMarkers(startOfInputRange, endOfInputRange);
+        output += expect("input.stringForTextMarkerRange(finalMarkerRange)", "'Hello world'");
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -282,6 +282,7 @@ public:
     // True if this marker points to an object with non-empty text runs.
     bool isInTextRun() const;
     AXTextMarker convertToDomOffset() const;
+    void clampOffsetToLengthIfNeeded(unsigned) const;
 
     // Find the next or previous marker, optionally stopping at the given ID and returning an invalid marker.
     AXTextMarker findMarker(AXDirection, CoalesceObjectBreaks = CoalesceObjectBreaks::Yes, IgnoreBRs = IgnoreBRs::No, std::optional<AXID> = std::nullopt) const;


### PR DESCRIPTION
#### 07bf5c2b4f0ca319913c56906e61ba6bcba6f92d
<pre>
AX: [AX Thread Text APIs] Clamp the offset if it is greater than the total length of the runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=289206">https://bugs.webkit.org/show_bug.cgi?id=289206</a>
<a href="https://rdar.apple.com/146340127">rdar://146340127</a>

Reviewed by Tyler Wilcock.

VoiceOver can hold on to markers, while the underlying tree and text runs change. If VoiceOver
tries to use one of these stale markers that points to an out of bounds position, one that is
greater than the current length of its runs, we can crash in findNextWordFromIndex since we
are trying to start our search from an out of bounds position.

To handle this case gracefully, let&apos;s clamp the offset to a position in-bounds.

* LayoutTests/accessibility/ax-thread-text-apis/stale-offset-no-crash-expected.txt: Added.
* LayoutTests/accessibility/ax-thread-text-apis/stale-offset-no-crash.html: Added.
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarker::clampOffsetToLengthIfNeeded const):
(WebCore::AXTextMarker::findWordOrSentence const):
(WebCore::AXTextMarker::toTextRunMarker const):
* Source/WebCore/accessibility/AXTextMarker.h:

Canonical link: <a href="https://commits.webkit.org/291685@main">https://commits.webkit.org/291685@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5662c4566f73eba241efa528e8f528bb7e953ce3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21675 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71516 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28887 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10081 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51850 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2288 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43500 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80035 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100696 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20711 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80529 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19867 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13859 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25873 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20382 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23842 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->