### PR TITLE
Address Safer cpp failures in SVGAnimatedProperty

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -98,7 +98,6 @@ style/StyleScope.h
 style/StyleScopeRuleSets.h
 style/StyleSharingResolver.cpp
 style/Styleable.h
-svg/properties/SVGAnimatedProperty.h
 svg/properties/SVGPropertyOwnerRegistry.h
 workers/WorkerAnimationController.h
 workers/WorkerConsoleClient.h

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -117,7 +117,7 @@ template<typename CharacterType> std::optional<FloatRect> SVGFitToViewBox::parse
     auto height = parseNumber(buffer, SuffixSkippingPolicy::DontSkip);
 
     if (validate) {
-        Ref document = m_viewBox->contextElement()->document();
+        Ref document = Ref { m_viewBox }->contextElement()->document();
 
         if (!x || !y || !width || !height) {
             document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.cpp
@@ -30,16 +30,26 @@
 
 namespace WebCore {
 
+SVGAnimatedProperty::SVGAnimatedProperty(SVGElement* contextElement)
+    : m_contextElement(contextElement)
+{
+}
+
+SVGElement* SVGAnimatedProperty::contextElement() const
+{
+    return m_contextElement.get();
+}
+
 SVGPropertyOwner* SVGAnimatedProperty::owner() const
 {
-    return m_contextElement;
+    return m_contextElement.get();
 }
 
 void SVGAnimatedProperty::commitPropertyChange(SVGProperty*)
 {
     if (!m_contextElement)
         return;
-    RefPtr protectedContextElement = m_contextElement;
+    RefPtr protectedContextElement = m_contextElement.get();
     protectedContextElement->commitPropertyChange(*this);
 }
 

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.h
@@ -29,20 +29,22 @@
 #include "SVGPropertyOwner.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakHashSet.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
     
 class SVGElement;
+class WeakPtrImplWithEventTargetData;
 
 class SVGAnimatedProperty : public RefCounted<SVGAnimatedProperty>, public SVGPropertyOwner {
 public:
     virtual ~SVGAnimatedProperty() = default;
     
     // Manage the relationship with the owner.
-    bool isAttached() const { return m_contextElement; }
+    bool isAttached() const { return !!m_contextElement; }
     void detach() { m_contextElement = nullptr; }
-    SVGElement* contextElement() const { return m_contextElement; }
+    SVGElement* contextElement() const;
     
     virtual String baseValAsString() const { return emptyString(); }
     virtual String animValAsString() const { return emptyString(); }
@@ -62,15 +64,11 @@ public:
     virtual void instanceStopAnimation(SVGAttributeAnimator& animator) { stopAnimation(animator); }
     
 protected:
-    SVGAnimatedProperty(SVGElement* contextElement)
-        : m_contextElement(contextElement)
-    {
-    }
-    
+    explicit SVGAnimatedProperty(SVGElement*);
     SVGPropertyOwner* owner() const override;
     void commitPropertyChange(SVGProperty*) override;
     
-    SVGElement* m_contextElement { nullptr };
+    WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_contextElement;
     WeakHashSet<SVGAttributeAnimator> m_animators;
 };
 

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyPairAccessor.h
@@ -58,10 +58,20 @@ protected:
     Ref<AnimatedPropertyType2>& property2(OwnerType& owner) const { return m_accessor2.property(owner); }
     const Ref<AnimatedPropertyType2>& property2(const OwnerType& owner) const { return m_accessor2.property(owner); }
 
+    Ref<AnimatedPropertyType1> propertyProperty1(const OwnerType& owner) const
+    {
+        return property1(owner);
+    }
+
+    Ref<AnimatedPropertyType2> propertyProperty2(const OwnerType& owner) const
+    {
+        return property2(owner);
+    }
+
     void detach(const OwnerType& owner) const override
     {
-        property1(owner)->detach();
-        property2(owner)->detach();
+        propertyProperty1(owner)->detach();
+        propertyProperty2(owner)->detach();
     }
 
     bool matches(const OwnerType& owner, const SVGAnimatedProperty& animatedProperty) const override


### PR DESCRIPTION
#### 9c8f69ce3d0f940ef6830546291a7eb594d21143
<pre>
Address Safer cpp failures in SVGAnimatedProperty
<a href="https://bugs.webkit.org/show_bug.cgi?id=289213">https://bugs.webkit.org/show_bug.cgi?id=289213</a>
<a href="https://rdar.apple.com/problem/146348229">rdar://problem/146348229</a>

Reviewed by Chris Dumez.

Fix a clang static analyzer warning in SVGAnimatedProperty.

* Source/WebCore/svg/properties/SVGAnimatedProperty.cpp:
(WebCore::SVGAnimatedProperty::owner const):
(WebCore::SVGAnimatedProperty::commitPropertyChange):
* Source/WebCore/svg/properties/SVGAnimatedProperty.h:
(WebCore::SVGAnimatedProperty::contextElement const):

Canonical link: <a href="https://commits.webkit.org/291847@main">https://commits.webkit.org/291847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00fb1570632cbf561f184585761985108997a913

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22130 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71792 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29139 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52133 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10069 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2653 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43956 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80311 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101183 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21165 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15404 "Found 2 new test failures: imported/w3c/IndexedDB-private-browsing/idbcursor_advance_index8.html imported/w3c/IndexedDB-private-browsing/idbcursor_continue_index8.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80806 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80979 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24721 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2084 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14327 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21149 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26328 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->