### PR TITLE
[WebGPU] Make descriptor count / pointer initialization more consistent

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
@@ -243,8 +243,8 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
     WGPUDeviceDescriptor backingDescriptor {
         .nextInChain = nullptr,
         .label = label.data(),
-        .requiredFeatureCount = static_cast<uint32_t>(features.size()),
-        .requiredFeatures = features.data(),
+        .requiredFeatureCount = features.size(),
+        .requiredFeatures = features.size() ? features.data() : nullptr,
         .requiredLimits = &requiredLimits,
         .defaultQueue = {
             { },

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -111,8 +111,8 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
     WGPURenderPassDescriptor backingDescriptor {
         .nextInChain = descriptor.maxDrawCount ? &maxDrawCount.chain : nullptr,
         .label = label.data(),
-        .colorAttachmentCount = static_cast<uint32_t>(colorAttachments.size()),
-        .colorAttachments = colorAttachments.data(),
+        .colorAttachmentCount = colorAttachments.size(),
+        .colorAttachments = colorAttachments.size() ? colorAttachments.data() : nullptr,
         .depthStencilAttachment = depthStencilAttachment ? &depthStencilAttachment.value() : nullptr,
         .occlusionQuerySet = descriptor.occlusionQuerySet ? convertToBackingContext->convertToBacking(*descriptor.protectedOcclusionQuerySet()) : nullptr,
         .timestampWrites = timestampWrites.querySet ? &timestampWrites : nullptr

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -141,8 +141,8 @@ RefPtr<Texture> DeviceImpl::createTexture(const TextureDescriptor& descriptor)
         convertToBackingContext->convertToBacking(descriptor.format),
         descriptor.mipLevelCount,
         descriptor.sampleCount,
-        static_cast<uint32_t>(backingTextureFormats.size()),
-        backingTextureFormats.data(),
+        backingTextureFormats.size(),
+        backingTextureFormats.size() ? backingTextureFormats.data() : nullptr,
     };
 
     return TextureImpl::create(adoptWebGPU(wgpuDeviceCreateTexture(m_backing.get(), &backingDescriptor)), descriptor.format, descriptor.dimension, convertToBackingContext);
@@ -238,8 +238,8 @@ RefPtr<BindGroupLayout> DeviceImpl::createBindGroupLayout(const BindGroupLayoutD
     WGPUBindGroupLayoutDescriptor backingDescriptor {
         nullptr,
         label.data(),
-        static_cast<uint32_t>(backingEntries.size()),
-        backingEntries.data(),
+        backingEntries.size(),
+        backingEntries.size() ? backingEntries.data() : nullptr,
     };
 
     return BindGroupLayoutImpl::create(adoptWebGPU(wgpuDeviceCreateBindGroupLayout(m_backing.get(), &backingDescriptor)), m_convertToBackingContext);
@@ -259,7 +259,7 @@ RefPtr<PipelineLayout> DeviceImpl::createPipelineLayout(const PipelineLayoutDesc
     WGPUPipelineLayoutDescriptor backingDescriptor {
         nullptr,
         label.data(),
-        descriptor.bindGroupLayouts ? static_cast<uint32_t>(backingBindGroupLayouts.size()) : 0,
+        descriptor.bindGroupLayouts ? backingBindGroupLayouts.size() : 0,
         descriptor.bindGroupLayouts ? backingBindGroupLayouts.data() : nullptr,
     };
 
@@ -296,8 +296,8 @@ RefPtr<BindGroup> DeviceImpl::createBindGroup(const BindGroupDescriptor& descrip
         nullptr,
         label.data(),
         convertToBackingContext->convertToBacking(descriptor.protectedLayout().get()),
-        static_cast<uint32_t>(backingEntries.size()),
-        backingEntries.data(),
+        backingEntries.size(),
+        backingEntries.size() ? backingEntries.data() : nullptr,
     };
 
     return BindGroupImpl::create(adoptWebGPU(wgpuDeviceCreateBindGroup(m_backing.get(), &backingDescriptor)), convertToBackingContext);
@@ -337,7 +337,7 @@ RefPtr<ShaderModule> DeviceImpl::createShaderModule(const ShaderModuleDescriptor
     WGPUShaderModuleDescriptor backingDescriptor {
         &backingWGSLDescriptor.chain,
         label.data(),
-        static_cast<uint32_t>(hintsEntries.size()),
+        hintsEntries.size(),
         hintsEntries.size() ? &hintsEntries[0] : nullptr,
     };
 
@@ -377,8 +377,8 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
             nullptr,
             convertToBackingContext.convertToBacking(descriptor.compute.protectedModule().get()),
             entryPoint ? entryPoint->data() : nullptr,
-            static_cast<uint32_t>(backingConstantEntries.size()),
-            backingConstantEntries.data(),
+            backingConstantEntries.size(),
+            backingConstantEntries.size() ? backingConstantEntries.data() : nullptr,
         }
     };
 
@@ -436,8 +436,8 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         return WGPUVertexBufferLayout {
             buffer ? buffer->arrayStride : WGPU_COPY_STRIDE_UNDEFINED,
             buffer ? convertToBackingContext.convertToBacking(buffer->stepMode) : WGPUVertexStepMode_Vertex,
-            static_cast<uint32_t>(backingAttributes[i].size()),
-            backingAttributes[i].data(),
+            backingAttributes[i].size(),
+            backingAttributes[i].size() ? backingAttributes[i].data() : nullptr,
         };
     });
 
@@ -536,10 +536,10 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         nullptr,
         descriptor.fragment ? convertToBackingContext.convertToBacking(descriptor.fragment->protectedModule().get()) : nullptr,
         fragmentEntryPoint ? fragmentEntryPoint->data() : nullptr,
-        static_cast<uint32_t>(fragmentConstantEntries.size()),
-        fragmentConstantEntries.data(),
-        static_cast<uint32_t>(colorTargets.size()),
-        colorTargets.data(),
+        fragmentConstantEntries.size(),
+        fragmentConstantEntries.size() ? fragmentConstantEntries.data() : nullptr,
+        colorTargets.size(),
+        colorTargets.size() ? colorTargets.data() : nullptr,
     };
 
     WGPUPrimitiveDepthClipControl depthClipControl = {
@@ -558,10 +558,10 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
             nullptr,
             convertToBackingContext.convertToBacking(descriptor.vertex.protectedModule().get()),
             vertexEntryPoint ? vertexEntryPoint->data() : nullptr,
-            static_cast<uint32_t>(vertexConstantEntries.size()),
-            vertexConstantEntries.data(),
-            static_cast<uint32_t>(backingBuffers.size()),
-            backingBuffers.data(),
+            vertexConstantEntries.size(),
+            vertexConstantEntries.size() ? vertexConstantEntries.data() : nullptr,
+            backingBuffers.size(),
+            backingBuffers.size() ? backingBuffers.data() : nullptr,
         },
         .primitive = {
             descriptor.primitive && descriptor.primitive->unclippedDepth ? &depthClipControl.chain : nullptr,
@@ -654,8 +654,8 @@ RefPtr<RenderBundleEncoder> DeviceImpl::createRenderBundleEncoder(const RenderBu
     WGPURenderBundleEncoderDescriptor backingDescriptor {
         nullptr,
         label.data(),
-        static_cast<uint32_t>(backingColorFormats.size()),
-        backingColorFormats.data(),
+        backingColorFormats.size(),
+        backingColorFormats.size() ? backingColorFormats.data() : nullptr,
         descriptor.depthStencilFormat ? convertToBackingContext->convertToBacking(*descriptor.depthStencilFormat) : WGPUTextureFormat_Undefined,
         descriptor.sampleCount,
         descriptor.depthReadOnly,

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -45,7 +45,7 @@ Ref<PipelineLayout> Device::createPipelineLayout(const WGPUPipelineLayoutDescrip
         return PipelineLayout::createInvalid(*this);
 
     std::optional<Vector<Ref<BindGroupLayout>>> optionalBindGroupLayouts = std::nullopt;
-    if (auto descriptorBindGroupLayouts = descriptor.bindGroupLayoutsSpan(); descriptorBindGroupLayouts.data()) {
+    if (auto descriptorBindGroupLayouts = descriptor.bindGroupLayoutsSpan(); !descriptorBindGroupLayouts.empty()) {
         auto& deviceLimits = limits();
 
         if (descriptorBindGroupLayouts.size() > deviceLimits.maxBindGroups) {

--- a/Source/WebGPU/WebGPU/RenderBundle.h
+++ b/Source/WebGPU/WebGPU/RenderBundle.h
@@ -100,7 +100,7 @@ private:
     RefPtr<RenderBundleEncoder> m_renderBundleEncoder;
     NSArray<RenderBundleICBWithResources*> *m_renderBundlesResources;
     WGPURenderBundleEncoderDescriptor m_descriptor;
-    Vector<WGPUTextureFormat> m_descriptorColorFormats;
+    const Vector<WGPUTextureFormat> m_descriptorColorFormats;
     HashSet<RefPtr<const BindGroup>> m_bindGroups;
 
     NSString* m_lastErrorString { nil };

--- a/Source/WebGPU/WebGPU/RenderBundle.mm
+++ b/Source/WebGPU/WebGPU/RenderBundle.mm
@@ -60,8 +60,7 @@ RenderBundle::RenderBundle(NSArray<RenderBundleICBWithResources*> *resources, Re
     , m_commandCount(commandCount)
     , m_makeSubmitInvalid(makeSubmitInvalid)
 {
-    if (m_descriptorColorFormats.size())
-        m_descriptor.colorFormats = &m_descriptorColorFormats[0];
+    m_descriptor.colorFormats = m_descriptorColorFormats.size() ? &m_descriptorColorFormats[0] : nullptr;
 
     ASSERT(m_renderBundleEncoder || m_renderBundlesResources.count);
 }

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.h
@@ -195,7 +195,7 @@ private:
     WeakPtr<RenderPassEncoder> m_renderPassEncoder;
     id<MTLIndirectRenderCommand> m_currentCommand { nil };
     WGPURenderBundleEncoderDescriptor m_descriptor;
-    Vector<WGPUTextureFormat> m_descriptorColorFormats;
+    const Vector<WGPUTextureFormat> m_descriptorColorFormats;
     NSString* m_lastErrorString { nil };
     bool m_requiresCommandReplay { false };
     bool m_finished { false };

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -217,8 +217,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     , m_descriptorColorFormats(descriptor.colorFormats ? Vector<WGPUTextureFormat>(std::span { descriptor.colorFormats, descriptor.colorFormatCount }) : Vector<WGPUTextureFormat>())
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 {
-    if (m_descriptorColorFormats.size())
-        m_descriptor.colorFormats = &m_descriptorColorFormats[0];
+    m_descriptor.colorFormats = m_descriptorColorFormats.size() ? &m_descriptorColorFormats[0] : nullptr;
     m_icbArray = [NSMutableArray array];
     m_bindGroupDynamicOffsets = BindGroupDynamicOffsetsContainer();
 #if ENABLE(WEBGPU_ALWAYS_USE_ICB_REPLAY)


### PR DESCRIPTION
#### cff04f81eb10bd7f7b8fad6204252122612c94e6
<pre>
[WebGPU] Make descriptor count / pointer initialization more consistent
<a href="https://rdar.apple.com/146352901">rdar://146352901</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289215">https://bugs.webkit.org/show_bug.cgi?id=289215</a>

Reviewed by Mike Wyrzykowski.

In a number of the descriptor structs in WebGPU.h (and a couple of our
own descriptor structs), lists of objects are described with a count
variable and a pointer. We are not consistent about how we initialize
these.

1. In <a href="https://bugs.webkit.org/show_bug.cgi?id=261511">https://bugs.webkit.org/show_bug.cgi?id=261511</a> we updated the
   WebGPU.h API header, and that updated the count member variables to
   be size_t. Adjust call sites so we no longer static_cast any counts
   down to uint32_t.

2. We sometimes look at whether the span or vector we&apos;re initializing
   from is empty, and if so store nullptr, and in other cases store
   whatever is returned from span::data() / Vector::data(). Always check
   and use nullptr when we&apos;re initializing from an empty list.

3. The RenderBundle and RenderBundleEncoder constructors initialize
   their m_descriptor members by copying the descriptor object passed
   in. This uses a copy constructor, and so causes the object to begin
   with a pointer to data held elsewhere. In the constructor body, we
   overwrite the pointer, but only if the size is non-zero. Change this
   to initialize to nullptr of the size is zero, so we don&apos;t keep around
   a stale pointer to someone else&apos;s memory (even if we wouldn&apos;t
   currently use it).

4. While here, make the Vector member variables on RenderBundle and
   RenderBundleEncoder that we keep a pointer into const, to make it
   less likely we modify it. (Another option would be to use a fixed
   allocation that cannot be modified, like UniqueArray, but UniqueArray
   does not have all the nice API that Vector has, nor its bounds
   checking operator[].)

5. Device::createPipelineLayout checks that
   descriptor.bindGroupLayoutsSpan() has a non-null based pointer, but
   semantically we want to check if the span is empty. If we have a span
   formed by a non-null base pointer and a zero count, we&apos;d still
   proceed to create optionalBindGroupLayouts, which is wasteful. Change
   this to check the span&apos;s emptiness.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp:
(WebCore::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::DeviceImpl::createTexture):
(WebCore::WebGPU::DeviceImpl::createBindGroupLayout):
(WebCore::WebGPU::DeviceImpl::createPipelineLayout):
(WebCore::WebGPU::DeviceImpl::createBindGroup):
(WebCore::WebGPU::DeviceImpl::createShaderModule):
(WebCore::WebGPU::convertToBacking):
(WebCore::WebGPU::DeviceImpl::createRenderBundleEncoder):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(WebGPU::Device::createPipelineLayout):
* Source/WebGPU/WebGPU/RenderBundle.h:
* Source/WebGPU/WebGPU/RenderBundle.mm:
(WebGPU::RenderBundle::RenderBundle):
* Source/WebGPU/WebGPU/RenderBundleEncoder.h:
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:

Canonical link: <a href="https://commits.webkit.org/291688@main">https://commits.webkit.org/291688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52b595461b0a60d625e7aae423d3a074917df44e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13251 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/2987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44205 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13545 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71524 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28895 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51858 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2301 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100716 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20731 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80545 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80616 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19870 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1772 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13879 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20715 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25893 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20402 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23862 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->