### PR TITLE
Address Safer CPP in more service / shared worker classes

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations
@@ -9,4 +9,3 @@ platform/ios/PlaybackSessionInterfaceIOS.h
 rendering/RenderAncestorIterator.h
 svg/properties/SVGPropertyOwnerRegistry.h
 workers/DedicatedWorkerThread.h
-workers/service/context/ServiceWorkerThread.h

--- a/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations
@@ -107,6 +107,5 @@ workers/WorkerNotificationClient.h
 workers/WorkerOrWorkletGlobalScope.h
 workers/service/NavigationPreloadManager.h
 workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.h
-workers/service/context/ServiceWorkerThreadProxy.h
 xml/XMLHttpRequestProgressEventThrottle.h
 xml/XMLHttpRequestUpload.h

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -72,8 +72,4 @@ style/StyleResolver.cpp
 testing/Internals.cpp
 testing/ServiceWorkerInternals.cpp
 workers/WorkerGlobalScope.cpp
-workers/service/context/SWContextManager.cpp
-workers/service/context/ServiceWorkerThread.cpp
-workers/service/context/ServiceWorkerThreadProxy.cpp
-workers/shared/context/SharedWorkerContextManager.cpp
 xml/XSLTProcessor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -370,7 +370,6 @@ bindings/js/JSReportingObserverCustom.cpp
 bindings/js/JSResizeObserverCustom.cpp
 bindings/js/JSResizeObserverEntryCustom.cpp
 bindings/js/JSSVGViewSpecCustom.cpp
-bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
 bindings/js/JSShadowRootCustom.cpp
 bindings/js/JSStaticRangeCustom.cpp
 bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
@@ -1423,7 +1422,6 @@ workers/service/FetchEvent.cpp
 workers/service/NavigationPreloadManager.cpp
 workers/service/ServiceWorker.cpp
 workers/service/ServiceWorkerClientData.cpp
-workers/service/ServiceWorkerClients.cpp
 workers/service/ServiceWorkerContainer.cpp
 workers/service/ServiceWorkerGlobalScope.cpp
 workers/service/ServiceWorkerRegistration.cpp
@@ -1432,16 +1430,8 @@ workers/service/background-fetch/BackgroundFetch.cpp
 workers/service/background-fetch/BackgroundFetchEngine.cpp
 workers/service/background-fetch/BackgroundFetchRegistration.cpp
 workers/service/background-fetch/ServiceWorkerRegistrationBackgroundFetchAPI.cpp
-workers/service/context/SWContextManager.cpp
-workers/service/context/ServiceWorkerFetch.cpp
-workers/service/context/ServiceWorkerInspectorProxy.cpp
-workers/service/context/ServiceWorkerThread.cpp
-workers/service/context/ServiceWorkerThreadProxy.cpp
-workers/service/server/SWScriptStorage.cpp
 workers/shared/SharedWorker.cpp
 workers/shared/SharedWorkerScriptLoader.cpp
-workers/shared/context/SharedWorkerContextManager.cpp
-workers/shared/context/SharedWorkerThreadProxy.cpp
 worklets/PaintWorkletGlobalScope.cpp
 worklets/WorkletGlobalScope.cpp
 worklets/WorkletPendingTasks.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -169,6 +169,5 @@ workers/WorkerThread.cpp
 workers/service/ExtendableEvent.cpp
 workers/service/ServiceWorkerContainer.cpp
 workers/service/ServiceWorkerGlobalScope.cpp
-workers/service/context/ServiceWorkerThreadProxy.cpp
 workers/shared/SharedWorkerObjectConnection.cpp
 xml/XMLHttpRequest.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -779,11 +779,8 @@ workers/service/ServiceWorkerGlobalScope.cpp
 workers/service/ServiceWorkerRegistration.cpp
 workers/service/WorkerSWClientConnection.cpp
 workers/service/background-fetch/BackgroundFetchEngine.cpp
-workers/service/context/SWContextManager.cpp
-workers/service/context/ServiceWorkerThread.cpp
 workers/shared/SharedWorkerObjectConnection.cpp
 workers/shared/SharedWorkerScriptLoader.cpp
-workers/shared/context/SharedWorkerContextManager.cpp
 worklets/Worklet.cpp
 xml/XMLHttpRequest.cpp
 xml/XPathFunctions.cpp

--- a/Source/WebCore/workers/ScriptBuffer.h
+++ b/Source/WebCore/workers/ScriptBuffer.h
@@ -50,6 +50,7 @@ public:
 
     String toString() const;
     const FragmentedSharedBuffer* buffer() const { return m_buffer.get().get(); }
+    RefPtr<const FragmentedSharedBuffer> protectedBuffer() const { return m_buffer.get(); }
 
     ScriptBuffer isolatedCopy() const { return ScriptBuffer(m_buffer ? RefPtr<FragmentedSharedBuffer>(m_buffer.copy()) : nullptr); }
     explicit operator bool() const { return !!m_buffer; }

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -140,9 +140,9 @@ private:
     void resetUserGesture() { m_isProcessingUserGesture = false; }
 
     ServiceWorkerContextData m_contextData;
-    Ref<ServiceWorkerRegistration> m_registration;
-    Ref<ServiceWorker> m_serviceWorker;
-    Ref<ServiceWorkerClients> m_clients;
+    const Ref<ServiceWorkerRegistration> m_registration;
+    const Ref<ServiceWorker> m_serviceWorker;
+    const Ref<ServiceWorkerClients> m_clients;
     Vector<Ref<ExtendableEvent>> m_extendedEvents;
 
     uint64_t m_lastRequestIdentifier { 0 };

--- a/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp
@@ -139,9 +139,10 @@ static void processResponse(Ref<Client>&& client, Expected<Ref<FetchResponse>, s
                 return;
             }
 
-            if (auto* chunk = result.returnValue())
-                client->didReceiveData(SharedBuffer::create(*chunk));
-            else
+            if (auto* chunk = result.returnValue()) {
+                Ref buffer = SharedBuffer::create(*chunk);
+                client->didReceiveData(buffer);
+            } else
                 client->didFinish(response ? response->networkLoadMetrics() : NetworkLoadMetrics { });
         });
         return;

--- a/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp
@@ -106,7 +106,7 @@ void ServiceWorkerInspectorProxy::disconnectFromWorker(FrontendChannel& channel)
 
         // In case the worker is paused running debugger tasks, ensure we break out of
         // the pause since this will be the last debugger task we send to the worker.
-        downcast<WorkerGlobalScope>(context).thread().stopRunningDebuggerTasks();
+        downcast<WorkerGlobalScope>(context).protectedThread()->stopRunningDebuggerTasks();
     });
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -270,8 +270,8 @@ void ServiceWorkerThread::queueTaskToFirePushEvent(std::optional<Vector<uint8_t>
     UNUSED_PARAM(payload);
 #endif
 
-    auto& serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
-    serviceWorkerGlobalScope.eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, data = WTFMove(data), callback = WTFMove(callback)]() mutable {
+    Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
+    serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, data = WTFMove(data), callback = WTFMove(callback)]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
 
         serviceWorkerGlobalScope->setHasPendingSilentPushEvent(true);
@@ -350,8 +350,8 @@ void ServiceWorkerThread::queueTaskToFireDeclarativePushEvent(NotificationPayloa
 
 void ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent(std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData)
 {
-    auto& serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
-    serviceWorkerGlobalScope.eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, newSubscriptionData = WTFMove(newSubscriptionData), oldSubscriptionData = WTFMove(oldSubscriptionData)]() mutable {
+    Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
+    serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope, newSubscriptionData = WTFMove(newSubscriptionData), oldSubscriptionData = WTFMove(oldSubscriptionData)]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
 
         RefPtr<PushSubscription> newSubscription;
@@ -379,8 +379,8 @@ void ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent(std::option
 #if ENABLE(NOTIFICATION_EVENT)
 void ServiceWorkerThread::queueTaskToFireNotificationEvent(NotificationData&& data, NotificationEventType eventType, Function<void(bool)>&& callback)
 {
-    auto& serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
-    serviceWorkerGlobalScope.eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, data = WTFMove(data), eventType, callback = WTFMove(callback)]() mutable {
+    Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
+    serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, data = WTFMove(data), eventType, callback = WTFMove(callback)]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireNotificationEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
 
         auto notification = Notification::create(serviceWorkerGlobalScope.get(), WTFMove(data));
@@ -417,8 +417,8 @@ void ServiceWorkerThread::queueTaskToFireNotificationEvent(NotificationData&& da
 
 void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInformation&& info, Function<void(bool)>&& callback)
 {
-    auto& serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
-    serviceWorkerGlobalScope.eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
+    Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
+    serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
 
         Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
@@ -455,8 +455,8 @@ void ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent(BackgroundFetchInf
 
 void ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent(BackgroundFetchInformation&& info, Function<void(bool)>&& callback)
 {
-    auto& serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
-    serviceWorkerGlobalScope.eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope = Ref { serviceWorkerGlobalScope }, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
+    Ref serviceWorkerGlobalScope = downcast<ServiceWorkerGlobalScope>(*globalScope());
+    serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [serviceWorkerGlobalScope, info = crossThreadCopy(WTFMove(info)), callback = WTFMove(callback)]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
 
         Ref manager = ServiceWorkerRegistrationBackgroundFetchAPI::backgroundFetch(serviceWorkerGlobalScope->registration());
@@ -488,6 +488,11 @@ void ServiceWorkerThread::finishedEvaluatingScript()
 
     scope->storeEventTypesToHandle();
     m_doesHandleFetch = scope->hasFetchEventHandler();
+}
+
+WorkerObjectProxy& ServiceWorkerThread::workerObjectProxy() const
+{
+    return m_workerObjectProxy.get();
 }
 
 void ServiceWorkerThread::start(Function<void(const String&, bool)>&& callback)
@@ -559,11 +564,11 @@ void ServiceWorkerThread::heartBeatTimerFired()
         return;
     }
 
-    auto* serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier());
+    RefPtr serviceWorkerThreadProxy = SWContextManager::singleton().serviceWorkerThreadProxy(identifier());
     if (!serviceWorkerThreadProxy || serviceWorkerThreadProxy->isTerminatingOrTerminated())
         return;
 
-    auto* connection = SWContextManager::singleton().connection();
+    RefPtr connection = SWContextManager::singleton().connection();
     if (!connection)
         return;
 
@@ -591,7 +596,7 @@ void ServiceWorkerThread::finishedFiringInstallEvent(bool hasRejectedAnyPromise)
 {
     m_state = State::Idle;
 
-    if (auto* connection = SWContextManager::singleton().connection())
+    if (RefPtr connection = SWContextManager::singleton().connection())
         connection->didFinishInstall(m_jobDataIdentifier, identifier(), !hasRejectedAnyPromise);
 }
 
@@ -605,7 +610,7 @@ void ServiceWorkerThread::finishedFiringActivateEvent()
 {
     m_state = State::Idle;
 
-    if (auto* connection = SWContextManager::singleton().connection())
+    if (RefPtr connection = SWContextManager::singleton().connection())
         connection->didFinishActivation(identifier());
 }
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.h
@@ -36,6 +36,7 @@
 #include "Settings.h"
 #include "Timer.h"
 #include "WorkerThread.h"
+#include <wtf/CheckedRef.h>
 #include <wtf/OptionSet.h>
 
 namespace WebCore {
@@ -60,7 +61,7 @@ public:
     }
     virtual ~ServiceWorkerThread();
 
-    WorkerObjectProxy& workerObjectProxy() const { return m_workerObjectProxy; }
+    WorkerObjectProxy& workerObjectProxy() const;
 
     void start(Function<void(const String&, bool)>&&);
 
@@ -119,7 +120,7 @@ private:
     std::optional<ServiceWorkerJobDataIdentifier> m_jobDataIdentifier;
     std::optional<ServiceWorkerContextData> m_contextData; // Becomes std::nullopt after the ServiceWorkerGlobalScope has been created.
     std::optional<ServiceWorkerData> m_workerData; // Becomes std::nullopt after the ServiceWorkerGlobalScope has been created.
-    WorkerObjectProxy& m_workerObjectProxy;
+    const CheckedRef<WorkerObjectProxy> m_workerObjectProxy;
     bool m_doesHandleFetch { false };
 
     bool m_isHandlingFetchEvent { false };

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -178,7 +178,7 @@ RefPtr<CacheStorageConnection> ServiceWorkerThreadProxy::createCacheStorageConne
 {
     ASSERT(isMainThread());
     if (!m_cacheStorageConnection)
-        m_cacheStorageConnection = m_cacheStorageProvider.createCacheStorageConnection();
+        m_cacheStorageConnection = Ref { m_cacheStorageProvider.get() }->createCacheStorageConnection();
     return m_cacheStorageConnection;
 }
 
@@ -199,8 +199,8 @@ std::unique_ptr<FetchLoader> ServiceWorkerThreadProxy::createBlobLoader(FetchLoa
 
 void ServiceWorkerThreadProxy::networkStateChanged(bool isOnLine)
 {
-    for (auto& proxy : allServiceWorkerThreadProxies())
-        proxy.notifyNetworkStateChange(isOnLine);
+    for (Ref proxy : allServiceWorkerThreadProxies())
+        proxy->notifyNetworkStateChange(isOnLine);
 }
 
 void ServiceWorkerThreadProxy::notifyNetworkStateChange(bool isOnline)
@@ -381,8 +381,8 @@ void ServiceWorkerThreadProxy::firePushEvent(std::optional<Vector<uint8_t>>&& da
         payloadCopy = *proposedPayload;
 
     bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, data = crossThreadCopy(WTFMove(data)), proposedPayload = crossThreadCopy(WTFMove(proposedPayload))](auto&) mutable {
-        thread().queueTaskToFirePushEvent(WTFMove(data), WTFMove(proposedPayload), [this, protectedThis = WTFMove(protectedThis), identifier](bool result, std::optional<NotificationPayload> resultPayload) mutable {
-            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result, resultPayload = crossThreadCopy(WTFMove(resultPayload))]() mutable {
+        thread().queueTaskToFirePushEvent(WTFMove(data), WTFMove(proposedPayload), [this, protectedThis = Ref { *this }, identifier](bool result, std::optional<NotificationPayload> resultPayload) mutable {
+            callOnMainThread([this, protectedThis = Ref { *this }, identifier, result, resultPayload = crossThreadCopy(WTFMove(resultPayload))]() mutable {
                 if (auto callback = m_ongoingNotificationPayloadFunctionalEventTasks.take(identifier))
                     callback(result, WTFMove(resultPayload));
                 if (m_ongoingNotificationPayloadFunctionalEventTasks.isEmpty())
@@ -416,8 +416,8 @@ void ServiceWorkerThreadProxy::fireNotificationEvent(NotificationData&& data, No
     ASSERT(!m_ongoingFunctionalEventTasks.contains(identifier));
     m_ongoingFunctionalEventTasks.add(identifier, WTFMove(callback));
     bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, data = WTFMove(data).isolatedCopy(), eventType](auto&) mutable {
-        thread().queueTaskToFireNotificationEvent(WTFMove(data), eventType, [this, protectedThis = WTFMove(protectedThis), identifier](bool result) mutable {
-            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result]() mutable {
+        thread().queueTaskToFireNotificationEvent(WTFMove(data), eventType, [this, protectedThis = Ref { *this }, identifier](bool result) mutable {
+            callOnMainThread([this, protectedThis = Ref { *this }, identifier, result]() mutable {
                 if (auto callback = m_ongoingFunctionalEventTasks.take(identifier))
                     callback(result);
                 if (m_ongoingFunctionalEventTasks.isEmpty())
@@ -443,8 +443,8 @@ void ServiceWorkerThreadProxy::fireBackgroundFetchEvent(BackgroundFetchInformati
     ASSERT(!m_ongoingFunctionalEventTasks.contains(identifier));
     m_ongoingFunctionalEventTasks.add(identifier, WTFMove(callback));
     bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, info = crossThreadCopy(WTFMove(info))](auto&) mutable {
-        thread().queueTaskToFireBackgroundFetchEvent(WTFMove(info), [this, protectedThis = WTFMove(protectedThis), identifier](bool result) mutable {
-            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result]() mutable {
+        thread().queueTaskToFireBackgroundFetchEvent(WTFMove(info), [this, protectedThis = Ref { *this }, identifier](bool result) mutable {
+            callOnMainThread([this, protectedThis = Ref { *this }, identifier, result]() mutable {
                 if (auto callback = m_ongoingFunctionalEventTasks.take(identifier))
                     callback(result);
                 if (m_ongoingFunctionalEventTasks.isEmpty())
@@ -465,8 +465,8 @@ void ServiceWorkerThreadProxy::fireBackgroundFetchClickEvent(BackgroundFetchInfo
     ASSERT(!m_ongoingFunctionalEventTasks.contains(identifier));
     m_ongoingFunctionalEventTasks.add(identifier, WTFMove(callback));
     bool isPosted = postTaskForModeToWorkerOrWorkletGlobalScope([this, protectedThis = Ref { *this }, identifier, info = crossThreadCopy(WTFMove(info))](auto&) mutable {
-        thread().queueTaskToFireBackgroundFetchClickEvent(WTFMove(info), [this, protectedThis = WTFMove(protectedThis), identifier](bool result) mutable {
-            callOnMainThread([this, protectedThis = WTFMove(protectedThis), identifier, result]() mutable {
+        thread().queueTaskToFireBackgroundFetchClickEvent(WTFMove(info), [this, protectedThis = Ref { *this }, identifier](bool result) mutable {
+            callOnMainThread([this, protectedThis = Ref { *this }, identifier, result]() mutable {
                 if (auto callback = m_ongoingFunctionalEventTasks.take(identifier))
                     callback(result);
                 if (m_ongoingFunctionalEventTasks.isEmpty())

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -41,6 +41,7 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/URLHash.h>
+#include <wtf/WeakRef.h>
 
 namespace WebCore {
 
@@ -132,13 +133,13 @@ private:
     // WorkerBadgeProxy
     void setAppBadge(std::optional<uint64_t>) final;
 
-    Ref<Page> m_page;
-    Ref<Document> m_document;
+    const Ref<Page> m_page;
+    const Ref<Document> m_document;
 #if ENABLE(REMOTE_INSPECTOR)
-    Ref<ServiceWorkerDebuggable> m_remoteDebuggable;
+    const Ref<ServiceWorkerDebuggable> m_remoteDebuggable;
 #endif
-    Ref<ServiceWorkerThread> m_serviceWorkerThread;
-    CacheStorageProvider& m_cacheStorageProvider;
+    const Ref<ServiceWorkerThread> m_serviceWorkerThread;
+    WeakRef<CacheStorageProvider> m_cacheStorageProvider;
     RefPtr<CacheStorageConnection> m_cacheStorageConnection;
     bool m_isTerminatingOrTerminated { false };
 

--- a/Source/WebCore/workers/service/server/SWScriptStorage.cpp
+++ b/Source/WebCore/workers/service/server/SWScriptStorage.cpp
@@ -90,7 +90,7 @@ ScriptBuffer SWScriptStorage::store(const ServiceWorkerRegistrationKey& registra
     size_t size = script.buffer() ? script.buffer()->size() : 0;
 
     auto iterateOverBufferAndWriteData = [&](NOESCAPE const Function<bool(std::span<const uint8_t>)>& writeData) {
-        script.buffer()->forEachSegment([&](std::span<const uint8_t> span) {
+        script.protectedBuffer()->forEachSegment([&](std::span<const uint8_t> span) {
             writeData(span);
         });
     };

--- a/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp
@@ -60,29 +60,29 @@ void SharedWorkerContextManager::stopSharedWorker(SharedWorkerIdentifier sharedW
 
     // FIXME: We should be able to deal with the thread being unresponsive here.
 
-    auto& thread = worker->thread();
-    thread.stop([worker = WTFMove(worker)]() mutable {
+    Ref thread = worker->thread();
+    thread->stop([worker = WTFMove(worker)]() mutable {
         // Spin the runloop before releasing the shared worker thread proxy, as there would otherwise be
         // a race towards its destruction.
         callOnMainThread([worker = WTFMove(worker)] { });
     });
 
-    if (auto* connection = SharedWorkerContextManager::singleton().connection())
+    if (RefPtr connection = SharedWorkerContextManager::singleton().connection())
         connection->sharedWorkerTerminated(sharedWorkerIdentifier);
 }
 
 void SharedWorkerContextManager::suspendSharedWorker(SharedWorkerIdentifier sharedWorkerIdentifier)
 {
-    auto* worker = m_workerMap.get(sharedWorkerIdentifier);
-    RELEASE_LOG(SharedWorker, "SharedWorkerContextManager::suspendSharedWorker: sharedWorkerIdentifier=%" PRIu64 ", worker=%p", sharedWorkerIdentifier.toUInt64(), worker);
+    RefPtr worker = m_workerMap.get(sharedWorkerIdentifier);
+    RELEASE_LOG(SharedWorker, "SharedWorkerContextManager::suspendSharedWorker: sharedWorkerIdentifier=%" PRIu64 ", worker=%p", sharedWorkerIdentifier.toUInt64(), worker.get());
     if (worker)
         worker->thread().suspend();
 }
 
 void SharedWorkerContextManager::resumeSharedWorker(SharedWorkerIdentifier sharedWorkerIdentifier)
 {
-    auto* worker = m_workerMap.get(sharedWorkerIdentifier);
-    RELEASE_LOG(SharedWorker, "SharedWorkerContextManager::resumeSharedWorker: sharedWorkerIdentifier=%" PRIu64 ", worker=%p", sharedWorkerIdentifier.toUInt64(), worker);
+    RefPtr worker = m_workerMap.get(sharedWorkerIdentifier);
+    RELEASE_LOG(SharedWorker, "SharedWorkerContextManager::resumeSharedWorker: sharedWorkerIdentifier=%" PRIu64 ", worker=%p", sharedWorkerIdentifier.toUInt64(), worker.get());
     if (worker)
         worker->thread().resume();
 }
@@ -118,8 +118,8 @@ void SharedWorkerContextManager::registerSharedWorkerThread(Ref<SharedWorkerThre
 void SharedWorkerContextManager::Connection::postConnectEvent(SharedWorkerIdentifier sharedWorkerIdentifier, TransferredMessagePort&& transferredPort, String&& sourceOrigin, CompletionHandler<void(bool)>&& completionHandler)
 {
     ASSERT(isMainThread());
-    auto* proxy = SharedWorkerContextManager::singleton().sharedWorker(sharedWorkerIdentifier);
-    RELEASE_LOG(SharedWorker, "SharedWorkerContextManager::Connection::postConnectEvent: sharedWorkerIdentifier=%" PRIu64 ", proxy=%p", sharedWorkerIdentifier.toUInt64(), proxy);
+    RefPtr proxy = SharedWorkerContextManager::singleton().sharedWorker(sharedWorkerIdentifier);
+    RELEASE_LOG(SharedWorker, "SharedWorkerContextManager::Connection::postConnectEvent: sharedWorkerIdentifier=%" PRIu64 ", proxy=%p", sharedWorkerIdentifier.toUInt64(), proxy.get());
     if (!proxy)
         return completionHandler(false);
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -173,7 +173,7 @@ RefPtr<CacheStorageConnection> SharedWorkerThreadProxy::createCacheStorageConnec
 {
     ASSERT(isMainThread());
     if (!m_cacheStorageConnection)
-        m_cacheStorageConnection = m_cacheStorageProvider->createCacheStorageConnection();
+        m_cacheStorageConnection = Ref { m_cacheStorageProvider.get() }->createCacheStorageConnection();
     return m_cacheStorageConnection;
 }
 

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -96,10 +96,10 @@ private:
 
     ReportingClient* reportingClient() const final;
 
-    Ref<Page> m_page;
-    Ref<Document> m_document;
+    const Ref<Page> m_page;
+    const Ref<Document> m_document;
     ScriptExecutionContextIdentifier m_contextIdentifier;
-    Ref<SharedWorkerThread> m_workerThread;
+    const Ref<SharedWorkerThread> m_workerThread;
     WeakRef<CacheStorageProvider> m_cacheStorageProvider;
     RefPtr<CacheStorageConnection> m_cacheStorageConnection;
     bool m_isTerminatingOrTerminated { false };


### PR DESCRIPTION
#### c7726c33a69aa3ded981be1b3012c3f1c4101cbc
<pre>
Address Safer CPP in more service / shared worker classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=289217">https://bugs.webkit.org/show_bug.cgi?id=289217</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/NoUncheckedPtrMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoUncountedMemberCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/workers/ScriptBuffer.h:
(WebCore::ScriptBuffer::protectedBuffer const):
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::setConnection):
(WebCore::SWContextManager::startedServiceWorker):
(WebCore::SWContextManager::fireInstallEvent):
(WebCore::SWContextManager::fireActivateEvent):
(WebCore::SWContextManager::firePushEvent):
(WebCore::SWContextManager::firePushSubscriptionChangeEvent):
(WebCore::SWContextManager::fireNotificationEvent):
(WebCore::SWContextManager::fireBackgroundFetchEvent):
(WebCore::SWContextManager::fireBackgroundFetchClickEvent):
(WebCore::SWContextManager::stopWorker):
(WebCore::SWContextManager::postTaskToServiceWorker):
(WebCore::SWContextManager::setAsInspected):
(WebCore::SWContextManager::removeFetch):
* Source/WebCore/workers/service/context/ServiceWorkerFetch.cpp:
(WebCore::ServiceWorkerFetch::processResponse):
* Source/WebCore/workers/service/context/ServiceWorkerInspectorProxy.cpp:
(WebCore::ServiceWorkerInspectorProxy::disconnectFromWorker):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFirePushEvent):
(WebCore::ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireNotificationEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent):
(WebCore::ServiceWorkerThread::workerObjectProxy const):
(WebCore::ServiceWorkerThread::heartBeatTimerFired):
(WebCore::ServiceWorkerThread::finishedFiringInstallEvent):
(WebCore::ServiceWorkerThread::finishedFiringActivateEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThread.h:
(WebCore::ServiceWorkerThread::workerObjectProxy const): Deleted.
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::createCacheStorageConnection):
(WebCore::ServiceWorkerThreadProxy::networkStateChanged):
(WebCore::ServiceWorkerThreadProxy::firePushEvent):
(WebCore::ServiceWorkerThreadProxy::fireNotificationEvent):
(WebCore::ServiceWorkerThreadProxy::fireBackgroundFetchEvent):
(WebCore::ServiceWorkerThreadProxy::fireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/service/server/SWScriptStorage.cpp:
(WebCore::SWScriptStorage::store):
* Source/WebCore/workers/shared/context/SharedWorkerContextManager.cpp:
(WebCore::SharedWorkerContextManager::stopSharedWorker):
(WebCore::SharedWorkerContextManager::suspendSharedWorker):
(WebCore::SharedWorkerContextManager::resumeSharedWorker):
(WebCore::SharedWorkerContextManager::Connection::postConnectEvent):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::createCacheStorageConnection):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:

Canonical link: <a href="https://commits.webkit.org/291704@main">https://commits.webkit.org/291704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5c56ab6a96788904235288102c4e522a007af36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98748 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44268 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21758 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71571 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28940 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2354 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80087 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100783 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20794 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15174 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21046 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79924 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19884 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24470 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13951 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20778 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25956 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20465 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22206 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->