### PR TITLE
When playing sound through an AudioContext, stale audio buffer data plays after seek

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h
@@ -62,7 +62,7 @@ public:
     void setPlayerItem(AVPlayerItem *);
     void setAudioTrack(AVAssetTrack *);
 
-    using AudioCallback = Function<void(uint64_t startFrame, uint64_t numberOfFrames)>;
+    using AudioCallback = Function<void(uint64_t startFrame, uint64_t numberOfFrames, bool needFlush)>;
     WEBCORE_EXPORT void setAudioCallback(AudioCallback&&);
     using ConfigureAudioStorageCallback = Function<std::unique_ptr<CARingBuffer>(const CAAudioStreamDescription&, size_t frameCount)>;
     WEBCORE_EXPORT void setConfigureAudioStorageCallback(ConfigureAudioStorageCallback&&);

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEB_AUDIO)
 
+#include "AudioSampleDataSource.h"
 #include "CAAudioStreamDescription.h"
 #include "WebAudioSourceProvider.h"
 #include <CoreAudio/CoreAudioTypes.h>
@@ -46,7 +47,6 @@ class LoggerHelper;
 
 namespace WebCore {
 
-class AudioSampleDataSource;
 class CAAudioStreamDescription;
 class PlatformAudioData;
 class WebAudioBufferList;
@@ -58,9 +58,10 @@ public:
     ~WebAudioSourceProviderCocoa();
 
 protected:
-    void receivedNewAudioSamples(const PlatformAudioData&, const AudioStreamDescription&, size_t);
+    using NeedsFlush = AudioSampleDataSource::NeedsFlush;
+    void receivedNewAudioSamples(const PlatformAudioData&, const AudioStreamDescription&, size_t, NeedsFlush = NeedsFlush::No);
 
-        void setPollSamplesCount(size_t);
+    void setPollSamplesCount(size_t);
 
 private:
     virtual void hasNewClient(AudioSourceProviderClient*) = 0;

--- a/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm
@@ -30,7 +30,6 @@
 
 #import "AudioBus.h"
 #import "AudioChannel.h"
-#import "AudioSampleDataSource.h"
 #import "AudioSourceProviderClient.h"
 #import "Logging.h"
 #import "WebAudioBufferList.h"
@@ -137,7 +136,7 @@ void WebAudioSourceProviderCocoa::prepare(const AudioStreamBasicDescription& for
 }
 
 // May get called on a background thread.
-void WebAudioSourceProviderCocoa::receivedNewAudioSamples(const PlatformAudioData& data, const AudioStreamDescription& description, size_t frameCount)
+void WebAudioSourceProviderCocoa::receivedNewAudioSamples(const PlatformAudioData& data, const AudioStreamDescription& description, size_t frameCount, NeedsFlush needsFlush)
 {
     ASSERT(description.platformDescription().type == PlatformDescription::CAAudioStreamBasicType);
     auto& basicDescription = *std::get<const AudioStreamBasicDescription*>(description.platformDescription().description);
@@ -147,7 +146,7 @@ void WebAudioSourceProviderCocoa::receivedNewAudioSamples(const PlatformAudioDat
     if (!m_dataSource)
         return;
 
-    m_dataSource->pushSamples(MediaTime(m_writeCount, m_inputDescription->sampleRate()), data, frameCount);
+    m_dataSource->pushSamples(MediaTime(m_writeCount, m_inputDescription->sampleRate()), data, frameCount, needsFlush);
 
     m_writeCount += frameCount;
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp
@@ -40,8 +40,8 @@ Ref<RemoteAudioSourceProviderProxy> RemoteAudioSourceProviderProxy::create(WebCo
     localProvider.setConfigureAudioStorageCallback([remoteProvider](auto&&... args) {
         return remoteProvider->configureAudioStorage(args...);
     });
-    localProvider.setAudioCallback([remoteProvider](auto startFrame, auto numberOfFrames) {
-        remoteProvider->newAudioSamples(startFrame, numberOfFrames);
+    localProvider.setAudioCallback([remoteProvider](auto startFrame, auto numberOfFrames, bool needsFlush) {
+        remoteProvider->newAudioSamples(startFrame, numberOfFrames, needsFlush);
     });
 
     return remoteProvider;
@@ -66,9 +66,9 @@ std::unique_ptr<WebCore::CARingBuffer> RemoteAudioSourceProviderProxy::configure
     return caRingBuffer;
 }
 
-void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames)
+void RemoteAudioSourceProviderProxy::newAudioSamples(uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
 {
-    protectedConnection()->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames }, 0);
+    protectedConnection()->send(Messages::RemoteAudioSourceProviderManager::AudioSamplesAvailable { m_identifier, startFrame, numberOfFrames, needsFlush }, 0);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h
@@ -47,7 +47,7 @@ public:
     static Ref<RemoteAudioSourceProviderProxy> create(WebCore::MediaPlayerIdentifier, Ref<IPC::Connection>&&, WebCore::AudioSourceProviderAVFObjC&);
     ~RemoteAudioSourceProviderProxy();
 
-    void newAudioSamples(uint64_t startFrame, uint64_t endFrame);
+    void newAudioSamples(uint64_t startFrame, uint64_t endFrame, bool);
 
 private:
     RemoteAudioSourceProviderProxy(WebCore::MediaPlayerIdentifier, Ref<IPC::Connection>&&);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
@@ -83,9 +83,9 @@ void RemoteAudioSourceProvider::hasNewClient(AudioSourceProviderClient* client)
         gpuProcessConnection->protectedConnection()->send(Messages::RemoteMediaPlayerProxy::SetShouldEnableAudioSourceProvider { !!client }, m_identifier);
 }
 
-void RemoteAudioSourceProvider::audioSamplesAvailable(const PlatformAudioData& data, const AudioStreamDescription& description, size_t size)
+void RemoteAudioSourceProvider::audioSamplesAvailable(const PlatformAudioData& data, const AudioStreamDescription& description, size_t size, bool needsFlush)
 {
-    receivedNewAudioSamples(data, description, size);
+    receivedNewAudioSamples(data, description, size, needsFlush ? NeedsFlush::Yes : NeedsFlush::No);
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h
@@ -44,7 +44,7 @@ public:
     static Ref<RemoteAudioSourceProvider> create(WebCore::MediaPlayerIdentifier, WTF::LoggerHelper&);
     ~RemoteAudioSourceProvider();
 
-    void audioSamplesAvailable(const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t);
+    void audioSamplesAvailable(const WebCore::PlatformAudioData&, const WebCore::AudioStreamDescription&, size_t, bool);
     void close();
 
     WebCore::MediaPlayerIdentifier identifier() const { return m_identifier; }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp
@@ -103,7 +103,7 @@ void RemoteAudioSourceProviderManager::audioStorageChanged(MediaPlayerIdentifier
     iterator->value->setStorage(WTFMove(handle), description);
 }
 
-void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifier identifier, uint64_t startFrame, uint64_t numberOfFrames)
+void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifier identifier, uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
 {
     ASSERT(!WTF::isMainRunLoop());
 
@@ -112,7 +112,7 @@ void RemoteAudioSourceProviderManager::audioSamplesAvailable(MediaPlayerIdentifi
         RELEASE_LOG_ERROR(Media, "Unable to find provider %llu for audioSamplesAvailable", identifier.toUInt64());
         return;
     }
-    iterator->value->audioSamplesAvailable(startFrame, numberOfFrames);
+    iterator->value->audioSamplesAvailable(startFrame, numberOfFrames, needsFlush);
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioSourceProviderManager::RemoteAudio);
@@ -133,7 +133,7 @@ void RemoteAudioSourceProviderManager::RemoteAudio::setStorage(ConsumerSharedCAR
     m_buffer = makeUnique<WebAudioBufferList>(description);
 }
 
-void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames)
+void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
 {
     if (!m_buffer) {
         RELEASE_LOG_ERROR(Media, "buffer for audio provider %llu is null", m_provider->identifier().toUInt64());
@@ -149,7 +149,7 @@ void RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable(uint64
 
     m_ringBuffer->fetch(m_buffer->list(), numberOfFrames, startFrame);
 
-    m_provider->audioSamplesAvailable(*m_buffer, *m_description, numberOfFrames);
+    m_provider->audioSamplesAvailable(*m_buffer, *m_description, numberOfFrames, needsFlush);
 }
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h
@@ -57,7 +57,7 @@ private:
 
     // Messages
     void audioStorageChanged(WebCore::MediaPlayerIdentifier, ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
-    void audioSamplesAvailable(WebCore::MediaPlayerIdentifier, uint64_t startFrame, uint64_t numberOfFrames);
+    void audioSamplesAvailable(WebCore::MediaPlayerIdentifier, uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush);
 
     void setConnection(RefPtr<IPC::Connection>&&);
 
@@ -67,7 +67,7 @@ private:
         explicit RemoteAudio(Ref<RemoteAudioSourceProvider>&&);
 
         void setStorage(ConsumerSharedCARingBuffer::Handle&&, const WebCore::CAAudioStreamDescription&);
-        void audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames);
+        void audioSamplesAvailable(uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush);
 
     private:
         const Ref<RemoteAudioSourceProvider> m_provider;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in
@@ -31,7 +31,7 @@
 ]
 messages -> RemoteAudioSourceProviderManager {
     AudioStorageChanged(WebCore::MediaPlayerIdentifier id, struct WebKit::ConsumerSharedCARingBufferHandle storageHandle, WebCore::CAAudioStreamDescription description)
-    AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames)
+    AudioSamplesAvailable(WebCore::MediaPlayerIdentifier id, uint64_t startFrame, uint64_t numberOfFrames, bool needsFlush)
 }
 
 #endif


### PR DESCRIPTION
#### 80b43161244b75fb66a86a352c81d5b15e7045a2
<pre>
When playing sound through an AudioContext, stale audio buffer data plays after seek
<a href="https://bugs.webkit.org/show_bug.cgi?id=288879">https://bugs.webkit.org/show_bug.cgi?id=288879</a>
<a href="https://rdar.apple.com/146057507">rdar://146057507</a>

Reviewed by Youenn Fablet.

Prior the move of the AudioSourceProvider to the GPU process,
AudioSourceProvider::provideInput would be regularly called to get
the next audio data to be provided back to an AudioContext.
AudioSourceProviderAVFObjC::provideInput would detect if a flush or seek
occurred and would then discard any stale content before returning new data.

Since 230539@main however, the audio produced by the media player in the GPU
process is immediately sent to the WebContent process and stored in the
AudioSampleDataSource&apos;s ring buffer ready to be retrieved by the AudioContext,
in effect deprecating AudioSourceProviderAVFObjC::provideInput (and making
it dead code).
As such, when we reset or seek the media player, any data set to become stale
has already been queued in the WP and will be pulled next.

To get around this issue, we sent to the content process the information
that earlier data received is now stale and needs to be flushed.
When the AudioSampleDataSource::pullSamples is next called, any audio data
still pending in the AudioSampleDataSource received earlier than the data
following the request for flushing will be dropped.

Manually verified using provided test site.

* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.h:
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pushSamplesInternal):
(WebCore::AudioSampleDataSource::pushSamples):
(WebCore::AudioSampleDataSource::pullSamples):
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm:
(WebCore::AudioSourceProviderAVFObjC::process):
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.h:
* Source/WebCore/platform/mediastream/mac/WebAudioSourceProviderCocoa.mm:
(WebCore::WebAudioSourceProviderCocoa::receivedNewAudioSamples):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.cpp:
(WebKit::RemoteAudioSourceProviderProxy::create):
(WebKit::RemoteAudioSourceProviderProxy::newAudioSamples):
* Source/WebKit/GPUProcess/media/RemoteAudioSourceProviderProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp:
(WebKit::RemoteAudioSourceProvider::audioSamplesAvailable):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp:
(WebKit::RemoteAudioSourceProviderManager::audioSamplesAvailable):
(WebKit::RemoteAudioSourceProviderManager::RemoteAudio::audioSamplesAvailable):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProviderManager.messages.in:

Canonical link: <a href="https://commits.webkit.org/291763@main">https://commits.webkit.org/291763@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50aa763505fd43fed8eb125d313d1cbde7626cc4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98967 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96009 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71693 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29043 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10269 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52032 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2522 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43802 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80212 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/2604 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101006 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21011 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80062 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24609 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1969 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14168 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26173 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24142 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22423 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->