### PR TITLE
[WebGPU] idl constants should be namespace constants, not an interface with constant values

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
     Exposed=(Window,Worker),
     SecureContext
 ]
-interface GPUBufferUsage {
+namespace GPUBufferUsage {
     const GPUFlagsConstant MAP_READ      = 0x0001;
     const GPUFlagsConstant MAP_WRITE     = 0x0002;
     const GPUFlagsConstant COPY_SRC      = 0x0004;

--- a/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long GPUColorWriteFlags;
     Exposed=(Window,Worker),
     SecureContext
 ]
-interface GPUColorWrite {
+namespace GPUColorWrite {
     const GPUFlagsConstant RED   = 0x1;
     const GPUFlagsConstant GREEN = 0x2;
     const GPUFlagsConstant BLUE  = 0x4;

--- a/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long GPUMapModeFlags;
     Exposed=(Window,Worker),
     SecureContext
 ]
-interface GPUMapMode {
+namespace GPUMapMode {
     const GPUFlagsConstant READ  = 0x0001;
     const GPUFlagsConstant WRITE = 0x0002;
 };

--- a/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long GPUShaderStageFlags;
     Exposed=(Window,Worker),
     SecureContext
 ]
-interface GPUShaderStage {
+namespace GPUShaderStage {
     const GPUFlagsConstant VERTEX   = 0x1;
     const GPUFlagsConstant FRAGMENT = 0x2;
     const GPUFlagsConstant COMPUTE  = 0x4;

--- a/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
     Exposed=(Window,Worker),
     SecureContext
 ]
-interface GPUTextureUsage {
+namespace GPUTextureUsage {
     const GPUFlagsConstant COPY_SRC          = 0x01;
     const GPUFlagsConstant COPY_DST          = 0x02;
     const GPUFlagsConstant TEXTURE_BINDING   = 0x04;


### PR DESCRIPTION
#### 332bf421e29d24986a9643cb4c337e910c26c22a
<pre>
[WebGPU] idl constants should be namespace constants, not an interface with constant values
<a href="https://bugs.webkit.org/show_bug.cgi?id=289222">https://bugs.webkit.org/show_bug.cgi?id=289222</a>
<a href="https://rdar.apple.com/146361873">rdar://146361873</a>

Reviewed by Cameron McCormack.

Specification says these should be namespace constants, not
interface constants.

WebKit added support for namespace constants ~3 years ago, but
some of these files predated such support.

* Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUColorWrite.idl:
* Source/WebCore/Modules/WebGPU/GPUMapMode.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderStage.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl:

Canonical link: <a href="https://commits.webkit.org/291687@main">https://commits.webkit.org/291687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2193f50572a855c65836f2b5a138c3fbe6f247e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44221 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71533 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10098 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51867 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2314 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43536 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80053 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100734 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15139 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80548 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/20999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79886 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19869 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24433 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1785 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13897 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20731 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25909 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20418 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23878 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->