### PR TITLE
Refactoring: Making FontCascadeFonts "free" of FontSelector

### DIFF
--- a/Source/WebCore/platform/graphics/FontCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCache.cpp
@@ -352,9 +352,9 @@ RefPtr<OpenTypeVerticalData> FontCache::verticalData(const FontPlatformData& pla
 }
 #endif
 
-void FontCache::updateFontCascade(const FontCascade& fontCascade, RefPtr<FontSelector>&& fontSelector)
+void FontCache::updateFontCascade(const FontCascade& fontCascade)
 {
-    fontCascade.updateFonts(m_fontCascadeCache.retrieveOrAddCachedFonts(fontCascade.fontDescription(), WTFMove(fontSelector)));
+    fontCascade.updateFonts(m_fontCascadeCache.retrieveOrAddCachedFonts(fontCascade.fontDescription(), fontCascade.fontSelector()));
 }
 
 size_t FontCache::fontCount()

--- a/Source/WebCore/platform/graphics/FontCache.h
+++ b/Source/WebCore/platform/graphics/FontCache.h
@@ -177,7 +177,7 @@ public:
 
     static void releaseNoncriticalMemoryInAllFontCaches();
 
-    void updateFontCascade(const FontCascade&, RefPtr<FontSelector>&&);
+    void updateFontCascade(const FontCascade&);
 
 #if PLATFORM(WIN)
     RefPtr<Font> fontFromDescriptionAndLogFont(const FontDescription&, const LOGFONT&, String& outFontFamilyName);

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -88,6 +88,7 @@ FontCascade::FontCascade(const FontCascade& other)
     , m_fontDescription(other.m_fontDescription)
     , m_spacing(other.m_spacing)
     , m_fonts(other.m_fonts)
+    , m_fontSelector(other.m_fontSelector)
     , m_generation(other.m_generation)
     , m_useBackslashAsYenSymbol(other.m_useBackslashAsYenSymbol)
     , m_enableKerning(computeEnableKerning())
@@ -104,6 +105,7 @@ FontCascade& FontCascade::operator=(const FontCascade& other)
     m_useBackslashAsYenSymbol = other.m_useBackslashAsYenSymbol;
     m_enableKerning = other.m_enableKerning;
     m_requiresShaping = other.m_requiresShaping;
+    m_fontSelector = other.m_fontSelector;
     return *this;
 }
 
@@ -112,17 +114,17 @@ bool FontCascade::operator==(const FontCascade& other) const
     if (m_fontDescription != other.m_fontDescription || m_spacing != other.m_spacing)
         return false;
 
-    if (m_fonts == other.m_fonts)
-        return true;
+    if (m_fonts != other.m_fonts)
+        return false;
 
     if (!m_fonts || !other.m_fonts)
         return false;
 
-    if (m_fonts->fontSelector() != other.m_fonts->fontSelector())
+    if (fontSelector() != other.fontSelector())
         return false;
 
     // Can these cases actually somehow occur? All fonts should get wiped out by full style recalc.
-    if (m_fonts->fontSelectorVersion() != other.m_fonts->fontSelectorVersion())
+    if (fontSelectorVersion() != other.fontSelectorVersion())
         return false;
 
     if (m_fonts->generation() != other.m_fonts->generation())
@@ -137,10 +139,15 @@ bool FontCascade::isCurrent(const FontSelector& fontSelector) const
         return false;
     if (m_fonts->generation() != FontCache::forCurrentThread().generation())
         return false;
-    if (m_fonts->fontSelectorVersion() != fontSelector.version())
+    if (fontSelectorVersion() != fontSelector.version())
         return false;
 
     return true;
+}
+
+unsigned FontCascade::fontSelectorVersion() const
+{
+    return m_fontSelector ? Ref { *m_fontSelector }->version() : 0;
 }
 
 void FontCascade::updateFonts(Ref<FontCascadeFonts>&& fonts) const
@@ -152,7 +159,8 @@ void FontCascade::updateFonts(Ref<FontCascadeFonts>&& fonts) const
 
 void FontCascade::update(RefPtr<FontSelector>&& fontSelector) const
 {
-    FontCache::forCurrentThread().updateFontCascade(*this, WTFMove(fontSelector));
+    m_fontSelector = WTFMove(fontSelector);
+    FontCache::forCurrentThread().updateFontCascade(*this);
 }
 
 GlyphBuffer FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis) const
@@ -424,7 +432,7 @@ GlyphData FontCascade::glyphDataForCharacter(char32_t c, bool mirror, FontVarian
 
     auto emojiPolicy = resolveEmojiPolicy(m_fontDescription.variantEmoji(), c);
 
-    return protectedFonts()->glyphDataForCharacter(c, m_fontDescription, variant, emojiPolicy);
+    return protectedFonts()->glyphDataForCharacter(c, m_fontDescription, protectedFontSelector().get(), variant, emojiPolicy);
 }
 
 
@@ -1928,11 +1936,11 @@ TextStream& operator<<(TextStream& ts, const FontCascade& fontCascade)
 {
     ts << fontCascade.fontDescription();
 
-    if (fontCascade.fonts()) {
-        ts << ", font selector " << fontCascade.fonts()->fontSelector();
-        ts << ", font selector version " << fontCascade.fonts()->fontSelectorVersion();
+    if (fontCascade.fontSelector())
+        ts << ", font selector " << fontCascade.fontSelector();
+
+    if (fontCascade.fonts())
         ts << ", generation " << fontCascade.fonts()->generation();
-    }
 
     return ts;
 }

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -55,6 +55,7 @@ class TextStream;
 namespace WebCore {
 
 class GraphicsContext;
+class FontSelector;
 class LayoutRect;
 class RenderStyle;
 class RenderText;
@@ -138,6 +139,7 @@ public:
     bool isCurrent(const FontSelector&) const;
     void updateFonts(Ref<FontCascadeFonts>&&) const;
     WEBCORE_EXPORT void update(RefPtr<FontSelector>&& = nullptr) const;
+    unsigned fontSelectorVersion() const;
 
     enum class CustomFontNotReadyAction : bool { DoNotPaintIfFontNotReady, UseFallbackIfFontNotReady };
     WEBCORE_EXPORT FloatSize drawText(GraphicsContext&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
@@ -283,6 +285,8 @@ public:
     static CodePath s_codePath;
 
     FontSelector* fontSelector() const;
+    RefPtr<FontSelector> protectedFontSelector() const;
+
     static bool isInvisibleReplacementObjectCharacter(char32_t character)
     {
         if (character != objectReplacementCharacter)
@@ -374,6 +378,7 @@ private:
     mutable FontCascadeDescription m_fontDescription;
     Spacing m_spacing;
     mutable RefPtr<FontCascadeFonts> m_fonts;
+    mutable RefPtr<FontSelector> m_fontSelector;
     mutable unsigned m_generation { 0 };
     bool m_useBackslashAsYenSymbol { false };
     bool m_enableKerning { false }; // Computed from m_fontDescription.
@@ -384,7 +389,7 @@ private:
 inline Ref<const Font> FontCascade::primaryFont() const
 {
     ASSERT(m_fonts);
-    Ref font = protectedFonts()->primaryFont(m_fontDescription);
+    Ref font = protectedFonts()->primaryFont(m_fontDescription, protectedFontSelector().get());
     m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(font);
     return font;
 }
@@ -392,25 +397,29 @@ inline Ref<const Font> FontCascade::primaryFont() const
 inline const FontRanges& FontCascade::fallbackRangesAt(unsigned index) const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->realizeFallbackRangesAt(m_fontDescription, index);
+    return protectedFonts()->realizeFallbackRangesAt(m_fontDescription, protectedFontSelector().get(), index);
 }
 
 inline bool FontCascade::isFixedPitch() const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->isFixedPitch(m_fontDescription);
+    return protectedFonts()->isFixedPitch(m_fontDescription, protectedFontSelector().get());
 }
 
 inline bool FontCascade::canTakeFixedPitchFastContentMeasuring() const
 {
     ASSERT(m_fonts);
-    return protectedFonts()->canTakeFixedPitchFastContentMeasuring(m_fontDescription);
+    return protectedFonts()->canTakeFixedPitchFastContentMeasuring(m_fontDescription, protectedFontSelector().get());
 }
 
 inline FontSelector* FontCascade::fontSelector() const
 {
-    RefPtr fonts = m_fonts;
-    return fonts ? fonts->fontSelector() : nullptr;
+    return m_fontSelector.get();
+}
+
+inline RefPtr<FontSelector> FontCascade::protectedFontSelector() const
+{
+    return m_fontSelector;
 }
 
 inline float FontCascade::tabWidth(const Font& font, const TabSize& tabSize, float position, Font::SyntheticBoldInclusion syntheticBoldInclusion) const

--- a/Source/WebCore/platform/graphics/FontCascadeCache.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.cpp
@@ -103,15 +103,15 @@ static FontCascadeCacheKey makeFontCascadeCacheKey(const FontCascadeDescription&
     };
 }
 
-Ref<FontCascadeFonts> FontCascadeCache::retrieveOrAddCachedFonts(const FontCascadeDescription& fontDescription, RefPtr<FontSelector>&& fontSelector)
+Ref<FontCascadeFonts> FontCascadeCache::retrieveOrAddCachedFonts(const FontCascadeDescription& fontDescription, FontSelector* fontSelector)
 {
-    auto key = makeFontCascadeCacheKey(fontDescription, fontSelector.get());
+    auto key = makeFontCascadeCacheKey(fontDescription, fontSelector);
     auto addResult = m_entries.add(key, nullptr);
     if (!addResult.isNewEntry)
         return addResult.iterator->value->fonts.get();
 
     auto& newEntry = addResult.iterator->value;
-    newEntry = makeUnique<FontCascadeCacheEntry>(FontCascadeCacheEntry { WTFMove(key), FontCascadeFonts::create(WTFMove(fontSelector)) });
+    newEntry = makeUnique<FontCascadeCacheEntry>(FontCascadeCacheEntry { WTFMove(key), FontCascadeFonts::create() });
     Ref<FontCascadeFonts> fonts = newEntry->fonts.get();
 
     static constexpr unsigned unreferencedPruneInterval = 50;

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -269,7 +269,7 @@ public:
     void clearWidthCaches();
     void pruneUnreferencedEntries();
     void pruneSystemFallbackFonts();
-    Ref<FontCascadeFonts> retrieveOrAddCachedFonts(const FontCascadeDescription&, RefPtr<FontSelector>&&);
+    Ref<FontCascadeFonts> retrieveOrAddCachedFonts(const FontCascadeDescription&, FontSelector*);
 
 private:
     UncheckedKeyHashMap<FontCascadeCacheKey, std::unique_ptr<FontCascadeCacheEntry>, FontCascadeCacheKeyHash, FontCascadeCacheKeyHashTraits> m_entries;

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -54,45 +54,41 @@ class FontCascadeFonts : public RefCounted<FontCascadeFonts> {
     WTF_MAKE_NONCOPYABLE(FontCascadeFonts);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(FontCascadeFonts);
 public:
-    static Ref<FontCascadeFonts> create(RefPtr<FontSelector>&& fontSelector) { return adoptRef(*new FontCascadeFonts(WTFMove(fontSelector))); }
+    static Ref<FontCascadeFonts> create() { return adoptRef(*new FontCascadeFonts()); }
     static Ref<FontCascadeFonts> createForPlatformFont(const FontPlatformData& platformData) { return adoptRef(*new FontCascadeFonts(platformData)); }
 
     WEBCORE_EXPORT ~FontCascadeFonts();
 
     bool isForPlatformFont() const { return m_isForPlatformFont; }
 
-    GlyphData glyphDataForCharacter(char32_t, const FontCascadeDescription&, FontVariant, ResolvedEmojiPolicy);
+    GlyphData glyphDataForCharacter(char32_t, const FontCascadeDescription&, FontSelector*, FontVariant, ResolvedEmojiPolicy);
 
-    bool isFixedPitch(const FontCascadeDescription&);
+    bool isFixedPitch(const FontCascadeDescription&, FontSelector*);
 
-    bool canTakeFixedPitchFastContentMeasuring(const FontCascadeDescription&);
+    bool canTakeFixedPitchFastContentMeasuring(const FontCascadeDescription&, FontSelector*);
 
     bool isLoadingCustomFonts() const;
 
-    FontSelector* fontSelector() { return m_fontSelector.get(); }
-    const FontSelector* fontSelector() const { return m_fontSelector.get(); }
-
     // FIXME: It should be possible to combine fontSelectorVersion and generation.
-    unsigned fontSelectorVersion() const { return m_fontSelectorVersion; }
     unsigned generation() const { return m_generation; }
 
     WidthCache& widthCache() { return m_widthCache; }
     const WidthCache& widthCache() const { return m_widthCache; }
 
-    const Font& primaryFont(const FontCascadeDescription&);
-    WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, unsigned fallbackIndex);
+    const Font& primaryFont(const FontCascadeDescription&, FontSelector*);
+    WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, FontSelector*, unsigned fallbackIndex);
 
     void pruneSystemFallbacks();
 
 private:
-    FontCascadeFonts(RefPtr<FontSelector>&&);
+    FontCascadeFonts();
     FontCascadeFonts(const FontPlatformData&);
 
-    GlyphData glyphDataForSystemFallback(char32_t, const FontCascadeDescription&, FontVariant, ResolvedEmojiPolicy, bool systemFallbackShouldBeInvisible);
-    GlyphData glyphDataForVariant(char32_t, const FontCascadeDescription&, FontVariant, ResolvedEmojiPolicy, unsigned fallbackIndex = 0);
+    GlyphData glyphDataForSystemFallback(char32_t, const FontCascadeDescription&, FontSelector*, FontVariant, ResolvedEmojiPolicy, bool systemFallbackShouldBeInvisible);
+    GlyphData glyphDataForVariant(char32_t, const FontCascadeDescription&, FontSelector*, FontVariant, ResolvedEmojiPolicy, unsigned fallbackIndex = 0);
 
-    WEBCORE_EXPORT void determinePitch(const FontCascadeDescription&);
-    WEBCORE_EXPORT void determineCanTakeFixedPitchFastContentMeasuring(const FontCascadeDescription&);
+    WEBCORE_EXPORT void determinePitch(const FontCascadeDescription&, FontSelector*);
+    WEBCORE_EXPORT void determineCanTakeFixedPitchFastContentMeasuring(const FontCascadeDescription&, FontSelector*);
 
     Vector<FontRanges, 1> m_realizedFallbackRanges;
     unsigned m_lastRealizedFallbackIndex { 0 };
@@ -121,11 +117,9 @@ private:
     UncheckedKeyHashSet<RefPtr<Font>> m_systemFallbackFontSet;
 
     SingleThreadWeakPtr<const Font> m_cachedPrimaryFont;
-    const RefPtr<FontSelector> m_fontSelector;
 
     WidthCache m_widthCache;
 
-    unsigned m_fontSelectorVersion { 0 };
     unsigned short m_generation { 0 };
     Pitch m_pitch { UnknownPitch };
     bool m_isForPlatformFont { false };
@@ -135,31 +129,31 @@ private:
 #endif
 };
 
-inline bool FontCascadeFonts::isFixedPitch(const FontCascadeDescription& description)
+inline bool FontCascadeFonts::isFixedPitch(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
     if (m_pitch == UnknownPitch)
-        determinePitch(description);
+        determinePitch(description, fontSelector);
     return m_pitch == FixedPitch;
 }
 
-inline bool FontCascadeFonts::canTakeFixedPitchFastContentMeasuring(const FontCascadeDescription& description)
+inline bool FontCascadeFonts::canTakeFixedPitchFastContentMeasuring(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
     if (m_canTakeFixedPitchFastContentMeasuring == TriState::Indeterminate)
-        determineCanTakeFixedPitchFastContentMeasuring(description);
+        determineCanTakeFixedPitchFastContentMeasuring(description, fontSelector);
     return m_canTakeFixedPitchFastContentMeasuring == TriState::True;
 }
 
-inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& description)
+inline const Font& FontCascadeFonts::primaryFont(const FontCascadeDescription& description, FontSelector* fontSelector)
 {
     ASSERT(m_thread ? m_thread->ptr() == &Thread::currentSingleton() : isMainThread());
     if (!m_cachedPrimaryFont) {
-        auto& primaryRanges = realizeFallbackRangesAt(description, 0);
+        auto& primaryRanges = realizeFallbackRangesAt(description, fontSelector, 0);
         m_cachedPrimaryFont = primaryRanges.glyphDataForCharacter(' ', ExternalResourceDownloadPolicy::Allow).font.get();
         if (!m_cachedPrimaryFont)
             m_cachedPrimaryFont = primaryRanges.rangeAt(0).font(ExternalResourceDownloadPolicy::Allow);
         else if (m_cachedPrimaryFont->isInterstitial()) {
             for (unsigned index = 1; ; ++index) {
-                auto& localRanges = realizeFallbackRangesAt(description, index);
+                auto& localRanges = realizeFallbackRangesAt(description, fontSelector, index);
                 if (localRanges.isNull())
                     break;
                 WeakPtr font = localRanges.glyphDataForCharacter(' ', ExternalResourceDownloadPolicy::Forbid).font.get();

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2746,6 +2746,11 @@ const FontCascade& RenderStyle::fontCascade() const
     return m_inheritedData->fontData->fontCascade;
 }
 
+FontCascade& RenderStyle::fontCascade()
+{
+    return m_inheritedData.access().fontData.access().fontCascade;
+}
+
 const FontMetrics& RenderStyle::metricsOfPrimaryFont() const
 {
     return m_inheritedData->fontData->fontCascade.metricsOfPrimaryFont();

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -592,6 +592,7 @@ public:
     inline FieldSizing fieldSizing() const;
 
     WEBCORE_EXPORT const FontCascade& fontCascade() const;
+    WEBCORE_EXPORT FontCascade& fontCascade();
     WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const;
     WEBCORE_EXPORT const FontCascadeDescription& fontDescription() const;
 


### PR DESCRIPTION
#### 9ab41908f1d8e47dc4ec29e7af03be97c6e8d110
<pre>
Refactoring: Making FontCascadeFonts &quot;free&quot; of FontSelector
<a href="https://bugs.webkit.org/show_bug.cgi?id=289265">https://bugs.webkit.org/show_bug.cgi?id=289265</a>
<a href="https://rdar.apple.com/146405854">rdar://146405854</a>

Reviewed by Matthieu Dubet.

FontCascadeFonts is currently store in FontCascadeCache.
FontCascadeFonts currently holds a RefPtr to its related FontSelector.

In order to make it possible to share FontCascadeFont across documents (for specific simple cases),
we need to make FontCascadeFont free of context.

This patch proposes that FontCascade should hold the FontSelector instead.
FontCascade is already responsible for interfacing between FontCascadeDescription
and FontCascadeFonts. Also, FontCascadeFonts is usually accessed through
FontCascade via functions like ::glyphDataForCharacter, ::width and others, so it
make it simpler for passing the FontSelector to FontCascadeFonts when needed.

This patch is just a refactoring preparation and should produce no changes.

* Source/WebCore/platform/graphics/FontCache.cpp:
(WebCore::FontCache::updateFontCascade):
* Source/WebCore/platform/graphics/FontCache.h:
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::FontCascade):
(WebCore::FontCascade::operator=):
(WebCore::FontCascade::operator== const):
(WebCore::FontCascade::isCurrent const):
(WebCore::FontCascade::fontSelectorVersion const):
(WebCore::FontCascade::update const):
(WebCore::FontCascade::glyphDataForCharacter const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::primaryFont const):
(WebCore::FontCascade::fallbackRangesAt const):
(WebCore::FontCascade::isFixedPitch const):
(WebCore::FontCascade::canTakeFixedPitchFastContentMeasuring const):
(WebCore::FontCascade::fontSelector const):
* Source/WebCore/platform/graphics/FontCascadeCache.cpp:
(WebCore::FontCascadeCache::retrieveOrAddCachedFonts):
* Source/WebCore/platform/graphics/FontCascadeCache.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::FontCascadeFonts):
(WebCore::FontCascadeFonts::determinePitch):
(WebCore::FontCascadeFonts::determineCanTakeFixedPitchFastContentMeasuring):
(WebCore::FontCascadeFonts::realizeFallbackRangesAt):
(WebCore::findBestFallbackFont):
(WebCore::FontCascadeFonts::glyphDataForSystemFallback):
(WebCore::FontCascadeFonts::glyphDataForVariant):
(WebCore::FontCascadeFonts::glyphDataForCharacter):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::create):
(WebCore::FontCascadeFonts::isFixedPitch):
(WebCore::FontCascadeFonts::canTakeFixedPitchFastContentMeasuring):
(WebCore::FontCascadeFonts::primaryFont):
(WebCore::FontCascadeFonts::fontSelector): Deleted.
(WebCore::FontCascadeFonts::fontSelector const): Deleted.
(WebCore::FontCascadeFonts::fontSelectorVersion const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::fontCascade):
* Source/WebCore/rendering/style/RenderStyle.h:

Canonical link: <a href="https://commits.webkit.org/291745@main">https://commits.webkit.org/291745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3615085e2f3146a4fa5b3df06ef3d23c95c1faeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93847 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/13430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98853 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95897 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21863 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10195 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51958 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9879 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2433 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43688 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100889 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20899 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79985 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24530 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20883 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20570 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24030 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22311 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->