### PR TITLE
Address Safer CPP warnings in HTMLDetailsElement.cpp and HTMLSummaryElement.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -680,7 +680,6 @@ html/HTMLButtonElement.cpp
 html/HTMLCanvasElement.cpp
 html/HTMLCollection.cpp
 html/HTMLCollectionInlines.h
-html/HTMLDetailsElement.cpp
 html/HTMLElement.cpp
 html/HTMLFormControlElement.cpp
 html/HTMLFormControlsCollection.cpp
@@ -708,7 +707,6 @@ html/HTMLPlugInImageElement.cpp
 html/HTMLProgressElement.cpp
 html/HTMLSelectElement.cpp
 html/HTMLStyleElement.cpp
-html/HTMLSummaryElement.cpp
 html/HTMLTableCellElement.cpp
 html/HTMLTableElement.cpp
 html/HTMLTablePartElement.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -359,7 +359,6 @@ html/HTMLAnchorElement.cpp
 html/HTMLAttachmentElement.cpp
 html/HTMLCanvasElement.cpp
 html/HTMLCollection.cpp
-html/HTMLDetailsElement.cpp
 html/HTMLDocument.cpp
 html/HTMLElement.cpp
 html/HTMLFieldSetElement.cpp
@@ -378,7 +377,6 @@ html/HTMLPictureElement.cpp
 html/HTMLSelectElement.cpp
 html/HTMLSlotElement.cpp
 html/HTMLStyleElement.cpp
-html/HTMLSummaryElement.cpp
 html/HTMLTableElement.cpp
 html/HTMLTableRowElement.cpp
 html/HTMLTextFormControlElement.cpp

--- a/Source/WebCore/dom/ElementRareData.h
+++ b/Source/WebCore/dom/ElementRareData.h
@@ -378,6 +378,11 @@ inline ShadowRoot* Element::shadowRoot() const
     return hasRareData() ? elementRareData()->shadowRoot() : nullptr;
 }
 
+inline RefPtr<ShadowRoot> Node::protectedShadowRoot() const
+{
+    return shadowRoot();
+}
+
 inline void Element::removeShadowRoot()
 {
     RefPtr shadowRoot = this->shadowRoot();

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -135,6 +135,11 @@ void Event::setTarget(RefPtr<EventTarget>&& target)
         receivedTarget();
 }
 
+RefPtr<EventTarget> Event::protectedTarget() const
+{
+    return m_target;
+}
+
 RefPtr<EventTarget> Event::protectedCurrentTarget() const
 {
     return m_currentTarget;

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -76,6 +76,7 @@ public:
     enum EventInterfaceType interfaceType() const { return static_cast<enum EventInterfaceType>(m_eventInterface); }
 
     EventTarget* target() const { return m_target.get(); }
+    RefPtr<EventTarget> protectedTarget() const;
     void setTarget(RefPtr<EventTarget>&&);
 
     EventTarget* currentTarget() const { return m_currentTarget.get(); }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -269,6 +269,7 @@ public:
     ShadowRoot* containingShadowRoot() const;
     RefPtr<ShadowRoot> protectedContainingShadowRoot() const;
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
+    inline RefPtr<ShadowRoot> protectedShadowRoot() const; // Defined in ElementRareData.h
     bool isClosedShadowHidden(const Node&) const;
 
     HTMLSlotElement* assignedSlot() const;

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -76,7 +76,7 @@ void DetailsSlotAssignment::hostChildElementDidChange(const Element& childElemen
 
 const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child) const
 {
-    auto& details = downcast<HTMLDetailsElement>(*child.parentNode());
+    Ref details = downcast<HTMLDetailsElement>(*child.parentNode());
 
     // The first summary child gets assigned to the summary slot.
     if (is<HTMLSummaryElement>(child)) {
@@ -103,42 +103,43 @@ HTMLDetailsElement::~HTMLDetailsElement() = default;
 
 void HTMLDetailsElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 {
-    auto summarySlot = HTMLSlotElement::create(slotTag, document());
+    Ref document = this->document();
+    Ref summarySlot = HTMLSlotElement::create(slotTag, document);
     summarySlot->setAttributeWithoutSynchronization(nameAttr, summarySlotName());
-    m_summarySlot = summarySlot.get();
 
-    auto defaultSummary = HTMLSummaryElement::create(summaryTag, document());
-    defaultSummary->appendChild(Text::create(document(), defaultDetailsSummaryText()));
+    Ref defaultSummary = HTMLSummaryElement::create(summaryTag, document);
+    defaultSummary->appendChild(Text::create(document, defaultDetailsSummaryText()));
     m_defaultSummary = defaultSummary.get();
 
     summarySlot->appendChild(defaultSummary);
     root.appendChild(summarySlot);
+    m_summarySlot = WTFMove(summarySlot);
 
-    m_defaultSlot = HTMLSlotElement::create(slotTag, document());
-    m_defaultSlot->setUserAgentPart(UserAgentParts::detailsContent());
+    Ref defaultSlot = HTMLSlotElement::create(slotTag, document);
+    defaultSlot->setUserAgentPart(UserAgentParts::detailsContent());
     ASSERT(!hasAttribute(openAttr));
-    m_defaultSlot->setInlineStyleProperty(CSSPropertyContentVisibility, CSSValueHidden);
-    m_defaultSlot->setInlineStyleProperty(CSSPropertyDisplay, CSSValueBlock);
-    root.appendChild(*m_defaultSlot);
+    defaultSlot->setInlineStyleProperty(CSSPropertyContentVisibility, CSSValueHidden);
+    defaultSlot->setInlineStyleProperty(CSSPropertyDisplay, CSSValueBlock);
+    root.appendChild(defaultSlot);
+    m_defaultSlot = WTFMove(defaultSlot);
 
     static MainThreadNeverDestroyed<const String> stylesheet(StringImpl::createWithoutCopying(detailsElementShadowUserAgentStyleSheet));
-    auto style = HTMLStyleElement::create(HTMLNames::styleTag, document(), false);
+    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document, false);
     style->setTextContent(String { stylesheet });
     root.appendChild(WTFMove(style));
 }
 
 bool HTMLDetailsElement::isActiveSummary(const HTMLSummaryElement& summary) const
 {
-    if (!m_summarySlot->assignedNodes())
+    RefPtr summarySlot = m_summarySlot.get();
+    if (!summarySlot->assignedNodes())
         return &summary == m_defaultSummary;
 
     if (summary.parentNode() != this)
         return false;
 
-    RefPtr slot = shadowRoot()->findAssignedSlot(summary);
-    if (!slot)
-        return false;
-    return slot == m_summarySlot.get();
+    RefPtr slot = protectedShadowRoot()->findAssignedSlot(summary);
+    return slot && slot == summarySlot.get();
 }
 
 void HTMLDetailsElement::queueDetailsToggleEventTask(ToggleState oldState, ToggleState newState)
@@ -146,7 +147,7 @@ void HTMLDetailsElement::queueDetailsToggleEventTask(ToggleState oldState, Toggl
     if (!m_toggleEventTask)
         m_toggleEventTask = ToggleEventTask::create(*this);
 
-    m_toggleEventTask->queue(oldState, newState);
+    RefPtr { m_toggleEventTask }->queue(oldState, newState);
 }
 
 void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -155,9 +156,10 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
     if (name == openAttr) {
         if (oldValue != newValue) {
             RefPtr root = shadowRoot();
+            RefPtr defaultSlot = m_defaultSlot;
             ASSERT(root);
             if (!newValue.isNull()) {
-                m_defaultSlot->removeInlineStyleProperty(CSSPropertyContentVisibility);
+                defaultSlot->removeInlineStyleProperty(CSSPropertyContentVisibility);
                 queueDetailsToggleEventTask(ToggleState::Closed, ToggleState::Open);
                 if (!attributeWithoutSynchronization(nameAttr).isEmpty()) {
                     ShouldNotFireMutationEventsScope scope(document());
@@ -165,7 +167,7 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
                         otherDetailsElement->removeAttribute(openAttr);
                 }
             } else {
-                m_defaultSlot->setInlineStyleProperty(CSSPropertyContentVisibility, CSSValueHidden);
+                defaultSlot->setInlineStyleProperty(CSSPropertyContentVisibility, CSSValueHidden);
                 queueDetailsToggleEventTask(ToggleState::Open, ToggleState::Closed);
             }
         }
@@ -190,9 +192,9 @@ Vector<RefPtr<HTMLDetailsElement>> HTMLDetailsElement::otherElementsInNameGroup(
 {
     Vector<RefPtr<HTMLDetailsElement>> otherElementsInNameGroup;
     const auto& detailElementName = attributeWithoutSynchronization(nameAttr);
-    for (auto& element : descendantsOfType<HTMLDetailsElement>(rootNode())) {
-        if (&element != this && element.attributeWithoutSynchronization(nameAttr) == detailElementName)
-            otherElementsInNameGroup.append(&element);
+    for (Ref element : descendantsOfType<HTMLDetailsElement>(rootNode())) {
+        if (element.ptr() != this && element->attributeWithoutSynchronization(nameAttr) == detailElementName)
+            otherElementsInNameGroup.append(WTFMove(element));
     }
     return otherElementsInNameGroup;
 }

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -57,7 +57,7 @@ RefPtr<HTMLDetailsElement> HTMLSummaryElement::detailsElement() const
     if (auto* parent = dynamicDowncast<HTMLDetailsElement>(parentElement()))
         return parent;
     // Fallback summary element is in the shadow tree.
-    if (auto* details = dynamicDowncast<HTMLDetailsElement>(shadowHost()))
+    if (RefPtr details = dynamicDowncast<HTMLDetailsElement>(shadowHost()))
         return details;
     return nullptr;
 }
@@ -94,7 +94,7 @@ void HTMLSummaryElement::defaultEventHandler(Event& event)
 {
     if (isActiveSummary()) {
         auto& eventNames = WebCore::eventNames();
-        if (event.type() == eventNames.DOMActivateEvent && !isInSummaryInteractiveContent(event.target())) {
+        if (event.type() == eventNames.DOMActivateEvent && !isInSummaryInteractiveContent(event.protectedTarget().get())) {
             if (RefPtr<HTMLDetailsElement> details = detailsElement())
                 details->toggleOpen();
             event.setDefaultHandled();


### PR DESCRIPTION
#### 8bbba2aa777cf326e24a4e5c63b1f51bd52315ff
<pre>
Address Safer CPP warnings in HTMLDetailsElement.cpp and HTMLSummaryElement.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=289225">https://bugs.webkit.org/show_bug.cgi?id=289225</a>
<a href="https://rdar.apple.com/146363831">rdar://146363831</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/ElementRareData.h:
(WebCore::Node::protectedShadowRoot const):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::protectedTarget const):
* Source/WebCore/dom/Event.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::DetailsSlotAssignment::slotNameForHostChild const):
(WebCore::HTMLDetailsElement::didAddUserAgentShadowRoot):
(WebCore::HTMLDetailsElement::isActiveSummary const):
(WebCore::HTMLDetailsElement::queueDetailsToggleEventTask):
(WebCore::HTMLDetailsElement::attributeChanged):
(WebCore::HTMLDetailsElement::otherElementsInNameGroup):
* Source/WebCore/html/HTMLSummaryElement.cpp:
(WebCore::HTMLSummaryElement::detailsElement const):
(WebCore::HTMLSummaryElement::defaultEventHandler):

Canonical link: <a href="https://commits.webkit.org/291716@main">https://commits.webkit.org/291716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64128f6d5c0a30bf08e0a90e997ee74c4505d004

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93796 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/13370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3109 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/98802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95846 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21812 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/98802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96798 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/98802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/9846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2391 "Passed tests") | [  ~~🛠 wpe-cairo~~](https://ews-build.webkit.org/#/builders/65/builds/43637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20848 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/121/builds/21100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80708 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/79954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/19897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-2-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15043 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20832 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/20519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/129/builds/23979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/22260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->