### PR TITLE
[WPE] WPEPlatform: add WPEViewAccessible interface

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp
@@ -494,7 +494,12 @@ void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebC
 #if USE(ATK)
 AtkObject* PageClientImpl::accessible()
 {
-    return ATK_OBJECT(m_view.accessible());
+#if ENABLE(WPE_PLATFORM)
+    if (m_view.wpeView())
+        return nullptr;
+#endif
+
+    return ATK_OBJECT(static_cast<WKWPE::ViewLegacy&>(m_view).accessible());
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp
@@ -47,10 +47,6 @@ View::View()
 
 View::~View()
 {
-#if USE(ATK)
-    if (m_accessible)
-        webkitWebViewAccessibleSetWebView(m_accessible.get(), nullptr);
-#endif
     m_pageProxy->close();
 }
 
@@ -134,15 +130,6 @@ void View::close()
 {
     m_pageProxy->close();
 }
-
-#if USE(ATK)
-WebKitWebViewAccessible* View::accessible() const
-{
-    if (!m_accessible)
-        m_accessible = webkitWebViewAccessibleNew(const_cast<View*>(this));
-    return m_accessible.get();
-}
-#endif
 
 #if ENABLE(FULLSCREEN_API)
 bool View::isFullScreen() const

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebView.h
@@ -30,7 +30,6 @@
 #include "KeyAutoRepeatHandler.h"
 #include "PageClientImpl.h"
 #include "WebFullScreenManagerProxy.h"
-#include "WebKitWebViewAccessible.h"
 #include "WebPageProxy.h"
 #include <WebCore/ActivityState.h>
 #include <memory>
@@ -88,10 +87,6 @@ public:
     const WebCore::IntSize& size() const { return m_size; }
     OptionSet<WebCore::ActivityState> viewState() const { return m_viewStateFlags; }
 
-#if USE(ATK)
-    WebKitWebViewAccessible* accessible() const;
-#endif
-
     virtual struct wpe_view_backend* backend() const { return nullptr; }
 #if ENABLE(WPE_PLATFORM)
     virtual WPEView* wpeView() const { return nullptr; }
@@ -121,9 +116,6 @@ protected:
 #endif
     WebKit::InputMethodFilter m_inputMethodFilter;
     WebKit::KeyAutoRepeatHandler m_keyAutoRepeatHandler;
-#if USE(ATK)
-    mutable GRefPtr<WebKitWebViewAccessible> m_accessible;
-#endif
 };
 
 } // namespace WKWPE

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
@@ -298,6 +298,11 @@ ViewLegacy::~ViewLegacy()
     wpe_view_backend_set_fullscreen_client(m_backend, nullptr, nullptr);
 #endif
 
+#if USE(ATK)
+    if (m_accessible)
+        webkitWebViewAccessibleSetWebView(m_accessible.get(), nullptr);
+#endif
+
     viewsVector().removeAll(this);
 }
 
@@ -403,5 +408,14 @@ void ViewLegacy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& cal
     RELEASE_ASSERT(m_pageProxy->drawingArea());
     downcast<DrawingAreaProxyCoordinatedGraphics>(*m_pageProxy->drawingArea()).dispatchAfterEnsuringDrawing(WTFMove(callback));
 }
+
+#if USE(ATK)
+WebKitWebViewAccessible* ViewLegacy::accessible() const
+{
+    if (!m_accessible)
+        m_accessible = webkitWebViewAccessibleNew(const_cast<ViewLegacy*>(this));
+    return m_accessible.get();
+}
+#endif
 
 } // namespace WKWPE

--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WPEWebView.h"
+#include "WebKitWebViewAccessible.h"
 #include <wtf/glib/GRefPtr.h>
 
 struct wpe_input_keyboard_event;
@@ -56,6 +57,10 @@ public:
     static WebKit::WebPageProxy* platformWebPageProxyForGamepadInput();
 #endif
 
+#if USE(ATK)
+    WebKitWebViewAccessible* accessible() const;
+#endif
+
 private:
     ViewLegacy(struct wpe_view_backend*, const API::PageConfiguration&);
 
@@ -72,6 +77,10 @@ private:
 #if ENABLE(TOUCH_EVENTS)
     std::unique_ptr<WebKit::TouchGestureController> m_touchGestureController;
 #endif
+#if USE(ATK)
+    mutable GRefPtr<WebKitWebViewAccessible> m_accessible;
+#endif
+
 };
 
 } // namespace WKWPE

--- a/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp
@@ -75,10 +75,19 @@ WPEView* WebPageProxy::wpeView() const
 
 void WebPageProxy::bindAccessibilityTree(const String& plugID)
 {
-#if USE(ATK)
     RefPtr pageClient = this->pageClient();
     if (!pageClient)
         return;
+
+#if ENABLE(WPE_PLATFORM)
+    if (auto* view = wpeView()) {
+        if (auto* accessible = wpe_view_get_accessible(view))
+            wpe_view_accessible_bind(accessible, plugID.utf8().data());
+        return;
+    }
+#endif
+
+#if USE(ATK)
     auto* accessible = static_cast<PageClientImpl&>(*pageClient).accessible();
     atk_socket_embed(ATK_SOCKET(accessible), const_cast<char*>(plugID.utf8().data()));
     atk_object_notify_state_change(accessible, ATK_STATE_TRANSIENT, FALSE);

--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -35,6 +35,7 @@ set(WPEPlatform_SOURCES
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEVersion.cpp
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.cpp
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEViewAccessible.cpp
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.cpp
 )
 
@@ -59,6 +60,7 @@ set(WPEPlatform_INSTALLED_HEADERS
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPESettings.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevel.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/WPEView.h
+    ${WEBKIT_DIR}/WPEPlatform/wpe/WPEViewAccessible.h
     ${WEBKIT_DIR}/WPEPlatform/wpe/wpe-platform.h
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEConfig.h
     ${WPEPlatform_DERIVED_SOURCES_DIR}/wpe/WPEEnumTypes.h

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -1105,3 +1105,22 @@ WPEGestureController* wpe_view_get_gesture_controller(WPEView* view)
 
     return view->priv->gestureController->get();
 }
+
+/**
+ * wpe_view_get_accessible:
+ * @view: a #WPEView
+ *
+ * Get the #WPEViewAccessible of @view.
+ *
+ * Returns: (transfer none) (nullable): a #WPEViewAccessible or %NULL
+ */
+WPEViewAccessible* wpe_view_get_accessible(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+
+    auto* viewClass = WPE_VIEW_GET_CLASS(view);
+    if (viewClass->get_accessible)
+        return viewClass->get_accessible(view);
+
+    return nullptr;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.h
@@ -46,31 +46,33 @@ typedef struct _WPEDisplay WPEDisplay;
 typedef struct _WPEEvent WPEEvent;
 typedef struct _WPEScreen WPEScreen;
 typedef struct _WPERectangle WPERectangle;
+typedef struct _WPEViewAccessible WPEViewAccessible;
 
 struct _WPEViewClass
 {
     GObjectClass parent_class;
 
-    gboolean (* render_buffer)         (WPEView            *view,
-                                        WPEBuffer          *buffer,
-                                        const WPERectangle *damage_rects,
-                                        guint               n_damage_rects,
-                                        GError            **error);
-    gboolean (* lock_pointer)          (WPEView            *view);
-    gboolean (* unlock_pointer)        (WPEView            *view);
-    void     (* set_cursor_from_name)  (WPEView            *view,
-                                        const char         *name);
-    void     (* set_cursor_from_bytes) (WPEView            *view,
-                                        GBytes             *bytes,
-                                        guint               width,
-                                        guint               height,
-                                        guint               stride,
-                                        guint               hotspot_x,
-                                        guint               hotspot_y);
-    void     (* set_opaque_rectangles) (WPEView            *view,
-                                        WPERectangle       *rects,
-                                        guint               n_rects);
-    gboolean (* can_be_mapped)         (WPEView            *view);
+    gboolean           (* render_buffer)         (WPEView            *view,
+                                                  WPEBuffer          *buffer,
+                                                  const WPERectangle *damage_rects,
+                                                  guint               n_damage_rects,
+                                                  GError            **error);
+    gboolean           (* lock_pointer)          (WPEView            *view);
+    gboolean           (* unlock_pointer)        (WPEView            *view);
+    void               (* set_cursor_from_name)  (WPEView            *view,
+                                                  const char         *name);
+    void               (* set_cursor_from_bytes) (WPEView            *view,
+                                                  GBytes             *bytes,
+                                                  guint               width,
+                                                  guint               height,
+                                                  guint               stride,
+                                                  guint               hotspot_x,
+                                                  guint               hotspot_y);
+    void               (* set_opaque_rectangles) (WPEView            *view,
+                                                  WPERectangle       *rects,
+                                                  guint               n_rects);
+    gboolean           (* can_be_mapped)         (WPEView            *view);
+    WPEViewAccessible *(* get_accessible)        (WPEView            *view);
 
     gpointer padding[32];
 };
@@ -146,6 +148,7 @@ WPE_API void                    wpe_view_set_opaque_rectangles         (WPEView 
 WPE_API void                    wpe_view_set_gesture_controller        (WPEView            *view,
                                                                         WPEGestureController *controller);
 WPE_API WPEGestureController   *wpe_view_get_gesture_controller        (WPEView            *view);
+WPE_API WPEViewAccessible      *wpe_view_get_accessible                (WPEView            *view);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEViewAccessible.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEViewAccessible.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,36 +22,37 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#include "config.h"
+#include "WPEViewAccessible.h"
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
-#include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEGestureController.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEScreen.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
-#include <wpe/WPEViewAccessible.h>
+/**
+ * WPEViewAccessible:
+ * @See_also: #WPEView
+ *
+ * A #WPEView accessible interface.
+ *
+ * This interface enables implementing accessibility.
+ */
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_DEFINE_INTERFACE(WPEViewAccessible, wpe_view_accessible, G_TYPE_OBJECT)
 
-#endif /* __WPE_PLATFORM_H__ */
+static void wpe_view_accessible_default_init(WPEViewAccessibleInterface*)
+{
+}
+
+/**
+ * wpe_view_accessible_bind:
+ * @accessible: a #WPEViewAccessible
+ * @plug_id: the plug identifier
+ *
+ * Bind @accessible with the given @plug_id.
+ */
+void wpe_view_accessible_bind(WPEViewAccessible* accessible, const char* plugID)
+{
+    g_return_if_fail(accessible);
+    g_return_if_fail(plugID);
+
+    auto* accessibleInterface = WPE_VIEW_ACCESSIBLE_GET_IFACE(accessible);
+    accessibleInterface->bind(accessible, plugID);
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEViewAccessible.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEViewAccessible.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -22,36 +22,33 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef __WPE_PLATFORM_H__
-#define __WPE_PLATFORM_H__
 
-#define __WPE_PLATFORM_H_INSIDE__
+#ifndef WPEViewAccessible_h
+#define WPEViewAccessible_h
 
-#include <wpe/WPEEnumTypes.h>
-#include <wpe/WPEEvent.h>
-#include <wpe/WPEBuffer.h>
-#include <wpe/WPEBufferDMABuf.h>
-#include <wpe/WPEBufferDMABufFormats.h>
-#include <wpe/WPEBufferSHM.h>
-#include <wpe/WPEColor.h>
-#include <wpe/WPEConfig.h>
+#if !defined(__WPE_PLATFORM_H_INSIDE__) && !defined(BUILDING_WEBKIT)
+#error "Only <wpe/wpe-platform.h> can be included directly."
+#endif
+
+#include <glib-object.h>
 #include <wpe/WPEDefines.h>
-#include <wpe/WPEDisplay.h>
-#include <wpe/WPEEGLError.h>
-#include <wpe/WPEGestureController.h>
-#include <wpe/WPEInputMethodContext.h>
-#include <wpe/WPEKeymap.h>
-#include <wpe/WPEKeyUnicode.h>
-#include <wpe/WPEKeymapXKB.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPEKeysyms.h>
-#include <wpe/WPERectangle.h>
-#include <wpe/WPEScreen.h>
-#include <wpe/WPEToplevel.h>
-#include <wpe/WPEVersion.h>
-#include <wpe/WPEView.h>
-#include <wpe/WPEViewAccessible.h>
 
-#undef __WPE_PLATFORM_H_INSIDE__
+G_BEGIN_DECLS
 
-#endif /* __WPE_PLATFORM_H__ */
+#define WPE_TYPE_VIEW_ACCESSIBLE (wpe_view_accessible_get_type())
+WPE_API G_DECLARE_INTERFACE (WPEViewAccessible, wpe_view_accessible, WPE, VIEW_ACCESSIBLE, GObject)
+
+struct _WPEViewAccessibleInterface
+{
+    GTypeInterface parent_interface;
+
+    void (* bind) (WPEViewAccessible *accessible,
+                   const char        *plug_id);
+};
+
+WPE_API void wpe_view_accessible_bind (WPEViewAccessible *accessible,
+                                       const char        *plug_id);
+
+G_END_DECLS
+
+#endif /* WPEViewAccessible_h */


### PR DESCRIPTION
#### 439dc000a9675b6628215a3081f7c7f5f8c2c376
<pre>
[WPE] WPEPlatform: add WPEViewAccessible interface
<a href="https://bugs.webkit.org/show_bug.cgi?id=289227">https://bugs.webkit.org/show_bug.cgi?id=289227</a>

Reviewed by Adrian Perez de Castro.

To allow platforms to provide an accessible view object to bind to the
web process a11y tree.

* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::accessible):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::~View):
(WKWPE::View::accessible const): Deleted.
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::~ViewLegacy):
(WKWPE::ViewLegacy::accessible const):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h:
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::bindAccessibilityTree):
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpe_view_set_gesture_controller):
(wpe_view_get_gesture_controller):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/WPEViewAccessible.cpp: Added.
(wpe_view_accessible_default_init):
(wpe_view_accessible_bind):
* Source/WebKit/WPEPlatform/wpe/WPEViewAccessible.h: Added.
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:

Canonical link: <a href="https://commits.webkit.org/291762@main">https://commits.webkit.org/291762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/409a01052b03883b766052d1e6297f44591a6fd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98719 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44239 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13582 "Hash 409a0105 for PR 41988 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21729 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71541 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28911 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96715 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/130/builds/13582 "Hash 409a0105 for PR 41988 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51875 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/130/builds/13582 "Hash 409a0105 for PR 41988 does not build (failure)") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43554 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/130/builds/13582 "Hash 409a0105 for PR 41988 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100753 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80556 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79894 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24444 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13918 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15068 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20749 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25927 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20436 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23896 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->