### PR TITLE
Register WPE_SETTING_DRM_SCALE and provide a sane default

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp
@@ -38,8 +38,11 @@
 #include <fcntl.h>
 #include <gio/gio.h>
 #include <libudev.h>
+#include <wtf/ASCIICType.h>
+#include <wtf/dtoa.h>
 #include <wtf/glib/WTFGType.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/StringView.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 /**
@@ -65,6 +68,14 @@ struct _WPEDisplayDRMPrivate {
 WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(WPEDisplayDRM, wpe_display_drm, WPE_TYPE_DISPLAY, WPEDisplay,
     wpeEnsureExtensionPointsRegistered();
     g_io_extension_point_implement(WPE_DISPLAY_EXTENSION_POINT_NAME, g_define_type_id, "wpe-display-drm", -100))
+
+static void wpeDisplayDRMConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_display_drm_parent_class)->constructed(object);
+
+    auto* settings = wpe_display_get_settings(WPE_DISPLAY(object));
+    RELEASE_ASSERT(wpe_settings_register(settings, WPE_SETTING_DRM_SCALE, G_VARIANT_TYPE_DOUBLE, g_variant_new_double(1.0), nullptr));
+}
 
 static void wpeDisplayDRMDispose(GObject* object)
 {
@@ -307,12 +318,20 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
     displayDRM->priv->device = device;
     displayDRM->priv->connector = WTFMove(connector);
 
-    double scale;
-    if (const char* scaleString = getenv("WPE_DRM_SCALE"))
-        scale = g_ascii_strtod(scaleString, nullptr);
-    else {
-        auto* settings = wpe_display_get_settings(WPE_DISPLAY(displayDRM));
-        scale = wpe_settings_get_double(settings, WPE_SETTING_DRM_SCALE, nullptr);
+    static const auto scaleIsInBounds = [](double scale) {
+        return (scale >= 0.05) && (scale <= 20.0);
+    };
+
+    std::optional<double> scaleFromEnvironment;
+    if (const auto scaleString = StringView::fromLatin1(getenv("WPE_DRM_SCALE"))) {
+        RELEASE_ASSERT(scaleString.is8Bit());
+        auto trimmedScaleString = scaleString.trim(isASCIIWhitespace<LChar>);
+        size_t parsedLength = 0;
+        auto scale = parseDouble(trimmedScaleString, parsedLength);
+        if (parsedLength == trimmedScaleString.length() && scaleIsInBounds(scale))
+            scaleFromEnvironment = scale;
+        else
+            g_warning_once("Invalid WPE_DRM_SCALE='%*s' value, or out of bounds.", static_cast<int>(scaleString.span8().size()), scaleString.span8().data());
     }
 
     int x = crtc->x();
@@ -320,6 +339,19 @@ static gboolean wpeDisplayDRMSetup(WPEDisplayDRM* displayDRM, const char* device
     int width = crtc->width();
     int height = crtc->height();
     displayDRM->priv->screen = wpeScreenDRMCreate(WTFMove(crtc), *displayDRM->priv->connector);
+
+    double scale = scaleFromEnvironment.value_or(wpeScreenDRMGuessScale(WPE_SCREEN_DRM(displayDRM->priv->screen.get())));
+    RELEASE_ASSERT(wpe_settings_set_double(wpe_display_get_settings(WPE_DISPLAY(displayDRM)), WPE_SETTING_DRM_SCALE, scale, WPE_SETTINGS_SOURCE_PLATFORM, nullptr));
+
+    GUniqueOutPtr<GError> settingsError;
+    double scaleFromSettings = wpe_settings_get_double(wpe_display_get_settings(WPE_DISPLAY(displayDRM)), WPE_SETTING_DRM_SCALE, &settingsError.outPtr());
+    RELEASE_ASSERT(!settingsError);
+    if (scaleIsInBounds(scaleFromSettings))
+        scale = scaleFromSettings;
+    else
+        g_warning_once("Ignoring out of bounds WPE_SETTING_DRM_SCALE value '%.2f'.", scaleFromSettings);
+    RELEASE_ASSERT(scaleIsInBounds(scale));
+
     wpe_screen_set_position(displayDRM->priv->screen.get(), x / scale, y / scale);
     wpe_screen_set_size(displayDRM->priv->screen.get(), width / scale, height / scale);
     wpe_screen_set_scale(displayDRM->priv->screen.get(), scale);
@@ -395,6 +427,7 @@ static gboolean wpeDisplayDRMUseExplicitSync(WPEDisplay* display)
 static void wpe_display_drm_class_init(WPEDisplayDRMClass* displayDRMClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(displayDRMClass);
+    objectClass->constructed = wpeDisplayDRMConstructed;
     objectClass->dispose = wpeDisplayDRMDispose;
 
     WPEDisplayClass* displayClass = WPE_DISPLAY_CLASS(displayDRMClass);

--- a/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h
+++ b/Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h
@@ -31,3 +31,4 @@
 WPEScreen* wpeScreenDRMCreate(std::unique_ptr<WPE::DRM::Crtc>&&, const WPE::DRM::Connector&);
 drmModeModeInfo* wpeScreenDRMGetMode(WPEScreenDRM*);
 const WPE::DRM::Crtc wpeScreenDRMGetCrtc(WPEScreenDRM*);
+double wpeScreenDRMGuessScale(WPEScreenDRM*);


### PR DESCRIPTION
#### f2bd2968f34cb46e63e17e3cfd2151882a177046
<pre>
Register WPE_SETTING_DRM_SCALE and provide a sane default
<a href="https://bugs.webkit.org/show_bug.cgi?id=289230">https://bugs.webkit.org/show_bug.cgi?id=289230</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/WPEPlatform/wpe/drm/WPEDisplayDRM.cpp:
(wpeDisplayDRMConstructed): Added, registers the WPE_SETTING_DRM_SCALE
setting.
(wpeDisplayDRMSetup): Improve the logic that parses the WPE_DRM_SCALE
environment variable, checking for parsing errors and the value of the
variable. If the value from the environment cannot be used, call
wpeScreenDRMGuessScale() to find a reasonable default for the screen.
While at it, bounds-check values possibly set by the application and
avoid using them if too small or too big.
(wpe_display_drm_class_init):
* Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRM.cpp:
(wpeScreenDRMGuessScale): Added, switches from 1.0 scaling to 2.0 if the
screen is at least 1200px tall and has a density of 192dpi. The logic
could use more finesse, choosing fractional values in between but works
well enough as a first approach.
* Source/WebKit/WPEPlatform/wpe/drm/WPEScreenDRMPrivate.h:

Canonical link: <a href="https://commits.webkit.org/291757@main">https://commits.webkit.org/291757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddb3317d5576b9d2ed51d950de6cf9c27ac10b3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44386 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71628 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28986 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10202 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84805 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51963 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9886 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43702 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80151 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2518 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/100994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15254 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80643 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79989 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24538 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1902 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14069 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15067 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26074 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->