### PR TITLE
[JSC] Implement `Array.prototype.copyWithin` in C++

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-copyWithin-contiguous.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-contiguous.js
@@ -1,0 +1,12 @@
+function test(array, target, start, end) {
+    array.copyWithin(target, start, end);
+}
+noInline(test);
+
+let array = new Array(1024);
+for (let j = 0; j < array.length; j++)
+    array[j] = { j };
+
+for (let i = 0; i < 1e6; i++) {
+    array.copyWithin(i % 512, 256, 768);
+}

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-double.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-double.js
@@ -1,0 +1,12 @@
+function test(array, target, start, end) {
+    array.copyWithin(target, start, end);
+}
+noInline(test);
+
+let array = new Array(1024);
+for (let j = 0; j < array.length; j++)
+    array[j] = j + 0.5;
+
+for (let i = 0; i < 1e6; i++) {
+    array.copyWithin(i % 512, 256, 768);
+}

--- a/JSTests/microbenchmarks/array-prototype-copyWithin-int32.js
+++ b/JSTests/microbenchmarks/array-prototype-copyWithin-int32.js
@@ -1,0 +1,12 @@
+function test(array, target, start, end) {
+    array.copyWithin(target, start, end);
+}
+noInline(test);
+
+let array = new Array(1024);
+for (let j = 0; j < array.length; j++)
+    array[j] = j;
+
+for (let i = 0; i < 1e6; i++) {
+    array.copyWithin(i % 512, 256, 768);
+}

--- a/JSTests/stress/array-prototype-copyWithin-contiguous.js
+++ b/JSTests/stress/array-prototype-copyWithin-contiguous.js
@@ -1,0 +1,31 @@
+function compareArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+    }
+}
+
+{
+    let obj1 = { a: 1 };
+    let obj2 = { b: 2 };
+    let arr = [obj1, "hello", 123, obj2, null, "end"];
+    arr.copyWithin(1, 3, 5); 
+    compareArray(arr, [obj1, obj2, null, obj2, null, "end"]);
+}
+
+{
+    let obj1 = {};
+    let obj2 = {};
+    let arr = ["x", "y", "z", obj1, obj2, "tail"];
+    arr.copyWithin(2, 1); 
+    compareArray(arr, ["x", "y", "y", "z", obj1, obj2]);
+}
+
+{
+    let obj = { test: 123 };
+    let arr = [null, obj, "aaa", 42];
+    arr.copyWithin(1, 2, 2); 
+    compareArray(arr, [null, obj, "aaa", 42]);
+}

--- a/JSTests/stress/array-prototype-copyWithin-double.js
+++ b/JSTests/stress/array-prototype-copyWithin-double.js
@@ -1,0 +1,26 @@
+function compareArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+    }
+}
+
+{
+    let arr = [1.5, 2, 3.25, 4, 5.75, 6, 7.125, 8];
+    arr.copyWithin(3, 0, 2); 
+    compareArray(arr, [1.5, 2, 3.25, 1.5, 2, 6, 7.125, 8]);
+}
+
+{
+    let arr = [100.5, 200.1, 300, 400.9, 500];
+    arr.copyWithin(3, 1, 3); 
+    compareArray(arr, [100.5, 200.1, 300, 200.1, 300]);
+}
+
+{
+    let arr = [1, 2, 3.3, 4.4];
+    arr.copyWithin(0, 3, 2);
+    compareArray(arr, [1, 2, 3.3, 4.4]);
+}

--- a/JSTests/stress/array-prototype-copyWithin-int32.js
+++ b/JSTests/stress/array-prototype-copyWithin-int32.js
@@ -1,0 +1,32 @@
+function compareArray(a, b) {
+    if (a.length !== b.length)
+        throw new Error(`Expected length ${b.length} but got ${a.length}`);
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i])
+            throw new Error(`${i}: Expected ${b[i]} but got ${a[i]}`);
+    }
+}
+
+{
+    let arr = [0, 1, 2, 3, 4, 5, 6, 7];
+    arr.copyWithin(0, 3);
+    compareArray(arr, [3, 4, 5, 6, 7, 5, 6, 7]);
+}
+
+{
+    let arr = [100, 200, 300, 400];
+    arr.copyWithin(2, 0, 2);
+    compareArray(arr, [100, 200, 100, 200]);
+}
+
+{
+    let arr = [10, 11, 12, 13, 14];
+    arr.copyWithin(-2, -3);
+    compareArray(arr, [10, 11, 12, 12, 13]);
+}
+
+{
+    let arr = [0, 1, 2, 3, 4, 5];
+    arr.copyWithin(2, 3);
+    compareArray(arr, [0, 1, 3, 4, 5, 5]);
+}

--- a/Source/JavaScriptCore/builtins/ArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/ArrayPrototype.js
@@ -274,63 +274,6 @@ function findLastIndex(callback /*, thisArg */)
 }
 
 @linkTimeConstant
-function maxWithPositives(a, b)
-{
-    "use strict";
-
-    return (a < b) ? b : a;
-}
-
-@linkTimeConstant
-function minWithMaybeNegativeZeroAndPositive(maybeNegativeZero, positive)
-{
-    "use strict";
-
-    return (maybeNegativeZero < positive) ? maybeNegativeZero : positive;
-}
-
-function copyWithin(target, start /*, end */)
-{
-    "use strict";
-
-    var array = @toObject(this, "Array.prototype.copyWithin requires that |this| not be null or undefined");
-    var length = @toLength(array.length);
-
-    var relativeTarget = @toIntegerOrInfinity(target);
-    var to = (relativeTarget < 0) ? @maxWithPositives(length + relativeTarget, 0) : @minWithMaybeNegativeZeroAndPositive(relativeTarget, length);
-
-    var relativeStart = @toIntegerOrInfinity(start);
-    var from = (relativeStart < 0) ? @maxWithPositives(length + relativeStart, 0) : @minWithMaybeNegativeZeroAndPositive(relativeStart, length);
-
-    var relativeEnd;
-    var end = @argument(2);
-    if (end === @undefined)
-        relativeEnd = length;
-    else
-        relativeEnd = @toIntegerOrInfinity(end);
-
-    var finalValue = (relativeEnd < 0) ? @maxWithPositives(length + relativeEnd, 0) : @minWithMaybeNegativeZeroAndPositive(relativeEnd, length);
-
-    var count = @minWithMaybeNegativeZeroAndPositive(finalValue - from, length - to);
-
-    var direction = 1;
-    if (from < to && to < from + count) {
-        direction = -1;
-        from = from + count - 1;
-        to = to + count - 1;
-    }
-
-    for (var i = 0; i < count; ++i, from += direction, to += direction) {
-        if (from in array)
-            array[to] = array[from];
-        else
-            delete array[to];
-    }
-
-    return array;
-}
-
-@linkTimeConstant
 function flatIntoArray(target, source, sourceLength, targetIndex, depth)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -103,6 +103,7 @@
     macro(constructor) \
     macro(count) \
     macro(counters) \
+    macro(copyWithin) \
     macro(dateStyle) \
     macro(day) \
     macro(days) \

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -127,6 +127,8 @@ public:
 
     std::optional<bool> fastIncludes(JSGlobalObject*, JSValue,  uint64_t fromIndex, uint64_t length);
 
+    bool fastCopywithin(JSGlobalObject*, uint64_t from64, uint64_t to64, uint64_t count64, uint64_t length64);
+
     ALWAYS_INLINE bool definitelyNegativeOneMiss() const;
 
     enum ShiftCountMode {


### PR DESCRIPTION
#### db79b71cfdc4b1d72a3c3665dee777fe7ba7249d
<pre>
[JSC] Implement `Array.prototype.copyWithin` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=289237">https://bugs.webkit.org/show_bug.cgi?id=289237</a>

Reviewed by Yusuke Suzuki.

This patch implements `Array#copyWithin` in C++ using `memmove`.

                                               TipOfTree                  Patched

array-prototype-copyWithin-contiguous      451.9835+-25.0049    ^    258.7830+-1.3483        ^ definitely 1.7466x faster
array-prototype-copyWithin-double          386.9415+-1.3776     ^    258.2341+-4.6019        ^ definitely 1.4984x faster
array-prototype-copyWithin-int32           345.7076+-2.5341     ^    244.2431+-1.7288        ^ definitely 1.4154x faster

* JSTests/microbenchmarks/array-prototype-copyWithin-int32.js: Added.
(test):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::ArrayPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastCopywithin):
* Source/JavaScriptCore/runtime/JSArray.h:

Canonical link: <a href="https://commits.webkit.org/291766@main">https://commits.webkit.org/291766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6a339a26455fe106b0482fc8b024a60cbe9f8ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44252 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71552 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28924 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96728 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84713 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51886 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9802 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2340 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43567 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86436 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100854 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92392 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20778 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80711 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79977 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19932 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24456 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1811 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/13934 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/25940 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115042 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20449 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->