### PR TITLE
Clarify RemoteDisplayListRecorder ownership

### DIFF
--- a/LayoutTests/ipc/create-image-buffer-crash.html
+++ b/LayoutTests/ipc/create-image-buffer-crash.html
@@ -51,7 +51,8 @@
             }
           },
           pixelFormat: format,
-          renderingResourceIdentifier: 393230 + format
+          identifier: randomIPCID(),
+          contextIdentifier: randomIPCID()
         });
       } catch {}
     }

--- a/LayoutTests/ipc/executor.js
+++ b/LayoutTests/ipc/executor.js
@@ -14,9 +14,9 @@ export default class Executor {
     }
 
     createInstance() {
-        this._remoteRenderingBackend.CreateRemoteImageBufferSet({
-            bufferSetIdentifier: 1234n,
-            displayListIdentifier: 1235n,
+        this._remoteRenderingBackend.CreateImageBufferSet({
+            identifier: 1234n,
+            contextIdentifier: 1235n,
         });
 
         this._remoteRenderingBackend.PrepareImageBufferSetsForDisplay({
@@ -50,8 +50,8 @@ export default class Executor {
                     renderingUpdateID: 1n
                 });
 
-                this._remoteRenderingBackend.ReleaseRemoteImageBufferSet({
-                    bufferSetIdentifier: 1234n,
+                this._remoteRenderingBackend.ReleaseImageBufferSet({
+                    identifier: 1234n,
                 });
             }
         };

--- a/LayoutTests/ipc/invalid-path-segments-crash.html
+++ b/LayoutTests/ipc/invalid-path-segments-crash.html
@@ -28,6 +28,7 @@ window.setTimeout(async () => {
   connection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
 
   const imageBufferIdentifier = randomIPCID();
+  const contextIdentifier = randomIPCID();
   const snapshotIdentifier = randomIPCID();
 
   renderingBackend.CreateImageBuffer({
@@ -43,13 +44,14 @@ window.setTimeout(async () => {
       }
     },
     pixelFormat: 1,
-    renderingResourceIdentifier: imageBufferIdentifier
+    identifier: imageBufferIdentifier,
+    contextIdentifier: contextIdentifier
   });
 
   const didCreateBackend = connection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
 
   const imageBuffer = connection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
-  const displayListRecorder = connection.newInterface("RemoteDisplayListRecorder", imageBufferIdentifier);
+  const displayListRecorder = connection.newInterface("RemoteDisplayListRecorder", contextIdentifier);
   const pageID = IPC.pageID;
 
   displayListRecorder.BeginPage({

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -24,6 +24,7 @@ window.setTimeout(async () => {
     streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
 
     const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+    const contextIdentifier = Math.floor(Math.random() * 0x1000000);
     remoteRenderingBackend.CreateImageBuffer({
         logicalSize: {width: 128, height: 128},
         renderingMode: 0,
@@ -31,7 +32,8 @@ window.setTimeout(async () => {
         resolutionScale: 1.0,
         colorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}},
         pixelFormat: 0,
-        renderingResourceIdentifier: imageBufferIdentifier
+        identifier: imageBufferIdentifier,
+        contextIdentifier: contextIdentifier
     });
     const didCreateBackendReply = streamConnection.connection.waitForMessage(imageBufferIdentifier, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
 

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.h
@@ -57,8 +57,8 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
-    void addSerializedImageBuffer(WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>);
-    RefPtr<WebCore::ImageBuffer> takeSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
+    bool addSerializedImageBuffer(RemoteSerializedImageBufferIdentifier, Ref<WebCore::ImageBuffer>);
+    RefPtr<WebCore::ImageBuffer> takeSerializedImageBuffer(RemoteSerializedImageBufferIdentifier);
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -80,7 +80,7 @@ private:
     RemoteSharedResourceCache(GPUConnectionToWebProcess&);
 
     // Messages
-    void releaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier);
+    void releaseSerializedImageBuffer(RemoteSerializedImageBufferIdentifier);
 
     IPC::ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<WebCore::ImageBuffer>> m_serializedImageBuffers;
     WebCore::ProcessIdentity m_resourceOwner;

--- a/Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in
+++ b/Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in
@@ -24,7 +24,7 @@
 
 [ExceptionForEnabledBy]
 messages -> RemoteSharedResourceCache {
-    void ReleaseSerializedImageBuffer(WebCore::RenderingResourceIdentifier imageBuffer)
+    void ReleaseSerializedImageBuffer(WebKit::RemoteSerializedImageBufferIdentifier identifier)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -52,9 +52,16 @@
 namespace WebKit {
 using namespace WebCore;
 
-RemoteDisplayListRecorder::RemoteDisplayListRecorder(ImageBuffer& imageBuffer, RenderingResourceIdentifier imageBufferIdentifier, RemoteRenderingBackend& renderingBackend)
+Ref<RemoteDisplayListRecorder> RemoteDisplayListRecorder::create(WebCore::ImageBuffer& imageBuffer, RemoteDisplayListRecorderIdentifier identifier, RemoteRenderingBackend& renderingBackend)
+{
+    auto instance = adoptRef(*new RemoteDisplayListRecorder(imageBuffer, identifier, renderingBackend));
+    instance->startListeningForIPC();
+    return instance;
+}
+
+RemoteDisplayListRecorder::RemoteDisplayListRecorder(ImageBuffer& imageBuffer, RemoteDisplayListRecorderIdentifier identifier, RemoteRenderingBackend& renderingBackend)
     : m_imageBuffer(imageBuffer)
-    , m_imageBufferIdentifier(imageBufferIdentifier)
+    , m_identifier(identifier)
     , m_renderingBackend(renderingBackend)
     , m_sharedResourceCache(renderingBackend.sharedResourceCache())
 {
@@ -85,12 +92,12 @@ std::optional<SourceImage> RemoteDisplayListRecorder::sourceImage(RenderingResou
 
 void RemoteDisplayListRecorder::startListeningForIPC()
 {
-    m_renderingBackend->protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteDisplayListRecorder::messageReceiverName(), m_imageBufferIdentifier.toUInt64());
+    m_renderingBackend->protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteDisplayListRecorder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteDisplayListRecorder::stopListeningForIPC()
 {
-    m_renderingBackend->protectedStreamConnection()->stopReceivingMessages(Messages::RemoteDisplayListRecorder::messageReceiverName(), m_imageBufferIdentifier.toUInt64());
+    m_renderingBackend->protectedStreamConnection()->stopReceivingMessages(Messages::RemoteDisplayListRecorder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteDisplayListRecorder::save()

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -29,6 +29,7 @@
 
 #include "ArrayReferenceTuple.h"
 #include "Decoder.h"
+#include "RemoteDisplayListRecorderIdentifier.h"
 #include "RemoteRenderingBackend.h"
 #include "StreamMessageReceiver.h"
 #include "StreamServerConnection.h"
@@ -54,12 +55,7 @@ struct SharedPreferencesForWebProcess;
 
 class RemoteDisplayListRecorder : public IPC::StreamMessageReceiver, public CanMakeWeakPtr<RemoteDisplayListRecorder> {
 public:
-    static Ref<RemoteDisplayListRecorder> create(WebCore::ImageBuffer& imageBuffer, WebCore::RenderingResourceIdentifier imageBufferIdentifier, RemoteRenderingBackend& renderingBackend)
-    {
-        auto instance = adoptRef(*new RemoteDisplayListRecorder(imageBuffer, imageBufferIdentifier, renderingBackend));
-        instance->startListeningForIPC();
-        return instance;
-    }
+    static Ref<RemoteDisplayListRecorder> create(WebCore::ImageBuffer&, RemoteDisplayListRecorderIdentifier, RemoteRenderingBackend&);
     ~RemoteDisplayListRecorder();
 
     void stopListeningForIPC();
@@ -152,7 +148,7 @@ public:
     void setURLForRect(const URL&, const WebCore::FloatRect&);
 
 private:
-    RemoteDisplayListRecorder(WebCore::ImageBuffer&, WebCore::RenderingResourceIdentifier, RemoteRenderingBackend&);
+    RemoteDisplayListRecorder(WebCore::ImageBuffer&, RemoteDisplayListRecorderIdentifier, RemoteRenderingBackend&);
 
     void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
 
@@ -171,7 +167,7 @@ private:
 #endif
 
     const Ref<WebCore::ImageBuffer> m_imageBuffer;
-    const WebCore::RenderingResourceIdentifier m_imageBufferIdentifier;
+    const RemoteDisplayListRecorderIdentifier m_identifier;
     const Ref<RemoteRenderingBackend> m_renderingBackend;
     const Ref<RemoteSharedResourceCache> m_sharedResourceCache;
     RefPtr<WebCore::ControlFactory> m_controlFactory;

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -29,29 +29,31 @@
 #include "GPUConnectionToWebProcess.h"
 #include "ImageBufferBackendHandleSharing.h"
 #include "Logging.h"
+#include "RemoteDisplayListRecorder.h"
 #include "RemoteImageBufferSetMessages.h"
 #include "RemoteImageBufferSetProxyMessages.h"
 #include "RemoteRenderingBackend.h"
 #include "RemoteRenderingBackendProxyMessages.h"
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/NullImageBufferBackend.h>
 
 #if ENABLE(GPU_PROCESS)
 
-#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, &m_backend->gpuConnectionToWebProcess().connection(), message)
+#define MESSAGE_CHECK(assertion, message) MESSAGE_CHECK_WITH_MESSAGE_BASE(assertion, &m_renderingBackend->gpuConnectionToWebProcess().connection(), message)
 
 namespace WebKit {
 
-Ref<RemoteImageBufferSet> RemoteImageBufferSet::create(RemoteImageBufferSetIdentifier identifier, WebCore::RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend& backend)
+Ref<RemoteImageBufferSet> RemoteImageBufferSet::create(RemoteImageBufferSetIdentifier identifier, RemoteDisplayListRecorderIdentifier contextIdentifier, RemoteRenderingBackend& renderingBackend)
 {
-    auto instance = adoptRef(*new RemoteImageBufferSet(identifier, displayListIdentifier, backend));
+    auto instance = adoptRef(*new RemoteImageBufferSet(identifier, contextIdentifier, renderingBackend));
     instance->startListeningForIPC();
     return instance;
 }
 
-RemoteImageBufferSet::RemoteImageBufferSet(RemoteImageBufferSetIdentifier identifier, WebCore::RenderingResourceIdentifier displayListIdentifier, RemoteRenderingBackend& backend)
+RemoteImageBufferSet::RemoteImageBufferSet(RemoteImageBufferSetIdentifier identifier, RemoteDisplayListRecorderIdentifier contextIdentifier, RemoteRenderingBackend& renderingBackend)
     : m_identifier(identifier)
-    , m_displayListIdentifier(displayListIdentifier)
-    , m_backend(&backend)
+    , m_contextIdentifier(contextIdentifier)
+    , m_renderingBackend(renderingBackend)
 {
 }
 
@@ -72,18 +74,17 @@ RemoteImageBufferSet::~RemoteImageBufferSet()
 
 void RemoteImageBufferSet::startListeningForIPC()
 {
-    m_backend->protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
+    m_renderingBackend->protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteImageBufferSet::stopListeningForIPC()
 {
-    if (auto backend = std::exchange(m_backend, { }))
-        backend->protectedStreamConnection()->stopReceivingMessages(Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
+    m_renderingBackend->protectedStreamConnection()->stopReceivingMessages(Messages::RemoteImageBufferSet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 IPC::StreamConnectionWorkQueue& RemoteImageBufferSet::workQueue() const
 {
-    return m_backend->workQueue();
+    return m_renderingBackend->workQueue();
 }
 
 void RemoteImageBufferSet::updateConfiguration(const RemoteImageBufferSetConfiguration& configuration)
@@ -94,11 +95,7 @@ void RemoteImageBufferSet::updateConfiguration(const RemoteImageBufferSetConfigu
 
 void RemoteImageBufferSet::endPrepareForDisplay(RenderingUpdateID renderingUpdateID)
 {
-    RefPtr backend = m_backend;
-    if (m_displayListCreated) {
-        backend->releaseDisplayListRecorder(m_displayListIdentifier);
-        m_displayListCreated = false;
-    }
+    m_context.reset();
 
     RefPtr frontBuffer = m_frontBuffer;
     if (frontBuffer)
@@ -118,7 +115,7 @@ void RemoteImageBufferSet::endPrepareForDisplay(RenderingUpdateID renderingUpdat
     }
 
     outputData.bufferCacheIdentifiers = BufferIdentifierSet { bufferIdentifier(frontBuffer), bufferIdentifier(m_backBuffer), bufferIdentifier(m_secondaryBackBuffer) };
-    backend->protectedStreamConnection()->send(Messages::RemoteImageBufferSetProxy::DidPrepareForDisplay(WTFMove(outputData), renderingUpdateID), m_identifier);
+    m_renderingBackend->protectedStreamConnection()->send(Messages::RemoteImageBufferSetProxy::DidPrepareForDisplay(WTFMove(outputData), renderingUpdateID), m_identifier);
 #endif
 }
 
@@ -138,15 +135,13 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
         inputData.dirtyRegion = layerBounds;
     }
 
-    RefPtr backend = m_backend;
-
     if (!m_frontBuffer) {
         WebCore::ImageBufferCreationContext creationContext;
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
         if (m_configuration.includeDisplayList == WebCore::IncludeDynamicContentScalingDisplayList::Yes)
             creationContext.dynamicContentScalingResourceCache = ensureDynamicContentScalingResourceCache();
 #endif
-        m_frontBuffer = backend->allocateImageBuffer(m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat, WTFMove(creationContext), WebCore::RenderingResourceIdentifier::generate());
+        m_frontBuffer = m_renderingBackend->allocateImageBuffer(m_configuration.logicalSize, m_configuration.renderingMode, m_configuration.renderingPurpose, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.pixelFormat, WTFMove(creationContext));
         m_frontBufferIsCleared = true;
     }
 
@@ -154,8 +149,12 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
         << m_frontBuffer << ", " << m_backBuffer << ", " << m_secondaryBackBuffer << "]");
 
     if (displayRequirement != SwapBuffersDisplayRequirement::NeedsNoDisplay) {
-        backend->createDisplayListRecorder(m_frontBuffer, m_displayListIdentifier);
-        m_displayListCreated = true;
+        RefPtr imageBuffer = m_frontBuffer;
+        if (!imageBuffer) {
+            imageBuffer = ImageBuffer::create<NullImageBufferBackend>({ 0, 0 }, 1, DestinationColorSpace::SRGB(), ImageBufferPixelFormat::BGRA8, RenderingPurpose::Unspecified, { });
+            RELEASE_ASSERT(imageBuffer);
+        }
+        m_context = RemoteDisplayListRecorder::create(*imageBuffer, m_contextIdentifier, m_renderingBackend);
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -28,8 +28,8 @@
     DispatchedTo=GPU
 ]
 messages -> RemoteRenderingBackend Stream {
-    CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
-    ReleaseImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)
+    CreateImageBuffer(WebCore::FloatSize logicalSize, WebCore::RenderingMode renderingMode, WebCore::RenderingPurpose renderingPurpose, float resolutionScale, WebCore::DestinationColorSpace colorSpace, enum:uint8_t WebCore::ImageBufferPixelFormat pixelFormat, WebCore::RenderingResourceIdentifier identifier, WebKit::RemoteDisplayListRecorderIdentifier contextIdentifier)
+    ReleaseImageBuffer(WebCore::RenderingResourceIdentifier identifier)
     GetImageBufferResourceLimitsForTesting() -> (struct WebCore::ImageBufferResourceLimits limits) Async
     DestroyGetPixelBufferSharedMemory()
     CacheNativeImage(WebCore::ShareableBitmapHandle handle, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
@@ -44,10 +44,10 @@ messages -> RemoteRenderingBackend Stream {
     ReleaseGradient(WebCore::RenderingResourceIdentifier identifier)
     CacheFilter(Ref<WebCore::Filter> filter) NotStreamEncodable
     ReleaseFilter(WebCore::RenderingResourceIdentifier identifier)
-    ReleaseAllDrawingResources()
-    ReleaseAllImageResources()
-    CreateRemoteImageBufferSet(WebKit::RemoteImageBufferSetIdentifier bufferSetIdentifier, WebCore::RenderingResourceIdentifier displayListIdentifier)
-    ReleaseRemoteImageBufferSet(WebKit::RemoteImageBufferSetIdentifier bufferSetIdentifier)
+    ReleaseMemory()
+    ReleaseNativeImages()
+    CreateImageBufferSet(WebKit::RemoteImageBufferSetIdentifier identifier, WebKit::RemoteDisplayListRecorderIdentifier contextIdentifier)
+    ReleaseImageBufferSet(WebKit::RemoteImageBufferSetIdentifier identifier)
 
 #if PLATFORM(COCOA)
     // These messages also result in the 'DidPrepareForDisplay' message being
@@ -64,8 +64,8 @@ messages -> RemoteRenderingBackend Stream {
     Flush(IPC::Semaphore semaphore) NotStreamEncodable
 #endif
 
-    MoveToSerializedBuffer(WebCore::RenderingResourceIdentifier sourceImageBuffer)
-    MoveToImageBuffer(WebCore::RenderingResourceIdentifier destinationImageBuffer)
+    MoveToSerializedBuffer(WebCore::RenderingResourceIdentifier identifier, WebKit::RemoteSerializedImageBufferIdentifier serializedIdentifier)
+    MoveToImageBuffer(WebKit::RemoteSerializedImageBufferIdentifier identifier, WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebKit::RemoteDisplayListRecorderIdentifier contextIdentifier)
 
 #if PLATFORM(COCOA)
     DidDrawRemoteToPDF(WebCore::PageIdentifier pageID, WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::SnapshotIdentifier snapshotIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -142,10 +142,10 @@ RefPtr<FontCustomPlatformData> RemoteResourceCache::cachedFontCustomPlatformData
 void RemoteResourceCache::releaseAllResources()
 {
     m_imageBuffers.clear();
-    releaseAllDrawingResources();
+    releaseMemory();
 }
 
-void RemoteResourceCache::releaseAllDrawingResources()
+void RemoteResourceCache::releaseMemory()
 {
     m_nativeImages.clear();
     m_gradients.clear();
@@ -155,7 +155,7 @@ void RemoteResourceCache::releaseAllDrawingResources()
     m_fontCustomPlatformDatas.clear();
 }
 
-void RemoteResourceCache::releaseAllImageResources()
+void RemoteResourceCache::releaseNativeImages()
 {
     m_nativeImages.clear();
 }

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -75,8 +75,8 @@ public:
     RefPtr<WebCore::FontCustomPlatformData> cachedFontCustomPlatformData(WebCore::RenderingResourceIdentifier) const;
 
     void releaseAllResources();
-    void releaseAllDrawingResources();
-    void releaseAllImageResources();
+    void releaseMemory();
+    void releaseNativeImages();
 
 private:
     UncheckedKeyHashMap<WebCore::RenderingResourceIdentifier, Ref<WebCore::ImageBuffer>> m_imageBuffers;

--- a/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
+++ b/Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in
@@ -27,7 +27,7 @@ additional_forward_declaration: namespace IPC { template<typename> struct Object
 additional_forward_declaration: namespace WebCore { using RenderingResourceIdentifier = AtomicObjectIdentifier<RenderingResourceIdentifierType>; }
 additional_forward_declaration: namespace WebCore { using SnapshotIdentifier = AtomicObjectIdentifier<SnapshotIdentifierType>; }
 additional_forward_declaration: namespace WebKit { using RemoteVideoFrameIdentifier = AtomicObjectIdentifier<RemoteVideoFrameIdentifierType>; }
-additional_forward_declaration: namespace WebKit { using RemoteSerializedImageBufferIdentifier = WebCore::RenderingResourceIdentifier; }
+additional_forward_declaration: namespace WebKit { using RemoteSerializedImageBufferIdentifier = AtomicObjectIdentifier<RemoteSerializedImageBufferIdentifierType>; }
 
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
 

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -413,6 +413,7 @@ def serialized_identifiers():
         'WebKit::RemoteCDMIdentifier',
         'WebKit::RemoteCDMInstanceIdentifier',
         'WebKit::RemoteCDMInstanceSessionIdentifier',
+        'WebKit::RemoteDisplayListRecorderIdentifier',
         'WebKit::RemoteLegacyCDMIdentifier',
         'WebKit::RemoteLegacyCDMSessionIdentifier',
         'WebKit::RemoteMediaRecorderPrivateWriterIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -65,6 +65,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
 #include "RemoteCDMInstanceSessionIdentifier.h"
 #endif
+#include "RemoteDisplayListRecorderIdentifier.h"
 #include "RemoteImageBufferSetIdentifier.h"
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
 #include "RemoteLegacyCDMIdentifier.h"
@@ -647,6 +648,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
     static_assert(sizeof(uint64_t) == sizeof(WebKit::RemoteCDMInstanceSessionIdentifier));
 #endif
+    static_assert(sizeof(uint64_t) == sizeof(WebKit::RemoteDisplayListRecorderIdentifier));
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
     static_assert(sizeof(uint64_t) == sizeof(WebKit::RemoteLegacyCDMIdentifier));
 #endif
@@ -801,6 +803,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
 #if ENABLE(GPU_PROCESS) && ENABLE(ENCRYPTED_MEDIA)
         "WebKit::RemoteCDMInstanceSessionIdentifier"_s,
 #endif
+        "WebKit::RemoteDisplayListRecorderIdentifier"_s,
 #if ENABLE(GPU_PROCESS) && ENABLE(LEGACY_ENCRYPTED_MEDIA)
         "WebKit::RemoteLegacyCDMIdentifier"_s,
 #endif

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
@@ -50,7 +50,7 @@ RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackin
         return;
     }
 
-    m_bufferSet = collection->protectedLayerTreeContext()->ensureProtectedRemoteRenderingBackendProxy()->createRemoteImageBufferSet();
+    m_bufferSet = collection->protectedLayerTreeContext()->ensureProtectedRemoteRenderingBackendProxy()->createImageBufferSet();
 }
 
 RemoteLayerWithRemoteRenderingBackingStore::~RemoteLayerWithRemoteRenderingBackingStore()

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -200,6 +200,8 @@ template: enum class WebKit::LegacyCustomProtocolIDType
 template: enum class WebKit::LibWebRTCResolverIdentifierType
 template: enum class WebKit::LogStreamIdentifierType
 template: enum class WebKit::QuotaIncreaseRequestIdentifierType
+template: enum class WebKit::RemoteDisplayListRecorderIdentifierType
+template: enum class WebKit::RemoteSerializedImageBufferIdentifierType
 template: enum class WebKit::RemoteVideoFrameIdentifierType
 template: enum class WebKit::RenderingBackendIdentifierType
 template: enum class WebKit::VideoDecoderIdentifierType

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6595,6 +6595,7 @@
 		7B22007129B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.h; sourceTree = "<group>"; };
 		7B2DDD5E27CCD9710060ABAB /* IPCStreamTesterProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTesterProxy.h; sourceTree = "<group>"; };
 		7B2E73472CA2C611002C1A84 /* SyncRequestID.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyncRequestID.h; sourceTree = "<group>"; };
+		7B43C1292D79B0EA00B119F7 /* RemoteDisplayListRecorderIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteDisplayListRecorderIdentifier.h; sourceTree = "<group>"; };
 		7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueueMap.h; sourceTree = "<group>"; };
 		7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueue.h; sourceTree = "<group>"; };
 		7B483F1D25CDDA9B00120486 /* MessageReceiveQueueMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MessageReceiveQueueMap.cpp; sourceTree = "<group>"; };
@@ -13032,6 +13033,7 @@
 				0FC5FB6529C4ECEE001EDFE5 /* PrepareBackingStoreBuffersData.cpp */,
 				0F65956C27E10C2C00EE874B /* PrepareBackingStoreBuffersData.h */,
 				86D1967629A4E7B50083B077 /* PrepareBackingStoreBuffersData.serialization.in */,
+				7B43C1292D79B0EA00B119F7 /* RemoteDisplayListRecorderIdentifier.h */,
 				F48BB8DE26F9635D001C1C40 /* RemoteDisplayListRecorderProxy.cpp */,
 				F48BB8DD26F9635D001C1C40 /* RemoteDisplayListRecorderProxy.h */,
 				7B904165254AFDEA006EEB8C /* RemoteGraphicsContextGLProxy.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderIdentifier.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderIdentifier.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,15 @@
 
 #pragma once
 
-#if ENABLE(GPU_PROCESS)
+#if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
-#include "ObjectIdentifierReferenceTracker.h"
-#include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/ObjectIdentifier.h>
 
 namespace WebKit {
 
-enum class RemoteSerializedImageBufferIdentifierType { };
-using RemoteSerializedImageBufferIdentifier = AtomicObjectIdentifier<RemoteSerializedImageBufferIdentifierType>;
-using RemoteSerializedImageBufferReadReference = IPC::ObjectIdentifierReadReference<RemoteSerializedImageBufferIdentifier>;
-using RemoteSerializedImageBufferWriteReference = IPC::ObjectIdentifierWriteReference<RemoteSerializedImageBufferIdentifier>;
-using RemoteSerializedImageBufferReference = IPC::ObjectIdentifierReference<RemoteSerializedImageBufferIdentifier>;
-using RemoteSerializedImageBufferReferenceTracker = IPC::ObjectIdentifierReferenceTracker<RemoteSerializedImageBufferIdentifier>;
+enum class RemoteDisplayListRecorderIdentifierType { };
+using RemoteDisplayListRecorderIdentifier = AtomicObjectIdentifier<RemoteDisplayListRecorderIdentifierType>;
 
 } // namespace WebKit
 
-#endif // ENABLE(GPU_PROCESS)
+#endif

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -81,7 +81,7 @@ public:
 // probably can't while it uses batching for prepare and volatility.
 class RemoteImageBufferSetProxy : public IPC::WorkQueueMessageReceiver<WTF::DestructionThread::Any>, public Identified<RemoteImageBufferSetIdentifier> {
 public:
-    RemoteImageBufferSetProxy(RemoteRenderingBackendProxy&);
+    static Ref<RemoteImageBufferSetProxy> create(RemoteRenderingBackendProxy&);
     ~RemoteImageBufferSetProxy();
 
     OptionSet<BufferInSetType> requestedVolatility() { return m_requestedVolatility; }
@@ -95,15 +95,15 @@ public:
 #endif
 
     WebCore::GraphicsContext& context();
-    bool hasContext() const { return !!m_displayListRecorder; }
+    bool hasContext() const { return !!m_context; }
 
-    WebCore::RenderingResourceIdentifier displayListResourceIdentifier() const { return m_displayListIdentifier; }
+    RemoteDisplayListRecorderIdentifier contextIdentifier() const { return m_contextIdentifier; }
 
     std::unique_ptr<ThreadSafeImageBufferSetFlusher> flushFrontBufferAsync(ThreadSafeImageBufferSetFlusher::FlushType);
 
     void setConfiguration(RemoteImageBufferSetConfiguration&&);
     void willPrepareForDisplay();
-    void remoteBufferSetWasDestroyed();
+    void disconnect();
 
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     std::optional<WebCore::DynamicContentScalingDisplayList> dynamicContentScalingDisplayList();
@@ -116,15 +116,15 @@ public:
     void close();
 
 private:
+    RemoteImageBufferSetProxy(RemoteRenderingBackendProxy&);
     template<typename T> auto send(T&& message);
     template<typename T> auto sendSync(T&& message);
     RefPtr<IPC::StreamClientConnection> connection() const;
     void didBecomeUnresponsive() const;
 
+    const RemoteDisplayListRecorderIdentifier m_contextIdentifier { RemoteDisplayListRecorderIdentifier::generate() };
     WeakPtr<RemoteRenderingBackendProxy> m_remoteRenderingBackendProxy;
-
-    WebCore::RenderingResourceIdentifier m_displayListIdentifier;
-    std::unique_ptr<RemoteDisplayListRecorderProxy> m_displayListRecorder;
+    std::optional<RemoteDisplayListRecorderProxy> m_context;
 
     OptionSet<BufferInSetType> m_requestedVolatility;
     OptionSet<BufferInSetType> m_confirmedVolatility;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -94,23 +94,16 @@ public:
     RemoteResourceCacheProxy& remoteResourceCacheProxy() { return m_remoteResourceCacheProxy; }
 
     void transferImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, WebCore::ImageBuffer&);
-    void moveToSerializedBuffer(WebCore::RenderingResourceIdentifier);
-    void moveToImageBuffer(WebCore::RenderingResourceIdentifier);
+    std::unique_ptr<RemoteSerializedImageBufferProxy> moveToSerializedBuffer(RemoteImageBufferProxy&);
+    Ref<RemoteImageBufferProxy> moveToImageBuffer(RemoteSerializedImageBufferProxy&);
 
 #if PLATFORM(COCOA)
     void didDrawRemoteToPDF(WebCore::PageIdentifier, WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::SnapshotIdentifier);
 #endif
-
-    void createRemoteImageBuffer(WebCore::ImageBuffer&);
     bool isCached(const WebCore::ImageBuffer&) const;
 
-    // IPC::MessageReceiver
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
-    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
-
-    // Messages to be sent.
-    RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat);
-    void releaseImageBuffer(WebCore::RenderingResourceIdentifier);
+    RefPtr<RemoteImageBufferProxy> createImageBuffer(const WebCore::FloatSize&, WebCore::RenderingMode, WebCore::RenderingPurpose, float resolutionScale, const WebCore::DestinationColorSpace&, WebCore::ImageBufferPixelFormat);
+    void releaseImageBuffer(RemoteImageBufferProxy&);
     bool getPixelBufferForImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::PixelBufferFormat& destinationFormat, const WebCore::IntRect& srcRect, std::span<uint8_t> result);
     RefPtr<WebCore::ShareableBitmap> getShareableBitmap(WebCore::RenderingResourceIdentifier, WebCore::PreserveResolution);
     void cacheNativeImage(WebCore::ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
@@ -125,11 +118,11 @@ public:
     void releaseGradient(WebCore::RenderingResourceIdentifier);
     void cacheFilter(Ref<WebCore::Filter>&&);
     void releaseFilter(WebCore::RenderingResourceIdentifier);
-    void releaseAllDrawingResources();
-    void releaseAllImageResources();
+    void releaseMemory();
+    void releaseNativeImages();
     void markSurfacesVolatile(Vector<std::pair<Ref<RemoteImageBufferSetProxy>, OptionSet<BufferInSetType>>>&&, CompletionHandler<void(bool madeAllVolatile)>&&, bool forcePurge);
-    RefPtr<RemoteImageBufferSetProxy> createRemoteImageBufferSet();
-    void releaseRemoteImageBufferSet(RemoteImageBufferSetProxy&);
+    Ref<RemoteImageBufferSetProxy> createImageBufferSet();
+    void releaseImageBufferSet(RemoteImageBufferSetProxy&);
     void getImageBufferResourceLimitsForTesting(CompletionHandler<void(WebCore::ImageBufferResourceLimits)>&&);
 
 #if USE(GRAPHICS_LAYER_WC)
@@ -178,6 +171,8 @@ public:
     void didBecomeUnresponsive();
 
     static constexpr Seconds defaultTimeout = 15_s;
+
+    unsigned nativeImageCountForTesting() const;
 private:
     explicit RemoteRenderingBackendProxy(SerialFunctionDispatcher&);
 
@@ -187,6 +182,10 @@ private:
     template<typename T> auto sendSync(T&& message) { return sendSync(std::forward<T>(message), renderingBackendIdentifier()); }
     template<typename T, typename C, typename U, typename V, typename W> auto sendWithAsyncReply(T&& message, C&& callback, ObjectIdentifierGeneric<U, V, W>);
     template<typename T, typename C> auto sendWithAsyncReply(T&& message, C&& callback) { return sendWithAsyncReply(std::forward<T>(message), std::forward<C>(callback), renderingBackendIdentifier()); }
+
+    // IPC::MessageReceiver
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    bool didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
 
     // Connection::Client
     void didClose(IPC::Connection&) final;
@@ -221,7 +220,8 @@ private:
     RefPtr<WebCore::SharedMemory> m_getPixelBufferSharedMemory;
     WebCore::Timer m_destroyGetPixelBufferSharedMemoryTimer { *this, &RemoteRenderingBackendProxy::destroyGetPixelBufferSharedMemory };
     HashMap<MarkSurfacesAsVolatileRequestIdentifier, CompletionHandler<void(bool)>> m_markAsVolatileRequests;
-    HashMap<RemoteImageBufferSetIdentifier, ThreadSafeWeakPtr<RemoteImageBufferSetProxy>> m_bufferSets;
+    HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<RemoteImageBufferProxy>> m_imageBuffers;
+    HashMap<RemoteImageBufferSetIdentifier, ThreadSafeWeakPtr<RemoteImageBufferSetProxy>> m_imageBufferSets;
     Ref<WorkQueue> m_queue;
 
     RenderingUpdateID m_renderingUpdateID;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -53,13 +53,8 @@ public:
     RemoteResourceCacheProxy(RemoteRenderingBackendProxy&);
     ~RemoteResourceCacheProxy();
 
-    void cacheImageBuffer(RemoteImageBufferProxy&);
-    RefPtr<RemoteImageBufferProxy> cachedImageBuffer(WebCore::RenderingResourceIdentifier) const;
-    void forgetImageBuffer(WebCore::RenderingResourceIdentifier);
-
     void recordNativeImageUse(WebCore::NativeImage&, const WebCore::DestinationColorSpace&);
     void recordFontUse(WebCore::Font&);
-    void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
     void recordGradientUse(WebCore::Gradient&);
     void recordFilterUse(WebCore::Filter&);
@@ -67,13 +62,10 @@ public:
 
     void didPaintLayers();
 
-    void remoteResourceCacheWasDestroyed();
     void releaseMemory();
-    void releaseAllImageResources();
+    void releaseNativeImages();
     
-    unsigned imagesCountForTesting() const { return m_nativeImages.size(); }
-
-    void clear();
+    unsigned nativeImageCountForTesting() const { return m_nativeImages.size(); }
 
 private:
     // WebCore::RenderingResourceObserver.
@@ -84,13 +76,9 @@ private:
 
     void finalizeRenderingUpdateForFonts();
     void prepareForNextRenderingUpdate();
-    void clearFontMap();
-    void clearFontCustomPlatformDataMap();
-    void clearImageBufferBackends();
-    void clearRenderingResources();
-    void clearNativeImages();
+    void releaseFonts();
+    void releaseFontCustomPlatformDatas();
 
-    HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<RemoteImageBufferProxy>> m_imageBuffers;
     HashSet<WebCore::RenderingResourceIdentifier> m_nativeImages;
     HashSet<WebCore::RenderingResourceIdentifier> m_gradients;
     HashSet<WebCore::RenderingResourceIdentifier> m_decomposedGlyphs;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5202,8 +5202,8 @@ void WebPage::didCompleteRenderingFrame()
 void WebPage::releaseMemory(Critical)
 {
 #if ENABLE(GPU_PROCESS)
-    if (m_remoteRenderingBackendProxy)
-        m_remoteRenderingBackendProxy->remoteResourceCacheProxy().releaseMemory();
+    if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
+        renderingBackend->releaseMemory();
 #endif
 
     m_foundTextRangeController->clearCachedRanges();
@@ -5212,8 +5212,8 @@ void WebPage::releaseMemory(Critical)
 void WebPage::willDestroyDecodedDataForAllImages()
 {
 #if ENABLE(GPU_PROCESS)
-    if (m_remoteRenderingBackendProxy)
-        m_remoteRenderingBackendProxy->remoteResourceCacheProxy().releaseAllImageResources();
+    if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
+        renderingBackend->releaseNativeImages();
 #endif
 
     if (RefPtr drawingArea = m_drawingArea)
@@ -5223,12 +5223,10 @@ void WebPage::willDestroyDecodedDataForAllImages()
 unsigned WebPage::remoteImagesCountForTesting() const
 {
 #if ENABLE(GPU_PROCESS)
-    if (!m_remoteRenderingBackendProxy)
-        return 0;
-    return m_remoteRenderingBackendProxy->remoteResourceCacheProxy().imagesCountForTesting();
-#else
-    return 0;
+    if (RefPtr renderingBackend = m_remoteRenderingBackendProxy)
+        return renderingBackend->nativeImageCountForTesting();
 #endif
+return 0;
 }
 
 WebInspector* WebPage::inspector(LazyCreationPolicy behavior)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -641,9 +641,9 @@
 		A14FC58B1B89927100D107EB /* ContentFilteringPlugIn.mm in Sources */ = {isa = PBXBuildFile; fileRef = A14FC5891B89927100D107EB /* ContentFilteringPlugIn.mm */; };
 		A170E3AA2ABA7857009EA799 /* VectorCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A170E3A22ABA7857009EA799 /* VectorCocoa.mm */; };
 		A17191AD2CD2DB090088944E /* WKWebViewLogging.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17191AC2CD2DB090088944E /* WKWebViewLogging.mm */; };
-		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24B2D6D2A4E00C63915 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2472D6D295400C63915 /* GPUExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24C2D6D2A4E00C63915 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2482D6D295400C63915 /* NetworkingExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A176D24D2D6D2A4E00C63915 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = A176D2492D6D295400C63915 /* WebContentExtension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1798B7F22431D2B000764BD /* libWebCoreTestSupport.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A1798B7E22431D2B000764BD /* libWebCoreTestSupport.dylib */; };
 		A1798B8522433647000764BD /* WebProcessPlugInWithInternals.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1798B8422433647000764BD /* WebProcessPlugInWithInternals.mm */; };
 		A17991881E1C994E00A505ED /* SharedBuffer.mm in Sources */ = {isa = PBXBuildFile; fileRef = A17991861E1C994E00A505ED /* SharedBuffer.mm */; };


### PR DESCRIPTION
#### 5dea043b68035875317207996f913f76b80b0cff
<pre>
Clarify RemoteDisplayListRecorder ownership
<a href="https://bugs.webkit.org/show_bug.cgi?id=289238">https://bugs.webkit.org/show_bug.cgi?id=289238</a>
<a href="https://rdar.apple.com/146384034">rdar://146384034</a>

Reviewed by Matt Woodrow.

RemoteRenderingBackend composition was:

RemoteRenderingBackend
  0..n RemoteDisplayListRecorder
  0..m RemoteImageBuffer
  0..k RemoteImageBufferSet
This was unneccessary, as RemoteRenderingBackend directly created
only RemoteImageBuffers and RemoteImageBufferSets. Additionally,
RemoteImageBufferSet created RemoteImageBuffers that were not actually
asked by the WebContent process.

RemoteDisplayListRecorder messages were by convention sent
to the identifier of the RemoteImageBuffer that owned it. This
caused part of the above confusion, as RemoteImageBufferSet was
forced to create an artificial RemoteImageBuffer.

RemoteSerializedImageBuffer was identified by its originating
RemoteImageBuffer. This caused part of the above confusion.

Fix by:
Change the RemoteRenderingBackend composition:

RemoteRenderingBackend
  0..n RemoteImageBuffer
      1 RemoteDisplayListRecorder
  0..m RemoteImageBufferSet
      1 RemoteDisplayListRecorder

Each RemoteImageBuffer has a context.
Each RemoteImageBufferSet has a context.

Add RemoteDisplayListRecorderIdentifier to identify
RemoteDisplayListRecorder unambiguously.

Change RemoteSerializedImageBufferIdentifier be a real type-specific
identifier. Previously it was an alias to unrelated
RenderingResourceIdentifier.

Make RemoteRenderingBackend::CreateImageBuffer select the
RemoteDisplayListRecorder identifier explictly. In other words,
the message is a create-type message for both RemoteImageBuffer and
RemoteDisplayListRecorder.

Make RemoteRenderingBackend::MoveToImageBuffer select the
RemoteImageBuffer and RemoteDisplayListRecorder identifier explictly. In
other words, the message is a create-type message for both
RemoteImageBuffer and RemoteDisplayListRecorder. The message is a
destroy-type message for RemoteSerializedImageBuffer.

Make RemoteRenderingBackend::MoveToSerializedBuffer select the
RemoteSerializedImageBufferImageBuffer identifier explicitly. In other
words, the message is a create-type message for
RemoteSerializedImageBuffer. The message is a destroy-type message for
both RemoteImageBuffer and its implicit RemoteDisplayListRecorder.

Structure the RemoteRenderingBackendProxy, RemoteImageBufferProxy,
RemoteDisplayListRecorderProxy code so that RemoteRenderingBackendProxy
is more normal type acting on other types. Before it was a bit more
convoluted type that just sent messages, i.e the sending messages leaked
to RemoteRenderingBackendProxy interface.

* Source/WebKit/GPUProcess/RemoteSharedResourceCache.cpp:
(WebKit::RemoteSharedResourceCache::addSerializedImageBuffer):
(WebKit::RemoteSharedResourceCache::takeSerializedImageBuffer):
(WebKit::RemoteSharedResourceCache::releaseSerializedImageBuffer):
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.h:
* Source/WebKit/GPUProcess/RemoteSharedResourceCache.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::create):
(WebKit::RemoteDisplayListRecorder::RemoteDisplayListRecorder):
(WebKit::RemoteDisplayListRecorder::controlFactory):
(WebKit::RemoteDisplayListRecorder::imageBuffer const):
(WebKit::RemoteDisplayListRecorder::startListeningForIPC):
(WebKit::RemoteDisplayListRecorder::stopListeningForIPC):
(WebKit::RemoteDisplayListRecorder::drawControlPart):
(WebKit::RemoteDisplayListRecorder::sharedPreferencesForWebProcess const):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
(WebKit::RemoteDisplayListRecorder::create): Deleted.
(WebKit::RemoteDisplayListRecorder::protectedControlFactory): Deleted.
(WebKit::RemoteDisplayListRecorder::protectedRenderingBackend const): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::create):
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
(WebKit::RemoteImageBuffer::~RemoteImageBuffer):
(WebKit::RemoteImageBuffer::startListeningForIPC):
(WebKit::RemoteImageBuffer::stopListeningForIPC):
(WebKit::RemoteImageBuffer::sinkIntoImageBuffer):
(WebKit::RemoteImageBuffer::getPixelBuffer):
(WebKit::RemoteImageBuffer::getPixelBufferWithNewMemory):
(WebKit::RemoteImageBuffer::putPixelBuffer):
(WebKit::RemoteImageBuffer::getShareableBitmap):
(WebKit::RemoteImageBuffer::filteredNativeImage):
(WebKit::RemoteImageBuffer::convertToLuminanceMask):
(WebKit::RemoteImageBuffer::transformToColorSpace):
(WebKit::RemoteImageBuffer::flushContext):
(WebKit::RemoteImageBuffer::flushContextSync):
(WebKit::RemoteImageBuffer::dynamicContentScalingDisplayList):
(WebKit::RemoteImageBuffer::workQueue const):
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
(WebKit::RemoteImageBuffer::identifier const): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::create):
(WebKit::RemoteImageBufferSet::RemoteImageBufferSet):
(WebKit::RemoteImageBufferSet::startListeningForIPC):
(WebKit::RemoteImageBufferSet::stopListeningForIPC):
(WebKit::RemoteImageBufferSet::workQueue const):
(WebKit::RemoteImageBufferSet::endPrepareForDisplay):
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.h:
(): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
(WebKit::RemoteRenderingBackend::moveToSerializedBuffer):
(WebKit::RemoteRenderingBackend::moveToImageBuffer):
(WebKit::allocateImageBufferInternal):
(WebKit::RemoteRenderingBackend::allocateImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBuffer):
(WebKit::RemoteRenderingBackend::releaseImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBufferSet):
(WebKit::RemoteRenderingBackend::releaseImageBufferSet):
(WebKit::RemoteRenderingBackend::releaseAllDrawingResources):
(WebKit::RemoteRenderingBackend::createDisplayListRecorder): Deleted.
(WebKit::RemoteRenderingBackend::releaseDisplayListRecorder): Deleted.
(WebKit::RemoteRenderingBackend::didFailCreateImageBuffer): Deleted.
(WebKit::RemoteRenderingBackend::didCreateImageBuffer): Deleted.
(WebKit::RemoteRenderingBackend::createRemoteImageBufferSet): Deleted.
(WebKit::RemoteRenderingBackend::releaseRemoteImageBufferSet): Deleted.
(WebKit::RemoteRenderingBackend::takeImageBuffer): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Platform/IPC/ObjectIdentifierReference.serialization.in:
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/GeneratedWebKitSecureCoding.cpp:
(WebKit::dictionaryForWebKitSecureCodingType):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm:
(WebKit::RemoteLayerWithRemoteRenderingBackingStore::RemoteLayerWithRemoteRenderingBackingStore):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderIdentifier.h: Copied from Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::RemoteDisplayListRecorderProxy):
(WebKit::m_renderingBackend):
(WebKit::RemoteDisplayListRecorderProxy::send):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
(WebKit::m_renderingMode): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
(WebKit::RemoteDisplayListRecorderProxy::identifier const):
(WebKit::RemoteDisplayListRecorderProxy::setClient):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::RemoteImageBufferProxy):
(WebKit::m_context):
(WebKit::m_renderingBackend):
(WebKit::RemoteImageBufferProxy::~RemoteImageBufferProxy):
(WebKit::RemoteImageBufferProxy::assertDispatcherIsCurrent const):
(WebKit::RemoteImageBufferProxy::connection const):
(WebKit::RemoteImageBufferProxy::didBecomeUnresponsive const):
(WebKit::RemoteImageBufferProxy::didCreateBackend):
(WebKit::RemoteImageBufferProxy::ensureBackend const):
(WebKit::RemoteImageBufferProxy::copyNativeImage const):
(WebKit::RemoteImageBufferProxy::filteredNativeImage):
(WebKit::RemoteImageBufferProxy::getPixelBuffer const):
(WebKit::RemoteImageBufferProxy::disconnect):
(WebKit::RemoteImageBufferProxy::isValid const):
(WebKit::RemoteImageBufferProxy::context const):
(WebKit::RemoteImageBufferProxy::putPixelBuffer):
(WebKit::RemoteImageBufferProxy::flushDrawingContext):
(WebKit::RemoteImageBufferProxy::flushDrawingContextAsync):
(WebKit::RemoteImageBufferProxy::sinkIntoSerializedImageBuffer):
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
(WebKit::RemoteSerializedImageBufferProxy::sinkIntoImageBuffer):
(WebKit::RemoteSerializedImageBufferProxy::~RemoteSerializedImageBufferProxy):
(WebKit::m_remoteDisplayList): Deleted.
(): Deleted.
(WebKit::RemoteImageBufferProxy::clearBackend): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteSerializedImageBufferProxy::parameters const):
(WebKit::RemoteSerializedImageBufferProxy::info const):
(WebKit::RemoteImageBufferProxy::create): Deleted.
(WebKit::RemoteImageBufferProxy::putPixelBuffer): Deleted.
(WebKit::RemoteSerializedImageBufferProxy::renderingResourceIdentifier): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxy::create):
(WebKit::RemoteImageBufferSetProxy::RemoteImageBufferSetProxy):
(WebKit::RemoteImageBufferSetProxy::close):
(WebKit::RemoteImageBufferSetProxy::willPrepareForDisplay):
(WebKit::RemoteImageBufferSetProxy::disconnect):
(WebKit::RemoteImageBufferSetProxy::context):
(WebKit::RemoteImageBufferSetProxy::remoteBufferSetWasDestroyed): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
(WebKit::RemoteImageBufferSetProxy::hasContext const):
(WebKit::RemoteImageBufferSetProxy::contextIdentifier const):
(WebKit::RemoteImageBufferSetProxy::displayListResourceIdentifier const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::~RemoteRenderingBackendProxy):
(WebKit::RemoteRenderingBackendProxy::didClose):
(WebKit::RemoteRenderingBackendProxy::createImageBuffer):
(WebKit::RemoteRenderingBackendProxy::releaseImageBuffer):
(WebKit::RemoteRenderingBackendProxy::createImageBufferSet):
(WebKit::RemoteRenderingBackendProxy::releaseImageBufferSet):
(WebKit::RemoteRenderingBackendProxy::moveToSerializedBuffer):
(WebKit::RemoteRenderingBackendProxy::moveToImageBuffer):
(WebKit::RemoteRenderingBackendProxy::releaseMemory):
(WebKit::RemoteRenderingBackendProxy::releaseAllImageResources):
(WebKit::RemoteRenderingBackendProxy::didMarkLayersAsVolatile):
(WebKit::RemoteRenderingBackendProxy::dispatchMessage):
(WebKit::RemoteRenderingBackendProxy::isCached const):
(WebKit::RemoteRenderingBackendProxy::createRemoteImageBuffer): Deleted.
(WebKit::RemoteRenderingBackendProxy::createDisplayListRecorder): Deleted.
(WebKit::RemoteRenderingBackendProxy::createRemoteImageBufferSet): Deleted.
(WebKit::RemoteRenderingBackendProxy::releaseRemoteImageBufferSet): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::~RemoteResourceCacheProxy):
(WebKit::RemoteResourceCacheProxy::disconnect):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
(WebKit::RemoteResourceCacheProxy::releaseAllImageResources):
(WebKit::RemoteResourceCacheProxy::clear): Deleted.
(WebKit::RemoteResourceCacheProxy::cacheImageBuffer): Deleted.
(WebKit::RemoteResourceCacheProxy::cachedImageBuffer const): Deleted.
(WebKit::RemoteResourceCacheProxy::forgetImageBuffer): Deleted.
(WebKit::RemoteResourceCacheProxy::recordImageBufferUse): Deleted.
(WebKit::RemoteResourceCacheProxy::clearImageBufferBackends): Deleted.
(WebKit::RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteSerializedImageBufferIdentifier.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::releaseMemory):
(WebKit::WebPage::willDestroyDecodedDataForAllImages):

Canonical link: <a href="https://commits.webkit.org/292758@main">https://commits.webkit.org/292758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e31c2c6757f53bb58837abc54b46214f3926fcc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/97041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/16664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/6869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/102122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/47566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/99086 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/16956 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/25114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/73925 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/31135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/100044 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/12789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/87765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/54261 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/96529 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/12541 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/5619 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/46896 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/82614 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/5698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/104143 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/24115 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/17592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/82973 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/24366 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/83871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/82369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/27056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/4600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/17617 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/24080 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/29228 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/23903 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/27215 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/25476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->