### PR TITLE
[Cocoa] Address Safer CPP warnings in AVVideoCapture.mm

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -82,6 +82,10 @@ public:
 #define DEBUG_LOG_IF_POSSIBLE(...)      if (RefPtr logger = loggerPtr()) logger->debug(logChannel(), __VA_ARGS__)
 #define WILL_LOG_IF_POSSIBLE(_level_)   if (RefPtr logger = loggerPtr()) logger->willLog(logChannel(), _level_)
 
+#define ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)  if (RefPtr logger = thisPtr->loggerPtr()) ALWAYS_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
+#define ERROR_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)   if (RefPtr logger = thisPtr->loggerPtr()) ERROR_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
+#define INFO_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, ...)    if (RefPtr logger = thisPtr->loggerPtr()) INFO_LOG_WITH_THIS(thisPtr, __VA_ARGS__)
+
 #if defined(__OBJC__)
 #define OBJC_LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(__PRETTY_FUNCTION__, self.logIdentifier)
 #define OBJC_ALWAYS_LOG(...)     if (self.loggerPtr && self.logChannel) self.loggerPtr->logAlways(*self.logChannel, __VA_ARGS__)
@@ -118,6 +122,10 @@ public:
 #define ALWAYS_LOG_WITH_THIS(thisPtr, channelName, ...)   (UNUSED_PARAM(channelName))
 #define ERROR_LOG_WITH_THIS(thisPtr, channelName, ...)    (UNUSED_PARAM(channelName))
 #define INFO_LOG_WITH_THIS(thisPtr, channelName, ...)     (UNUSED_PARAM(channelName))
+
+#define ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)  (UNUSED_PARAM(channelName))
+#define ERROR_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)   (UNUSED_PARAM(channelName))
+#define INFO_LOG_WITH_THIS_IF_POSSIBLE(thisPtr, channelName, ...)    (UNUSED_PARAM(channelName))
 
 #define ALWAYS_LOG_IF(condition, ...)     ((void)0)
 #define ERROR_LOG_IF(condition, ...)      ((void)0)

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1084,7 +1084,6 @@ platform/mediastream/cocoa/DisplayCaptureSourceCocoa.h
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
 platform/mediastream/libwebrtc/LibWebRTCAudioModule.cpp
 platform/mediastream/mac/AVCaptureDeviceManager.mm
-platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/MediaStreamTrackAudioSourceProviderCocoa.cpp
 platform/mediastream/mac/MockAudioSharedUnit.mm
 platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -139,7 +139,6 @@ platform/mediastream/RealtimeMediaSource.cpp
 platform/mediastream/RealtimeMediaSourceCenter.cpp
 platform/mediastream/RealtimeVideoCaptureSource.cpp
 platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.cpp
-platform/mediastream/mac/AVVideoCaptureSource.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mediastream/mac/ScreenCaptureKitCaptureSource.mm
 rendering/BackgroundPainter.cpp

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -206,7 +206,7 @@ std::optional<double> AVVideoCaptureSource::computeMaxZoom(AVCaptureDeviceFormat
 #endif
 }
 
-static WorkQueue& photoQueue()
+static WorkQueue& photoQueueSingleton()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("WebKit::AVPhotoCapture Queue"_s);
     return queue.get();
@@ -257,7 +257,7 @@ AVVideoCaptureSource::AVVideoCaptureSource(AVCaptureDevice* avDevice, const Capt
 
 AVVideoCaptureSource::~AVVideoCaptureSource()
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
     [m_objcObserver disconnect];
     [m_device removeObserver:m_objcObserver.get() forKeyPath:@"suspended"];
@@ -310,7 +310,7 @@ void AVVideoCaptureSource::startupTimerFired()
 
 void AVVideoCaptureSource::clearSession()
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     ASSERT(m_session);
     [m_session removeObserver:m_objcObserver.get() forKeyPath:@"running"];
     m_session = nullptr;
@@ -324,7 +324,7 @@ void AVVideoCaptureSource::startProducingData()
     }
 
     bool isRunning = !![m_session isRunning];
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, isRunning);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, isRunning);
     if (isRunning)
         return;
 
@@ -347,7 +347,7 @@ void AVVideoCaptureSource::stopProducingData()
     if (!m_session)
         return;
 
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, !![m_session isRunning]);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, !![m_session isRunning]);
     [m_objcObserver removeNotificationObservers];
     stopSession();
 
@@ -365,7 +365,7 @@ void AVVideoCaptureSource::stopSession()
     @try {
         [m_session stopRunning];
     } @catch(NSException *exception) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error calling -stopRunning ", [[exception name] UTF8String], ", reason : ", exception.reason);
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "error calling -stopRunning ", [[exception name] UTF8String], ", reason : ", exception.reason);
     }
 
     rejectPendingPhotoRequest("Track stopped"_s);
@@ -424,7 +424,7 @@ void AVVideoCaptureSource::settingsDidChange(OptionSet<RealtimeMediaSourceSettin
         return;
 
     m_pendingSettingsChanges = settings;
-    scheduleDeferredTask([this, whiteBalanceModeChanged, torchChanged] {
+    scheduleDeferredTask([protectedThis = Ref { *this }, this, whiteBalanceModeChanged, torchChanged] {
         startApplyingConstraints();
         if (whiteBalanceModeChanged)
             updateWhiteBalanceMode();
@@ -590,12 +590,12 @@ AVCapturePhotoOutput* AVVideoCaptureSource::photoOutput()
         m_photoOutput = adoptNS([PAL::allocAVCapturePhotoOutputInstance() init]);
 
         if (!m_photoOutput) {
-            ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "unable to allocate AVCapturePhotoOutput");
+            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to allocate AVCapturePhotoOutput");
             return nullptr;
         }
 
         if (![session() canAddOutput:m_photoOutput.get()]) {
-            ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "unable to add photo output");
+            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to add photo output");
             return nullptr;
         }
         [session() addOutput:m_photoOutput.get()];
@@ -609,7 +609,7 @@ void AVVideoCaptureSource::resolvePendingPhotoRequest(Vector<uint8_t>&& data, co
     Locker lock { m_photoLock };
 
     if (!m_photoProducer) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "no photo producer");
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "no photo producer");
         return;
     }
 
@@ -624,7 +624,7 @@ void AVVideoCaptureSource::rejectPendingPhotoRequest(const String& error)
     if (!m_photoProducer)
         return;
 
-    ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, error);
+    ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, error);
     m_photoProducer->reject(error);
     m_photoProducer = nullptr;
 }
@@ -707,7 +707,7 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
     {
         Locker lock { m_photoLock };
         if (m_photoProducer) {
-            ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "m_photoProducer should be NULL!");
+            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "m_photoProducer should be NULL!");
             return TakePhotoNativePromise::createAndReject("Internal error"_s);
         }
 
@@ -715,13 +715,13 @@ auto AVVideoCaptureSource::takePhotoInternal(PhotoSettings&& photoSettings) -> R
         promise = static_cast<Ref<TakePhotoNativePromise>>(*m_photoProducer);
     }
 
-    auto avPhotoSettings = photoConfiguration(photoSettings);
+    RetainPtr<AVCapturePhotoSettings> avPhotoSettings = photoConfiguration(photoSettings);
     if (!avPhotoSettings) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "photoConfiguration() failed");
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "photoConfiguration() failed");
         return TakePhotoNativePromise::createAndReject("Internal error"_s);
     }
 
-    photoQueue().dispatch([this, protectedThis = Ref { *this }, avPhotoSettings = WTFMove(avPhotoSettings), photoOutput = WTFMove(photoOutput)] {
+    photoQueueSingleton().dispatch([protectedThis = Ref { *this }, this, avPhotoSettings = WTFMove(avPhotoSettings), photoOutput = WTFMove(photoOutput)] {
         ASSERT(!isMainThread());
 
         if ([avPhotoSettings respondsToSelector:@selector(setMaxPhotoDimensions:)]) {
@@ -814,7 +814,7 @@ double AVVideoCaptureSource::facingModeFitnessScoreAdjustment() const
         relativePriority = cameraCaptureDeviceTypes().count;
 
     auto fitnessScore = cameraCaptureDeviceTypes().count - relativePriority;
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, captureDevice().label(), " has fitness adjustment ", fitnessScore);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, captureDevice().label(), " has fitness adjustment ", fitnessScore);
 
     return fitnessScore;
 }
@@ -840,7 +840,7 @@ void AVVideoCaptureSource::applyFrameRateAndZoomWithPreset(double requestedFrame
     // Updating the device configuration may switch off the torch. We reenable torch asynchronously if needed.
     if (torch()) {
         m_pendingSettingsChanges = { RealtimeMediaSourceSettings::Flag::Torch };
-        scheduleDeferredTask([this] {
+        scheduleDeferredTask([protectedThis = Ref { *this }, this] {
             startApplyingConstraints();
             updateTorch();
             endApplyingConstraints();
@@ -879,14 +879,14 @@ void AVVideoCaptureSource::setSessionSizeFrameRateAndZoom()
     if (!m_currentPreset)
         return;
 
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, SizeFrameRateAndZoom { m_currentPreset->size().width(), m_currentPreset->size().height(), m_currentFrameRate, m_currentZoom }
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, SizeFrameRateAndZoom { m_currentPreset->size().width(), m_currentPreset->size().height(), m_currentFrameRate, m_currentZoom }
 #if PLATFORM(IOS_FAMILY)
         , " binned: ", !!m_currentPreset->format().isVideoBinned
 #endif
     );
 
     if (areSettingsMatching()) {
-        ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, " settings already match");
+        ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, " settings already match");
         return;
     }
 
@@ -920,23 +920,23 @@ void AVVideoCaptureSource::setSessionSizeFrameRateAndZoom()
             else if (PAL::CMTimeCompare(frameDuration, frameRateRange.maxFrameDuration) > 0)
                 frameDuration = frameRateRange.maxFrameDuration;
 
-            ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "setting frame rate to ", m_currentFrameRate, ", duration ", PAL::toMediaTime(frameDuration));
+            ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "setting frame rate to ", m_currentFrameRate, ", duration ", PAL::toMediaTime(frameDuration));
 
             [device() setActiveVideoMinFrameDuration: frameDuration];
             [device() setActiveVideoMaxFrameDuration: frameDuration];
         } else
-            ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "cannot find proper frame rate range for the selected preset\n");
+            ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "cannot find proper frame rate range for the selected preset\n");
 
 #if PLATFORM(IOS_FAMILY)
         if (m_currentZoom != device().videoZoomFactor) {
-            ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "setting zoom to ", m_currentZoom);
+            ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "setting zoom to ", m_currentZoom);
             [device() setVideoZoomFactor:m_currentZoom];
         }
 #endif
 
         m_appliedPreset = m_currentPreset;
     } @catch(NSException *exception) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error configuring device ", exception.name, ", reason : ", exception.reason);
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "error configuring device ", exception.name, ", reason : ", exception.reason);
         ASSERT_NOT_REACHED();
     }
 
@@ -1003,7 +1003,7 @@ void AVVideoCaptureSource::updateWhiteBalanceMode()
     @try {
         device.whiteBalanceMode = whiteBalanceModeFromMeteringMode(whiteBalanceMode());
     } @catch(NSException *exception) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error setting white balance mode ", [[exception name] UTF8String], ", reason : ", exception.reason);
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "error setting white balance mode ", [[exception name] UTF8String], ", reason : ", exception.reason);
     }
 
     [device unlockForConfiguration];
@@ -1034,7 +1034,7 @@ void AVVideoCaptureSource::updateTorch()
             [device setTorchMode:(AVCaptureTorchMode)m_defaultTorchMode];
 
     } @catch(NSException *exception) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "error turning on torch ", exception.name, ", reason : ", exception.reason);
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "error turning on torch ", exception.name, ", reason : ", exception.reason);
     }
 
     [device unlockForConfiguration];
@@ -1057,7 +1057,7 @@ bool AVVideoCaptureSource::setupSession()
     if (m_session)
         return true;
 
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     String mediaEnvironment = RealtimeMediaSourceCenter::singleton().currentMediaEnvironment();
@@ -1079,13 +1079,13 @@ bool AVVideoCaptureSource::setupSession()
 
     if (!m_session) {
 #if ENABLE(EXTENSION_CAPABILITIES)
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "allocating AVCaptureSession without media environment nor identity");
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "allocating AVCaptureSession without media environment nor identity");
 #endif
         m_session = adoptNS([PAL::allocAVCaptureSessionInstance() init]);
     }
 
     if (!m_session) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "failed to allocate AVCaptureSession");
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "failed to allocate AVCaptureSession");
         captureFailed();
         return false;
     }
@@ -1117,27 +1117,29 @@ AVFrameRateRange* AVVideoCaptureSource::frameDurationForFrameRate(double rate)
     }
 
     if (!bestFrameRateRange)
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "no frame rate range for rate ", rate);
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "no frame rate range for rate ", rate);
 
     return bestFrameRateRange;
 }
 
 bool AVVideoCaptureSource::setupCaptureSession()
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
     beginConfiguration();
-    auto scopeExit = WTF::makeScopeExit([&] { commitConfiguration(); });
+    auto scopeExit = WTF::makeScopeExit([protectedThis = Ref { *this }] {
+        protectedThis->commitConfiguration();
+    });
 
     NSError *error = nil;
     RetainPtr<AVCaptureDeviceInput> videoIn = adoptNS([PAL::allocAVCaptureDeviceInputInstance() initWithDevice:device() error:&error]);
     if (error) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "failed to allocate AVCaptureDeviceInput ", error);
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "failed to allocate AVCaptureDeviceInput ", error);
         return false;
     }
 
     if (![session() canAddInput:videoIn.get()]) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "unable to add video input device");
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to add video input device");
         return false;
     }
     [session() addInput:videoIn.get()];
@@ -1150,7 +1152,7 @@ bool AVVideoCaptureSource::setupCaptureSession()
     [m_videoOutput setSampleBufferDelegate:m_objcObserver.get() queue:globaVideoCaptureSerialQueue()];
 
     if (![session() canAddOutput:m_videoOutput.get()]) {
-        ERROR_LOG_IF(loggerPtr(), LOGIDENTIFIER, "unable to add video output device");
+        ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "unable to add video output device");
         return false;
     }
     [session() addOutput:m_videoOutput.get()];
@@ -1176,7 +1178,7 @@ bool AVVideoCaptureSource::setupCaptureSession()
 
 void AVVideoCaptureSource::shutdownCaptureSession()
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_buffer = nullptr;
 }
 
@@ -1196,7 +1198,7 @@ void AVVideoCaptureSource::orientationChanged(IntDegrees orientation)
     ASSERT(orientation == 0 || orientation == 90 || orientation == -90 || orientation == 180);
     m_deviceOrientation = orientation;
     computeVideoFrameRotation();
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "rotation = ", m_videoFrameRotation, ", orientation = ", m_deviceOrientation);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "rotation = ", m_videoFrameRotation, ", orientation = ", m_deviceOrientation);
 }
 
 void AVVideoCaptureSource::rotationAngleForHorizonLevelDisplayChanged(const String& devicePersistentId, VideoFrameRotation videoFrameRotation)
@@ -1210,7 +1212,7 @@ void AVVideoCaptureSource::rotationAngleForHorizonLevelDisplayChanged(const Stri
         return;
 
     m_videoFrameRotation = videoFrameRotation;
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "rotation = ", m_videoFrameRotation);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, "rotation = ", m_videoFrameRotation);
     notifySettingsDidChangeObservers({ RealtimeMediaSourceSettings::Flag::Width, RealtimeMediaSourceSettings::Flag::Height });
 }
 
@@ -1265,9 +1267,9 @@ void AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto(RetainPtr<AVCap
 {
     if (error) {
         rejectPendingPhotoRequest("AVCapturePhotoOutput failed"_s);
-        RunLoop::protectedMain()->dispatch([this, protectedThis = Ref { *this }, logIdentifier = LOGIDENTIFIER, error = WTFMove(error)] {
+        RunLoop::protectedMain()->dispatch([protectedThis = Ref { *this }, logIdentifier = LOGIDENTIFIER, error = WTFMove(error)] {
             ASSERT(isMainThread());
-            ALWAYS_LOG_IF(loggerPtr(), logIdentifier, "failed: ", [error code], ", ", error.get());
+            ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, logIdentifier, "failed: ", [error code], ", ", error.get());
         });
         return;
     }
@@ -1294,8 +1296,8 @@ void AVVideoCaptureSource::reconfigureIfNeeded()
 
 void AVVideoCaptureSource::captureSessionIsRunningDidChange(bool state)
 {
-    scheduleDeferredTask([this, logIdentifier = LOGIDENTIFIER, state] {
-        ALWAYS_LOG_IF(loggerPtr(), logIdentifier, state);
+    scheduleDeferredTask([protectedThis = Ref { *this }, this, logIdentifier = LOGIDENTIFIER, state] {
+        ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, logIdentifier, state);
         if ((state == m_isRunning) && (state == !muted()))
             return;
 
@@ -1319,9 +1321,9 @@ void AVVideoCaptureSource::captureSessionIsRunningDidChange(bool state)
 void AVVideoCaptureSource::captureDeviceSuspendedDidChange()
 {
 #if !PLATFORM(IOS_FAMILY)
-    scheduleDeferredTask([this, logIdentifier = LOGIDENTIFIER] {
+    scheduleDeferredTask([protectedThis = Ref { *this }, this, logIdentifier = LOGIDENTIFIER] {
         m_interrupted = [m_device isSuspended];
-        ALWAYS_LOG_IF(loggerPtr(), logIdentifier, !!m_interrupted);
+        ALWAYS_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, logIdentifier, !!m_interrupted);
 
         updateVerifyCapturingTimer();
 
@@ -1378,14 +1380,14 @@ void AVVideoCaptureSource::generatePresets()
 void AVVideoCaptureSource::captureSessionRuntimeError(RetainPtr<NSError> error)
 {
     auto identifier = LOGIDENTIFIER;
-    ERROR_LOG_IF(loggerPtr(), identifier, [error code], ", ", error.get());
+    ERROR_LOG_IF_POSSIBLE(identifier, [error code], ", ", error.get());
 
     if (!m_isRunning || error.get().code != AVErrorMediaServicesWereReset)
         return;
 
-    scheduleDeferredTask([this, identifier] {
+    scheduleDeferredTask([protectedThis = Ref { *this }, this, identifier] {
         // Try to restart the session, but reset m_isRunning immediately so if it fails we won't try again.
-        ERROR_LOG_IF(loggerPtr(), identifier, "restarting session");
+        ERROR_LOG_WITH_THIS_IF_POSSIBLE(protectedThis, identifier, "restarting session");
         [m_session startRunning];
         m_isRunning = [m_session isRunning];
     });
@@ -1393,20 +1395,20 @@ void AVVideoCaptureSource::captureSessionRuntimeError(RetainPtr<NSError> error)
 
 void AVVideoCaptureSource::captureSessionBeginInterruption(RetainPtr<NSNotification> notification)
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, [notification userInfo][AVCaptureSessionInterruptionReasonKey]);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, [notification userInfo][AVCaptureSessionInterruptionReasonKey]);
     m_interrupted = true;
 }
 
 void AVVideoCaptureSource::captureSessionEndInterruption(RetainPtr<NSNotification>)
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_interrupted = false;
 }
 #endif
 
 void AVVideoCaptureSource::deviceDisconnected(RetainPtr<NSNotification> notification)
 {
-    ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER);
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (this->device() == [notification object])
         captureFailed();
 }
@@ -1472,7 +1474,7 @@ void AVVideoCaptureSource::deviceDisconnected(RetainPtr<NSNotification> notifica
     UNUSED_PARAM(object);
     UNUSED_PARAM(context);
 
-    auto source = m_captureSource.get();
+    RefPtr source = m_captureSource.get();
     if (!source)
         return;
 
@@ -1480,10 +1482,10 @@ void AVVideoCaptureSource::deviceDisconnected(RetainPtr<NSNotification> notifica
     bool willChange = [[change valueForKey:NSKeyValueChangeNotificationIsPriorKey] boolValue];
 
 #if !RELEASE_LOG_DISABLED
-    if (source->loggerPtr()) {
+    if (RefPtr logger = source->loggerPtr()) {
         auto identifier = Logger::LogSiteIdentifier("AVVideoCaptureSource"_s, "observeValueForKeyPath"_s, source->logIdentifier());
         RetainPtr<NSString> valueString = adoptNS([[NSString alloc] initWithFormat:@"%@", newValue]);
-        source->logger().logAlways(source->logChannel(), identifier, willChange ? "will" : "did", " change '", [keyPath UTF8String], "' to ", [valueString UTF8String]);
+        logger->logAlways(source->logChannel(), identifier, willChange ? "will" : "did", " change '", [keyPath UTF8String], "' to ", [valueString UTF8String]);
     }
 #endif
 


### PR DESCRIPTION
#### dc3d17fee381b256e4db62282bc0b29adbaab398
<pre>
[Cocoa] Address Safer CPP warnings in AVVideoCapture.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=289251">https://bugs.webkit.org/show_bug.cgi?id=289251</a>
<a href="https://rdar.apple.com/146394168">rdar://146394168</a>

Reviewed by Andy Estes.

* Source/WTF/wtf/LoggerHelper.h:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::~AVVideoCaptureSource):
(WebCore::AVVideoCaptureSource::clearSession):
(WebCore::AVVideoCaptureSource::startProducingData):
(WebCore::AVVideoCaptureSource::stopProducingData):
(WebCore::AVVideoCaptureSource::stopSession):
(WebCore::AVVideoCaptureSource::photoOutput):
(WebCore::AVVideoCaptureSource::resolvePendingPhotoRequest):
(WebCore::AVVideoCaptureSource::rejectPendingPhotoRequest):
(WebCore::AVVideoCaptureSource::takePhotoInternal):
(WebCore::AVVideoCaptureSource::facingModeFitnessScoreAdjustment const):
(WebCore::AVVideoCaptureSource::setSessionSizeFrameRateAndZoom):
(WebCore::AVVideoCaptureSource::updateWhiteBalanceMode):
(WebCore::AVVideoCaptureSource::updateTorch):
(WebCore::AVVideoCaptureSource::setupSession):
(WebCore::AVVideoCaptureSource::frameDurationForFrameRate):
(WebCore::AVVideoCaptureSource::setupCaptureSession):
(WebCore::AVVideoCaptureSource::shutdownCaptureSession):
(WebCore::AVVideoCaptureSource::orientationChanged):
(WebCore::AVVideoCaptureSource::rotationAngleForHorizonLevelDisplayChanged):
(WebCore::AVVideoCaptureSource::captureOutputDidFinishProcessingPhoto):
(WebCore::AVVideoCaptureSource::captureSessionIsRunningDidChange):
(WebCore::AVVideoCaptureSource::captureDeviceSuspendedDidChange):
(WebCore::AVVideoCaptureSource::captureSessionRuntimeError):
(WebCore::AVVideoCaptureSource::captureSessionBeginInterruption):
(WebCore::AVVideoCaptureSource::captureSessionEndInterruption):
(WebCore::AVVideoCaptureSource::deviceDisconnected):
(-[WebCoreAVVideoCaptureSourceObserver observeValueForKeyPath:ofObject:change:context:]):

Canonical link: <a href="https://commits.webkit.org/291787@main">https://commits.webkit.org/291787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7569412ab5e1b367336104b7fb214542b8fd742a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3332 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13887 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71741 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29084 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97006 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84905 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52080 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2571 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43847 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86714 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80249 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2653 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101053 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92670 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21056 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15345 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80111 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19952 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24655 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14218 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21040 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26218 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115320 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20727 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->