### PR TITLE
Nullptr crash in URLPatternUtilities::URLPatternComponent::matchSpecialSchemeProtocol

### DIFF
--- a/LayoutTests/fast/url/url-pattern-invalid-script-context-crash-expected.txt
+++ b/LayoutTests/fast/url/url-pattern-invalid-script-context-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if WebKit does not crash.
+
+

--- a/LayoutTests/fast/url/url-pattern-invalid-script-context-crash.html
+++ b/LayoutTests/fast/url/url-pattern-invalid-script-context-crash.html
@@ -1,0 +1,19 @@
+<script>
+	if (window.testRunner) {
+		testRunner.dumpAsText();
+		testRunner.waitUntilDone();
+	}
+
+	function runTest() {
+		try {
+			document.body.appendChild(frameElement);
+			let urlPattern = new URLPattern(undefined, undefined);
+		} catch {}
+	}
+
+	window.testRunner?.notifyDone();
+</script>
+<body onload="runTest()">
+	<p>This test passes if WebKit does not crash.</p>
+	<embed src="?t">
+</body>

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -80,7 +80,10 @@ bool URLPatternComponent::matchSpecialSchemeProtocol(ScriptExecutionContext& con
     JSC::JSLockHolder lock(vm);
 
     static constexpr std::array specialSchemeList { "ftp"_s, "file"_s, "http"_s, "https"_s, "ws"_s, "wss"_s };
-    auto protocolRegex = JSC::RegExpObject::create(vm, context.globalObject()->regExpStructure(), m_regularExpression.get(), true);
+    auto contextObject = context.globalObject();
+    if (!contextObject)
+        return false;
+    auto protocolRegex = JSC::RegExpObject::create(vm, contextObject->regExpStructure(), m_regularExpression.get(), true);
 
     auto isSchemeMatch = std::find_if(specialSchemeList.begin(), specialSchemeList.end(), [context = Ref { context }, &vm, &protocolRegex](const String& scheme) {
         auto maybeMatch = protocolRegex->exec(context->globalObject(), JSC::jsString(vm, scheme));
@@ -95,8 +98,11 @@ JSC::JSValue URLPatternComponent::componentExec(ScriptExecutionContext& context,
     Ref vm = context.vm();
     JSC::JSLockHolder lock(vm);
 
-    auto regex = JSC::RegExpObject::create(vm, context.globalObject()->regExpStructure(), m_regularExpression.get(), true);
-    return regex->exec(context.globalObject(), JSC::jsString(vm, comparedString));
+    auto contextObject = context.globalObject();
+    if (!contextObject)
+        return JSC::JSValue::JSFalse;
+    auto regex = JSC::RegExpObject::create(vm, contextObject->regExpStructure(), m_regularExpression.get(), true);
+    return regex->exec(contextObject, JSC::jsString(vm, comparedString));
 }
 
 // https://urlpattern.spec.whatwg.org/#create-a-component-match-result


### PR DESCRIPTION
#### 686d2e07250793712298d94b34773632e5af34b0
<pre>
Nullptr crash in URLPatternUtilities::URLPatternComponent::matchSpecialSchemeProtocol
<a href="https://bugs.webkit.org/show_bug.cgi?id=289260">https://bugs.webkit.org/show_bug.cgi?id=289260</a>
<a href="https://rdar.apple.com/145469598">rdar://145469598</a>

Reviewed by Ryosuke Niwa.

Added nullptr check for the script&apos;s context object.

* LayoutTests/fast/url/url-pattern-invalid-script-context-crash-expected.txt: Added.
* LayoutTests/fast/url/url-pattern-invalid-script-context-crash.html: Added.
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
(WebCore::URLPatternUtilities::URLPatternComponent::matchSpecialSchemeProtocol const):
(WebCore::URLPatternUtilities::URLPatternComponent::componentExec const):

Canonical link: <a href="https://commits.webkit.org/291805@main">https://commits.webkit.org/291805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bda2a2904f8f0db718fc2c04378e4075802981ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44517 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71721 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29072 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10302 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84896 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52061 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2558 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43833 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80238 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101039 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21042 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80729 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80882 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19975 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2004 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14203 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26204 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->