### PR TITLE
REGRESSION(291284@main) WebAutomationSession needs to push a command failure as soon as it gets it

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py
@@ -341,11 +341,13 @@ class CppBackendDispatcherImplementationGenerator(CppGenerator):
                     result_type_alias = 'CommandResult'
                     type_arguments = ['void']
 
+                # Immediately send an error message since this is an async response with a single error.
                 thunkLines = [
                     '[backendDispatcher = m_backendDispatcher.copyRef(), protocol_requestId](%s<%s> result) {' % (result_type_alias, ", ".join(type_arguments)),
                     '        if (!result) {',
                     '           ASSERT(!result.error().isEmpty());',
-                    '           backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, result.error());',
+                    '           backendDispatcher->reportProtocolError(protocol_requestId, BackendDispatcher::ServerError, result.error());',
+                    '           backendDispatcher->sendPendingErrors();',
                     '           return;',
                     '        }',
                 ]

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -375,7 +375,8 @@ void DatabaseBackendDispatcher::executeSQLAsyncOptionalReturnValues(long protoco
     m_agent->executeSQLAsyncOptionalReturnValues(*in_databaseId, in_query, [backendDispatcher = m_backendDispatcher.copyRef(), protocol_requestId](CommandResultOf<RefPtr<JSON::ArrayOf<String>>, String, std::optional<double>, RefPtr<JSON::Object>, RefPtr<JSON::Value>, std::optional<int>, RefPtr<Protocol::Database::Error>, std::optional<Protocol::Database::PrimaryColors>, RefPtr<Protocol::Database::ColorList>, String> result) {
         if (!result) {
            ASSERT(!result.error().isEmpty());
-           backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, result.error());
+           backendDispatcher->reportProtocolError(protocol_requestId, BackendDispatcher::ServerError, result.error());
+           backendDispatcher->sendPendingErrors();
            return;
         }
         auto [out_opt_columnNames, out_opt_notes, out_opt_timestamp, out_opt_values, out_opt_payload, out_opt_databaseId, out_opt_sqlError, out_opt_screenColor, out_opt_alternateColors, out_opt_printColor] = WTFMove(result.value());
@@ -463,7 +464,8 @@ void DatabaseBackendDispatcher::executeSQLAsync(long protocol_requestId, RefPtr<
     m_agent->executeSQLAsync(*in_databaseId, in_query, [backendDispatcher = m_backendDispatcher.copyRef(), protocol_requestId](CommandResultOf<Ref<JSON::ArrayOf<String>>, String, double, Ref<JSON::Object>, Ref<JSON::Value>, int, Ref<Protocol::Database::Error>, Protocol::Database::PrimaryColors, Ref<Protocol::Database::ColorList>, String> result) {
         if (!result) {
            ASSERT(!result.error().isEmpty());
-           backendDispatcher->reportProtocolError(BackendDispatcher::ServerError, result.error());
+           backendDispatcher->reportProtocolError(protocol_requestId, BackendDispatcher::ServerError, result.error());
+           backendDispatcher->sendPendingErrors();
            return;
         }
         auto [out_columnNames, out_notes, out_timestamp, out_values, out_payload, out_databaseId, out_sqlError, out_screenColor, out_alternateColors, out_printColor] = WTFMove(result.value());


### PR DESCRIPTION
#### cc06097b2c44c4543f1a689059eec6d32e9de6aa
<pre>
REGRESSION(291284@main) WebAutomationSession needs to push a command failure as soon as it gets it
<a href="https://bugs.webkit.org/show_bug.cgi?id=289259">https://bugs.webkit.org/show_bug.cgi?id=289259</a>

Reviewed by BJ Burg.

Ensure we flush the newly reported error as soon as we get them, to
avoid clients hanging waiting for a reply.

This aligns with the original CallbackBase::sendFailure behavior when
an error was reported.

Also make sure we report the right request id in the error.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_backend_dispatcher_implementation.py:
(CppBackendDispatcherImplementationGenerator._generate_dispatcher_implementation_for_command):
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:

Canonical link: <a href="https://commits.webkit.org/292050@main">https://commits.webkit.org/292050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86594c4f135c1617093a82699509705e91d786e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45303 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22826 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72320 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29622 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52652 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3322 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44643 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87482 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101873 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93433 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81320 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22094 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80701 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20159 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25263 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15075 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26939 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116124 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21482 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24953 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->