### PR TITLE
Regression(291671@main) unsafe cast in MicrotaskQueue::performMicrotaskCheckpoint()

### DIFF
--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -90,9 +90,26 @@ private:
 
 class MicrotaskDispatcher : public RefCounted<MicrotaskDispatcher> {
 public:
+    enum class Type : uint8_t {
+        None,
+        // WebCoreMicrotaskDispatcher starts from here.
+        JavaScript,
+        UserGestureIndicator,
+        Function,
+    };
+
+    explicit MicrotaskDispatcher(Type type)
+        : m_type(type)
+    { }
+
     virtual ~MicrotaskDispatcher() = default;
     virtual QueuedTask::Result run(QueuedTask&) = 0;
     virtual bool isRunnable() const = 0;
+    Type type() const { return m_type; }
+    bool isWebCoreMicrotaskDispatcher() const { return static_cast<uint8_t>(m_type) >= static_cast<uint8_t>(Type::JavaScript); }
+
+private:
+    Type m_type { Type::None };
 };
 
 class MarkedMicrotaskDeque {

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -78,7 +78,7 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
 
     m_microtaskQueue.performMicrotaskCheckpoint(vm,
         [&](JSC::QueuedTask& task) ALWAYS_INLINE_LAMBDA {
-            RefPtr dispatcher = static_cast<WebCoreMicrotaskDispatcher*>(task.dispatcher());
+            RefPtr dispatcher = downcast<WebCoreMicrotaskDispatcher>(task.dispatcher());
             if (UNLIKELY(!dispatcher))
                 return JSC::QueuedTask::Result::Discard;
 
@@ -88,6 +88,7 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
                 case WebCoreMicrotaskDispatcher::Type::JavaScript:
                     JSExecState::runTask(task.globalObject(), task);
                     break;
+                case WebCoreMicrotaskDispatcher::Type::None:
                 case WebCoreMicrotaskDispatcher::Type::UserGestureIndicator:
                 case WebCoreMicrotaskDispatcher::Type::Function:
                     dispatcher->run(task);

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -37,19 +37,11 @@ namespace WebCore {
 class WebCoreMicrotaskDispatcher : public JSC::MicrotaskDispatcher {
     WTF_MAKE_TZONE_ALLOCATED(WebCoreMicrotaskDispatcher);
 public:
-    enum class Type {
-        JavaScript,
-        UserGestureIndicator,
-        Function,
-    };
-
     WebCoreMicrotaskDispatcher(Type type, EventLoopTaskGroup& group)
-        : m_type(type)
+        : JSC::MicrotaskDispatcher(type)
         , m_group(group)
     {
     }
-
-    Type type() const { return m_type; }
 
     bool isRunnable() const final
     {
@@ -59,7 +51,6 @@ public:
     JSC::QueuedTask::Result currentRunnability() const;
 
 private:
-    Type m_type { Type::JavaScript };
     WeakPtr<EventLoopTaskGroup> m_group;
 };
 
@@ -90,3 +81,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::WebCoreMicrotaskDispatcher)
+    static bool isType(const JSC::MicrotaskDispatcher& dispatcher) { return dispatcher.isWebCoreMicrotaskDispatcher(); }
+SPECIALIZE_TYPE_TRAITS_END()


### PR DESCRIPTION
#### 895c874d3ff658c0bc36e89f946171db399ce1ca
<pre>
Regression(291671@main) unsafe cast in MicrotaskQueue::performMicrotaskCheckpoint()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289249">https://bugs.webkit.org/show_bug.cgi?id=289249</a>
<a href="https://rdar.apple.com/146400842">rdar://146400842</a>

Reviewed by Chris Dumez, Ryosuke Niwa, and Geoffrey Garen.

Suppress static analyzer&apos;s warning by adding typeId and cast helper.

* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::MicrotaskDispatcher::MicrotaskDispatcher):
(JSC::MicrotaskDispatcher::type const):
(JSC::MicrotaskDispatcher::isWebCoreMicrotaskDispatcher const):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/Microtasks.h:
(WebCore::WebCoreMicrotaskDispatcher::WebCoreMicrotaskDispatcher):
(isType):
(WebCore::WebCoreMicrotaskDispatcher::type const): Deleted.

Canonical link: <a href="https://commits.webkit.org/291735@main">https://commits.webkit.org/291735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a89042723c9cc659469bb21b74a800ab23843aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98811 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44331 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13675 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71600 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28968 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84766 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51935 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2401 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43646 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86515 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80123 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100846 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92471 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15214 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80612 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79956 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/19911 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24504 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1865 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14014 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15054 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20841 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115121 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20528 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/23988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22269 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->