### PR TITLE
More smart pointer adoption in UIProcess [v2]

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticatorResponse.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorResponse.cpp
@@ -67,11 +67,6 @@ AuthenticatorResponseData AuthenticatorResponse::data() const
     return data;
 }
 
-ArrayBuffer* AuthenticatorResponse::rawId() const
-{
-    return m_rawId.ptr();
-}
-
 void AuthenticatorResponse::setExtensions(AuthenticationExtensionsClientOutputs&& extensions)
 {
     m_extensions = WTFMove(extensions);

--- a/Source/WebCore/Modules/webauthn/AuthenticatorResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorResponse.h
@@ -52,7 +52,8 @@ public:
     virtual Type type() const = 0;
     virtual AuthenticatorResponseData data() const;
 
-    WEBCORE_EXPORT ArrayBuffer* rawId() const;
+    ArrayBuffer* rawId() const { return m_rawId.ptr(); }
+
     WEBCORE_EXPORT void setExtensions(AuthenticationExtensionsClientOutputs&&);
     WEBCORE_EXPORT AuthenticationExtensionsClientOutputs extensions() const;
     WEBCORE_EXPORT void setClientDataJSON(Ref<ArrayBuffer>&&);

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -25,10 +25,6 @@ Shared/Cocoa/WKNSString.mm
 Shared/Cocoa/WKNSURL.mm
 Shared/RemoteLayerTree/RemoteLayerWithInProcessRenderingBackingStore.mm
 Shared/RemoteLayerTree/RemoteLayerWithRemoteRenderingBackingStore.mm
-UIProcess/API/APINavigationClient.h
-UIProcess/API/APIPageConfiguration.cpp
-UIProcess/API/APIWebAuthenticationAssertionResponse.cpp
-UIProcess/API/APIWebAuthenticationAssertionResponse.h
 UIProcess/API/C/WKAuthenticationChallenge.cpp
 UIProcess/API/C/WKAuthenticationDecisionListener.cpp
 UIProcess/API/C/WKBackForwardListRef.cpp
@@ -116,10 +112,17 @@ UIProcess/API/Cocoa/_WKUserStyleSheet.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
 UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm
 UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
-UIProcess/BackgroundProcessResponsivenessTimer.cpp
-UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
 UIProcess/Cocoa/LegacyDownloadClient.mm
+<<<<<<< HEAD
 UIProcess/Cocoa/ModelElementControllerCocoa.mm
+=======
+UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
+UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+UIProcess/Cocoa/WKEditCommand.mm
+>>>>>>> db92893ddd84 (More smart pointer adoption in UIProcess [v2])
 UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm

--- a/Source/WebKit/UIProcess/API/APINavigationClient.h
+++ b/Source/WebKit/UIProcess/API/APINavigationClient.h
@@ -107,7 +107,7 @@ public:
     virtual void navigationActionDidBecomeDownload(WebKit::WebPageProxy&, NavigationAction&, WebKit::DownloadProxy&) { }
     virtual void contextMenuDidCreateDownload(WebKit::WebPageProxy&, WebKit::DownloadProxy&) { }
 
-    virtual void didReceiveAuthenticationChallenge(WebKit::WebPageProxy&, WebKit::AuthenticationChallengeProxy& challenge) { challenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::PerformDefaultHandling); }
+    virtual void didReceiveAuthenticationChallenge(WebKit::WebPageProxy&, WebKit::AuthenticationChallengeProxy& challenge) { challenge.protectedListener()->completeChallenge(WebKit::AuthenticationChallengeDisposition::PerformDefaultHandling); }
     virtual void shouldAllowLegacyTLS(WebKit::WebPageProxy&, WebKit::AuthenticationChallengeProxy&, CompletionHandler<void(bool)>&& completionHandler) { completionHandler(true); }
     virtual void didNegotiateModernTLS(const WTF::URL&) { }
     virtual bool shouldBypassContentModeSafeguards() const { return false; }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -377,7 +377,7 @@ void PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebPr
 
 bool PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() const
 {
-    if (preferences().siteIsolationEnabled())
+    if (protectedPreferences()->siteIsolationEnabled())
         return true;
     if (RefPtr processPool = m_data.processPool.getIfExists(); processPool && isInspectorProcessPool(*processPool)) {
         // Never delay process launch for inspector pages as inspector pages do not know how to transition from a terminated process.
@@ -428,7 +428,7 @@ bool PageConfiguration::applePayEnabled() const
     if (auto applePayEnabledOverride = m_data.applePayEnabledOverride)
         return *applePayEnabledOverride;
 
-    return preferences().applePayEnabled();
+    return protectedPreferences()->applePayEnabled();
 }
 
 void PageConfiguration::setApplePayEnabled(bool enabled)

--- a/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
+++ b/Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h
@@ -55,7 +55,7 @@ public:
 private:
     WebAuthenticationAssertionResponse(Ref<WebCore::AuthenticatorAssertionResponse>&&);
 
-    Ref<WebCore::AuthenticatorAssertionResponse> m_response;
+    const Ref<WebCore::AuthenticatorAssertionResponse> m_response;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -495,7 +495,7 @@ static NSMutableArray<NSURL *> *readOnlyAccessPaths()
 
         contentNavigation = loadWebContent(webView.get());
         if (!finished)
-            attributedStringActivity = [webView _page]->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("NSAttributedString serialization"_s);
+            attributedStringActivity = [webView _page]->protectedLegacyMainFrameProcess()->protectedThrottler()->foregroundActivity("NSAttributedString serialization"_s);
 
         ASSERT(contentNavigation);
         ASSERT(webView.get().loading);

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -348,7 +348,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
         return;
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
-    m_lifetimeActivity = throttler().foregroundActivity("Lifetime Activity"_s);
+    m_lifetimeActivity = protectedThrottler()->foregroundActivity("Lifetime Activity"_s);
     m_boostedJetsamAssertion = ProcessAssertion::create(*this, "Jetsam Boost"_s, ProcessAssertionType::BoostedJetsam);
 #endif
 
@@ -398,7 +398,7 @@ void AuxiliaryProcessProxy::wakeUpTemporarilyForIPC()
     // If we keep trying to send IPC to a suspended process, the outgoing message queue may grow large and result
     // in increased memory usage. To avoid this, we allow the process to stay alive for 1 second after draining
     // its message queue.
-    auto completionHandler = [activity = throttler().backgroundActivity("IPC sending due to large outgoing queue"_s)]() mutable {
+    auto completionHandler = [activity = protectedThrottler()->backgroundActivity("IPC sending due to large outgoing queue"_s)]() mutable {
         RunLoop::protectedMain()->dispatchAfter(1_s, [activity = WTFMove(activity)]() { });
     };
     sendWithAsyncReply(Messages::AuxiliaryProcess::MainThreadPing(), WTFMove(completionHandler), 0, { }, ShouldStartProcessThrottlerActivity::No);

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp
@@ -115,7 +115,7 @@ void BackgroundProcessResponsivenessTimer::timeoutTimerFired()
     if (!m_isResponsive)
         return;
 
-    if (!client().mayBecomeUnresponsive())
+    if (!protectedClient()->mayBecomeUnresponsive())
         return;
 
     setResponsive(false);
@@ -126,18 +126,18 @@ void BackgroundProcessResponsivenessTimer::setResponsive(bool isResponsive)
     if (m_isResponsive == isResponsive)
         return;
 
-    Ref protectedClient { client() };
+    Ref client = this->client();
 
-    client().willChangeIsResponsive();
+    client->willChangeIsResponsive();
     m_isResponsive = isResponsive;
-    client().didChangeIsResponsive();
+    client->didChangeIsResponsive();
 
     if (m_isResponsive) {
         RELEASE_LOG_ERROR(PerformanceLogging, "Notifying the client that background WebProcess with pid %d has become responsive again", m_webProcessProxy->processID());
-        client().didBecomeResponsive();
+        client->didBecomeResponsive();
     } else {
         RELEASE_LOG_ERROR(PerformanceLogging, "Notifying the client that background WebProcess with pid %d has become unresponsive", m_webProcessProxy->processID());
-        client().didBecomeUnresponsive();
+        client->didBecomeUnresponsive();
     }
 }
 

--- a/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
+++ b/Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h
@@ -58,6 +58,7 @@ private:
     bool isActive() const;
     void scheduleNextResponsivenessCheck();
     ResponsivenessTimer::Client& client() const;
+    Ref<ResponsivenessTimer::Client> protectedClient() const { return client(); }
 
     WeakRef<WebProcessProxy> m_webProcessProxy;
     Seconds m_checkingInterval;

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h
@@ -73,7 +73,7 @@ private:
     void playbackStateChanged(WebCore::MediaSessionPlaybackState) final;
     void trackIdentifierChanged(const String&) final;
 
-    Ref<GroupActivitiesSession> m_session;
+    const Ref<GroupActivitiesSession> m_session;
     RetainPtr<WKGroupActivitiesCoordinatorDelegate> m_delegate;
     RetainPtr<AVDelegatingPlaybackCoordinator> m_playbackCoordinator;
 

--- a/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
@@ -55,19 +55,21 @@
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePlayCommand:(AVDelegatingPlaybackCoordinatorPlayCommand *)playCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (_parent) {
-            _parent->issuePlayCommand(playCommand, [completionHandler = makeBlockPtr(completionHandler)] {
-                completionHandler();
-            });
-        }
+        RefPtr parent = _parent.get();
+        if (!parent)
+            return;
+        parent->issuePlayCommand(playCommand, [completionHandler = makeBlockPtr(completionHandler)] {
+            completionHandler();
+        });
     });
 }
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePauseCommand:(AVDelegatingPlaybackCoordinatorPauseCommand *)pauseCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (!_parent)
+        RefPtr parent = _parent.get();
+        if (!parent)
             return;
-        _parent->issuePauseCommand(pauseCommand, [completionHandler = makeBlockPtr(completionHandler)] {
+        parent->issuePauseCommand(pauseCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });
     });
@@ -75,9 +77,10 @@
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssueSeekCommand:(AVDelegatingPlaybackCoordinatorSeekCommand *)seekCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (!_parent)
+        RefPtr parent = _parent.get();
+        if (!parent)
             return;
-        _parent->issueSeekCommand(seekCommand, [completionHandler = makeBlockPtr(completionHandler)] {
+        parent->issueSeekCommand(seekCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });
     });
@@ -85,9 +88,10 @@
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssueBufferingCommand:(AVDelegatingPlaybackCoordinatorBufferingCommand *)bufferingCommand completionHandler:(void (^)(void))completionHandler {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (!_parent)
+        RefPtr parent = _parent.get();
+        if (!parent)
             return;
-        _parent->issueBufferingCommand(bufferingCommand, [completionHandler = makeBlockPtr(completionHandler)] {
+        parent->issueBufferingCommand(bufferingCommand, [completionHandler = makeBlockPtr(completionHandler)] {
             completionHandler();
         });
     });
@@ -95,8 +99,10 @@
 
 -(void)playbackCoordinator:(AVDelegatingPlaybackCoordinator *)coordinator didIssuePrepareTransitionCommand:(AVDelegatingPlaybackCoordinatorPrepareTransitionCommand *)prepareTransitionCommand {
     dispatch_async(dispatch_get_main_queue(), ^{
-        if (_parent)
-            _parent->issuePrepareTransitionCommand(prepareTransitionCommand);
+        RefPtr parent = _parent.get();
+        if (!parent)
+            return;
+        parent->issuePrepareTransitionCommand(prepareTransitionCommand);
     });
 }
 @end

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -105,18 +105,18 @@ void LegacyDownloadClient::didReceiveAuthenticationChallenge(DownloadProxy& down
         checker->didCallCompletionHandler();
         switch (disposition) {
         case NSURLSessionAuthChallengeUseCredential:
-            authenticationChallenge->listener().completeChallenge(AuthenticationChallengeDisposition::UseCredential, credential ? WebCore::Credential(credential) : WebCore::Credential());
+            authenticationChallenge->protectedListener()->completeChallenge(AuthenticationChallengeDisposition::UseCredential, credential ? WebCore::Credential(credential) : WebCore::Credential());
             break;
         case NSURLSessionAuthChallengePerformDefaultHandling:
-            authenticationChallenge->listener().completeChallenge(AuthenticationChallengeDisposition::PerformDefaultHandling);
+            authenticationChallenge->protectedListener()->completeChallenge(AuthenticationChallengeDisposition::PerformDefaultHandling);
             break;
             
         case NSURLSessionAuthChallengeCancelAuthenticationChallenge:
-            authenticationChallenge->listener().completeChallenge(AuthenticationChallengeDisposition::Cancel);
+            authenticationChallenge->protectedListener()->completeChallenge(AuthenticationChallengeDisposition::Cancel);
             break;
             
         case NSURLSessionAuthChallengeRejectProtectionSpace:
-            authenticationChallenge->listener().completeChallenge(AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
+            authenticationChallenge->protectedListener()->completeChallenge(AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
             break;
             
         default:

--- a/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm
@@ -65,7 +65,7 @@ namespace WebKit {
 WKModelView * ModelElementController::modelViewForModelIdentifier(ModelIdentifier modelIdentifier)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->preferences().modelElementEnabled())
+    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled())
         return nil;
 
     auto* proxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(webPageProxy->drawingArea());
@@ -155,7 +155,7 @@ void ModelElementController::setInteractionEnabledForModelElement(ModelIdentifie
 ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdentifier modelIdentifier)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->preferences().modelElementEnabled())
+    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled())
         return nullptr;
 
     return m_inlinePreviews.get(modelIdentifier.uuid).get();
@@ -164,7 +164,7 @@ ASVInlinePreview * ModelElementController::previewForModelIdentifier(ModelIdenti
 void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCore::FloatSize size, CompletionHandler<void(Expected<std::pair<String, uint32_t>, WebCore::ResourceError>)>&& completionHandler)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->preferences().modelElementEnabled()) {
+    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled()) {
         completionHandler(makeUnexpected(WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Model element disabled"_s }));
         return;
     }
@@ -213,7 +213,7 @@ void ModelElementController::modelElementCreateRemotePreview(String uuid, WebCor
 void ModelElementController::modelElementLoadRemotePreview(String uuid, URL fileURL, CompletionHandler<void(std::optional<WebCore::ResourceError>&&)>&& completionHandler)
 {
     RefPtr webPageProxy = m_webPageProxy.get();
-    if (!webPageProxy || !webPageProxy->preferences().modelElementEnabled()) {
+    if (!webPageProxy || !webPageProxy->protectedPreferences()->modelElementEnabled()) {
         completionHandler(WebCore::ResourceError { WebCore::errorDomainWebKitInternal, 0, { }, "Model element disabled"_s });
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -1611,7 +1611,7 @@ void NavigationState::didChangeIsLoading()
         }
         if (!m_networkActivity) {
             RELEASE_LOG(ProcessSuspension, "%p - NavigationState is taking a process network assertion because a page load started", this);
-            m_networkActivity = webView->_page->legacyMainFrameProcess().throttler().backgroundActivity("Page Load"_s);
+            m_networkActivity = webView->_page->legacyMainFrameProcess().protectedThrottler()->backgroundActivity("Page Load"_s);
         }
     } else if (m_networkActivity) {
         // The application is visible so we delay releasing the background activity for 3 seconds to give it a chance to start another navigation
@@ -1744,7 +1744,7 @@ void NavigationState::didSwapWebProcesses()
     // Transfer our background assertion from the old process to the new one.
     auto webView = this->webView();
     if (m_networkActivity && webView)
-        m_networkActivity = webView->_page->legacyMainFrameProcess().throttler().backgroundActivity("Page Load"_s);
+        m_networkActivity = webView->_page->legacyMainFrameProcess().protectedThrottler()->backgroundActivity("Page Load"_s);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm
@@ -579,7 +579,7 @@ void SystemPreviewController::takeActivityToken()
     if (!page)
         return;
 
-    m_activity = page->legacyMainFrameProcess().throttler().backgroundActivity("System preview download"_s);
+    m_activity = page->legacyMainFrameProcess().protectedThrottler()->backgroundActivity("System preview download"_s);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1235,7 +1235,7 @@ void WebProcessPool::setProcessesShouldSuspend(bool shouldSuspend)
 
     m_processesShouldSuspend = shouldSuspend;
     for (auto& process : m_processes) {
-        process->throttler().setAllowsActivities(!m_processesShouldSuspend);
+        process->protectedThrottler()->setAllowsActivities(!m_processesShouldSuspend);
 
 #if ENABLE(WEBXR) && !USE(OPENXR)
         if (!m_processesShouldSuspend) {

--- a/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp
@@ -273,12 +273,12 @@ void ModelProcessProxy::updateProcessAssertion()
 
     if (hasAnyForegroundWebProcesses) {
         if (!ProcessThrottler::isValidForegroundActivity(m_activityFromWebProcesses.get()))
-            m_activityFromWebProcesses = throttler().foregroundActivity("Model for foreground view(s)"_s);
+            m_activityFromWebProcesses = protectedThrottler()->foregroundActivity("Model for foreground view(s)"_s);
         return;
     }
     if (hasAnyBackgroundWebProcesses) {
         if (!ProcessThrottler::isValidBackgroundActivity(m_activityFromWebProcesses.get()))
-            m_activityFromWebProcesses = throttler().backgroundActivity("Model for background view(s)"_s);
+            m_activityFromWebProcesses = protectedThrottler()->backgroundActivity("Model for background view(s)"_s);
         return;
     }
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -87,7 +87,7 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
     , m_isProcessSwappingForNewWindow(page.protectedPreferences()->siteIsolationEnabled() && page.openedByDOM())
     , m_provisionalLoadURL(isProcessSwappingOnNavigationResponse ? request.url() : URL())
 #if USE(RUNNINGBOARD)
-    , m_provisionalLoadActivity(m_frameProcess->process().throttler().foregroundActivity("Provisional Load"_s))
+    , m_provisionalLoadActivity(m_frameProcess->process().protectedThrottler()->foregroundActivity("Provisional Load"_s))
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     , m_contextIDForVisibilityPropagationInWebProcess(suspendedPage ? suspendedPage->contextIDForVisibilityPropagationInWebProcess() : 0)

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -121,7 +121,7 @@ SuspendedPageProxy::SuspendedPageProxy(WebPageProxy& page, Ref<WebProcessProxy>&
     , m_shouldDelayClosingUntilFirstLayerFlush(shouldDelayClosingUntilFirstLayerFlush)
     , m_suspensionTimeoutTimer(RunLoop::main(), this, &SuspendedPageProxy::suspensionTimedOut)
 #if USE(RUNNINGBOARD)
-    , m_suspensionActivity(m_process->throttler().backgroundActivity("Page suspension for back/forward cache"_s))
+    , m_suspensionActivity(m_process->protectedThrottler()->backgroundActivity("Page suspension for back/forward cache"_s))
 #endif
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     , m_contextIDForVisibilityPropagationInWebProcess(page.contextIDForVisibilityPropagationInWebProcess())

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6194,7 +6194,7 @@ void WebPageProxy::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& p
     RefPtr<ProcessThrottler::Activity> activity;
 #if USE(RUNNINGBOARD)
     if (RefPtr pageClient = this->pageClient(); pageClient && pageClient->canTakeForegroundAssertions())
-        activity = m_legacyMainFrameProcess->throttler().foregroundActivity("WebPageProxy::runJavaScriptInFrameInScriptWorld"_s);
+        activity = m_legacyMainFrameProcess->protectedThrottler()->foregroundActivity("WebPageProxy::runJavaScriptInFrameInScriptWorld"_s);
 #endif
 
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::RunJavaScriptInFrameInScriptWorld(parameters, frameID, world.worldData(), wantsResult), [activity = WTFMove(activity), callbackFunction = WTFMove(callbackFunction)] (auto&& result) mutable {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -2558,7 +2558,7 @@ void WebProcessProxy::startBackgroundActivityForFullscreenInput()
     if (m_backgroundActivityForFullscreenFormControls)
         return;
 
-    m_backgroundActivityForFullscreenFormControls = throttler().backgroundActivity("Fullscreen input"_s);
+    m_backgroundActivityForFullscreenFormControls = protectedThrottler()->backgroundActivity("Fullscreen input"_s);
     WEBPROCESSPROXY_RELEASE_LOG(ProcessSuspension, "startBackgroundActivityForFullscreenInput: UIProcess is taking a background assertion because it is presenting fullscreen UI for form controls.");
 }
 

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -94,7 +94,7 @@ void PlatformXRSystem::ensureImmersiveSessionActivity()
     if (m_immersiveSessionActivity && m_immersiveSessionActivity->isValid())
         return;
 
-    m_immersiveSessionActivity = page->protectedLegacyMainFrameProcess()->throttler().foregroundActivity("XR immersive session"_s);
+    m_immersiveSessionActivity = page->protectedLegacyMainFrameProcess()->protectedThrottler()->foregroundActivity("XR immersive session"_s);
 }
 
 void PlatformXRSystem::enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -431,7 +431,7 @@ void WebPageProxy::selectTextWithGranularityAtPoint(const WebCore::IntPoint poin
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -443,7 +443,7 @@ void WebPageProxy::selectPositionAtBoundaryWithDirection(const WebCore::IntPoint
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtBoundaryWithDirection(point, granularity, direction, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::selectPositionAtBoundaryWithDirection"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtBoundaryWithDirection(point, granularity, direction, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::selectPositionAtBoundaryWithDirection"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -455,7 +455,7 @@ void WebPageProxy::moveSelectionAtBoundaryWithDirection(WebCore::TextGranularity
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionAtBoundaryWithDirection(granularity, direction), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::moveSelectionAtBoundaryWithDirection"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionAtBoundaryWithDirection(granularity, direction), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::moveSelectionAtBoundaryWithDirection"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -467,7 +467,7 @@ void WebPageProxy::selectPositionAtPoint(const WebCore::IntPoint point, bool isI
         return;
     }
 
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtPoint(point, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::selectPositionAtPoint"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::SelectPositionAtPoint(point, isInteractingWithFocusedElement), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::selectPositionAtPoint"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -739,7 +739,7 @@ void WebPageProxy::moveSelectionByOffset(int32_t offset, CompletionHandler<void(
         return;
     }
     
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionByOffset(offset), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::moveSelectionByOffset"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::MoveSelectionByOffset(offset), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::moveSelectionByOffset"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }
@@ -1061,7 +1061,7 @@ void WebPageProxy::focusNextFocusedElement(bool isForward, CompletionHandler<voi
         return;
     }
     
-    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::FocusNextFocusedElement(isForward), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->throttler().backgroundActivity("WebPageProxy::focusNextFocusedElement"_s)] () mutable {
+    legacyMainFrameProcess().sendWithAsyncReply(Messages::WebPage::FocusNextFocusedElement(isForward), [callbackFunction = WTFMove(callbackFunction), backgroundActivity = m_legacyMainFrameProcess->protectedThrottler()->backgroundActivity("WebPageProxy::focusNextFocusedElement"_s)] () mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }


### PR DESCRIPTION
#### be09b6a1bf9e1b24781f7469b59c6381c293d024
<pre>
More smart pointer adoption in UIProcess [v2]
<a href="https://bugs.webkit.org/show_bug.cgi?id=289261">https://bugs.webkit.org/show_bug.cgi?id=289261</a>
<a href="https://rdar.apple.com/146401922">rdar://146401922</a>

Reviewed by Chris Dumez.

Identified by static analysis.

* Source/JavaScriptCore/runtime/MicrotaskQueue.h:
(JSC::MicrotaskDispatcher::isWebCoreMicrotaskDispatcher const):
* Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp:
(WebCore::YouTubePluginReplacement::createElementRenderer):
* Source/WebCore/Modules/webauthn/AuthenticatorResponse.cpp:
(WebCore::AuthenticatorResponse::rawId const): Deleted.
* Source/WebCore/Modules/webauthn/AuthenticatorResponse.h:
(WebCore::AuthenticatorResponse::rawId const):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/dom/Microtasks.h:
(isType):
* Source/WebKit/UIProcess/API/APINavigationClient.h:
(API::NavigationClient::didReceiveAuthenticationChallenge):
* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::delaysWebProcessLaunchUntilFirstLoad const):
(API::PageConfiguration::applePayEnabled const):
* Source/WebKit/UIProcess/API/APIWebAuthenticationAssertionResponse.h:
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(+[NSAttributedString _loadFromHTMLWithOptions:contentLoader:completionHandler:]):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
(WebKit::AuxiliaryProcessProxy::wakeUpTemporarilyForIPC):
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.cpp:
(WebKit::BackgroundProcessResponsivenessTimer::timeoutTimerFired):
(WebKit::BackgroundProcessResponsivenessTimer::setResponsive):
* Source/WebKit/UIProcess/BackgroundProcessResponsivenessTimer.h:
(WebKit::BackgroundProcessResponsivenessTimer::protectedClient const):
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.h:
* Source/WebKit/UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm:
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePlayCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePauseCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssueSeekCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssueBufferingCommand:completionHandler:]):
(-[WKGroupActivitiesCoordinatorDelegate playbackCoordinator:didIssuePrepareTransitionCommand:]):
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::didReceiveAuthenticationChallenge):
* Source/WebKit/UIProcess/Cocoa/ModelElementControllerCocoa.mm:
(WebKit::ModelElementController::modelViewForModelIdentifier):
(WebKit::ModelElementController::previewForModelIdentifier):
(WebKit::ModelElementController::modelElementCreateRemotePreview):
(WebKit::ModelElementController::modelElementLoadRemotePreview):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::didChangeIsLoading):
(WebKit::NavigationState::didSwapWebProcesses):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
(WebKit::NavigationSOAuthorizationSession::~NavigationSOAuthorizationSession):
* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::setProcessesShouldSuspend):
* Source/WebKit/UIProcess/Model/ModelProcessProxy.cpp:
(WebKit::ModelProcessProxy::updateProcessAssertion):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::SuspendedPageProxy):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::runJavaScriptInFrameInScriptWorld):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::startBackgroundActivityForFullscreenInput):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::selectTextWithGranularityAtPoint):
(WebKit::WebPageProxy::selectPositionAtBoundaryWithDirection):
(WebKit::WebPageProxy::moveSelectionAtBoundaryWithDirection):
(WebKit::WebPageProxy::selectPositionAtPoint):
(WebKit::WebPageProxy::moveSelectionByOffset):
(WebKit::WebPageProxy::focusNextFocusedElement):

Canonical link: <a href="https://commits.webkit.org/291911@main">https://commits.webkit.org/291911@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f9b28de74892df3f7290012729b9995153afac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96405 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22375 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/29345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97357 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52342 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2891 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44203 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101418 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21410 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81217 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80387 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24933 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14637 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15143 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21393 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21081 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24542 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22822 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->