### PR TITLE
[iOS] The highlight selection box of multi-column extends to unselected content

### DIFF
--- a/LayoutTests/editing/selection/ios/select-content-from-multicolumn-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-from-multicolumn-expected.txt
@@ -1,0 +1,15 @@
+When selecting content crossing multi columns, the highlight box of each column should not be coalesced.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 4
+PASS 150 is > selectionRects[0].width
+PASS selectionRects[1].width is 150
+PASS selectionRects[2].width is 150
+PASS 150 is > selectionRects[3].width
+PASS secondColumnLeft is > firstColumnRight
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Start. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula. End.

--- a/LayoutTests/editing/selection/ios/select-content-from-multicolumn.html
+++ b/LayoutTests/editing/selection/ios/select-content-from-multicolumn.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #container {
+        font-size: 16px;
+        width: 310px;
+    }
+</style>
+<script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("When selecting content crossing multi columns, the highlight box of each column should not be coalesced.");
+
+        var content = document.getElementById("content");
+        await UIHelper.longPressElement(content);
+        await UIHelper.waitForSelectionToAppear();
+        getSelection().selectAllChildren(content);
+        await UIHelper.waitForSelectionToAppear();
+        selectionRects = await UIHelper.getUISelectionViewRects();
+
+        if (selectionRects.length != 4) {
+            testFailed(`selectionRects.length should be 4, but got ${selectionRects.length}`);
+            finishJSTest();
+            return;
+        }
+        testPassed(`selectionRects.length is ${selectionRects.length}`);
+
+        // The highlight box does not extend to unselected content: "Start.".
+        shouldBeGreaterThan("150", "selectionRects[0].width");
+        shouldBe("selectionRects[1].width", "150");
+        shouldBe("selectionRects[2].width", "150");
+        // The highlight box does not extend to unselected content: "End."
+        shouldBeGreaterThan("150", "selectionRects[3].width");
+
+        firstColumnRight = selectionRects[0].left + selectionRects[0].width;
+        secondColumnLeft = selectionRects[3].left;
+        shouldBeGreaterThan("secondColumnLeft", "firstColumnRight");
+
+        finishJSTest();
+    });
+</script>
+</head>
+
+<body>
+    <div id="container">
+        <div style="column-count: 2; column-gap: 10px;">Start. <span id="content">Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.</span> End.</div>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-002-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-002-expected.txt
@@ -1,0 +1,15 @@
+When selecting multi-column content and others, the highlight box should not extend to the unselected column.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 4
+PASS 150 is > selectionRects[0].width
+PASS selectionRects[1].width is 150
+PASS selectionRects[2].width is 310
+PASS 310 is > selectionRects[3].width
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula. Here is the selected content at the end of multi-column.
+Here is the selected content outside of the multi-column element.

--- a/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-002.html
+++ b/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-002.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        #container {
+            font-size: 16px;
+            width: 310px;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        addEventListener("load", async () => {
+            description("When selecting multi-column content and others, the highlight box should not extend to the unselected column.");
+
+            var outside = document.getElementById("outside");
+            var inside = document.getElementById("inside");
+            await UIHelper.longPressElement(inside);
+            await UIHelper.waitForSelectionToAppear();
+
+            getSelection().setBaseAndExtent(inside, 0, outside, 1);
+            await UIHelper.ensurePresentationUpdate();
+
+            selectionRects = await UIHelper.getUISelectionViewRects();
+
+            if (selectionRects.length != 4) {
+                testFailed(`The value of selectionRects.length should be 4, but got ${selectionRects.length}`);
+                finishJSTest();
+                return;
+            }
+            testPassed(`selectionRects.length is ${selectionRects.length}`);
+
+            shouldBeGreaterThan("150", "selectionRects[0].width");
+            // The highlight box does not extend to unselected column.
+            shouldBe("selectionRects[1].width", "150");
+            shouldBe("selectionRects[2].width", "310");
+            shouldBeGreaterThan("310", "selectionRects[3].width");
+
+            finishJSTest();
+        });
+    </script>
+</head>
+
+<body>
+    <div id="container">
+        <div style="column-count: 2; column-gap: 10px;">Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.
+            <span id="inside">Here is the selected content at the end of multi-column.</span>
+        </div>
+        <p id="outside">Here is the selected content outside of the multi-column element.</p>
+    </div>
+</body>
+
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-expected.txt
@@ -1,0 +1,16 @@
+When selecting multi-column content and others, the highlight boxes should not be coalesced.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 5
+PASS selectionRects[0].width is 150
+PASS selectionRects[1].width is 150
+PASS selectionRects[2].width is 150
+PASS selectionRects[3].width is 310
+PASS outsideContentLineTop is > lastMultiColumnLineBottom
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.
+The selected content out of the multi-column element.

--- a/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn.html
+++ b/LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #container {
+        font-size: 16px;
+        width: 310px;
+    }
+</style>
+<script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("When selecting multi-column content and others, the highlight boxes should not be coalesced.");
+
+        var container = document.getElementById("container");
+        await UIHelper.longPressElement(container);
+        await UIHelper.waitForSelectionToAppear();
+        getSelection().selectAllChildren(container);
+        await UIHelper.waitForSelectionToAppear();
+        selectionRects = await UIHelper.getUISelectionViewRects();
+
+        if (selectionRects.length != 5) {
+            testFailed(`The value of selectionRects.length should be 5, but got ${selectionRects.length}`);
+            finishJSTest();
+            return;
+        }
+        testPassed(`selectionRects.length is ${selectionRects.length}`);
+
+        shouldBe("selectionRects[0].width", "150");
+        shouldBe("selectionRects[1].width", "150");
+        shouldBe("selectionRects[2].width", "150");
+        shouldBe("selectionRects[3].width", "310");
+
+        lastMultiColumnLineBottom = selectionRects[2].top + selectionRects[2].height;
+        outsideContentLineTop = selectionRects[3].top;
+        shouldBeGreaterThan("outsideContentLineTop", "lastMultiColumnLineBottom");
+
+        finishJSTest();
+    });
+</script>
+</head>
+
+<body>
+    <div id="container">
+        <div style="column-count: 2; column-gap: 10px;">Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit.Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.</div>
+        <p id="outside">The selected content out of the multi-column element.</p>
+    </div>
+</body>
+</html>

--- a/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-002-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-002-expected.txt
@@ -1,0 +1,16 @@
+When selecting content outside and inside multi-column, the highlight box should not extend to the unselected column.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 4
+PASS selectionRects[0].width is 310
+PASS selectionRects[1].width is 310
+PASS selectionRects[2].width is 150
+PASS 150 is > selectionRects[3].width
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Here is the selected content outside of the multi-column element.
+
+Here is the selected content at the beginning of multi-column. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.

--- a/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-002.html
+++ b/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-002.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        #container {
+            font-size: 16px;
+            width: 310px;
+        }
+    </style>
+    <script>
+        jsTestIsAsync = true;
+
+        addEventListener("load", async () => {
+            description("When selecting content outside and inside multi-column, the highlight box should not extend to the unselected column.");
+
+            var outside = document.getElementById("outside");
+            var inside = document.getElementById("inside");
+            await UIHelper.longPressElement(outside);
+            await UIHelper.waitForSelectionToAppear();
+
+            getSelection().setBaseAndExtent(outside, 0, inside, 1);
+            await UIHelper.ensurePresentationUpdate();
+
+            selectionRects = await UIHelper.getUISelectionViewRects();
+
+            if (selectionRects.length != 4) {
+                testFailed(`The value of selectionRects.length should be 4, but got ${selectionRects.length}`);
+                finishJSTest();
+                return;
+            }
+            testPassed(`selectionRects.length is ${selectionRects.length}`);
+
+            shouldBe("selectionRects[0].width", "310");
+            shouldBe("selectionRects[1].width", "310");
+            // The highlight box does not extend to the second column.
+            shouldBe("selectionRects[2].width", "150");
+            shouldBeGreaterThan("150", "selectionRects[3].width");
+
+            finishJSTest();
+        });
+    </script>
+</head>
+
+<body>
+    <div id="container">
+        <p id="outside">Here is the selected content outside of the multi-column element.</p>
+        <div style="column-count: 2; column-gap: 10px;"><span id="inside">Here is the selected content at the beginning of multi-column.</span> Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.</div>
+    </div>
+</body>
+
+</html>
+
+

--- a/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-expected.txt
+++ b/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-expected.txt
@@ -1,0 +1,18 @@
+When selecting content outside and inside multi-column, the highlight boxes should not be coalesced.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectionRects.length is 5
+PASS selectionRects[0].width is 310
+PASS selectionRects[1].width is 310
+PASS selectionRects[2].width is 150
+PASS selectionRects[3].width is 150
+PASS 150 is > selectionRects[4].width
+PASS firstMultiColumnLineTop is > outsideContentLineBottom
+PASS successfullyParsed is true
+
+TEST COMPLETE
+The selected content outside of the multi-column element.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.

--- a/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn.html
+++ b/LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+<meta charset="utf-8">
+
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #container {
+        font-size: 16px;
+        width: 310px;
+    }
+</style>
+<script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        description("When selecting content outside and inside multi-column, the highlight boxes should not be coalesced.");
+
+        var container = document.getElementById("container");
+        await UIHelper.longPressElement(container);
+        await UIHelper.waitForSelectionToAppear();
+        getSelection().selectAllChildren(container);
+        await UIHelper.waitForSelectionToAppear();
+        selectionRects = await UIHelper.getUISelectionViewRects();
+
+        if (selectionRects.length != 5) {
+            testFailed(`The value of selectionRects.length should be 5, but got ${selectionRects.length}`);
+            finishJSTest();
+            return;
+        }
+        testPassed(`selectionRects.length is ${selectionRects.length}`);
+
+        shouldBe("selectionRects[0].width", "310");
+        shouldBe("selectionRects[1].width", "310");
+        shouldBe("selectionRects[2].width", "150");
+        shouldBe("selectionRects[3].width", "150");
+        shouldBeGreaterThan("150", "selectionRects[4].width");
+
+        outsideContentLineBottom = selectionRects[1].top + selectionRects[1].height;
+        firstMultiColumnLineTop = selectionRects[2].top;
+        shouldBeGreaterThan("firstMultiColumnLineTop", "outsideContentLineBottom");
+
+        finishJSTest();
+    });
+</script>
+</head>
+
+<body>
+    <div id="container">
+        <p id="outside">The selected content outside of the multi-column element.</p>
+        <div style="column-count: 2; column-gap: 10px;">Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit.Morbi mauris ex, finibus quis aliquam ac, interdum facilisis ligula.</div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
#### 59699ab765b97b10bea512f32eb14585d895ab30
<pre>
[iOS] The highlight selection box of multi-column extends to unselected content
<a href="https://bugs.webkit.org/show_bug.cgi?id=270787">https://bugs.webkit.org/show_bug.cgi?id=270787</a>

Reviewed by Wenson Hsieh.

This patch fixes two types of extending issues:
1. When selecting text from both inside and outside a multi-column layout, the column geometries merge with
the surrounding elements, causing the highlight box to extend across the entire width of the outer element.
This can make it appear as though the selection extends into an unselected column. To resolve this,
set m_separateFromPreviousLine for multi-column content. Identify multi-column content by checking
if the element has multiColumnFlow or if it is a descendant of RenderMultiColumnFlow.

2. Since the top of the second line in one column aligns with the bottom of the first line in the adjacent column,
selecting text that starts at the first line of a column and extends into the next column causes the geometries united.
To fix this, set m_separateFromPreviousLine for each column, ensuring that geometries with m_separateFromPreviousLine do not unite.

* LayoutTests/editing/selection/ios/select-content-from-multicolumn-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-from-multicolumn.html: Added.
* LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-002-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-002.html: Added.
* LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-inside-and-outside-multicolumn.html: Added.
* LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-002-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-002.html: Added.
* LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn-expected.txt: Added.
* LayoutTests/editing/selection/ios/select-content-outside-and-inside-multicolumn.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::currentNodeRequiresToSeparateLines): Return true if the current node is multi-collumn.
(WebCore::hasAncestorRequiresToSeparateLines): Return true if it is a descendant of a multi-collumn element.
(WebCore::RenderObject::collectSelectionGeometries): Do not unite the rect if the geometry is m_separateFromPreviousLine.
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::collectSelectionGeometries): Set m_separateFromPreviousLine true if linebox is isFirstAfterPageBreak.

Canonical link: <a href="https://commits.webkit.org/291765@main">https://commits.webkit.org/291765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/024b4104a3dfeb09a362249ebe33c00feb05e322

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3294 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71705 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29051 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10279 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52044 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9964 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2535 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43812 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80220 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2617 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101017 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14178 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26183 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20692 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22433 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->