### PR TITLE
[Wasm] GC Arrays should have their payload allocated as a trailing array

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -708,6 +708,8 @@ public:
             masm->m_assembler.linkJump(m_label, masm->m_assembler.label());
 #endif
         }
+
+        void link(AbstractMacroAssemblerType& masm) const { link(&masm); }
         
         void linkTo(Label label, AbstractMacroAssemblerType* masm) const
         {

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -177,7 +177,6 @@ class Heap;
 
 #if ENABLE(WEBASSEMBLY)
 #define FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_ISO_SUBSPACE(v) \
-    v(webAssemblyArraySpace, webAssemblyArrayHeapCellType, JSWebAssemblyArray) \
     v(webAssemblyExceptionSpace, webAssemblyExceptionHeapCellType, JSWebAssemblyException) \
     v(webAssemblyFunctionSpace, webAssemblyFunctionHeapCellType, WebAssemblyFunction) \
     v(webAssemblyGlobalSpace, webAssemblyGlobalHeapCellType, JSWebAssemblyGlobal) \
@@ -190,6 +189,7 @@ class Heap;
 
 // FIXME: This is a bit confusingly named since the objects in here are exclusive to the subspace but they can vary in size thus can't be in an IsoSubspace.
 #define FOR_EACH_JSC_WEBASSEMBLY_DYNAMIC_NON_ISO_SUBSPACE(v) \
+    v(webAssemblyArraySpace, webAssemblyArrayHeapCellType, JSWebAssemblyArray, CompleteSubspace) \
     v(webAssemblyInstanceSpace, webAssemblyInstanceHeapCellType, JSWebAssemblyInstance, PreciseSubspace) \
     v(webAssemblyStructSpace, webAssemblyStructHeapCellType, JSWebAssemblyStruct, CompleteSubspace)
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1203,6 +1203,8 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result);
 
+    void emitArrayGetPayload(StorageType, GPRReg arrayGPR, GPRReg payloadGPR);
+
     PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result);
 
     PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType value);

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -355,13 +355,13 @@ public:
                 WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
                 JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
                 for (size_t i = 0; i < args.size(); i++)
-                    arrayObject->set(i, args[i].getVector());
+                    arrayObject->set(arrayObject->vm(), i, args[i].getVector());
             } else {
                 result = createNewArray(typeIndex, args.size(), { });
                 WASM_PARSER_FAIL_IF(result.isInvalid(), "Failed to allocate new array"_s);
                 JSWebAssemblyArray* arrayObject = jsCast<JSWebAssemblyArray*>(JSValue::decode(result.getValue()));
                 for (size_t i = 0; i < args.size(); i++)
-                    arrayObject->set(i, args[i].getValue());
+                    arrayObject->set(arrayObject->vm(), i, args[i].getValue());
             }
         }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -864,7 +864,6 @@ WASM_IPINT_EXTERN_CPP_DECL(array_set, Wasm::TypeIndex typeIndex, IPIntStackEntry
 
 WASM_IPINT_EXTERN_CPP_DECL(array_fill, IPIntStackEntry* sp)
 {
-    UNUSED_PARAM(instance);
     // sp[0] = size
     // sp[1] = value
     // sp[2] = offset
@@ -877,7 +876,7 @@ WASM_IPINT_EXTERN_CPP_DECL(array_fill, IPIntStackEntry* sp)
     EncodedJSValue value = sp[1].ref;
     uint32_t size = sp[0].i32;
 
-    if (!Wasm::arrayFill(arrayref, offset, value, size))
+    if (!Wasm::arrayFill(instance->vm(), arrayref, offset, value, size))
         IPINT_THROW(Wasm::ExceptionType::OutOfBoundsArrayFill);
 
     IPINT_END();

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1847,7 +1847,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFill, UCPUStrictInt32, (JSWe
     assertCalleeIsReferenced(callFrame, instance);
     VM& vm = instance->vm();
     NativeCallFrameTracer tracer(vm, callFrame);
-    return toUCPUStrictInt32(arrayFill(arrayValue, offset, value, size));
+    return toUCPUStrictInt32(arrayFill(vm, arrayValue, offset, value, size));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillVector, UCPUStrictInt32, (JSWebAssemblyInstance* instance, EncodedJSValue arrayValue, uint32_t offset, uint64_t lane0, uint64_t lane1, uint32_t size))
@@ -1856,7 +1856,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayFillVector, UCPUStrictInt32,
     assertCalleeIsReferenced(callFrame, instance);
     VM& vm = instance->vm();
     NativeCallFrameTracer tracer(vm, callFrame);
-    return toUCPUStrictInt32(arrayFill(arrayValue, offset, v128_t { lane0, lane1 }, size));
+    return toUCPUStrictInt32(arrayFill(vm, arrayValue, offset, v128_t { lane0, lane1 }, size));
 }
 
 JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationWasmArrayCopy, UCPUStrictInt32, (JSWebAssemblyInstance* instance, EncodedJSValue dst, uint32_t dstOffset, EncodedJSValue src, uint32_t srcOffset, uint32_t size))

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -501,7 +501,8 @@ WASM_SLOW_PATH_DECL(array_set)
 
 WASM_SLOW_PATH_DECL(array_fill)
 {
-    SlowPathFrameTracer tracer(instance->vm(), callFrame);
+    VM& vm = instance->vm();
+    SlowPathFrameTracer tracer(vm, callFrame);
 
     auto instruction = pc->as<WasmArrayFill>();
     EncodedJSValue arrayref = READ(instruction.m_arrayref).encodedJSValue();
@@ -511,7 +512,7 @@ WASM_SLOW_PATH_DECL(array_fill)
     EncodedJSValue value = READ(instruction.m_value).encodedJSValue();
     uint32_t size = READ(instruction.m_size).unboxedUInt32();
 
-    if (!Wasm::arrayFill(arrayref, offset, value, size))
+    if (!Wasm::arrayFill(vm, arrayref, offset, value, size))
         WASM_THROW(Wasm::ExceptionType::OutOfBoundsArrayFill);
     WASM_END_IMPL();
 }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Igalia S.L. All rights reserved.
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,145 +46,55 @@ Structure* JSWebAssemblyArray::createStructure(VM& vm, JSGlobalObject* globalObj
     return Structure::create(vm, globalObject, prototype, TypeInfo(WebAssemblyGCObjectType, StructureFlags), info());
 }
 
-JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, RefPtr<const Wasm::RTT>&& rtt)
+JSWebAssemblyArray::JSWebAssemblyArray(VM& vm, Structure* structure, Wasm::FieldType elementType, unsigned size, RefPtr<const Wasm::RTT>&& rtt)
     : Base(vm, structure, WTFMove(rtt))
     , m_elementType(elementType)
     , m_size(size)
 {
-    if (m_elementType.type.is<Wasm::PackedType>()) {
-        switch (m_elementType.type.as<Wasm::PackedType>()) {
-        case Wasm::PackedType::I8:
-            new (&m_payload8) FixedVector<uint8_t>(m_size);
-            m_payload8.fill(0);
-            return;
-        case Wasm::PackedType::I16:
-            new (&m_payload16) FixedVector<uint16_t>(m_size);
-            m_payload16.fill(0);
-            return;
-        }
-        return;
-    }
-
-    switch (m_elementType.type.as<Wasm::Type>().kind) {
-    case Wasm::TypeKind::I32:
-    case Wasm::TypeKind::F32:
-        new (&m_payload32) FixedVector<uint32_t>(m_size);
-        m_payload32.fill(0);
-        return;
-    case Wasm::TypeKind::V128:
-        new (&m_payload128) FixedVector<v128_t>(m_size);
-        m_payload128.fill(v128_t { });
-        return;
-    default:
-        new (&m_payload64) FixedVector<uint64_t>(m_size);
-        if (elementsAreRefTypes())
-            m_payload64.fill(JSValue::encode(jsNull()));
-        else
-            m_payload64.fill(0);
-        return;
+    if (elementsAreRefTypes())
+        std::fill(span<uint64_t>().begin(), span<uint64_t>().end(), JSValue::encode(jsNull()));
+    else {
+        zeroSpan(bytes());
     }
 }
 
-JSWebAssemblyArray::~JSWebAssemblyArray()
-{
-    if (m_elementType.type.is<Wasm::PackedType>()) {
-        switch (m_elementType.type.as<Wasm::PackedType>()) {
-        case Wasm::PackedType::I8:
-            m_payload8.~FixedVector<uint8_t>();
-            break;
-        case Wasm::PackedType::I16:
-            m_payload16.~FixedVector<uint16_t>();
-            break;
-        }
-        return;
-    }
-
-    switch (m_elementType.type.as<Wasm::Type>().kind) {
-    case Wasm::TypeKind::I32:
-    case Wasm::TypeKind::F32:
-        m_payload32.~FixedVector<uint32_t>();
-        break;
-    case Wasm::TypeKind::V128:
-        m_payload128.~FixedVector<v128_t>();
-        break;
-    default:
-        m_payload64.~FixedVector<uint64_t>();
-        break;
-    }
-}
-
-void JSWebAssemblyArray::fill(uint32_t offset, uint64_t value, uint32_t size)
+void JSWebAssemblyArray::fill(VM& vm, uint32_t offset, uint64_t value, uint32_t size)
 {
     // Handle ref types separately to ensure write barriers are in effect.
     if (elementsAreRefTypes()) {
+        // FIXME: We should have a GCSafeMemfill.
         for (size_t i = 0; i < size; i++)
-            set(offset + i, value);
+            set(vm, offset + i, value);
         return;
     }
 
-    if (m_elementType.type.is<Wasm::PackedType>()) {
-        switch (m_elementType.type.as<Wasm::PackedType>()) {
-        case Wasm::PackedType::I8:
-            memsetSpan(m_payload8.mutableSpan().subspan(offset, size), static_cast<uint8_t>(value));
-            return;
-        case Wasm::PackedType::I16:
-            std::fill(m_payload16.begin() + offset, m_payload16.begin() + offset + size, static_cast<uint16_t>(value));
-            return;
-        }
-    }
-
-    switch (m_elementType.type.as<Wasm::Type>().kind) {
-    case Wasm::TypeKind::I32:
-    case Wasm::TypeKind::F32:
-        std::fill(m_payload32.begin() + offset, m_payload32.begin() + offset + size, static_cast<uint32_t>(value));
-        return;
-    case Wasm::TypeKind::V128:
-        RELEASE_ASSERT_NOT_REACHED();
-        return;
-    default:
-        std::fill(m_payload64.begin() + offset, m_payload64.begin() + offset + size, value);
-        return;
-    }
+    visitSpanNonVector([&](auto span) ALWAYS_INLINE_LAMBDA {
+        span = span.subspan(offset, size);
+        std::fill(span.begin(), span.end(), value);
+    });
 }
 
-void JSWebAssemblyArray::fill(uint32_t offset, v128_t value, uint32_t size)
+void JSWebAssemblyArray::fill(VM&, uint32_t offset, v128_t value, uint32_t size)
 {
     ASSERT(m_elementType.type.unpacked().isV128());
-    std::fill(m_payload128.begin() + offset, m_payload128.begin() + offset + size, value);
+    auto payload = span<v128_t>().subspan(offset, size);
+    std::fill(payload.begin(), payload.end(), value);
 }
 
-void JSWebAssemblyArray::copy(JSWebAssemblyArray& dst, uint32_t dstOffset, uint32_t srcOffset, uint32_t size)
+void JSWebAssemblyArray::copy(VM& vm, JSWebAssemblyArray& dst, uint32_t dstOffset, uint32_t srcOffset, uint32_t size)
 {
     // Handle ref types separately to ensure write barriers are in effect.
     if (elementsAreRefTypes()) {
-        gcSafeMemmove(dst.m_payload64.mutableSpan().subspan(dstOffset).data(), m_payload64.span().subspan(srcOffset).data(), size * sizeof(JSValue));
-        vm().writeBarrier(this);
+        gcSafeMemmove(dst.span<uint64_t>().subspan(dstOffset).data(), span<uint64_t>().subspan(srcOffset).data(), size * sizeof(JSValue));
+        vm.writeBarrier(&dst);
         return;
     }
 
-    if (m_elementType.type.is<Wasm::PackedType>()) {
-        switch (m_elementType.type.as<Wasm::PackedType>()) {
-        case Wasm::PackedType::I8:
-            memmove(dst.m_payload8.mutableSpan().subspan(dstOffset).data(), m_payload8.span().subspan(srcOffset).data(), size * sizeof(uint8_t));
-            return;
-        case Wasm::PackedType::I16:
-            memmove(dst.m_payload16.mutableSpan().subspan(dstOffset).data(), m_payload16.span().subspan(srcOffset).data(), size * sizeof(uint16_t));
-            return;
-        }
-    }
-
-    switch (m_elementType.type.as<Wasm::Type>().kind) {
-    case Wasm::TypeKind::I32:
-    case Wasm::TypeKind::F32:
-        memmove(dst.m_payload32.mutableSpan().subspan(dstOffset).data(), m_payload32.span().subspan(srcOffset).data(), size * sizeof(uint32_t));
-        return;
-    case Wasm::TypeKind::V128:
-        memmove(dst.m_payload128.mutableSpan().subspan(dstOffset).data(), m_payload128.span().subspan(srcOffset).data(), size * sizeof(v128_t));
-        return;
-    default:
-        memmove(dst.m_payload64.mutableSpan().subspan(dstOffset).data(), m_payload64.span().subspan(srcOffset).data(), size * sizeof(uint64_t));
-        return;
-    }
+    visitSpan([&]<typename T>(std::span<T> srcSpan) ALWAYS_INLINE_LAMBDA {
+        srcSpan = srcSpan.subspan(srcOffset, size);
+        auto dstSpan = dst.span<T>().subspan(dstOffset, size);
+        memmoveSpan(dstSpan, srcSpan);
+    });
 }
 
 void JSWebAssemblyArray::destroy(JSCell* cell)
@@ -201,7 +111,7 @@ void JSWebAssemblyArray::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
 
     if (thisObject->elementsAreRefTypes())
-        visitor.appendValues(std::bit_cast<WriteBarrier<Unknown>*>(thisObject->reftypeData()), thisObject->size());
+        visitor.appendValues(std::bit_cast<WriteBarrier<Unknown>*>(thisObject->refTypeSpan().data()), thisObject->size());
 }
 
 DEFINE_VISIT_CHILDREN(JSWebAssemblyArray);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2022 Igalia S.L. All rights reserved.
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,9 +37,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+// Ideally this would just subclass TrailingArray<JSWebAssemblyArray, uint8_t> but we need the m_size field to be in units
+// of element size rather than byte size.
 class JSWebAssemblyArray final : public WebAssemblyGCObjectBase {
-    friend class LLIntOffsetsExtractor;
-
 public:
     using Base = WebAssemblyGCObjectBase;
     static constexpr DestructionMode needsDestruction = NeedsDestruction;
@@ -47,18 +47,18 @@ public:
     static void destroy(JSCell*);
 
     template<typename CellType, SubspaceAccess mode>
-    static GCClient::IsoSubspace* subspaceFor(VM& vm)
+    static CompleteSubspace* subspaceFor(VM& vm)
     {
-        return vm.webAssemblyArraySpace<mode>();
+        return vm.heap.webAssemblyArraySpace<mode>();
     }
 
     DECLARE_EXPORT_INFO;
 
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, size_t size, RefPtr<const Wasm::RTT>&& rtt)
+    static JSWebAssemblyArray* create(VM& vm, Structure* structure, Wasm::FieldType elementType, unsigned size, RefPtr<const Wasm::RTT>&& rtt)
     {
-        auto* object = new (NotNull, allocateCell<JSWebAssemblyArray>(vm)) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(rtt));
+        auto* object = new (NotNull, allocateCell<JSWebAssemblyArray>(vm, allocationSizeInBytes(elementType, size))) JSWebAssemblyArray(vm, structure, elementType, size, WTFMove(rtt));
         object->finishCreation(vm);
         return object;
     }
@@ -66,175 +66,140 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     Wasm::FieldType elementType() const { return m_elementType; }
+    static bool needsAlignmentCheck(Wasm::StorageType type) { return type.unpacked().isV128(); }
     size_t size() const { return m_size; }
+    size_t sizeInBytes() const { return size() * elementType().type.elementSize(); }
 
-    uint8_t* data()
+    template<typename T>
+    std::span<T> span() LIFETIME_BOUND
     {
-        if (m_elementType.type.is<Wasm::PackedType>()) {
-            switch (m_elementType.type.as<Wasm::PackedType>()) {
-            case Wasm::PackedType::I8:
-                return m_payload8.mutableSpan().data();
-            case Wasm::PackedType::I16:
-                return reinterpret_cast<uint8_t*>(m_payload16.mutableSpan().data());
-            }
-        }
-        ASSERT(m_elementType.type.is<Wasm::Type>());
-        switch (m_elementType.type.as<Wasm::Type>().kind) {
-        case Wasm::TypeKind::I32:
-        case Wasm::TypeKind::F32:
-            return reinterpret_cast<uint8_t*>(m_payload32.mutableSpan().data());
-        case Wasm::TypeKind::V128:
-            return reinterpret_cast<uint8_t*>(m_payload128.mutableSpan().data());
-        default:
-            return reinterpret_cast<uint8_t*>(m_payload64.mutableSpan().data());
-        }
+        ASSERT(sizeof(T) == elementType().type.elementSize());
+        uint8_t* data = this->data();
+        if constexpr (std::is_same_v<T, v128_t>)
+            data += isPreciseAllocation() ? PreciseAllocation::halfAlignment : 0;
+        else
+            ASSERT(!needsAlignmentCheck(elementType().type));
+        return { std::bit_cast<T*>(data), size() };
+    }
 
-        ASSERT_NOT_REACHED();
-        return nullptr;
-    };
-
+    template<typename T>
+    std::span<const T> span() const LIFETIME_BOUND { return const_cast<JSWebAssemblyArray*>(this)->span<T>(); }
 
     bool elementsAreRefTypes() const
     {
         return Wasm::isRefType(m_elementType.type.unpacked());
     }
 
-    uint64_t* reftypeData()
+    std::span<uint64_t> refTypeSpan() LIFETIME_BOUND
     {
-        RELEASE_ASSERT(elementsAreRefTypes());
-        return m_payload64.mutableSpan().data();
+        ASSERT(elementsAreRefTypes());
+        return span<uint64_t>();
     }
 
-    uint64_t get(uint32_t index)
+    ALWAYS_INLINE auto visitSpan(auto functor)
     {
         if (m_elementType.type.is<Wasm::PackedType>()) {
             switch (m_elementType.type.as<Wasm::PackedType>()) {
             case Wasm::PackedType::I8:
-                return static_cast<uint64_t>(m_payload8[index]);
+                return functor(span<uint8_t>());
             case Wasm::PackedType::I16:
-                return static_cast<uint64_t>(m_payload16[index]);
+                return functor(span<uint16_t>());
             }
         }
+
         // m_element_type must be a type, so we can get its kind
         ASSERT(m_elementType.type.is<Wasm::Type>());
         switch (m_elementType.type.as<Wasm::Type>().kind) {
         case Wasm::TypeKind::I32:
         case Wasm::TypeKind::F32:
-            return static_cast<uint64_t>(m_payload32[index]);
+            return functor(span<uint32_t>());
         case Wasm::TypeKind::V128:
-            // V128 is not supported in LLInt.
-            RELEASE_ASSERT_NOT_REACHED();
+            return functor(span<v128_t>());
         default:
-            return static_cast<uint64_t>(m_payload64[index]);
+            return functor(span<uint64_t>());
         }
     }
 
-    void set(uint32_t index, uint64_t value)
+    ALWAYS_INLINE auto visitSpanNonVector(auto functor)
     {
+        // Ideally this would have just been:
+        // return visitSpan([&][&]<typename T>(std::span<T> span) { RELEASE_ASSERT(!std::is_same<T, v128_t>::value); ... });
+        // but that causes weird compiler errors...
+
         if (m_elementType.type.is<Wasm::PackedType>()) {
             switch (m_elementType.type.as<Wasm::PackedType>()) {
             case Wasm::PackedType::I8:
-                m_payload8[index] = static_cast<uint8_t>(value);
-                break;
+                return functor(span<uint8_t>());
             case Wasm::PackedType::I16:
-                m_payload16[index] = static_cast<uint16_t>(value);
-                break;
+                return functor(span<uint16_t>());
             }
-            return;
         }
 
+        // m_element_type must be a type, so we can get its kind
         ASSERT(m_elementType.type.is<Wasm::Type>());
-
         switch (m_elementType.type.as<Wasm::Type>().kind) {
         case Wasm::TypeKind::I32:
         case Wasm::TypeKind::F32:
-            m_payload32[index] = static_cast<uint32_t>(value);
-            break;
-        case Wasm::TypeKind::I64:
-        case Wasm::TypeKind::F64:
-            m_payload64[index] = static_cast<uint64_t>(value);
-            break;
-        case Wasm::TypeKind::Externref:
-        case Wasm::TypeKind::Funcref:
-        case Wasm::TypeKind::Ref:
-        case Wasm::TypeKind::RefNull: {
-            WriteBarrier<Unknown>* pointer = std::bit_cast<WriteBarrier<Unknown>*>(m_payload64.mutableSpan().data());
-            pointer += index;
-            pointer->set(vm(), this, JSValue::decode(static_cast<EncodedJSValue>(value)));
-            break;
-        }
+            return functor(span<uint32_t>());
         case Wasm::TypeKind::V128:
-        default:
             RELEASE_ASSERT_NOT_REACHED();
-            break;
+        default:
+            return functor(span<uint64_t>());
         }
     }
 
-    void set(uint32_t index, v128_t value)
+    uint64_t get(uint32_t index)
+    {
+        // V128 is not supported in LLInt.
+        return visitSpanNonVector([&](auto span) ALWAYS_INLINE_LAMBDA -> uint64_t {
+            return span[index];
+        });
+    }
+
+    void set(VM& vm, uint32_t index, uint64_t value)
+    {
+        visitSpanNonVector([&]<typename T>(std::span<T> span) ALWAYS_INLINE_LAMBDA {
+            span[index] = static_cast<T>(value);
+            if (elementsAreRefTypes())
+                vm.writeBarrier(this);
+        });
+    }
+
+    void set(VM&, uint32_t index, v128_t value)
     {
         ASSERT(m_elementType.type.is<Wasm::Type>());
         ASSERT(m_elementType.type.as<Wasm::Type>().kind == Wasm::TypeKind::V128);
-        m_payload128[index] = value;
+        span<v128_t>()[index] = value;
     }
 
-    void fill(uint32_t, uint64_t, uint32_t);
-    void fill(uint32_t, v128_t, uint32_t);
-    void copy(JSWebAssemblyArray&, uint32_t, uint32_t, uint32_t);
+    void fill(VM&, uint32_t, uint64_t, uint32_t);
+    void fill(VM&, uint32_t, v128_t, uint32_t);
+    void copy(VM&, JSWebAssemblyArray&, uint32_t, uint32_t, uint32_t);
 
+    // We add 8 bytes for v128 arrays since a PreciseAllocation will have the wrong alignment as the base pointer for a PreciseAllocation is shifted by 8.
+    // Note: Technically this isn't needed since the GC/malloc always allocates 16 byte chunks so for precise allocations
+    // there will be a 8 spare bytes at the end. This is just a bit more explicit and shouldn't make a difference.
+    static size_t allocationSizeInBytes(Wasm::FieldType fieldType, unsigned size) { return sizeof(JSWebAssemblyArray) + size * fieldType.type.elementSize() + (needsAlignmentCheck(fieldType.type) * 8); }
     static constexpr ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_size); }
-    static constexpr ptrdiff_t offsetOfPayload() { return OBJECT_OFFSETOF(JSWebAssemblyArray, m_payload8) + FixedVector<uint8_t>::offsetOfStorage(); }
-    static ptrdiff_t offsetOfElements(Wasm::StorageType type)
-    {
-        if (type.is<Wasm::PackedType>()) {
-            switch (type.as<Wasm::PackedType>()) {
-            case Wasm::PackedType::I8:
-                return FixedVector<uint8_t>::Storage::offsetOfData();
-            case Wasm::PackedType::I16:
-                return FixedVector<uint16_t>::Storage::offsetOfData();
-            }
-        }
+    static constexpr ptrdiff_t offsetOfData() { return sizeof(JSWebAssemblyArray); }
 
-        ASSERT(type.is<Wasm::Type>());
+private:
+    friend class LLIntOffsetsExtractor;
+    std::span<uint8_t> bytes() { return { isPreciseAllocation() ? data() + PreciseAllocation::halfAlignment : data(), sizeInBytes() }; }
+    uint8_t* data() { return reinterpret_cast<uint8_t*>(this) + offsetOfData(); }
+    const uint8_t* data() const { return const_cast<JSWebAssemblyArray*>(this)->data(); }
 
-        switch (type.as<Wasm::Type>().kind) {
-        case Wasm::TypeKind::I32:
-        case Wasm::TypeKind::F32:
-            return FixedVector<uint32_t>::Storage::offsetOfData();
-        case Wasm::TypeKind::I64:
-        case Wasm::TypeKind::F64:
-        case Wasm::TypeKind::Ref:
-        case Wasm::TypeKind::RefNull:
-            return FixedVector<uint64_t>::Storage::offsetOfData();
-        case Wasm::TypeKind::V128:
-            return FixedVector<v128_t>::Storage::offsetOfData();
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-            break;
-        }
-
-        return 0;
-    }
-
-protected:
-    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, size_t, RefPtr<const Wasm::RTT>&&);
-    ~JSWebAssemblyArray();
+    JSWebAssemblyArray(VM&, Structure*, Wasm::FieldType, unsigned, RefPtr<const Wasm::RTT>&&);
 
     DECLARE_DEFAULT_FINISH_CREATION;
 
     Wasm::FieldType m_elementType;
-    size_t m_size;
-
-    // A union is used here to ensure the underlying storage is aligned correctly.
-    // The payload member used entirely depends on m_elementType, so no tag is required.
-    union {
-        void* zeroInit { nullptr };
-        FixedVector<uint8_t>  m_payload8;
-        FixedVector<uint16_t> m_payload16;
-        FixedVector<uint32_t> m_payload32;
-        FixedVector<uint64_t> m_payload64;
-        FixedVector<v128_t>   m_payload128;
-    };
+    unsigned m_size;
 };
+
+static_assert(std::is_final_v<JSWebAssemblyArray>, "JSWebAssemblyArray is a TrailingArray-like object so must know about all members");
+// We still have to check for PreciseAllocations since those are shifted by 8 bytes for v128 but this asserts our shifted offset will be correct.
+static_assert(!(JSWebAssemblyArray::offsetOfData() % alignof(v128_t)), "JSWebAssemblyArray storage needs to be aligned for v128_t");
 
 } // namespace JSC
 


### PR DESCRIPTION
#### d5ff0fe3ad796df135174f2e2032d33e4ac843de
<pre>
[Wasm] GC Arrays should have their payload allocated as a trailing array
<a href="https://bugs.webkit.org/show_bug.cgi?id=289258">https://bugs.webkit.org/show_bug.cgi?id=289258</a>
<a href="https://rdar.apple.com/146398985">rdar://146398985</a>

Reviewed by Yusuke Suzuki.

The backing store for Wasm GC Arrays is currently an out of line FixedVector.
This means accessing the array&apos;s backing store requires a dependent load, which
is inefficient. This patch causes the array&apos;s backing store to be allocated as a
trailing array. Unfortunately, We can&apos;t subclass `TrailingArray&lt;uint8_t&gt;` directly
since we want the size field to be an element count rather than a byte count.

Additionally, instead of manually switching over the different StorageTypes this
patch introduces a `visitSpan`/`visitSpanNonVector` so you can pass a polymorphic
lambda and have the helper give you the right view into storage. I checked the
assembly of a few functions and Clang will remove this abstraction.

* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::Jump::link const):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArrayGetPayload):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJITImpl::BBQJIT::emitArraySetUnchecked):
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::addArrayNewFixed):
* Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp:
(JSC::IPInt::WASM_IPINT_EXTERN_CPP_DECL):
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addArrayGet):
(JSC::Wasm::OMGIRGenerator::emitGetArrayPayloadBase):
(JSC::Wasm::OMGIRGenerator::emitArraySetUnchecked):
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperationsInlines.h:
(JSC::Wasm::fillArray):
(JSC::Wasm::arrayNew):
(JSC::Wasm::copyElementsInReverse):
(JSC::Wasm::createArrayFromDataSegment):
(JSC::Wasm::arrayNewElem):
(JSC::Wasm::arraySet):
(JSC::Wasm::doArrayFill):
(JSC::Wasm::arrayFill):
(JSC::Wasm::arrayCopy):
(JSC::Wasm::arrayInitElem):
(JSC::Wasm::arrayInitData):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::WASM_SLOW_PATH_DECL):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.cpp:
(JSC::JSWebAssemblyArray::JSWebAssemblyArray):
(JSC::JSWebAssemblyArray::fill):
(JSC::JSWebAssemblyArray::copy):
(JSC::JSWebAssemblyArray::visitChildrenImpl):
(JSC::JSWebAssemblyArray::~JSWebAssemblyArray): Deleted.
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:

Canonical link: <a href="https://commits.webkit.org/291760@main">https://commits.webkit.org/291760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c2803baa028aae6b546307feec2398be2ee756

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3225 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98914 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44435 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13789 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71661 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29021 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10240 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51997 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2480 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43751 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86618 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2562 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/101026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92574 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20960 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80678 "layout-tests (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80027 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19927 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14117 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26122 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115224 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20631 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24091 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->