### PR TITLE
Crash in WebChromeClient::clearPlaybackControlsManager due to RELEASE_ASSERT in WeakRef::get()

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -209,7 +209,7 @@ void WebChromeClient::chromeDestroyed()
 
 Ref<WebPage> WebChromeClient::protectedPage() const
 {
-    return m_page.get();
+    return *m_page;
 }
 
 void WebChromeClient::setWindowRect(const FloatRect& windowFrame)
@@ -1287,7 +1287,8 @@ void WebChromeClient::setUpPlaybackControlsManager(HTMLMediaElement& mediaElemen
 
 void WebChromeClient::clearPlaybackControlsManager()
 {
-    protectedPage()->playbackSessionManager().clearPlaybackControlsManager();
+    if (RefPtr page = m_page.get())
+        page->playbackSessionManager().clearPlaybackControlsManager();
 }
 
 void WebChromeClient::mediaEngineChanged(WebCore::HTMLMediaElement& mediaElement)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -57,7 +57,8 @@ public:
     WebChromeClient(WebPage&);
     ~WebChromeClient();
 
-    WebPage& page() const { return m_page.get(); }
+    // FIXME: these functions should return (ref) pointers that should be null-checked at callsites.
+    WebPage& page() const { return *m_page; }
     Ref<WebPage> protectedPage() const;
 
 #if PLATFORM(IOS_FAMILY)
@@ -569,7 +570,7 @@ private:
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 
-    WeakRef<WebPage> m_page;
+    WeakPtr<WebPage> m_page;
 };
 
 class AXRelayProcessSuspendedNotification {


### PR DESCRIPTION
#### 0d4da81abfddcf46d1e5f3e6130d5c330eacc3fa
<pre>
Crash in WebChromeClient::clearPlaybackControlsManager due to RELEASE_ASSERT in WeakRef::get()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289277">https://bugs.webkit.org/show_bug.cgi?id=289277</a>
<a href="https://rdar.apple.com/145885207">rdar://145885207</a>

Reviewed by Chris Dumez.

WebChromeClient is owned by its WebCore::Page but stores a WeakRef to a WebPage. If the
WebCore::Page outlives its WebPage then code that accesses this WeakRef will crash due to a
RELEASE_ASSERT in WeakRef::get() asserting that the underlying weak pointer is non-null. Since
WebChromeClient::clearPlaybackControlsManager is called on a timer, it may be called after its
WebPage has been destroyed but before its WebCore::Page has been.

Resolved this by changing WebChromeClient::m_page from a WeakRef to a WeakPtr, then null-checking
m_page before accessing it in WebChromeClient::clearPlaybackControlsManager. In a future change we
should null-check all accesses to m_page in WebChromeClient.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::protectedPage const):
(WebKit::WebChromeClient::clearPlaybackControlsManager):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:

Canonical link: <a href="https://commits.webkit.org/291754@main">https://commits.webkit.org/291754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/442aa240d847d22cbb1f9abc5ad949be55000855

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93845 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3160 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98851 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44371 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13723 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71616 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28980 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96847 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10196 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84799 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9880 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43686 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80145 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100887 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20897 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15243 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80636 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79981 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24527 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14054 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26059 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20568 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->