### PR TITLE
AX: Webpage crashes when I jump between PDF form fields with tab button while VoiceOver is on

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -314,18 +314,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)accessibilityAssociatedControlForAnnotation:(PDFAnnotation *)annotation
 {
-    RefPtr activeAnnotation = _pdfPlugin.get()->activeAnnotation();
-    if (!activeAnnotation)
-        return nil;
-
     id wrapper = nil;
-    callOnMainRunLoopAndWait([activeAnnotation, protectedSelf = retainPtr(self), &wrapper] {
+    callOnMainRunLoopAndWait([protectedSelf = retainPtr(self), &wrapper] {
+        RefPtr activeAnnotation = protectedSelf->_pdfPlugin.get()->activeAnnotation();
+        if (!activeAnnotation)
+            return;
+
         if (auto* axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
             if (RefPtr annotationElementAxObject = axObjectCache->getOrCreate(activeAnnotation->element()))
                 wrapper = annotationElementAxObject->wrapper();
         }
     });
-
     return wrapper;
 }
 


### PR DESCRIPTION
#### 00b6b278c28ad131bbe0dfd09754a90752277129
<pre>
AX: Webpage crashes when I jump between PDF form fields with tab button while VoiceOver is on
<a href="https://bugs.webkit.org/show_bug.cgi?id=289279">https://bugs.webkit.org/show_bug.cgi?id=289279</a>
<a href="https://rdar.apple.com/146420768">rdar://146420768</a>

Reviewed by Tyler Wilcock.

Plugin and activeAnnotation are not thread safe and we shouldn&apos;t access from secondary thread.

* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityAssociatedControlForAnnotation:]):

Canonical link: <a href="https://commits.webkit.org/291752@main">https://commits.webkit.org/291752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f48f7f3465b05d29acd9bba8257c91afff85380

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13429 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21862 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71617 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28981 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96848 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10194 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9878 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43687 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100888 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15244 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80637 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79982 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24528 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14055 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26060 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20569 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->