### PR TITLE
CoreIPCCFDictionary::createCFDictionary() doesn't validate key/value type

### DIFF
--- a/LayoutTests/ipc/coreipc.js
+++ b/LayoutTests/ipc/coreipc.js
@@ -18,18 +18,10 @@ function deepCopy(object) {
     return JSON.parse(JSON.stringify(object));
 }
 
-const FUZZ_MARKER = [
-    {type: 'uint64_t', value: 0x0},
-    {type: 'uint8_t', value: 0x46},
-    {type: 'uint8_t', value: 0x55},
-    {type: 'uint8_t', value: 0x5a},
-    {type: 'uint8_t', value: 0x5a},
-    {type: 'uint8_t', value: 0x46},
-    {type: 'uint8_t', value: 0x55},
-    {type: 'uint8_t', value: 0x5a},
-    {type: 'uint8_t', value: 0x5a},
-    {type: 'uint64_t', value: 0x41},
-];
+function splitClassAndFunction(name) {
+    const [clz, ...rest] = name.split("_");
+    return [clz, rest.join("_")];
+}
 
 class CoreIPCClass {
     messages;
@@ -39,7 +31,7 @@ class CoreIPCClass {
     Networking;
     messageByName = {};
 
-    default_timeout = 1;
+    default_timeout = 5;
 
     constructor() {
         // Take a copy of IPC dictionaries to avoid calling into IPC API frequently
@@ -62,7 +54,7 @@ class CoreIPCClass {
 
     initializeMessageByName() {
         for(const [key, value] of Object.entries(this.messages)) {
-            let [className, functionName] = key.split("_");
+            let [className, functionName] = splitClassAndFunction(key);
             value.className = className;
             value.functionName = functionName;
             this.messageByName[value.name] = value;
@@ -72,7 +64,7 @@ class CoreIPCClass {
     initializeMessages(process) {
         const messages = {};
         for(const [key, value] of Object.entries(this.messages)) {
-            let [className, functionName] = key.split("_");
+            let [className, functionName] = splitClassAndFunction(key);
             if(!(className in messages)) {
                 messages[className] = {};
             }
@@ -87,13 +79,11 @@ class CoreIPCClass {
             if(definition.isSync) {
                 return (connectionIdentifier, messageArguments) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    serializedArguments.push(FUZZ_MARKER);
                     IPC.sendSyncMessage(process, connectionIdentifier, name, this.default_timeout, serializedArguments);
                 }
             } else {
                 return (connectionIdentifier, messageArguments) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    serializedArguments.push(FUZZ_MARKER);
                     IPC.sendMessage(process, connectionIdentifier, name, serializedArguments);
                 }
             }
@@ -102,7 +92,6 @@ class CoreIPCClass {
             if(definition.isSync) {
                 return (connectionIdentifier, messageArguments, replyHandler) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    serializedArguments.push(FUZZ_MARKER);
                     const reply = IPC.sendSyncMessage(process, connectionIdentifier, name, this.default_timeout, serializedArguments);
                     if(reply && replyHandler) {
                         const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
@@ -113,7 +102,6 @@ class CoreIPCClass {
                 return (connectionIdentifier, messageArguments, replyHandler) => {
                     const connection = IPC.connectionForProcessTarget(process);
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    serializedArguments.push(FUZZ_MARKER);
                     connection.sendWithAsyncReply(connectionIdentifier, name, serializedArguments, (reply)=> {
                         if(replyHandler) {
                             const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
@@ -135,7 +123,7 @@ export class StreamConnection {
     handle;
     connection;
     constructor() {
-        this.#connectionPair = IPC.createStreamClientConnection(14, 0.1);
+        this.#connectionPair = IPC.createStreamClientConnection(14, 60);
         this.handle = this.#connectionPair[1];
         this.connection = this.#connectionPair[0];
         this.connection.open();
@@ -147,21 +135,25 @@ export class StreamConnection {
 }
 
 export class StreamConnectionInterface {
-    #connection;
-    #interfaceName;
     #connectionIdentifier;
     constructor(interfaceName, connectionIdentifier, connection) {
-        this.#interfaceName = interfaceName;
-        this.#connection = connection;
+        this.interfaceName = interfaceName;
+        this.connection = connection;
         this.#connectionIdentifier = connectionIdentifier;
-        this.initializeMessages(interfaceName);
+        this.generatedFunctions = [];
+        this.initializeMessages();
     }
 
-    initializeMessages(interfaceName) {
+    getIdentifier() {
+        return this.#connectionIdentifier;
+    }
+
+    initializeMessages() {
         for(const [key, value] of Object.entries(CoreIPC.messages)) {
-            let [className, functionName] = key.split("_");
-            if(className == interfaceName) {
+            let [className, functionName] = splitClassAndFunction(key);
+            if(className == this.interfaceName) {
                 this[functionName] = this.generateStreamSendingFunction(value);
+                this.generatedFunctions.push(functionName);
             }
         }
     }
@@ -172,12 +164,12 @@ export class StreamConnectionInterface {
             if(definition.isSync) {
                 return (messageArguments) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    this.#connection.sendSyncMessage(this.#connectionIdentifier, name, serializedArguments);
+                    this.connection.sendSyncMessage(this.#connectionIdentifier, name, serializedArguments);
                 }
             } else {
                 return (messageArguments) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    this.#connection.sendMessage(this.#connectionIdentifier, name, serializedArguments);
+                    this.connection.sendMessage(this.#connectionIdentifier, name, serializedArguments);
                 }
             }
         } else {
@@ -185,7 +177,7 @@ export class StreamConnectionInterface {
             if(definition.isSync) {
                 return (messageArguments, replyHandler) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    const reply = this.#connection.sendSyncMessage(this.#connectionIdentifier, name, serializedArguments);
+                    const reply = this.connection.sendSyncMessage(this.#connectionIdentifier, name, serializedArguments);
                     if(reply && replyHandler) {
                         const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
                         replyHandler(parsedReply, reply.buffer, typedReply);
@@ -194,7 +186,7 @@ export class StreamConnectionInterface {
             } else {
                 return (messageArguments, replyHandler) => {
                     const serializedArguments = ArgumentSerializer.serializeArguments(definition.arguments, messageArguments);
-                    this.#connection.sendWithAsyncReply(this.#connectionIdentifier, name, serializedArguments, (reply)=> {
+                    this.connection.sendWithAsyncReply(this.#connectionIdentifier, name, serializedArguments, (reply)=> {
                         if(replyHandler) {
                             const [parsedReply, typedReply] = ArgumentParser.parseReply(reply, replyArguments);
                             replyHandler(parsedReply, reply.buffer, typedReply);
@@ -220,6 +212,7 @@ const aliases = {
     'size_t': 'uint64_t',
     'pid_t': 'uint32_t',
     'unsigned short': 'uint16_t',
+    'const bool': 'bool',
     'const uint8_t': 'uint8_t',
     'const char': 'uint8_t',
     'unsigned long': 'uint64_t',
@@ -229,13 +222,41 @@ const aliases = {
     'long long': 'int64_t',
     'unsigned long long': 'uint64_t',
     'short': 'int16_t',
-    'GCGLenum': 'uint32_t',
     'const float': 'float',
     'const int32_t': 'int32_t',
     'const uint32_t': 'uint32_t',
     'NSInteger': 'int64_t',
     'NSUInteger': 'uint64_t',
-    'WebCore::ContextMenuAction': 'uint32_t'
+    'WebCore::ContextMenuAction': 'uint32_t',
+    'CGBitmapInfo': 'uint32_t',
+    'UInt32': 'uint32_t',
+    'CTFontDescriptorOptions': 'uint32_t',
+    'SystemMemoryPressureStatus': 'WTF::SystemMemoryPressureStatus',
+    // WebGL types
+    'GCGLenum': 'uint32_t',
+    'GCGLint': 'int32_t',
+    'GCGLErrorCodeSet': 'OptionSet<GCGLErrorCode>',
+    // these RetainPtr<T> should not be treated as optionnal because
+    // of the 'Ref wrapped by' in Source/WebKit/Shared/cf/CFTypes.serialization.in
+    // see generated code in WebKitBuild/Debug/DerivedSources/WebKit/WebKitPlatformGeneratedSerializers.mm
+    'RetainPtr<CFTypeRef>': 'WebKit::CoreIPCCFType',
+    'RetainPtr<CFDataRef>': 'WebKit::CoreIPCData',
+    'RetainPtr<CFStringRef>': 'String',
+    'RetainPtr<CFArrayRef>': 'WebKit::CoreIPCCFArray',
+    'RetainPtr<CFDictionaryRef>': 'WebKit::CoreIPCCFDictionary',
+    'RetainPtr<CFBooleanRef>': 'WebKit::CoreIPCBoolean',
+    'RetainPtr<CFNumberRef>': 'WebKit::CoreIPCNumber',
+    'RetainPtr<CFDateRef>': 'WebKit::CoreIPCDate',
+    'RetainPtr<CFURLRef>': 'WebKit::CoreIPCCFURL',
+    'RetainPtr<CFNullRef>': 'WebKit::CoreIPCNull',
+    'RetainPtr<SecAccessControlRef>': 'WebKit::CoreIPCSecAccessControl',
+    'RetainPtr<SecCertificateRef>': 'WebKit::CoreIPCSecCertificate',
+    'RetainPtr<SecKeychainItemRef>': 'WebKit::CoreIPCSecKeychainItem',
+    'RetainPtr<CVPixelBufferRef>': 'WebKit::CoreIPCCVPixelBufferRef',
+    'RetainPtr<SecTrustRef>': 'WebKit::CoreIPCSecTrust',
+    'RetainPtr<CFCharacterSetRef>': 'WebKit::CoreIPCCFCharacterSet',
+    'RetainPtr<CGColorRef>': 'WebCore::Color',
+    'RetainPtr<CGColorSpaceRef>': 'WebKit::CoreIPCCGColorSpace'
 }
 
 export function resolveAlias(argumentType) {
@@ -292,6 +313,7 @@ export class ArgumentSerializer {
     }
 
     static parseTemplate(name) {
+        name = name.trim();
         if(!name.endsWith(">")) {
             throw new SerializationError(`Cannot parse template '${ name }'. Does not end with '>'`);
         }
@@ -363,6 +385,32 @@ export class ArgumentSerializer {
         throw new SerializationError('argument of vector-type is not an array');
     }
 
+    static serializeArrayReferenceTuple(innerType, argument) {
+        const innerTypes = ArgumentSerializer.splitTemplateType(innerType);
+        if(Array.isArray(argument)) {
+            if(argument.length != innerTypes.length) {
+                throw new SerializationError(`expected ${ innerTypes.length } arguments but ${ argument.length } given`);
+            }
+            let allOfSameSize = argument.every((element) => argument[0].length == element.length);
+            if(!allOfSameSize) {
+                let sizes = argument.map(element => element.length);
+                throw new SerializationError(`ArrayReferenceTuple array elements must be have the same size: ${ sizes }`);
+            }
+            const result = [];
+            for(let i=0; i<innerTypes.length; i++) {
+                const argumentDefinition = {
+                    type: innerTypes[i],
+                }
+                for(let j=0; j<argument[i].length; j++) {
+                    argumentDefinition.name = `element#${ i }#${ j }`
+                    result.push(ArgumentSerializer.serializeArgument(argumentDefinition, argument[i][j]));
+                }
+            }
+            return [{value: argument[0].length, type: 'uint64_t'}, result]
+        }
+        throw new SerializationError('argument of ArrayReferenceTuple is not an array');
+    }
+
     static serializeHashSet(innerType, argument) {
         const splitType = ArgumentSerializer.splitTemplateType(innerType);
         innerType = splitType[0];
@@ -385,14 +433,10 @@ export class ArgumentSerializer {
     static serializeHashMap(innerType, argument) {
         if(Array.isArray(argument)) {
             const result = [];
-            const argumentDefinition = {
-                type: innerType,
-            };
             let count = 0;
             for(const element of argument) {
-                argumentDefinition.name = `key#${ count }`;
                 count += 1;
-                result.push([ ArgumentSerializer.serializeKeyValuePair(argumentDefinition, element) ]);
+                result.push([ ArgumentSerializer.serializeKeyValuePair(innerType, element) ]);
             }
             return [{value: count, type: 'uint32_t'}, result];
         }
@@ -461,7 +505,7 @@ export class ArgumentSerializer {
         const variantType = argument.variantType;
         const variantIndex = variantTypes.indexOf(variantType);
         if(variantIndex == -1) {
-            throw new SerializationError(`type '${ variantType }' is not valid for variant`);
+            throw new SerializationError(`type '${ variantType }' is not valid for variant (${ variantTypes })`);
         }
         if(!Object.hasOwn(argument, 'variant')) {
             throw new SerializationError('missing field \'variant\' when serializing variant');
@@ -490,6 +534,8 @@ export class ArgumentSerializer {
                 case 'ArrayReference':
                 case 'Span':
                     return ArgumentSerializer.serializeVector(innerType, argument);
+                case 'IPC::ArrayReferenceTuple':
+                    return ArgumentSerializer.serializeArrayReferenceTuple(innerType, argument);
                 case 'std::array':
                     return ArgumentSerializer.serializeStdArray(innerType, argument);
                 case 'HashSet':
@@ -500,6 +546,7 @@ export class ArgumentSerializer {
                     return ArgumentSerializer.serializePair(innerType, argument);
                 case 'OptionSet':
                     return ArgumentSerializer.serializeOptionSet(innerType, argumentDefinition.name, argument);
+                case 'WTF::Markable':
                 case 'Markable':
                     return ArgumentSerializer.serializeMarkable(innerType, argument);
                 case 'KeyValuePair':
@@ -525,7 +572,9 @@ export class ArgumentSerializer {
             if(argument < MIN_INT64 || argument > MAX_INT64) {
                 throw new SerializationError(`Identifier value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
             }
-            return {value: argument, type: 'uint64_t'};
+            // magic object identifier for WebGL hotpatches
+            let type = argumentDefinition.type.endsWith("::uint32_t") ? "uint32_t" : "uint64_t";
+            return {value: argument, type: type};
         }
         return undefined;
     }
@@ -621,15 +670,15 @@ export class ArgumentSerializer {
                 }
                 return {value: argument, type: argumentDefinition.type};
             case 'uint64_t':
-                if(typeof argument != "number") {
-                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
+                if(typeof argument != "number" && typeof argument != "bigint") {
+                    throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number. it is ${ typeof(argument) }. ${ argument }`);
                 }
                 if(argument < MIN_UINT || argument > MAX_UINT64) {
                     throw new SerializationError(`Primitive value (${ argumentDefinition.name }) of type ${ argumentDefinition.type } is out-of-bounds.`);
                 }
                 return {value: argument, type: argumentDefinition.type};
             case 'int64_t':
-                if(typeof argument != "number") {
+                if(typeof argument != "number" && typeof argument != "bigint") {
                     throw new SerializationError(`Primitive value of type ${ argumentDefinition.type } is not a number`);
                 }
                 if(argument < MIN_INT64 || argument > MAX_INT64) {
@@ -672,6 +721,30 @@ export class ArgumentSerializer {
                 if(argument === null) {
                     return [];
                 } else throw new SerializationError(`std::nullptr_t is not null`);
+            case 'WebCore::SharedMemory::Handle':
+            case 'WebCore::SharedMemoryHandle':
+            case 'MachSendRight':
+                if(typeof argument != 'object') {
+                    throw new SerializationError('SharedMemory argument is not an object');
+                }
+                if(!argument.protection) {
+                    throw new SerializationError('SharedMemory argument is missing \'protection\' attribute');
+                }
+                if(argument.protection != 'ReadOnly' && argument.protection != 'ReadWrite') {
+                    throw new SerializationError("SharedMemory protection should be either 'ReadWrite' or 'ReadOnly'");
+                }
+                if(!argument.handle) {
+                    throw new SerializationError('SharedMemory argument is missing \'handle\' attribute');
+                }
+                if(!argument.handle.writeBytes) {
+                    throw new SerializationError('SharedMemory handle argument is not an Object created with IPC.createSharedMemory');
+                }
+                return {value: argument.handle, type: 'SharedMemory', protection: argument.protection};
+            case 'IPC::Semaphore':
+                if(typeof(argument) != 'object' || !argument.signal) {
+                    throw new SerializationError('IPC::Semaphore argument is not an Object created with IPC.createSemaphore');
+                }
+                return {value: argument, type: 'Semaphore'};
         }
         return undefined;
     }
@@ -759,9 +832,16 @@ export class ArgumentParser {
 
     static parseIdentifier(buffer, position, argumentDefinition) {
         if(CoreIPC.objectIdentifiers.includes(argumentDefinition.type)) {
-            position = ArgumentParser.align(position, 8);
-            ArgumentParser.checkOutOfBounds(buffer, position, 8);
-            return [position + 8, {parsedValue: buffer.getBigUint64(position, true), parsedType: argumentDefinition.type}];
+            // magic object identifier for WebGL hotpatches
+            if(argumentDefinition.type.endsWith("::uint32_t")) {
+                position = ArgumentParser.align(position, 4);
+                ArgumentParser.checkOutOfBounds(buffer, position, 4);
+                return [position + 8, {parsedValue: buffer.getUint32(position, true), parsedType: argumentDefinition.type}];
+            } else {
+                position = ArgumentParser.align(position, 8);
+                ArgumentParser.checkOutOfBounds(buffer, position, 8);
+                return [position + 8, {parsedValue: buffer.getBigUint64(position, true), parsedType: argumentDefinition.type}];
+            }
         }
         return undefined;
     }
@@ -808,6 +888,24 @@ export class ArgumentParser {
         argumentDefinition.type = innerTypes[1];
         [position, element] = ArgumentParser.parseArgument(buffer, position, argumentDefinition);
         values.push(element);
+        return [position, values];
+    }
+
+    static parseHashMap(buffer, position, innerType) {
+        position = ArgumentParser.align(position, 4);
+        ArgumentParser.checkOutOfBounds(buffer, position, 4);
+        const elementCount = buffer.getUint32(position, true);
+        position += 4;
+        const values = [];
+        let element;
+        for(let index = 0; index < elementCount; index++) {
+            try {
+                [position, element] = ArgumentParser.parsePair(buffer, position, innerType);
+            } catch (error) {
+                throw new ParserError(`when parsing element #${ index } of HashMap: ${ error.message }`);
+            }
+            values.push(element);
+        }
         return [position, values];
     }
 
@@ -866,7 +964,7 @@ export class ArgumentParser {
                 case 'std::span':
                 case 'Vector': {
                     const [newPosition, values] = ArgumentParser.parseVector(buffer, position, innerType);
-                    return [newPosition, {parsedType: argumentDefinition.type, value: values}];
+                    return [newPosition, {parsedType: argumentDefinition.type, parsedValue: values}];
                 }
                 // TODO: HashSet and std::array and KeyValuePair and HashMap
                 case 'std::variant': {
@@ -881,6 +979,7 @@ export class ArgumentParser {
                     let [newPosition, optionSet] = ArgumentParser.parseEnum(buffer, position, {type: innerType, name: argumentDefinition.name});
                     return [newPosition, {parsedType: argumentDefinition.type, parsedValue: optionSet}];
                 }
+                case 'WTF::Markable':
                 case 'Markable': {
                     const [newPosition, value] = ArgumentParser.parseMarkable(buffer, position, innerType);
                     return [newPosition, {parsedType: argumentDefinition.type, parsedValue: value}]
@@ -888,6 +987,10 @@ export class ArgumentParser {
                 case 'Ref':
                 case 'UniqueRef': {
                     return ArgumentParser.parseArgument(buffer, position, {type: innerType, name: argumentDefinition.name});
+                }
+                case 'HashMap':
+                case 'MemoryCompactRobinHoodHashMap': {
+                    return ArgumentParser.parseHashMap(buffer, position, innerType);
                 }
                 default:
                     throw new ParserError(`Don't know how to parse template type '${ templateType }'`)

--- a/LayoutTests/ipc/invalid-ipc-cfdictionary-objects-crash-expected.txt
+++ b/LayoutTests/ipc/invalid-ipc-cfdictionary-objects-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/invalid-ipc-cfdictionary-objects-crash.html
+++ b/LayoutTests/ipc/invalid-ipc-cfdictionary-objects-crash.html
@@ -1,0 +1,119 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<html>
+<body>
+    <p>This test passes if WebKit does not crash.</p>
+    <script>
+
+        async function main() {
+            const streamConnection = CoreIPC.newStreamConnection();
+            const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+                renderingBackendIdentifier: renderingBackendIdentifier,
+                connectionHandle: streamConnection
+            });
+            const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+
+            const didInitializeReply = streamConnection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1)
+            streamConnection.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+            const graphicsContextGLIdentifier = Math.floor(Math.random() * 0x1000000);
+            const streamConnection2 = CoreIPC.newStreamConnection();
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateGraphicsContextGL(0, {
+                identifier: graphicsContextGLIdentifier,
+                attributes: {
+                    alpha: true,
+                    depth: true,
+                    stencil: false,
+                    antialias: true,
+                    premultipliedAlpha: true,
+                    preserveDrawingBuffer: false,
+                    powerPreference: 0,
+                    isWebGL2: true,
+                    windowGPUID: 0,
+                    xrCompatible: false,
+                    failContextCreationForTesting: 0
+                },
+                renderingBackendIdentifier: renderingBackendIdentifier,
+                serverConnection: streamConnection2,
+            });
+            const remoteGraphicsContextGL = streamConnection2.newInterface("RemoteGraphicsContextGL", graphicsContextGLIdentifier);
+
+            const wasCreatedReply = streamConnection2.connection.waitForMessage(graphicsContextGLIdentifier, IPC.messages.RemoteGraphicsContextGLProxy_WasCreated.name, 1)
+            streamConnection2.connection.setSemaphores(didInitializeReply[0].value, didInitializeReply[1].value);
+
+            remoteGraphicsContextGL.SetDrawingBufferColorSpace({
+                arg0: {
+                    serializableColorSpace: {
+                        alias: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: 'RetainPtr<CFTypeRef>',
+                                    variant: {
+                                        object: {
+                                            alias: {
+                                                variantType: "WebKit::CoreIPCCFDictionary",
+                                                variant: {
+                                                    vector: {
+                                                        optionalValue: [
+                                                        {
+                                                            key: {
+                                                                object: {
+                                                                    alias: {
+                                                                        variantType: "WebKit::CoreIPCCGColorSpace",
+                                                                        variant: {
+                                                                            m_cgColorSpace: {
+                                                                                alias: {
+                                                                                    variantType: "WebCore::ColorSpace",
+                                                                                    variant: 15
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            },
+                                                            value: {
+                                                                object: { alias: { variantType: "WebKit::CoreIPCBoolean", variant: { value: true } } }
+                                                            }
+                                                        }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        } 
+
+        globalThis.testRunner?.waitUntilDone();
+    </script>
+
+    <script type="module">
+        if (window.testRunner)
+            testRunner.dumpAsText();
+
+        if (window.IPC) {
+            const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+
+            window.CoreIPC = CoreIPC;
+            window.IPCWireTap = IPCWireTap;
+
+            setTimeout(() => {
+                try {
+                    main();
+                } catch {}
+                
+                finally {
+                    globalThis.testRunner?.notifyDone();
+                }
+
+            }, 100);
+        }
+        globalThis.testRunner?.notifyDone();
+    </script>
+</body>
+</html>

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlist.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlist.serialization.in
@@ -26,15 +26,15 @@ webkit_platform_headers: "ArgumentCodersCocoa.h" "CoreIPCPlistObject.h" "CoreIPC
 
 using WebKit::PlistValue = std::variant<WebKit::CoreIPCPlistArray, WebKit::CoreIPCPlistDictionary, WebKit::CoreIPCString, WebKit::CoreIPCNumber, WebKit::CoreIPCDate, WebKit::CoreIPCData>
 
-[WebKitPlatform] class WebKit::CoreIPCPlistObject {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCPlistObject {
     UniqueRef<WebKit::PlistValue> value();
 }
 
-[WebKitPlatform] class WebKit::CoreIPCPlistArray {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCPlistArray {
     Vector<WebKit::CoreIPCPlistObject> m_array;
 }
 
-[WebKitPlatform] class WebKit::CoreIPCPlistDictionary {
+[WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCPlistDictionary {
     Vector<KeyValuePair<WebKit::CoreIPCString, WebKit::CoreIPCPlistObject>> m_keyValuePairs;
 }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.h
@@ -39,6 +39,7 @@ public:
     CoreIPCPlistArray(NSArray *);
     CoreIPCPlistArray(const RetainPtr<NSArray>&);
     CoreIPCPlistArray(CoreIPCPlistArray&&);
+    CoreIPCPlistArray(const CoreIPCPlistArray&);
     CoreIPCPlistArray& operator=(CoreIPCPlistArray&&) = default;
     ~CoreIPCPlistArray();
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm
@@ -52,6 +52,8 @@ CoreIPCPlistArray::CoreIPCPlistArray(const RetainPtr<NSArray>& array)
 
 CoreIPCPlistArray::CoreIPCPlistArray(CoreIPCPlistArray&&) = default;
 
+CoreIPCPlistArray::CoreIPCPlistArray(const CoreIPCPlistArray&) = default;
+
 CoreIPCPlistArray::~CoreIPCPlistArray() = default;
 
 CoreIPCPlistArray::CoreIPCPlistArray(Vector<CoreIPCPlistObject>&& array)

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#include "CoreIPCPlistArray.h"
 #include "CoreIPCPlistObject.h"
 #include <wtf/ArgumentCoder.h>
 #include <wtf/KeyValuePair.h>
@@ -42,6 +43,7 @@ class CoreIPCPlistDictionary {
 public:
     CoreIPCPlistDictionary(NSDictionary *);
     CoreIPCPlistDictionary(const RetainPtr<NSDictionary>&);
+    CoreIPCPlistDictionary(const CoreIPCPlistDictionary&);
     CoreIPCPlistDictionary(CoreIPCPlistDictionary&&);
     CoreIPCPlistDictionary& operator=(CoreIPCPlistDictionary&&) = default;
     ~CoreIPCPlistDictionary();

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm
@@ -69,6 +69,8 @@ CoreIPCPlistDictionary::CoreIPCPlistDictionary(CoreIPCPlistDictionary&&) = defau
 
 CoreIPCPlistDictionary::~CoreIPCPlistDictionary() = default;
 
+CoreIPCPlistDictionary::CoreIPCPlistDictionary(const CoreIPCPlistDictionary&) = default;
+
 CoreIPCPlistDictionary::CoreIPCPlistDictionary(ValueType&& keyValuePairs)
     : m_keyValuePairs(WTFMove(keyValuePairs)) { }
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.h
@@ -28,6 +28,7 @@
 #if PLATFORM(COCOA)
 
 #include "ArgumentCodersCocoa.h"
+#include "StreamConnectionEncoder.h"
 #include <wtf/RetainPtr.h>
 #include <wtf/UniqueRef.h>
 
@@ -53,6 +54,8 @@ class CoreIPCPlistObject {
 public:
     CoreIPCPlistObject(id);
     CoreIPCPlistObject(UniqueRef<PlistValue>&&);
+    CoreIPCPlistObject(const CoreIPCPlistObject&);
+    CoreIPCPlistObject(CoreIPCPlistObject&&);
 
     RetainPtr<id> toID() const;
     static bool isPlistType(id);
@@ -70,6 +73,7 @@ namespace IPC {
 // makeUniqueRefWithoutFastMallocCheck<>, since we can't make the variant fast malloc'ed
 template<> struct ArgumentCoder<UniqueRef<WebKit::PlistValue>> {
     static void encode(Encoder&, const UniqueRef<WebKit::PlistValue>&);
+    static void encode(StreamConnectionEncoder&, const UniqueRef<WebKit::PlistValue>&);
     static std::optional<UniqueRef<WebKit::PlistValue>> decode(Decoder&);
 };
 

--- a/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm
@@ -89,13 +89,59 @@ RetainPtr<id> CoreIPCPlistObject::toID() const
     });
 }
 
+CoreIPCPlistObject::CoreIPCPlistObject(const CoreIPCPlistObject& other)
+    : m_value(makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCString()))
+{
+    PlistValue& plistValue = other.m_value.get();
+    WTF::switchOn(plistValue,
+        [&] (const CoreIPCPlistArray array) {
+            RetainPtr arrayPtr = array.toID();
+            m_value = makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCPlistArray(arrayPtr));
+            return;
+        },
+        [&] (const CoreIPCData data) {
+            RetainPtr dataPtr = data.toID();
+            m_value = makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCData(dataPtr.get()));
+            return;
+        },
+        [&] (const CoreIPCDate date) {
+            RetainPtr datePtr = date.toID();
+            m_value = makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCDate(datePtr.get()));
+            return;
+        },
+        [&] (const CoreIPCPlistDictionary dict) {
+            m_value = makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCPlistDictionary(dict.toID()));
+            return;
+        },
+        [&] (const CoreIPCNumber number) {
+            RetainPtr numPtr = number.toID();
+            m_value = makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCNumber(numPtr.get()));
+            return;
+        },
+        [&] (const CoreIPCString str) {
+            RetainPtr strPtr = str.toID();
+            m_value = makeUniqueRefWithoutFastMallocCheck<PlistValue>(CoreIPCString(strPtr.get()));
+            return;
+    });
+}
+
+CoreIPCPlistObject::CoreIPCPlistObject(CoreIPCPlistObject&& other)
+    : m_value(WTFMove(other.m_value))
+{
+}
+
 } // namespace WebKit
 
 namespace IPC {
 
 void ArgumentCoder<UniqueRef<WebKit::PlistValue>>::encode(Encoder& encoder, const UniqueRef<WebKit::PlistValue>& object)
 {
-    encoder << *object;
+    encoder << object;
+}
+
+void ArgumentCoder<UniqueRef<WebKit::PlistValue>>::encode(StreamConnectionEncoder& encoder, const UniqueRef<WebKit::PlistValue>& object)
+{
+    encoder << object;
 }
 
 std::optional<UniqueRef<WebKit::PlistValue>> ArgumentCoder<UniqueRef<WebKit::PlistValue>>::decode(Decoder& decoder)

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h
@@ -27,13 +27,17 @@
 
 #if PLATFORM(COCOA)
 
+#import "CoreIPCPlistDictionary.h"
+
 #import <CoreGraphics/CoreGraphics.h>
 #import <WebCore/Color.h>
 #import <WebCore/ColorSpace.h>
 #import <WebCore/ColorSpaceCG.h>
 #import <wtf/RetainPtr.h>
 
-using CGColorSpaceSerialization = std::variant<WebCore::ColorSpace, RetainPtr<CFStringRef>, RetainPtr<CFTypeRef>>;
+class CoreIPCPlistDictionary;
+
+using CGColorSpaceSerialization = std::variant<WebCore::ColorSpace, RetainPtr<CFStringRef>, WebKit::CoreIPCPlistDictionary>;
 
 namespace WebKit {
 class CoreIPCCGColorSpace {
@@ -44,15 +48,16 @@ public:
             m_cgColorSpace = *colorSpace;
         else if (RetainPtr<CFStringRef> name = CGColorSpaceGetName(cgColorSpace))
             m_cgColorSpace = WTFMove(name);
-        else if (auto propertyList = adoptCF(CGColorSpaceCopyPropertyList(cgColorSpace)))
-            m_cgColorSpace = WTFMove(propertyList);
-        else
+        else if (auto propertyList = adoptCF(CGColorSpaceCopyPropertyList(cgColorSpace))) {
+            if (CFGetTypeID(propertyList.get()) == CFDictionaryGetTypeID())
+                m_cgColorSpace = CoreIPCPlistDictionary((NSDictionary*)propertyList.get());
+        } else
             // FIXME: This should be removed once we can prove only non-null cgColorSpaces.
             m_cgColorSpace = WebCore::ColorSpace::SRGB;
     }
 
     CoreIPCCGColorSpace(CGColorSpaceSerialization data)
-        : m_cgColorSpace(data)
+        : m_cgColorSpace(WTFMove(data))
     {
     }
 
@@ -65,8 +70,9 @@ public:
             [](RetainPtr<CFStringRef> name) -> RetainPtr<CGColorSpaceRef> {
                 return adoptCF(CGColorSpaceCreateWithName(name.get()));
             },
-            [](RetainPtr<CFTypeRef> propertyList) -> RetainPtr<CGColorSpaceRef> {
-                return adoptCF(CGColorSpaceCreateWithPropertyList(propertyList.get()));
+            [](WebKit::CoreIPCPlistDictionary propertyList) -> RetainPtr<CGColorSpaceRef> {
+                RetainPtr pList = propertyList.toID();
+                return adoptCF(CGColorSpaceCreateWithPropertyList((CFPropertyListRef)pList.get()));
             }
         );
         if (UNLIKELY(!colorSpace))

--- a/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.serialization.in
+++ b/Source/WebKit/Shared/cf/CoreIPCCGColorSpace.serialization.in
@@ -27,6 +27,6 @@ webkit_platform_headers: "CoreIPCCGColorSpace.h"
 [WebKitPlatform, AdditionalEncoder=StreamConnectionEncoder] class WebKit::CoreIPCCGColorSpace {
     CGColorSpaceSerialization m_cgColorSpace;
 }
-using CGColorSpaceSerialization = std::variant<WebCore::ColorSpace, RetainPtr<CFStringRef>, RetainPtr<CFTypeRef>>;
+using CGColorSpaceSerialization = std::variant<WebCore::ColorSpace, RetainPtr<CFStringRef>, WebKit::CoreIPCPlistDictionary>;
 
 #endif


### PR DESCRIPTION
#### 634bc8c5b38a3a90f35b814582349382677740a5
<pre>
CoreIPCCFDictionary::createCFDictionary() doesn&apos;t validate key/value type
<a href="https://bugs.webkit.org/show_bug.cgi?id=289280">https://bugs.webkit.org/show_bug.cgi?id=289280</a>
<a href="https://rdar.apple.com/146384453">rdar://146384453</a>

Reviewed by NOBODY (OOPS!).

Restricted CGColorSpaceSerialization type to hold CoreIPCPlistDictionary values only.

* LayoutTests/ipc/coreipc.js:
(splitClassAndFunction):
(CoreIPCClass.prototype.initializeMessageByName):
(CoreIPCClass.prototype.initializeMessages):
(CoreIPCClass.prototype.generateSendingFunction):
(export.StreamConnection):
(export.StreamConnectionInterface):
(export.StreamConnectionInterface.prototype.getIdentifier):
(export.StreamConnectionInterface.prototype.initializeMessages):
(export.StreamConnectionInterface.prototype.generateStreamSendingFunction):
(export.ArgumentSerializer.parseTemplate):
(export.ArgumentSerializer):
* LayoutTests/ipc/invalid-ipc-cfdictionary-objects-crash-expected.txt: Added.
* LayoutTests/ipc/invalid-ipc-cfdictionary-objects-crash.html: Added.
* Source/WebKit/Shared/Cocoa/CoreIPCPlist.serialization.in:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistArray.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistDictionary.mm:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.h:
* Source/WebKit/Shared/Cocoa/CoreIPCPlistObject.mm:
(WebKit::CoreIPCPlistObject::CoreIPCPlistObject):
(IPC::ArgumentCoder&lt;UniqueRef&lt;WebKit::PlistValue&gt;&gt;::encode):
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.h:
(WebKit::CoreIPCCGColorSpace::CoreIPCCGColorSpace):
(WebKit::CoreIPCCGColorSpace::toCF const):
* Source/WebKit/Shared/cf/CoreIPCCGColorSpace.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/634bc8c5b38a3a90f35b814582349382677740a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/95397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/15000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/100444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45902 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/15287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/23431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72759 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/30024 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/98399 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11432 "Found 60 new test failures: accessibility/accessibility-node-reparent.html accessibility/ancestor-computation.html accessibility/announcement-notification.html accessibility/aria-braillelabel.html accessibility/aria-brailleroledescription.html accessibility/aria-checked-mixed-value.html accessibility/aria-controlled-table-row-visibility.html accessibility/aria-current-state-changed-notification.html accessibility/aria-current.html accessibility/aria-describedby-on-input.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/86111 "Found 2 new API test failures: TestWebKitAPI.SampledPageTopColor.HitTestHTMLImage, TestWebKitAPI.WebKit.LoadAndDecodeImage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/53090 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/11145 "Found 60 new test failures: imported/w3c/web-platform-tests/FileAPI/Blob-methods-from-detached-frame.html imported/w3c/web-platform-tests/FileAPI/FileReader/Progress_event_bubbles_cancelable.html imported/w3c/web-platform-tests/FileAPI/FileReader/workers.html imported/w3c/web-platform-tests/FileAPI/FileReaderSync.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-array-buffer.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-bytes.any.worker.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-dom.window.html imported/w3c/web-platform-tests/FileAPI/blob/Blob-constructor-endings.html ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3843 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/45238 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/82608 "Build was cancelled. Recent messages:OS: Sequoia (15.2), Xcode: 16.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (failure); re-run-api-tests (cancelled)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3938 "Found 23 new test failures: fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/images/animated-image-mp4.html fast/images/exif-orientation-background-image-repeat.html fast/images/exif-orientation-svg-feimage.html fast/images/jpegxl-with-color-profile.html fast/text/otsvg-spacing-canvas.html imported/mozilla/svg/filters/feSpecularLighting-1.svg imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-space-011.html imported/w3c/web-platform-tests/css/css-backgrounds/border-image-slice-fill-001.html ... (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/102481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/22447 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16383 "Found 60 new test failures: accessibility/ARIA-reflection.html accessibility/accessibility-crash-focused-element-change.html accessibility/accessibility-crash-setattribute.html accessibility/accessibility-crash-with-dynamic-inline-content.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-hierarchy.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81774 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/82122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/81146 "Passed tests") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25721 "Found 60 new test failures: http/wpt/webxr/events_transient_pointer_input_source.https.html http/wpt/webxr/xrDevice_requestSession_hand_tracking_feature.https.html http/wpt/webxr/xrDevice_requestSession_previously_enabled_feature_not_requested.https.html http/wpt/webxr/xrFrame_fillJointRadii.html http/wpt/webxr/xrFrame_fillJointRadii_missing_joint_pose.html http/wpt/webxr/xrFrame_fillPoses.html http/wpt/webxr/xrFrame_fillPoses_missing_joint_pose.html http/wpt/webxr/xrFrame_getJointPose.html http/wpt/webxr/xrFrame_getJointPose_missing_joint_pose.html http/wpt/webxr/xrHand.html ... (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/3141 "Found 22 new test failures: fast/canvas/canvas-createPattern-video-loading.html fast/canvas/canvas-createPattern-video-modify.html fast/images/animated-image-mp4.html fast/images/exif-orientation-background-image-repeat.html fast/images/exif-orientation-svg-feimage.html fast/images/jpegxl-with-color-profile.html fast/text/otsvg-spacing-canvas.html imported/mozilla/svg/filters/feSpecularLighting-1.svg imported/w3c/web-platform-tests/css/css-backgrounds/border-image-repeat-space-011.html imported/w3c/web-platform-tests/css/css-backgrounds/border-image-slice-fill-001.html ... (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/15738 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/22416 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27555 "Failed to build and analyze WebKit") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/22075 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25550 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->