### PR TITLE
Make back/forward policy delegate API

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h
@@ -29,6 +29,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class WKBackForwardListItem;
 @class WKDownload;
 @class WKNavigation;
 @class WKNavigationAction;
@@ -187,6 +188,22 @@ WK_SWIFT_UI_ACTOR
  @discussion The download needs its delegate to be set to receive updates about its progress.
 */
 - (void)webView:(WKWebView *)webView navigationResponse:(WKNavigationResponse *)navigationResponse didBecomeDownload:(WKDownload *)download WK_API_AVAILABLE(macos(11.3), ios(14.5));
+
+/*
+ @abstract Called when the webpage initiates a back/forward navigation via JavaScript
+ @param webView The web view invoking the delegate method.
+ @param backForwardListItem The back/forward list item that will be navigated to
+ @param willUseInstantBack Whether or not the navigation will resume a previously suspended webpage that is eligible for Instant Back
+ @param completionHandler The completion handler you must invoke to allow or disallow the navigation
+ @discussion Back/forward navigations - including those triggered by webpage JavaScript - will consult the WebKit client via this delegate.
+ If the `willUseInstantBack` argument is `YES`, then the navigation is to a webpage that is suspended in memory and might be resumed without
+ the normal webpage loading process.
+ Even if the `willUseInstantBack` argument is `YES`, it is possible that the suspended webpage will not be used and the normal loading
+ process will take place.
+ In the case where the normal webpage loading process takes place, additional navigation delegate calls will continue to happen for this
+ navigation starting with `decidePolicyForNavigationAction`
+*/
+- (void)webView:(WKWebView *)webView shouldGoToBackForwardListItem:(WKBackForwardListItem *)backForwardListItem willUseInstantBack:(BOOL)willUseInstantBack completionHandler:(void (^)(BOOL shouldGoToItem))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -277,6 +277,7 @@ private:
         bool webViewBackForwardListItemAddedRemoved : 1;
         bool webViewWillGoToBackForwardListItemInBackForwardCache : 1;
         bool webViewShouldGoToBackForwardListItemInBackForwardCacheCompletionHandler : 1;
+        bool webViewShouldGoToBackForwardListItemWillUseInstantBackCompletionHandler : 1;
 
 #if HAVE(APP_SSO)
         bool webViewDecidePolicyForSOAuthorizationLoadWithCurrentPolicyForExtensionCompletionHandler : 1;


### PR DESCRIPTION
#### 9b705a4990eba19136ff0e2ff448a6ccbf13b76a
<pre>
Make back/forward policy delegate API
<a href="https://rdar.apple.com/146401641">rdar://146401641</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289285">https://bugs.webkit.org/show_bug.cgi?id=289285</a>

Reviewed by Chris Dumez and Basuke Suzuki.

* Source/WebKit/UIProcess/API/Cocoa/WKNavigationDelegate.h:

* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::setNavigationDelegate):
(WebKit::NavigationState::NavigationClient::shouldGoToBackForwardListItem):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(-[BackForwardDelegateWithShouldGo webView:shouldGoToBackForwardListItem:willUseInstantBack:completionHandler:]):
(-[BackForwardDelegateWithShouldGo _webView:shouldGoToBackForwardListItem:inPageCache:completionHandler:]):
(-[BackForwardDelegateWithShouldGo webView:didFinishNavigation:]):
(-[BackForwardDelegateWithShouldGoSPI _webView:willGoToBackForwardListItem:inPageCache:]):
(TEST(WKNavigation, ShouldGoToBackForwardListItem)):

Canonical link: <a href="https://commits.webkit.org/291747@main">https://commits.webkit.org/291747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c9dfcfb6f4dee4c26d67e90c99899b00ae019ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93862 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/131/builds/13445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98868 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/44388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21878 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/44388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10201 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51961 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9885 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43705 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100905 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20914 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21166 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80764 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/79991 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19914 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24541 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/1903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20898 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20585 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24045 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/22326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->