### PR TITLE
Address more Safer CPP failures in WebViewImpl.mm

### DIFF
--- a/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
+++ b/Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm
@@ -57,7 +57,7 @@
 {
     if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
-            _webView->protectedPage()->setCaretBlinkingSuspended(false);
+            _webView->page().setCaretBlinkingSuspended(false);
         return;
     }
 
@@ -66,7 +66,7 @@
         if (NSTextInputContext *context = _webView->inputContext())
             context.showsCursorAccessories = YES;
 
-        _webView->protectedPage()->setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
     }
 }
 
@@ -77,26 +77,26 @@
 
     _caretType = WebCore::CaretAnimatorType::Default;
     if (_webView)
-        _webView->protectedPage()->setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Default);
 }
 
 - (void)dictationDidPause
 {
     if (_webView)
-        _webView->protectedPage()->setCaretBlinkingSuspended(true);
+        _webView->page().setCaretBlinkingSuspended(true);
 }
 
 - (void)dictationDidResume
 {
     if (_caretType == WebCore::CaretAnimatorType::Dictation) {
         if (_webView)
-            _webView->protectedPage()->setCaretBlinkingSuspended(false);
+            _webView->page().setCaretBlinkingSuspended(false);
         return;
     }
 
     _caretType = WebCore::CaretAnimatorType::Dictation;
     if (_webView)
-        _webView->protectedPage()->setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
+        _webView->page().setCaretAnimatorType(WebCore::CaretAnimatorType::Dictation);
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
+++ b/Source/WebKit/UIProcess/mac/CorrectionPanel.mm
@@ -93,7 +93,7 @@ String CorrectionPanel::dismissInternal(ReasonForDismissingAlternativeText reaso
 
 void CorrectionPanel::recordAutocorrectionResponse(WebViewImpl& webViewImpl, NSInteger spellCheckerDocumentTag, NSCorrectionResponse response, const String& replacedString, const String& replacementString)
 {
-    if (webViewImpl.protectedPage()->sessionID().isEphemeral())
+    if (webViewImpl.page().sessionID().isEphemeral())
         return;
 
     [[NSSpellChecker sharedSpellChecker] recordResponse:response toCorrection:replacementString forWord:replacedString language:nil inSpellDocumentWithTag:spellCheckerDocumentTag];

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -227,7 +227,6 @@ public:
     NSWindow *window();
 
     WebPageProxy& page() { return m_page.get(); }
-    Ref<WebPageProxy> protectedPage() const;
 
     WKWebView *view() const { return m_view.getAutoreleased(); }
 
@@ -891,8 +890,8 @@ private:
     std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
 
     WeakObjCPtr<WKWebView> m_view;
-    std::unique_ptr<PageClient> m_pageClient;
-    Ref<WebPageProxy> m_page;
+    const UniqueRef<PageClient> m_pageClient;
+    const Ref<WebPageProxy> m_page;
 
     DrawingAreaType m_drawingAreaType { DrawingAreaType::TiledCoreAnimation };
 


### PR DESCRIPTION
#### c5057d64bcd69499ba1b4bfaea96ae61ce4a6401
<pre>
Address more Safer CPP failures in WebViewImpl.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=289281">https://bugs.webkit.org/show_bug.cgi?id=289281</a>

Reviewed by Charlie Wolfe.

* Source/WebKit/Platform/cocoa/_WKWebViewTextInputNotifications.mm:
(-[_WKWebViewTextInputNotifications dictationDidStart]):
(-[_WKWebViewTextInputNotifications dictationDidEnd]):
(-[_WKWebViewTextInputNotifications dictationDidPause]):
(-[_WKWebViewTextInputNotifications dictationDidResume]):
* Source/WebKit/UIProcess/mac/CorrectionPanel.mm:
(WebKit::CorrectionPanel::recordAutocorrectionResponse):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::WebViewImpl):
(WebKit::m_flagsChangedEventMonitorTrackingArea):
(WebKit::WebViewImpl::shouldDelayWindowOrderingForEvent):
(WebKit::WebViewImpl::performDragOperation):
(WebKit::WebViewImpl::showWritingTools):
(WebKit::WebViewImpl::protectedPage const): Deleted.

Canonical link: <a href="https://commits.webkit.org/291755@main">https://commits.webkit.org/291755@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fece0f392b4ac915c5f67e0eb997f780f3a73e0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98871 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44391 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/28989 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96867 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10203 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84809 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51965 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9887 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43708 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80152 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100925 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80654 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80002 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24549 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14074 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26079 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20588 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24048 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->