### PR TITLE
[WPE] Crash in WKWPE::ViewLegacy::callAfterNextPresentationUpdate

### DIFF
--- a/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp
@@ -405,7 +405,9 @@ WebKit::WebPageProxy* ViewLegacy::platformWebPageProxyForGamepadInput()
 
 void ViewLegacy::callAfterNextPresentationUpdate(CompletionHandler<void()>&& callback)
 {
-    RELEASE_ASSERT(m_pageProxy->drawingArea());
+    if (!m_pageProxy->drawingArea())
+        return callback();
+
     downcast<DrawingAreaProxyCoordinatedGraphics>(*m_pageProxy->drawingArea()).dispatchAfterEnsuringDrawing(WTFMove(callback));
 }
 


### PR DESCRIPTION
#### d5ef4ceac97176cb50af134498e5f42e174a9b80
<pre>
[WPE] Crash in WKWPE::ViewLegacy::callAfterNextPresentationUpdate
<a href="https://bugs.webkit.org/show_bug.cgi?id=289282">https://bugs.webkit.org/show_bug.cgi?id=289282</a>

Reviewed by Carlos Garcia Campos.

After web process crashes, drawing area may be reset to null in `WebPageProxy::resetState`,
and calling `callAfterNextPresentationUpdate` on it could trigger release assert in
`WPEWebViewLegacy.cpp` inside `ViewLegacy::callAfterNextPresentationUpdate`. To avoid that,
we make sure the drawing area is still valid after receiving async reply from the web process.

* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::callAfterNextPresentationUpdate):

Canonical link: <a href="https://commits.webkit.org/291884@main">https://commits.webkit.org/291884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319eb42ab4893cebdb59f5dd46f8560d0b0dfafb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44526 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13882 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71730 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29078 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10307 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84964 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52070 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9988 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43842 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101048 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15342 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80738 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80100 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24648 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14213 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15127 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21035 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26213 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20722 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->