### PR TITLE
Calling history.back() in an iframe stops all pending network requests

### DIFF
--- a/LayoutTests/http/tests/navigation/back-in-iframe-does-not-stop-loading-expected.txt
+++ b/LayoutTests/http/tests/navigation/back-in-iframe-does-not-stop-loading-expected.txt
@@ -1,0 +1,4 @@
+CONSOLE MESSAGE: Received event: fetch completed
+This checks that history.back() in an iframe does not stop outstanding network requests.
+
+

--- a/LayoutTests/http/tests/navigation/back-in-iframe-does-not-stop-loading.html
+++ b/LayoutTests/http/tests/navigation/back-in-iframe-does-not-stop-loading.html
@@ -1,0 +1,16 @@
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onmessage = function (event) {
+    console.log(`Received event: ${event.data}`);
+    if (window.testRunner) {
+        testRunner.notifyDone();
+    }
+}
+</script>
+
+<p>This checks that history.back() in an iframe does not stop outstanding network requests.</p>
+<iframe src="resources/back-in-iframe-does-not-stop-loading-iframe.html"></iframe>

--- a/LayoutTests/http/tests/navigation/resources/back-in-iframe-does-not-stop-loading-iframe.html
+++ b/LayoutTests/http/tests/navigation/resources/back-in-iframe-does-not-stop-loading-iframe.html
@@ -1,0 +1,16 @@
+<script>
+function runTest() {
+    window.location.hash = "#test";
+    startFetch();
+    history.back();
+}
+
+function startFetch() {
+    fetch("../resources/slow-resource.pl?delay=1000")
+        .then(() => window.top.postMessage("fetch completed", "*"))
+        .catch((err) => window.top.postMessage(`fetch failed: ${err}`, "*"));
+}
+
+window.onload = () => setTimeout(runTest);
+</script>
+<p>This checks that history.back() in an iframe does not stop outstanding network requests.</p>

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -298,8 +298,8 @@ bool HistoryController::shouldStopLoadingForHistoryItem(HistoryItem& targetItem)
     if (!currentItem)
         return false;
 
-    // Don't abort the current load if we're navigating within the current document.
-    if (currentItem->shouldDoSameDocumentNavigationTo(targetItem))
+    // Don't abort the current load unless it's associated with a different document.
+    if (currentItem->documentSequenceNumber() == targetItem.documentSequenceNumber())
         return false;
 
     return true;
@@ -309,7 +309,7 @@ bool HistoryController::shouldStopLoadingForHistoryItem(HistoryItem& targetItem)
 // This includes recursion to handle loading into framesets properly
 void HistoryController::goToItem(HistoryItem& targetItem, FrameLoadType frameLoadType, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
 {
-    LOG(History, "HistoryController %p goToItem %p type=%d", this, &targetItem, static_cast<int>(frameLoadType));
+    RELEASE_LOG(History, "%p - HistoryController::goToItem: item %p, type=%d", this, &targetItem, static_cast<int>(frameLoadType));
 
     RefPtr page = m_frame->page();
     if (!page)
@@ -364,7 +364,7 @@ struct HistoryController::FrameToNavigate {
 
 void HistoryController::goToItemForNavigationAPI(HistoryItem& targetItem, FrameLoadType frameLoadType, LocalFrame& triggeringFrame, NavigationAPIMethodTracker* tracker)
 {
-    LOG(History, "HistoryController %p goToItemForNavigationAPI %p type=%d", this, &targetItem, static_cast<int>(frameLoadType));
+    RELEASE_LOG(History, "%p - HistoryController::goToItemForNavigationAPI: item %p type=%d", this, &targetItem, static_cast<int>(frameLoadType));
 
     Ref frame = m_frame.get();
     RefPtr page = frame->page();


### PR DESCRIPTION
#### c71c8ea9721a124f9013da3611269a193e74af4b
<pre>
Calling history.back() in an iframe stops all pending network requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=289294">https://bugs.webkit.org/show_bug.cgi?id=289294</a>
<a href="https://rdar.apple.com/146430092">rdar://146430092</a>

Reviewed by Brady Eidson.

Going back in an iframe stops all outstanding network requests. This is because `Page::goToItem`
will ask FrameLoader to stop all requests if we are doing a cross-doc navigation (as defined by
`HistoryItem::shouldDoSameDocumentNavigationTo`). However, in the case where the target top-level
HistoryItem is the same as the current top-level HistoryItem (as in the case of going back in an
iframe), `shouldDoSameDocumentNavigationTo` always returns false. So even though we&apos;re actually
staying in the same document, we still end up canceling all outstanding loads.

I thought about changing `shouldDoSameDocumentNavigationTo`, but that seems like it might be risky
and risk further breakage, since that heuristic hasn&apos;t been changed in many years.

I also thought about removing the call to eagerly stop all loaders at `Page::goToItem` time
entirely. It seems like we could just wait for those loaders to stop naturally once the document
navigation commits. However, changing this logic also seems potentially risky since it seems like we
started to depend on eager stopping to prevent some crashes (see r79107).

So I ended up keeping the eager call to stop all loaders in `Page::goToItem`, but it&apos;s now only
called if we are actually changing document objects as a result of the history navigation (as defined
by a differing document sequence numbers in the history item).

Some history I pulled up here trying to understand the original logic:

1. Brady first added the call to `FrameLoader::stopAllLoaders` to `Page::goToItem` in r18541. There
   is not much explanation for why this was added. Perhaps this is due to wanting to make sure
  `history.go(0)` acts similar to a reload (see r55375).

2. We exempted documents with only a state change from eager `stopAllLoaders` logic in r51644.

3. We started making `shouldDoSameDocumentNavigationTo` return false when targeting the current item
   in r61207 (refined in r68742) to fix a crash.

4. We exempted documents with only a hash change from eager `stopAllLoaders` logic in r79107.
   However, this change didn&apos;t fix the issue for hash changes in iframes (this bug) due to the
   change in (3).

* LayoutTests/http/tests/navigation/back-in-iframe-does-not-stop-loading-expected.txt: Added.
* LayoutTests/http/tests/navigation/back-in-iframe-does-not-stop-loading.html: Added.
* LayoutTests/http/tests/navigation/resources/back-in-iframe-does-not-stop-loading-iframe.html: Added.
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::shouldStopLoadingForHistoryItem const):
(WebCore::HistoryController::goToItem):
(WebCore::HistoryController::goToItemForNavigationAPI):

Canonical link: <a href="https://commits.webkit.org/291823@main">https://commits.webkit.org/291823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed077d47c3e4d4d921c23a3560403185a9ea4a4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99100 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44616 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71782 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29126 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52123 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2635 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43932 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80297 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101139 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80789 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80164 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24708 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14303 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26304 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20812 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24272 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->