### PR TITLE
[API-Tests-macOS-EWS]  TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen is timing out

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm
@@ -275,7 +275,8 @@ TEST(FullscreenVideoTextRecognition, AddVideoAfterEnteringFullscreen)
 
 // FIXME: Re-enable this test for iOS once webkit.org/b/248094 is resolved
 // FIXME: Re-enable this test once webkit.org/b/248093 is resolved.
-#if PLATFORM(IOS) || PLATFORM(VISION) || !defined(NDEBUG)
+// FIXME: Re-enable this test in Sonoma once webkit.org/b/289025 is resolved.
+#if PLATFORM(IOS) || PLATFORM(VISION) || !defined(NDEBUG) || (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED > 140000 && __MAC_OS_X_VERSION_MIN_REQUIRED < 150000)
 TEST(FullscreenVideoTextRecognition, DISABLED_DoNotAnalyzeVideoAfterExitingFullscreen)
 #else
 TEST(FullscreenVideoTextRecognition, DoNotAnalyzeVideoAfterExitingFullscreen)


### PR DESCRIPTION
#### 02bc1e428088ac7c7bc5730371eb85980beec92b
<pre>
[API-Tests-macOS-EWS]  TestWebKitAPI.FullscreenVideoTextRecognition.DoNotAnalyzeVideoAfterExitingFullscreen is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=289025">https://bugs.webkit.org/show_bug.cgi?id=289025</a>
<a href="https://rdar.apple.com/146064698">rdar://146064698</a>

Unreviewed test gardening

Skipping API test in Sonoma due to timeouts in EWS.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenVideoTextRecognition.mm:

Canonical link: <a href="https://commits.webkit.org/291780@main">https://commits.webkit.org/291780@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca66602c772daf3fd2d3303680ddaf859f63640a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93890 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71646 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29005 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96892 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10224 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84831 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/51982 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2468 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43733 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80169 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100935 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80664 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80012 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/19917 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1927 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14099 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15078 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20926 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24073 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->