### PR TITLE
[iOS] [Visual Bidi Selection] Selection flickers when selecting LTR text next to Indic numerals

### DIFF
--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7.html
@@ -30,23 +30,7 @@ jsTestIsAsync = true;
 addEventListener("load", async () => {
     description("Verifies that the selection remains visually consistent when selecting the entire first line in the paragraph below. To manually run the test, select the text highlighted in red, from right to left");
 
-    lineBounds = (() => {
-        const range = document.createRange();
-        range.selectNodeContents(document.querySelector("p[dir='rtl']"));
-        const clientRects = range.getClientRects();
-        const firstRect = clientRects[0];
-        const secondRect = clientRects[1];
-        const x = Math.min(firstRect.left, secondRect.left);
-        const y = Math.min(firstRect.top, secondRect.top);
-        const maxX = Math.max(firstRect.left + firstRect.width, secondRect.left + secondRect.width);
-        const maxY = Math.max(firstRect.top + firstRect.height, secondRect.top + secondRect.height);
-        return {
-            top: Math.round(y),
-            left: Math.round(x),
-            width: Math.round(maxX - x),
-            height: Math.round(maxY - y)
-        };
-    })();
+    lineBounds = UIHelper.computeLineBounds(document.querySelector("p[dir='rtl']"), 0, 1);
 
     let overlay = document.querySelector("div.overlay");
     overlay.style.top = `${lineBounds.top}px`;

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8.html
@@ -31,26 +31,9 @@ jsTestIsAsync = true;
 addEventListener("load", async () => {
     description("Verifies that the selection extends to select the contents of the second line, and the ending selection handle is placed on the left.");
 
-    function computeLineBounds(firstRunIndex, lastRunIndex) {
-        const range = document.createRange();
-        range.selectNodeContents(document.querySelector("p[dir='rtl']"));
-        const clientRects = range.getClientRects();
-        const firstRect = clientRects[firstRunIndex];
-        const secondRect = clientRects[lastRunIndex];
-        const x = Math.min(firstRect.left, secondRect.left);
-        const y = Math.min(firstRect.top, secondRect.top);
-        const maxX = Math.max(firstRect.left + firstRect.width, secondRect.left + secondRect.width);
-        const maxY = Math.max(firstRect.top + firstRect.height, secondRect.top + secondRect.height);
-        return {
-            top: Math.round(y),
-            left: Math.round(x),
-            width: Math.round(maxX - x),
-            height: Math.round(maxY - y)
-        };
-    }
-
-    firstLineBounds = computeLineBounds(0, 1);
-    lastLineBounds = computeLineBounds(2, 3);
+    let paragraph = document.querySelector("p[dir='rtl']");
+    firstLineBounds = UIHelper.computeLineBounds(paragraph, 0, 1);
+    lastLineBounds = UIHelper.computeLineBounds(paragraph, 2, 3);
 
     let overlay = document.querySelector("div.overlay");
     overlay.style.top = `${firstLineBounds.top}px`;

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-9-expected.txt
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-9-expected.txt
@@ -1,0 +1,15 @@
+۲۸۴۷۴۸۵۸۳۸۵۸۴۹ Hello
+
+Verifies that 'Hello' does not get visually unselected while extending the selection handle across Indic numerals
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS visuallyContiguousBeforeEndingSelection is true
+PASS visuallyContiguousAfterEndingSelection is true
+PASS selectionRectAfterEndingSelection.left is selectionRectBeforeEndingSelection.left
+PASS selectionRectAfterEndingSelection.width is > selectionRectBeforeEndingSelection.width
+PASS getSelection().toString() is "۲۸۴۷۴۸۵۸۳۸۵۸۴۹ Hello"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-9.html
+++ b/LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-9.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true VisuallyContiguousBidiTextSelectionEnabled=true ] -->
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    font-size: 24px;
+    font-family: system-ui;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that 'Hello' does not get visually unselected while extending the selection handle across Indic numerals");
+
+    paragraph = document.querySelector("p[dir='rtl']");
+    helloMidpoint = UIHelper.midPointOfRect(UIHelper.computeLineBounds(paragraph, 0));
+    urduTextMidpoint = UIHelper.midPointOfRect(UIHelper.computeLineBounds(paragraph, 2));
+
+    await UIHelper.longPressAtPoint(helloMidpoint.x, helloMidpoint.y);
+    await UIHelper.waitForSelectionToAppear();
+
+    const endHandlePoint = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(endHandlePoint.x, endHandlePoint.y)
+        .move(urduTextMidpoint.x + 30, urduTextMidpoint.y, 0.8)
+        .wait(0.2)
+        .takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    visuallyContiguousBeforeEndingSelection = await UIHelper.isSelectionVisuallyContiguous();
+    selectionRectBeforeEndingSelection = await UIHelper.selectionBounds();
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder().end().takeResult());
+    await UIHelper.ensurePresentationUpdate();
+
+    visuallyContiguousAfterEndingSelection = await UIHelper.isSelectionVisuallyContiguous();
+    selectionRectAfterEndingSelection = await UIHelper.selectionBounds();
+
+    shouldBeTrue("visuallyContiguousBeforeEndingSelection");
+    shouldBeTrue("visuallyContiguousAfterEndingSelection");
+    shouldBe("selectionRectAfterEndingSelection.left", "selectionRectBeforeEndingSelection.left");
+    shouldBeGreaterThan("selectionRectAfterEndingSelection.width", "selectionRectBeforeEndingSelection.width");
+    shouldBeEqualToString("getSelection().toString()", paragraph.textContent);
+
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <p dir="rtl">۲۸۴۷۴۸۵۸۳۸۵۸۴۹ Hello</p>
+    <div id="description"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1100,6 +1100,24 @@ window.UIHelper = class UIHelper {
         return { x: rect.left + (rect.width / 2), y: rect.top + (rect.height / 2) };
     }
 
+    static computeLineBounds(element, firstRunIndex, lastRunIndex = undefined) {
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        const clientRects = range.getClientRects();
+        const firstRect = clientRects[firstRunIndex];
+        const secondRect = clientRects[lastRunIndex || firstRunIndex];
+        const x = Math.min(firstRect.left, secondRect.left);
+        const y = Math.min(firstRect.top, secondRect.top);
+        const maxX = Math.max(firstRect.left + firstRect.width, secondRect.left + secondRect.width);
+        const maxY = Math.max(firstRect.top + firstRect.height, secondRect.top + secondRect.height);
+        return {
+            top: Math.round(y),
+            left: Math.round(x),
+            width: Math.round(maxX - x),
+            height: Math.round(maxY - y)
+        };
+    }
+
     static selectionCaretBackgroundColor()
     {
         return new Promise(resolve => {


### PR DESCRIPTION
#### 9105abab73883129180e27a5e6bbd163d5c6fe20
<pre>
[iOS] [Visual Bidi Selection] Selection flickers when selecting LTR text next to Indic numerals
<a href="https://bugs.webkit.org/show_bug.cgi?id=289302">https://bugs.webkit.org/show_bug.cgi?id=289302</a>
<a href="https://rdar.apple.com/144607260">rdar://144607260</a>

Reviewed by Aditya Keerthi.

Consider the following scenario, where two bidi LTR text runs are embedded in an RTL paragraph, with
only a space character in between; let&apos;s suppose the entire left word (second in logical order) is
selected below, with `S` and `E` denoting the selection start and end, respectively. The selection
highlight (as seen by the user) is also denoted below.

        &quot;Hello&quot;      &quot;۷۴۸۵۵&quot;
      S        E
    | ▦▦▦▦▦▦▦▦▦▦ | ▦▦▦▦▦▦▦▦▦▦ |
    | ---ltr---&gt; | ---ltr---&gt; |
    |&lt;------------------------| rtl ¶

      ▦▦▦▦▦▦▦▦▦▦               selection highlight

Now, suppose the user takes the selection end handle (`E`) and extends it into the right word, such
that the selection handles flip (due to reversing the logical base/extent) — that is, the previous
selection end becomes the new start of the selection, and the previous start becomes the new end:

        &quot;Hello&quot;      &quot;۷۴۸۵۵&quot;
               E        S
    | ▦▦▦▦▦▦▦▦▦▦ | ▦▦▦▦▦▦▦▦▦▦ |
    | ---ltr---&gt; | ---ltr---&gt; |
    |&lt;------------------------| rtl ¶

                ▦▦▦▦▦▦▦▦▦       selection highlight

Currently, our visual bidi selection heuristics naively join the two logically-contiguous, visually-
discontiguous selections together by combining them together to form a single, coalesced rect that
spans from the start position to the end position. In this particular scenario, this means that the
left word (&quot;Hello&quot; in this example) will appear visually unselected even though it&apos;s still selected
in the DOM, which in turn creates a confusing experience for the user (especially since it will be
selected both logically and visually once the user lets go anyways).

To fix this, we augment the heuristics in `makeBidiSelectionVisuallyContiguousIfNeeded`:

-   First, detect this above scenario by checking for a single-line selection, wherein all selection
    rects are of an opposite direction as the paragraph (or primary direction of the single-line
    selection range). In the above example, this would be two or more adjacent LTR selections, in an
    RTL paragraph.

-   Use the opposite endpoints of the selection rect when determining the final bounding rect of the
    coalesced, visually-contiguous selection. In the above example, instead of using the endpoints
    at the end of the selected text, we&apos;d use the start endpoints instead. To determine whether the
    start or end of the selection needs this treatment, we use `RenderedPosition` to check whether
    the start or end position lies on a bidi visual boundary.

The end result is that the selection will visually span from the start to the left-most visual
extent of &quot;Hello&quot; while the user is extending the selection:

        &quot;Hello&quot;      &quot;۷۴۸۵۵&quot;
               E        S
    | ▦▦▦▦▦▦▦▦▦▦ | ▦▦▦▦▦▦▦▦▦▦ |
    | ---ltr---&gt; | ---ltr---&gt; |
    |&lt;------------------------| rtl ¶

      ▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦       selection highlight

...and it will then snap to select the entire paragraph after the user lets go:

      &quot;Hello&quot;      &quot;۷۴۸۵۵&quot;
               E            S
    | ▦▦▦▦▦▦▦▦▦▦ | ▦▦▦▦▦▦▦▦▦▦ |
    | ---ltr---&gt; | ---ltr---&gt; |
    |&lt;------------------------| rtl ¶

      ▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦▦   selection highlight

* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-7.html:
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-8.html:
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-9-expected.txt: Added.
* LayoutTests/editing/selection/ios/bidi-visually-contiguous-selection-9.html: Added.

Add a new layout test to exercise the change, by verifying that selected text does not get visually
unselected, when long pressing on &quot;Hello&quot; and extending the selection end handle into Urdu (Indic)
numerals. The final logically and visually-contiguous selection should encompass the entire
paragraph.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.computeLineBounds):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::computeSelectionEndpointDirections):
(WebCore::makeBidiSelectionVisuallyContiguousIfNeeded):

See above for more details.

(WebCore::adjustTextDirectionForCoalescedGeometries):
(WebCore::RenderObject::collectSelectionGeometries):

Canonical link: <a href="https://commits.webkit.org/291799@main">https://commits.webkit.org/291799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb9e579112c308c860912bbc1467cabbcb20d6b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22031 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71742 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29090 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52081 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2574 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43857 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80250 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101063 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15349 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80745 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80897 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80110 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19965 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14228 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26228 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20737 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24197 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22478 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->