### PR TITLE
[JSC] Use shuffle algorithm from BBQ for CCallHelpers::shuffleRegisters

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -571,6 +571,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/CPU.h
     assembler/CPUInlines.h
     assembler/CodeLocation.h
+    assembler/DisallowMacroScratchRegisterUsage.h
     assembler/FastJITPermissions.h
     assembler/JITOperationList.h
     assembler/JITOperationValidation.h

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -28,6 +28,7 @@
 #if ENABLE(JIT)
 
 #include "AssemblyHelpers.h"
+#include "DisallowMacroScratchRegisterUsage.h"
 #include "FPRInfo.h"
 #include "GPRInfo.h"
 #include "OperationResult.h"
@@ -88,6 +89,43 @@ public:
         poke(GPRInfo::nonArgGPR0, POKE_ARGUMENT_OFFSET + argumentIndex - GPRInfo::numberOfArgumentRegisters);
     }
 
+    enum class ShuffleStatus : uint8_t {
+        ToMove,
+        BeingMoved,
+        Moved
+    };
+
+    template<typename RegType, size_t N, typename RegPair = std::pair<RegType, RegType>>
+    void emitShuffleMove(Vector<RegPair, N>& moves, Vector<ShuffleStatus, N>& status, unsigned index, RegType scratch)
+    {
+        status[index] = ShuffleStatus::BeingMoved;
+        for (unsigned i = 0; i < moves.size(); i ++) {
+            if (moves[i].first == moves[index].second) {
+                ASSERT(i != index);
+                switch (status[i]) {
+                case ShuffleStatus::ToMove:
+                    emitShuffleMove(moves, status, i, scratch);
+                    break;
+                case ShuffleStatus::BeingMoved: {
+                    if constexpr (std::is_same_v<RegType, FPRegisterID>)
+                        moveDouble(moves[i].first, scratch);
+                    else
+                        move(moves[i].first, scratch);
+                    moves[i].first = scratch;
+                    break;
+                }
+                case ShuffleStatus::Moved:
+                    break;
+                }
+            }
+        }
+        if constexpr (std::is_same_v<RegType, FPRegisterID>)
+            moveDouble(moves[index].first, moves[index].second);
+        else
+            move(moves[index].first, moves[index].second);
+        status[index] = ShuffleStatus::Moved;
+    }
+
     template<typename RegType, unsigned NumberOfRegisters>
     ALWAYS_INLINE void shuffleRegisters(std::array<RegType, NumberOfRegisters> sources, std::array<RegType, NumberOfRegisters> destinations)
     {
@@ -113,83 +151,22 @@ public:
             UNUSED_PARAM(destinations);
         }
 
-#if ASSERT_ENABLED
-        auto numUniqueSources = [&] () -> unsigned {
-            RegisterSetBuilder set;
-            for (auto& pair : pairs) {
-                RegType source = pair.first;
-                set.add(source, IgnoreVectors);
-            }
-            return set.numberOfSetRegisters();
-        };
+        Vector<ShuffleStatus, NumberOfRegisters> status;
+        status.fill(ShuffleStatus::ToMove, pairs.size());
 
-        auto numUniqueDests = [&] () -> unsigned {
-            RegisterSetBuilder set;
-            for (auto& pair : pairs) {
-                RegType dest = pair.second;
-                set.add(dest, IgnoreVectors);
-            }
-            return set.numberOfSetRegisters();
-        };
-#endif
+        RELEASE_ASSERT(m_allowScratchRegister); // We absolutely need one for the recursive shuffle algorithm.
+        auto scratch = scratchRegister();
 
-        while (!pairs.isEmpty()) {
-            RegisterSet freeDestinations;
-            for (auto& pair : pairs) {
-                RegType dest = pair.second;
-                freeDestinations.add(dest, IgnoreVectors);
-            }
-            for (auto& pair : pairs) {
-                RegType source = pair.first;
-                freeDestinations.remove(source);
-            }
-
-            if (freeDestinations.numberOfSetRegisters()) {
-                bool madeMove = false;
-                for (unsigned i = 0; i < pairs.size(); i++) {
-                    auto [source, dest] = pairs[i];
-                    if (freeDestinations.contains(dest, IgnoreVectors)) {
-                        // This means that this setup function cannot handle SIMD vectors as a part of parameters.
-                        // Now, this is guaranteed that we ensure FP parameter is always `double`.
-                        if constexpr (std::is_same_v<RegType, FPRReg>)
-                            moveDouble(source, dest);
-                        else
-                            move(source, dest);
-                        pairs.remove(i);
-                        madeMove = true;
-                        break;
-                    }
-                }
-                ASSERT_UNUSED(madeMove, madeMove);
-                continue;
-            }
-
-            ASSERT(numUniqueDests() == numUniqueSources());
-            ASSERT(numUniqueDests() == pairs.size());
-            // The set of source and destination registers are equivalent sets. This means we don't have
-            // any free destination registers that won't also clobber a source. We get around this by
-            // exchanging registers.
-
-            auto [source, dest] = pairs.first();
-            if constexpr (std::is_same_v<RegType, FPRReg>)
-                swapDouble(source, dest);
-            else
-                swap(source, dest);
-            pairs.remove(0);
-
-            RegType newSource = source;
-            for (auto& pair : pairs) {
-                RegType source = pair.first;
-                if (source == dest) {
-                    pair.first = newSource;
-                    break;
+        {
+            DisallowMacroScratchRegisterUsage disallowScratch(*this);
+            for (size_t i = 0; i < pairs.size(); i ++) {
+                if (status[i] == ShuffleStatus::ToMove) {
+                    if constexpr (std::is_same_v<RegType, RegisterID>)
+                        emitShuffleMove(pairs, status, i, scratch);
+                    else
+                        emitShuffleMove(pairs, status, i, fpTempRegister);
                 }
             }
-
-            // We may have introduced pairs that have the same source and destination. Remove those now.
-            pairs.removeAllMatching([](const auto& pair) {
-                return pair.first == pair.second;
-            });
         }
     }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1932,11 +1932,7 @@ private:
 
     void emitMove(Value src, Location dst);
 
-    enum class ShuffleStatus {
-        ToMove,
-        BeingMoved,
-        Moved
-    };
+    using ShuffleStatus = CCallHelpers::ShuffleStatus;
 
     template<size_t N, typename OverflowHandler>
     void emitShuffleMove(Vector<Value, N, OverflowHandler>& srcVector, Vector<Location, N, OverflowHandler>& dstVector, Vector<ShuffleStatus, N, OverflowHandler>& statusVector, unsigned index);


### PR DESCRIPTION
#### 40c330f75da3abf2cad6a49e51ec81e7adce87e9
<pre>
[JSC] Use shuffle algorithm from BBQ for CCallHelpers::shuffleRegisters
<a href="https://bugs.webkit.org/show_bug.cgi?id=289306">https://bugs.webkit.org/show_bug.cgi?id=289306</a>
<a href="https://rdar.apple.com/146442401">rdar://146442401</a>

Reviewed by Yusuke Suzuki.

Ports the shuffle algorithm used in the Wasm BBQ JIT to CCallHelpers::shuffleRegisters.
This results in fewer redundant moves being generated, particularly due to the fact we
are no longer using swaps to resolve dependent move cycles. Using this algorithm, we
elide 17234 out of 160180 moves total resolving shuffles on JetStream 2, a 10.7%
reduction, reducing code size and avoiding cheap but redundant work.

* Source/JavaScriptCore/jit/CCallHelpers.h:
(JSC::CCallHelpers::emitShuffleMove):
(JSC::CCallHelpers::scratchRegisterByType&lt;RegisterID&gt;):
(JSC::CCallHelpers::scratchRegisterByType&lt;FPRegisterID&gt;):
(JSC::CCallHelpers::shuffleRegisters):
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:

Canonical link: <a href="https://commits.webkit.org/291786@main">https://commits.webkit.org/291786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a41db803f50ff8f8f4c7b714542c07bbe248d186

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98929 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44450 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13805 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71673 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29022 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52011 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9929 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2489 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43766 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86633 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80192 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100969 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92589 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80690 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80044 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19950 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14132 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26137 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115239 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20646 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22387 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->