### PR TITLE
[WebDriver] Expose the target_platform config option to WPT tests

### DIFF
--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py
@@ -182,6 +182,7 @@ class WebDriverW3CExecutor(WdspecExecutor):
                           'webdriver': {'binary': webdriver_binary},
                           'wptserve': server_config,
                           'timeout_multiplier': 10,
+                          'target_platform': sys.platform,
                           }
                 with open(config_path, 'w') as f:
                     json.dump(config, f)

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -1502,6 +1502,32 @@
         "subtests": {
             "test_capability_default_value[setWindowRect-True]": {
                 "expected": {"wpe": {"status": ["SKIP"]}}
+            },
+            "test_capability_user_agent": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/b/180410"}}
+            }
+        }
+    },
+    "imported/w3c/webdriver/tests/classic/new_session/unhandled_prompt_behavior.py": {
+        "expected": {"all": {"status": ["FAIL"], "bug": "webkit.org/289307"}},
+        "subtests": {
+            "test_unhandled_prompt_behavior_as_string_default": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unhandled_prompt_behavior_as_string[accept]": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unhandled_prompt_behavior_as_string[accept and notify]": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unhandled_prompt_behavior_as_string[dismiss]": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unhandled_prompt_behavior_as_string[dismiss and notify]": {
+                "expected": {"all": {"status": ["PASS"]}}
+            },
+            "test_unhandled_prompt_behavior_as_string[ignore]": {
+                "expected": {"all": {"status": ["PASS"]}}
             }
         }
     },


### PR DESCRIPTION
#### c8cb96d37bbc4bd7e10c17f84d699e67fa157229
<pre>
[WebDriver] Expose the target_platform config option to WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=289309">https://bugs.webkit.org/show_bug.cgi?id=289309</a>

Reviewed by Carlos Garcia Campos.

Some tests rely on getting the actual info about the system where the
browser under automation is running. As we currently only support
running the suite locally, just use a simple sys.platform approach.

As a drive-by, also garden remaining `classic/new_session` failures.

* Tools/Scripts/webkitpy/webdriver_tests/webdriver_w3c_executor.py:
(WebDriverW3CExecutor._runner):
* WebDriverTests/TestExpectations.json:

Canonical link: <a href="https://commits.webkit.org/291769@main">https://commits.webkit.org/291769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a52d3d718153a6938d3d4591fd2d15e1b4425d81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/95981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13813 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71675 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29025 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96933 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52013 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/93426 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2500 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43774 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80193 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100977 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20983 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15317 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80687 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19934 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14140 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20967 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20654 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24114 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22395 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->