### PR TITLE
Update ActiveDOMObject::queueTaskKeepingObjectAlive() to play nicely with Safer CPP static analysis

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -43,7 +43,7 @@ public:
 #if !RELEASE_LOG_DISABLED
 
 #define LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(logClassName(), __func__, logIdentifier())
-#define LOGIDENTIFIER_WITH_THIS(thisPtr) WTF::Logger::LogSiteIdentifier(thisPtr->logClassName(), __func__, thisPtr->logIdentifier())
+#define LOGIDENTIFIER_WITH_THIS(thisPtr) WTF::Logger::LogSiteIdentifier((thisPtr)->logClassName(), __func__, (thisPtr)->logIdentifier())
 
 #if VERBOSE_RELEASE_LOG
 #define ALWAYS_LOG(...)     Ref { logger() }->logAlwaysVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
@@ -52,9 +52,9 @@ public:
 #define INFO_LOG(...)       Ref { logger() }->infoVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #define DEBUG_LOG(...)      Ref { logger() }->debugVerbose(logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 
-#define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { thisPtr->logger() }->logAlwaysVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { thisPtr->logger() }->errorVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
-#define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { thisPtr->logger() }->infoVerbose(thisPtr->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { (thisPtr)->logger() }->logAlwaysVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->errorVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { (thisPtr)->logger() }->infoVerbose((thisPtr)->logChannel(), __FILE__, __func__, __LINE__, __VA_ARGS__)
 #else
 #define ALWAYS_LOG(...)     Ref { logger() }->logAlways(logChannel(), __VA_ARGS__)
 #define ERROR_LOG(...)      Ref { logger() }->error(logChannel(), __VA_ARGS__)
@@ -62,9 +62,9 @@ public:
 #define INFO_LOG(...)       Ref { logger() }->info(logChannel(), __VA_ARGS__)
 #define DEBUG_LOG(...)      Ref { logger() }->debug(logChannel(), __VA_ARGS__)
 
-#define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { thisPtr->logger() }->logAlways(thisPtr->logChannel(), __VA_ARGS__)
-#define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { thisPtr->logger() }->error(thisPtr->logChannel(), __VA_ARGS__)
-#define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { thisPtr->logger() }->info(thisPtr->logChannel(), __VA_ARGS__)
+#define ALWAYS_LOG_WITH_THIS(thisPtr, ...)     Ref { (thisPtr)->logger() }->logAlways((thisPtr)->logChannel(), __VA_ARGS__)
+#define ERROR_LOG_WITH_THIS(thisPtr, ...)      Ref { (thisPtr)->logger() }->error((thisPtr)->logChannel(), __VA_ARGS__)
+#define INFO_LOG_WITH_THIS(thisPtr, ...)       Ref { (thisPtr)->logger() }->info((thisPtr)->logChannel(), __VA_ARGS__)
 #endif
 
 #define WILL_LOG(_level_)   Ref { logger() }->willLog(logChannel(), _level_)

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -389,11 +389,11 @@ ExceptionOr<Ref<GPUExternalTexture>> GPUDevice::importExternalTexture(const GPUE
         m_previouslyImportedExternalTexture.first = *videoElement;
         m_previouslyImportedExternalTexture.second = externalTexture.ptr();
         videoElementPtr->requestVideoFrameCallback(GPUDeviceVideoFrameRequestCallback::create(externalTexture.get(), *videoElementPtr, *this, scriptExecutionContext()));
-        queueTaskKeepingObjectAlive(*this, TaskSource::WebGPU, [protectedThis = Ref { *this }, videoElementPtr, externalTextureRef = externalTexture]() {
+        queueTaskKeepingObjectAlive(*this, TaskSource::WebGPU, [videoElementPtr, externalTextureRef = externalTexture](auto& gpuDevice) {
             if (!videoElementPtr)
                 return;
-            auto it = protectedThis->m_videoElementToExternalTextureMap.find(*videoElementPtr);
-            if (it == protectedThis->m_videoElementToExternalTextureMap.end() || externalTextureRef.ptr() != it->value.get())
+            auto it = gpuDevice.m_videoElementToExternalTextureMap.find(*videoElementPtr);
+            if (it == gpuDevice.m_videoElementToExternalTextureMap.end() || externalTextureRef.ptr() != it->value.get())
                 return;
 
             externalTextureRef->destroy();

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -175,22 +175,18 @@ void DOMAudioSession::scheduleStateChangeEvent()
         return;
 
     m_hasScheduleStateChangeEvent = true;
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [weakThis = WeakPtr { *this }] {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& session) {
+        if (session.isContextStopped())
             return;
 
-        if (protectedThis->isContextStopped())
-            return;
-
-        protectedThis->m_hasScheduleStateChangeEvent = false;
+        session.m_hasScheduleStateChangeEvent = false;
         auto newState = computeAudioSessionState();
 
-        if (protectedThis->m_state && *protectedThis->m_state == newState)
+        if (session.m_state && *session.m_state == newState)
             return;
 
-        protectedThis->m_state = newState;
-        protectedThis->dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        session.m_state = newState;
+        session.dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -175,21 +175,21 @@ void MediaKeySession::generateRequest(const AtomString& initDataType, const Buff
     // 8. Let session type be this object's session type.
     // 9. Let promise be a new promise.
     // 10. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, initData = SharedBuffer::create(initData.span()), initDataType, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [initData = SharedBuffer::create(initData.span()), initDataType, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto& session) mutable {
         // 10.1. If the init data is not valid for initDataType, reject promise with a newly created TypeError.
         // 10.2. Let sanitized init data be a validated and sanitized version of init data.
-        RefPtr<SharedBuffer> sanitizedInitData = m_implementation->sanitizeInitData(initDataType, initData);
+        RefPtr<SharedBuffer> sanitizedInitData = session.m_implementation->sanitizeInitData(initDataType, initData);
 
         // 10.3. If the preceding step failed, reject promise with a newly created TypeError.
         if (!sanitizedInitData) {
-            ERROR_LOG(identifier, "::task() Rejected: cannot sanitize init data");
+            ERROR_LOG_WITH_THIS(&session, identifier, "::task() Rejected: cannot sanitize init data");
             promise->reject(ExceptionCode::TypeError);
             return;
         }
 
         // 10.4. If sanitized init data is empty, reject promise with a NotSupportedError.
         if (sanitizedInitData->isEmpty()) {
-            ERROR_LOG(identifier, "::task() Rejected: empty sanitized init data");
+            ERROR_LOG_WITH_THIS(&session, identifier, "::task() Rejected: empty sanitized init data");
             promise->reject(ExceptionCode::NotSupportedError);
             return;
         }
@@ -200,8 +200,8 @@ void MediaKeySession::generateRequest(const AtomString& initDataType, const Buff
         // 10.8. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 10.9. Use the cdm to execute the following steps:
         // 10.9.1. If the sanitized init data is not supported by the cdm, reject promise with a NotSupportedError.
-        if (!m_implementation->supportsInitData(initDataType, *sanitizedInitData)) {
-            ERROR_LOG(identifier, "::task() Rejected: unsupported initDataType (", initDataType, ") or sanitized initData");
+        if (!session.m_implementation->supportsInitData(initDataType, *sanitizedInitData)) {
+            ERROR_LOG_WITH_THIS(&session, identifier, "::task() Rejected: unsupported initDataType (", initDataType, ") or sanitized initData");
             promise->reject(ExceptionCode::NotSupportedError);
             return;
         }
@@ -219,14 +219,15 @@ void MediaKeySession::generateRequest(const AtomString& initDataType, const Buff
         //     2. Let requested license type be a non-persistable license that will
         //        persist a record of key usage.
 
-        if (m_sessionType == MediaKeySessionType::PersistentUsageRecord) {
-            m_recordOfKeyUsage.clear();
-            m_firstDecryptTime = 0;
-            m_latestDecryptTime = 0;
+        if (session.m_sessionType == MediaKeySessionType::PersistentUsageRecord) {
+            session.m_recordOfKeyUsage.clear();
+            session.m_firstDecryptTime = 0;
+            session.m_latestDecryptTime = 0;
         }
 
-        m_instanceSession->requestLicense(m_sessionType, keyGroupingStrategy(), initDataType, sanitizedInitData.releaseNonNull(), [this, weakThis, promise = WTFMove(promise), identifier = WTFMove(identifier)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
-            if (!weakThis)
+        session.m_instanceSession->requestLicense(session.m_sessionType, session.keyGroupingStrategy(), initDataType, sanitizedInitData.releaseNonNull(), [weakThis = WeakPtr { session }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             // 10.9.3. Let session id be a unique Session ID string.
@@ -246,24 +247,24 @@ void MediaKeySession::generateRequest(const AtomString& initDataType, const Buff
             }
 
             // 10.10. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, promise = WTFMove(promise), message = WTFMove(message), messageType, sessionId, succeeded, identifier = WTFMove(identifier)] () mutable {
+            protectedThis->queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [promise = WTFMove(promise), message = WTFMove(message), messageType, sessionId, succeeded, identifier = WTFMove(identifier)](auto& session) mutable {
                 // 10.10.1. If any of the preceding steps failed, reject promise with a new DOMException whose name is the appropriate error name.
                 if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
-                    ERROR_LOG(identifier, "::task() Rejected: failed to request license");
+                    ERROR_LOG_WITH_THIS(&session, identifier, "::task() Rejected: failed to request license");
                     promise->reject(ExceptionCode::NotSupportedError);
                     return;
                 }
                 // 10.10.2. Set the sessionId attribute to session id.
-                m_sessionId = sessionId;
+                session.m_sessionId = sessionId;
 
                 // 10.9.3. Let this object's callable value be true.
-                m_callable = true;
+                session.m_callable = true;
 
                 // 10.9.3. Run the Queue a "message" Event algorithm on the session, providing message type and message.
-                enqueueMessage(messageType, message);
+                session.enqueueMessage(messageType, message);
 
                 // 10.9.3. Resolve promise.
-                ALWAYS_LOG(identifier, "::task() Resolved");
+                ALWAYS_LOG_WITH_THIS(&session, identifier, "::task() Resolved");
                 promise->resolve();
             });
         });
@@ -304,12 +305,12 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
 
     // 7. Let promise be a new promise.
     // 8. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, sessionId, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [sessionId, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto& session) mutable {
         // 8.1. Let sanitized session ID be a validated and/or sanitized version of sessionId.
         // 8.2. If the preceding step failed, or if sanitized session ID is empty, reject promise with a newly created TypeError.
-        std::optional<String> sanitizedSessionId = m_implementation->sanitizeSessionId(sessionId);
+        std::optional<String> sanitizedSessionId = session.m_implementation->sanitizeSessionId(sessionId);
         if (!sanitizedSessionId || sanitizedSessionId->isEmpty()) {
-            ERROR_LOG(identifier, "Rejected: sanitizedSSessionID empty");
+            ERROR_LOG_WITH_THIS(&session, identifier, "Rejected: sanitizedSSessionID empty");
             promise->reject(ExceptionCode::TypeError);
             return;
         }
@@ -318,7 +319,7 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
         // FIXME: This needs a global MediaKeySession tracker.
 
         String origin;
-        if (RefPtr document = downcast<Document>(scriptExecutionContext()))
+        if (RefPtr document = downcast<Document>(session.scriptExecutionContext()))
             origin = document->securityOrigin().toString();
 
         // 8.4. Let expiration time be NaN.
@@ -326,8 +327,8 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
         // 8.6. Let message type be null.
         // 8.7. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 8.8. Use the cdm to execute the following steps:
-        m_instanceSession->loadSession(m_sessionType, *sanitizedSessionId, origin, [this, weakThis, promise = WTFMove(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTFMove(identifier)] (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
-            auto protectedThis = RefPtr { weakThis.get() };
+        session.m_instanceSession->loadSession(session.m_sessionType, *sanitizedSessionId, origin, [weakThis = WeakPtr { session }, promise = WTFMove(promise), sanitizedSessionId = *sanitizedSessionId, identifier = WTFMove(identifier)] (std::optional<CDMInstanceSession::KeyStatusVector>&& knownKeys, std::optional<double>&& expiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+            RefPtr protectedThis = weakThis.get();
             if (!protectedThis) {
                 promise->reject(ExceptionCode::InvalidStateError);
                 return;
@@ -347,15 +348,15 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
             if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
                 switch (failure) {
                 case CDMInstanceSession::SessionLoadFailure::NoSessionData:
-                    ALWAYS_LOG(identifier, "::task() Resolved: NoSessionData");
+                    ALWAYS_LOG_WITH_THIS(protectedThis, identifier, "::task() Resolved: NoSessionData");
                     promise->resolve<IDLBoolean>(false);
                     return;
                 case CDMInstanceSession::SessionLoadFailure::MismatchedSessionType:
-                    ERROR_LOG(identifier, "::task() Rejected: MismatchedSessionType");
+                    ERROR_LOG_WITH_THIS(protectedThis, identifier, "::task() Rejected: MismatchedSessionType");
                     promise->reject(ExceptionCode::TypeError);
                     return;
                 case CDMInstanceSession::SessionLoadFailure::QuotaExceeded:
-                    ERROR_LOG(identifier, "::task() Rejected: QuotaExceeded");
+                    ERROR_LOG_WITH_THIS(protectedThis, identifier, "::task() Rejected: QuotaExceeded");
                     promise->reject(ExceptionCode::QuotaExceededError);
                     return;
                 case CDMInstanceSession::SessionLoadFailure::None:
@@ -366,33 +367,33 @@ void MediaKeySession::load(const String& sessionId, Ref<DeferredPromise>&& promi
             }
 
             // 8.9. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, knownKeys = WTFMove(knownKeys), expiration = WTFMove(expiration), message = WTFMove(message), sanitizedSessionId, succeeded, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+            protectedThis->queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [knownKeys = WTFMove(knownKeys), expiration = WTFMove(expiration), message = WTFMove(message), sanitizedSessionId, succeeded, promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
                 // 8.9.1. If any of the preceding steps failed, reject promise with a the appropriate error name.
                 if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
-                    ERROR_LOG(identifier, "::task() Rejected: Other failure");
+                    ERROR_LOG_WITH_THIS(&session, identifier, "::task() Rejected: Other failure");
                     promise->reject(ExceptionCode::NotSupportedError);
                     return;
                 }
 
                 // 8.9.2. Set the sessionId attribute to sanitized session ID.
                 // 8.9.3. Let this object's callable value be true.
-                m_sessionId = sanitizedSessionId;
-                m_callable = true;
+                session.m_sessionId = sanitizedSessionId;
+                session.m_callable = true;
 
                 // 8.9.4. If the loaded session contains information about any keys (there are known keys), run the Update Key Statuses algorithm on the session, providing each key's key ID along with the appropriate MediaKeyStatus.
                 if (knownKeys)
-                    updateKeyStatuses(WTFMove(*knownKeys));
+                    session.updateKeyStatuses(WTFMove(*knownKeys));
 
                 // 8.9.5. Run the Update Expiration algorithm on the session, providing expiration time.
                 // This must be run, and NaN is the default value if the CDM instance doesn't provide one.
-                updateExpiration(expiration.value_or(std::numeric_limits<double>::quiet_NaN()));
+                session.updateExpiration(expiration.value_or(std::numeric_limits<double>::quiet_NaN()));
 
                 // 8.9.6. If message is not null, run the Queue a "message" Event algorithm on the session, providing message type and message.
                 if (message)
-                    enqueueMessage(message->first, WTFMove(message->second));
+                    session.enqueueMessage(message->first, WTFMove(message->second));
 
                 // 8.9.7. Resolve promise with true.
-                ALWAYS_LOG(identifier, "::task() Resolved");
+                ALWAYS_LOG_WITH_THIS(&session, identifier, "::task() Resolved");
                 promise->resolve<IDLBoolean>(true);
             });
         });
@@ -428,13 +429,13 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
     // 4. Let response copy be a copy of the contents of the response parameter.
     // 5. Let promise be a new promise.
     // 6. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, response = SharedBuffer::create(response.span()), promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [response = SharedBuffer::create(response.span()), promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
         // 6.1. Let sanitized response be a validated and/or sanitized version of response copy.
-        RefPtr<SharedBuffer> sanitizedResponse = m_implementation->sanitizeResponse(response);
+        RefPtr<SharedBuffer> sanitizedResponse = session.m_implementation->sanitizeResponse(response);
 
         // 6.2. If the preceding step failed, or if sanitized response is empty, reject promise with a newly created TypeError.
         if (!sanitizedResponse || sanitizedResponse->isEmpty()) {
-            ERROR_LOG(identifier, "::task - Rejected: empty sanitized response");
+            ERROR_LOG_WITH_THIS(&session, identifier, "::task - Rejected: empty sanitized response");
             promise->reject(ExceptionCode::TypeError);
             return;
         }
@@ -444,8 +445,9 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
         // 6.5. Let session closed be false.
         // 6.6. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 6.7. Use the cdm to execute the following steps:
-        m_instanceSession->updateLicense(m_sessionId, m_sessionType, sanitizedResponse.releaseNonNull(), [this, weakThis, promise = WTFMove(promise), identifier = WTFMove(identifier)] (bool sessionWasClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
-            if (!weakThis)
+        session.m_instanceSession->updateLicense(session.m_sessionId, session.m_sessionType, sanitizedResponse.releaseNonNull(), [weakThis = WeakPtr { session }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (bool sessionWasClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& changedKeys, std::optional<double>&& changedExpiration, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             // 6.7.1. If the format of sanitized response is invalid in any way, reject promise with a newly created TypeError.
@@ -471,7 +473,7 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
             // NOTE: Steps 6.7.1. and 6.7.2. should be implemented in CDMInstance.
 
             if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
-                ERROR_LOG(identifier, "::task() Rejected: Failed");
+                ERROR_LOG_WITH_THIS(protectedThis, identifier, "::task() Rejected: Failed");
                 promise->reject(ExceptionCode::TypeError);
                 return;
             }
@@ -480,12 +482,12 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
             //   6.7.3.1. Let message be that message.
             //   6.7.3.2. Let message type be the appropriate MediaKeyMessageType for the message.
             // 6.8. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, sessionWasClosed, changedKeys = WTFMove(changedKeys), changedExpiration = WTFMove(changedExpiration), message = WTFMove(message), promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+            protectedThis->queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [sessionWasClosed, changedKeys = WTFMove(changedKeys), changedExpiration = WTFMove(changedExpiration), message = WTFMove(message), promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
                 // 6.8.1.
                 if (sessionWasClosed) {
                     // ↳ If session closed is true:
                     //   Run the Session Closed algorithm on this object.
-                    sessionClosed();
+                    session.sessionClosed();
                 } else {
                     // ↳ Otherwise:
                     //   Run the following steps:
@@ -494,11 +496,11 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
                     //              processing be necessary to determine with certainty the status of a key, use "status-pending". Once the additional processing
                     //              for one or more keys has completed, run the Update Key Statuses algorithm again with the actual status(es).
                     if (changedKeys)
-                        updateKeyStatuses(WTFMove(*changedKeys));
+                        session.updateKeyStatuses(WTFMove(*changedKeys));
 
                     //     6.8.1.2. If the expiration time for the session changed, run the Update Expiration algorithm on the session, providing the new expiration time.
                     if (changedExpiration)
-                        updateExpiration(*changedExpiration);
+                        session.updateExpiration(*changedExpiration);
 
                     //     6.8.1.3. If any of the preceding steps failed, reject promise with a new DOMException whose name is the appropriate error name.
                     // FIXME: At this point the implementations of preceding steps can't fail.
@@ -521,12 +523,12 @@ void MediaKeySession::update(const BufferSource& response, Ref<DeferredPromise>&
                             break;
                         }
 
-                        enqueueMessage(messageType, WTFMove(message->second));
+                        session.enqueueMessage(messageType, WTFMove(message->second));
                     }
                 }
 
                 // 6.8.2. Resolve promise.
-                ALWAYS_LOG(identifier, "::task() Resolved");
+                ALWAYS_LOG_WITH_THIS(&session, identifier, "::task() Resolved");
                 promise->resolve();
             });
         });
@@ -561,20 +563,21 @@ void MediaKeySession::close(Ref<DeferredPromise>&& promise)
 
     // 4. Let promise be a new promise.
     // 5. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
         // 5.1. Let cdm be the CDM instance represented by session's cdm instance value.
         // 5.2. Use cdm to close the key session associated with session.
-        m_instanceSession->closeSession(m_sessionId, [this, weakThis, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
-            if (!weakThis)
+        session.m_instanceSession->closeSession(session.m_sessionId, [weakThis = WeakPtr { session }, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             // 5.3. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+            queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
                 // 5.3.1. Run the Session Closed algorithm on the session.
-                sessionClosed();
+                session.sessionClosed();
 
                 // 5.3.2. Resolve promise.
-                ALWAYS_LOG(identifier, "::task() Resolved");
+                ALWAYS_LOG_WITH_THIS(&session, identifier, "::task() Resolved");
                 promise->resolve();
             });
         });
@@ -602,14 +605,15 @@ void MediaKeySession::remove(Ref<DeferredPromise>&& promise)
 
     // 3. Let promise be a new promise.
     // 4. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, weakThis = WeakPtr { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
         // 4.1. Let cdm be the CDM instance represented by this object's cdm instance value.
         // 4.2. Let message be null.
         // 4.3. Let message type be null.
 
         // 4.4. Use the cdm to execute the following steps:
-        m_instanceSession->removeSessionData(m_sessionId, m_sessionType, [this, weakThis, promise = WTFMove(promise), identifier = WTFMove(identifier)] (CDMInstanceSession::KeyStatusVector&& keys, RefPtr<SharedBuffer>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
-            if (!weakThis)
+        session.m_instanceSession->removeSessionData(session.m_sessionId, session.m_sessionType, [weakThis = WeakPtr { session }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (CDMInstanceSession::KeyStatusVector&& keys, RefPtr<SharedBuffer>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
 
             // 4.4.1. If any license(s) and/or key(s) are associated with the session:
@@ -627,16 +631,16 @@ void MediaKeySession::remove(Ref<DeferredPromise>&& promise)
             // NOTE: Step 4.4.1. should be implemented in CDMInstance.
 
             // 4.5. Queue a task to run the following steps:
-            queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, keys = WTFMove(keys), message = WTFMove(message), succeeded, promise = WTFMove(promise), identifier = WTFMove(identifier)] () mutable {
+            queueTaskKeepingObjectAlive(*protectedThis, TaskSource::Networking, [keys = WTFMove(keys), message = WTFMove(message), succeeded, promise = WTFMove(promise), identifier = WTFMove(identifier)](auto& session) mutable {
                 // 4.5.1. Run the Update Key Statuses algorithm on the session, providing all key ID(s) in the session along with the "released" MediaKeyStatus value for each.
-                updateKeyStatuses(WTFMove(keys));
+                session.updateKeyStatuses(WTFMove(keys));
 
                 // 4.5.2. Run the Update Expiration algorithm on the session, providing NaN.
-                updateExpiration(std::numeric_limits<double>::quiet_NaN());
+                session.updateExpiration(std::numeric_limits<double>::quiet_NaN());
 
                 // 4.5.3. If any of the preceding steps failed, reject promise with a new DOMException whose name is the appropriate error name.
                 if (succeeded == CDMInstanceSession::SuccessValue::Failed) {
-                    ERROR_LOG(identifier, "Rejected: failed");
+                    ERROR_LOG_WITH_THIS(&session, identifier, "Rejected: failed");
                     promise->reject(ExceptionCode::NotSupportedError);
                     return;
                 }
@@ -644,10 +648,10 @@ void MediaKeySession::remove(Ref<DeferredPromise>&& promise)
                 // 4.5.4. Let message type be "license-release".
                 // 4.5.5. If message is not null, run the Queue a "message" Event algorithm on the session, providing message type and message.
                 if (message)
-                    enqueueMessage(MediaKeyMessageType::LicenseRelease, *message);
+                    session.enqueueMessage(MediaKeyMessageType::LicenseRelease, *message);
 
                 // 4.5.6. Resolve promise.
-                ALWAYS_LOG(identifier, "Resolved");
+                ALWAYS_LOG_WITH_THIS(&session, identifier, "Resolved");
                 promise->resolve();
             });
         });
@@ -735,10 +739,9 @@ void MediaKeySession::updateKeyStatuses(CDMInstanceSession::KeyStatusVector&& in
     queueTaskToDispatchEvent(*this, TaskSource::Networking, Event::create(eventNames().keystatuseschangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
     // 6. Queue a task to run the Attempt to Resume Playback If Necessary algorithm on each of the media element(s) whose mediaKeys attribute is the MediaKeys object that created the session.
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking,
-        [this] () mutable {
-            if (m_keys)
-                m_keys->attemptToResumePlaybackOnClients();
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [](auto& session) mutable {
+            if (RefPtr keys = session.m_keys.get())
+                keys->attemptToResumePlaybackOnClients();
         });
 }
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
@@ -67,7 +67,7 @@ void MediaKeySystemAccess::createMediaKeys(Document& document, Ref<DeferredPromi
     // When this method is invoked, the user agent must run the following steps:
     // 1. Let promise be a new promise.
     // 2. Run the following steps in parallel:
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, promise = WTFMove(promise)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, promise = WTFMove(promise)]() mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -90,7 +90,7 @@ void MediaKeySystemRequest::allow(String&& mediaKeysHashSalt)
     if (!scriptExecutionContext())
         return;
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this, mediaKeysHashSalt = WTFMove(mediaKeysHashSalt)] () mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this, mediaKeysHashSalt = WTFMove(mediaKeysHashSalt)] () mutable {
         if (auto allowCompletionHandler = std::exchange(m_allowCompletionHandler, { }))
             allowCompletionHandler(WTFMove(mediaKeysHashSalt), WTFMove(m_promise));
     });

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -94,7 +94,7 @@ void GamepadHapticActuator::playEffect(EffectType effectType, GamepadEffectParam
     }
     auto& currentEffectPromise = promiseForEffectType(effectType);
     if (auto playingEffectPromise = std::exchange(currentEffectPromise, nullptr)) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [playingEffectPromise = WTFMove(playingEffectPromise)] {
+        queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [playingEffectPromise = WTFMove(playingEffectPromise)](auto&) {
             playingEffectPromise->resolve<IDLEnumeration<Result>>(Result::Preempted);
         });
     }
@@ -110,7 +110,7 @@ void GamepadHapticActuator::playEffect(EffectType effectType, GamepadEffectParam
         auto& currentEffectPromise = promiseForEffectType(effectType);
         if (playingEffectPromise != currentEffectPromise)
             return; // Was already pre-empted.
-        queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [playingEffectPromise = std::exchange(currentEffectPromise, nullptr), success] {
+        queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [playingEffectPromise = std::exchange(currentEffectPromise, nullptr), success](auto&) {
             playingEffectPromise->resolve<IDLEnumeration<Result>>(success ? Result::Complete : Result::Preempted);
         });
     });
@@ -124,7 +124,7 @@ void GamepadHapticActuator::reset(Ref<DeferredPromise>&& promise)
         return;
     }
     stopEffects([this, protectedThis = makePendingActivity(*this), promise = WTFMove(promise)]() mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [promise = WTFMove(promise)] {
+        queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [promise = WTFMove(promise)](auto&) {
             promise->resolve<IDLEnumeration<Result>>(Result::Complete);
         });
     });
@@ -137,7 +137,7 @@ void GamepadHapticActuator::stopEffects(CompletionHandler<void()>&& completionHa
 
     auto dualRumbleEffectPromise = std::exchange(m_dualRumbleEffectPromise, nullptr);
     auto triggerRumbleEffectPromise = std::exchange(m_triggerRumbleEffectPromise, nullptr);
-    queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [dualRumbleEffectPromise = WTFMove(dualRumbleEffectPromise), triggerRumbleEffectPromise = WTFMove(triggerRumbleEffectPromise)] {
+    queueTaskKeepingObjectAlive(*this, TaskSource::Gamepad, [dualRumbleEffectPromise = WTFMove(dualRumbleEffectPromise), triggerRumbleEffectPromise = WTFMove(triggerRumbleEffectPromise)](auto&) {
         if (dualRumbleEffectPromise)
             dualRumbleEffectPromise->resolve<IDLEnumeration<Result>>(Result::Preempted);
         if (triggerRumbleEffectPromise)

--- a/Source/WebCore/Modules/mediastream/ImageCapture.cpp
+++ b/Source/WebCore/Modules/mediastream/ImageCapture.cpp
@@ -80,7 +80,7 @@ void ImageCapture::takePhoto(PhotoSettings&& settings, DOMPromiseDeferred<IDLInt
     }
 
     m_track->takePhoto(WTFMove(settings))->whenSettled(RunLoop::protectedMain(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto&& result) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
             if (!result) {
                 ERROR_LOG(identifier, "rejecting promise: ", result.error().message());
                 promise.reject(WTFMove(result.error()));
@@ -109,7 +109,7 @@ void ImageCapture::getPhotoCapabilities(DOMPromiseDeferred<IDLDictionary<PhotoCa
     }
 
     m_track->getPhotoCapabilities()->whenSettled(RunLoop::protectedMain(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto&& result) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
 #if RELEASE_LOG_DISABLED
             UNUSED_PARAM(this);
 #endif
@@ -142,7 +142,7 @@ void ImageCapture::getPhotoSettings(DOMPromiseDeferred<IDLDictionary<PhotoSettin
     }
 
     m_track->getPhotoSettings()->whenSettled(RunLoop::protectedMain(), [this, protectedThis = Ref { *this }, promise = WTFMove(promise), identifier = WTFMove(identifier)] (auto&& result) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::ImageCapture, [this, promise = WTFMove(promise), result = WTFMove(result), identifier = WTFMove(identifier)] () mutable {
 #if RELEASE_LOG_DISABLED
             UNUSED_PARAM(this);
 #endif

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -390,7 +390,7 @@ void MediaStreamTrack::applyConstraints(const std::optional<MediaTrackConstraint
     }
 
     m_private->applyConstraints(createMediaConstraints(constraints), [this, protectedThis = Ref { *this }, constraints, promise = WTFMove(promise)](auto&& error) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [protectedThis = WTFMove(protectedThis), error = WTFMove(error), constraints, promise = WTFMove(promise)]() mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [protectedThis = WTFMove(protectedThis), error = WTFMove(error), constraints, promise = WTFMove(promise)]() mutable {
             if (error) {
                 promise.rejectType<IDLInterface<OverconstrainedError>>(OverconstrainedError::create(error->invalidConstraint, WTFMove(error->message)));
                 return;
@@ -487,7 +487,7 @@ void MediaStreamTrack::trackEnded(MediaStreamTrackPrivate&)
     // http://w3c.github.io/mediacapture-main/#life-cycle
     // When a MediaStreamTrack track ends for any reason other than the stop() method being invoked, the User Agent must
     // queue a task that runs the following steps:
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, muted = m_private->muted()] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, muted = m_private->muted()] {
         // 1. If the track's readyState attribute has the value ended already, then abort these steps.
         if (!isAllowedToRunScript() || m_readyState == State::Ended)
             return;
@@ -535,7 +535,7 @@ void MediaStreamTrack::trackMutedChanged(MediaStreamTrackPrivate&)
     if (m_shouldFireMuteEventImmediately)
         updateMuted();
     else
-        queueTaskKeepingObjectAlive(*this, TaskSource::Networking, WTFMove(updateMuted));
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, WTFMove(updateMuted));
 
     configureTrackRendering();
 
@@ -552,7 +552,7 @@ void MediaStreamTrack::trackSettingsChanged(MediaStreamTrackPrivate&)
 
 void MediaStreamTrack::trackConfigurationChanged(MediaStreamTrackPrivate&)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
         if (!scriptExecutionContext() || scriptExecutionContext()->activeDOMObjectsAreStopped() || m_private->muted() || ended())
             return;
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -253,7 +253,7 @@ void PeerConnectionBackend::createOfferSucceeded(String&& sdp)
     ASSERT(m_offerAnswerCallback);
     validateSDP(sdp);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Offer, sdp });
     });
 }
@@ -265,7 +265,7 @@ void PeerConnectionBackend::createOfferFailed(Exception&& exception)
 
     ASSERT(m_offerAnswerCallback);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
         callback(WTFMove(exception));
     });
 }
@@ -286,7 +286,7 @@ void PeerConnectionBackend::createAnswerSucceeded(String&& sdp)
 
     ASSERT(m_offerAnswerCallback);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), sdp = WTFMove(sdp)]() mutable {
         callback(RTCSessionDescriptionInit { RTCSdpType::Answer, sdp });
     });
 }
@@ -298,7 +298,7 @@ void PeerConnectionBackend::createAnswerFailed(Exception&& exception)
 
     ASSERT(m_offerAnswerCallback);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [callback = WTFMove(m_offerAnswerCallback), exception = WTFMove(exception)]() mutable {
         callback(WTFMove(exception));
     });
 }
@@ -363,7 +363,7 @@ void PeerConnectionBackend::setLocalDescriptionSucceeded(std::optional<Descripti
         DEBUG_LOG(LOGIDENTIFIER, "Transceiver states: ", *transceiverStates);
     ASSERT(m_setDescriptionCallback);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
         Ref peerConnection = m_peerConnection.get();
         if (peerConnection->isClosed())
             return;
@@ -429,7 +429,7 @@ void PeerConnectionBackend::setLocalDescriptionFailed(Exception&& exception)
 
     ASSERT(m_setDescriptionCallback);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
         if (m_peerConnection->isClosed())
             return;
 
@@ -454,7 +454,7 @@ void PeerConnectionBackend::setRemoteDescriptionSucceeded(std::optional<Descript
     ASSERT(m_setDescriptionCallback);
 
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), descriptionStates = WTFMove(descriptionStates), transceiverStates = WTFMove(transceiverStates), sctpBackend = WTFMove(sctpBackend), maxMessageSize]() mutable {
         Ref peerConnection = m_peerConnection.get();
         if (peerConnection->isClosed())
             return;
@@ -559,7 +559,7 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
 
     ASSERT(m_setDescriptionCallback);
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, callback = WTFMove(m_setDescriptionCallback), exception = WTFMove(exception)]() mutable {
         if (m_peerConnection->isClosed())
             return;
 
@@ -570,7 +570,7 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
 void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
 {
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, state] {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [this, state] {
         if (state == RTCIceGatheringState::Complete) {
             doneGatheringCandidates();
             return;
@@ -626,7 +626,7 @@ void PeerConnectionBackend::addIceCandidate(RTCIceCandidate* iceCandidate, Funct
             return;
 
         Ref peerConnection = weakThis->m_peerConnection.get();
-        peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [peerConnection, callback = WTFMove(callback), result = std::forward<Result>(result)] () mutable {
+        peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [peerConnection, callback = WTFMove(callback), result = std::forward<Result>(result)] () mutable {
             if (peerConnection->isClosed())
                 return;
 
@@ -669,7 +669,7 @@ void PeerConnectionBackend::validateSDP(const String& sdp) const
 void PeerConnectionBackend::newICECandidate(String&& sdp, String&& mid, unsigned short sdpMLineIndex, String&& serverURL, std::optional<DescriptionStates>&& descriptions)
 {
     Ref peerConnection = m_peerConnection.get();
-    peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, sdp = WTFMove(sdp), mid = WTFMove(mid), sdpMLineIndex, serverURL = WTFMove(serverURL), descriptions = WTFMove(descriptions)]() mutable {
+    peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [logSiteIdentifier = LOGIDENTIFIER, this, sdp = WTFMove(sdp), mid = WTFMove(mid), sdpMLineIndex, serverURL = WTFMove(serverURL), descriptions = WTFMove(descriptions)]() mutable {
         Ref peerConnection = m_peerConnection.get();
         if (peerConnection->isClosed())
             return;

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -54,7 +54,7 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, std:
     ASSERT(handler);
     auto channel = adoptRef(*new RTCDataChannel(context, WTFMove(handler), WTFMove(label), WTFMove(options), state));
     channel->suspendIfNeeded();
-    queueTaskKeepingObjectAlive(channel.get(), TaskSource::Networking, [channel = channel.ptr()] {
+    legacyQueueTaskKeepingObjectAlive(channel.get(), TaskSource::Networking, [channel = channel.ptr()] {
         if (!channel->m_isDetachable)
             return;
         channel->m_isDetachable = false;
@@ -175,7 +175,7 @@ bool RTCDataChannel::virtualHasPendingActivity() const
 
 void RTCDataChannel::didChangeReadyState(RTCDataChannelState newState)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, newState] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, newState] {
         if (m_stopped || m_readyState == RTCDataChannelState::Closed || m_readyState == newState)
             return;
 
@@ -230,7 +230,7 @@ void RTCDataChannel::didDetectError(Ref<RTCError>&& error)
 
 void RTCDataChannel::bufferedAmountIsDecreasing(size_t amount)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, amount] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, amount] {
         auto previousBufferedAmount = m_bufferedAmount;
         m_bufferedAmount -= amount;
         if (previousBufferedAmount > m_bufferedAmountLowThreshold && m_bufferedAmount <= m_bufferedAmountLowThreshold)
@@ -338,7 +338,7 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, RTCD
         remoteHandlerPtr->setLocalIdentifier(channel->identifier());
 
     if (state == RTCDataChannelState::Open) {
-        channel->queueTaskKeepingObjectAlive(channel.get(), TaskSource::Networking, [channel = channel.ptr()] {
+        channel->legacyQueueTaskKeepingObjectAlive(channel.get(), TaskSource::Networking, [channel = channel.ptr()] {
             channel->fireOpenEventIfNeeded();
         });
     }

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -80,7 +80,7 @@ bool RTCDtlsTransport::virtualHasPendingActivity() const
 
 void RTCDtlsTransport::onStateChanged(RTCDtlsTransportState state, Vector<Ref<JSC::ArrayBuffer>>&& certificates)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state, certificates = WTFMove(certificates)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state, certificates = WTFMove(certificates)]() mutable {
         if (m_state == RTCDtlsTransportState::Closed)
             return;
 

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.cpp
@@ -71,7 +71,7 @@ bool RTCIceTransport::virtualHasPendingActivity() const
 
 void RTCIceTransport::onStateChanged(RTCIceTransportState state)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state]() mutable {
         if (m_isStopped)
             return;
 
@@ -89,7 +89,7 @@ void RTCIceTransport::onStateChanged(RTCIceTransportState state)
 
 void RTCIceTransport::onGatheringStateChanged(RTCIceGatheringState state)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state]() mutable {
         if (m_isStopped)
             return;
 
@@ -103,7 +103,7 @@ void RTCIceTransport::onGatheringStateChanged(RTCIceGatheringState state)
 
 void RTCIceTransport::onSelectedCandidatePairChanged(RefPtr<RTCIceCandidate>&& local, RefPtr<RTCIceCandidate>&& remote)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, local = WTFMove(local), remote = WTFMove(remote)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, local = WTFMove(local), remote = WTFMove(remote)]() mutable {
         if (m_isStopped)
             return;
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -799,7 +799,7 @@ void RTCPeerConnection::updateIceGatheringState(RTCIceGatheringState newState)
 {
     ALWAYS_LOG(LOGIDENTIFIER, newState);
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, newState] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, newState] {
         if (isClosed() || m_iceGatheringState == newState)
             return;
 
@@ -811,7 +811,7 @@ void RTCPeerConnection::updateIceGatheringState(RTCIceGatheringState newState)
 
 void RTCPeerConnection::updateIceConnectionState(RTCIceConnectionState)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
         if (isClosed())
             return;
         auto newState = computeIceConnectionStateFromIceTransports();
@@ -943,7 +943,7 @@ void RTCPeerConnection::processIceTransportChanges()
 
 void RTCPeerConnection::updateNegotiationNeededFlag(std::optional<uint32_t> eventId)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, eventId]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, eventId]() mutable {
         if (isClosed())
             return;
         if (!eventId) {
@@ -969,7 +969,7 @@ void RTCPeerConnection::updateNegotiationNeededFlag(std::optional<uint32_t> even
 
 void RTCPeerConnection::scheduleEvent(Ref<Event>&& event)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, event = WTFMove(event)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, event = WTFMove(event)]() mutable {
         dispatchEvent(event);
     });
 }
@@ -982,7 +982,7 @@ void RTCPeerConnection::dispatchEvent(Event& event)
 
 void RTCPeerConnection::dispatchDataChannelEvent(UniqueRef<RTCDataChannelHandler>&& channelHandler, String&& label, RTCDataChannelInit&& channelInit)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, label = WTFMove(label), channelHandler = WTFMove(channelHandler), channelInit = WTFMove(channelInit)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, label = WTFMove(label), channelHandler = WTFMove(channelHandler), channelInit = WTFMove(channelInit)]() mutable {
         if (isClosed())
             return;
 

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
@@ -71,7 +71,7 @@ bool RTCSctpTransport::virtualHasPendingActivity() const
 
 void RTCSctpTransport::onStateChanged(RTCSctpTransportState state, std::optional<double> maxMessageSize, std::optional<unsigned short> maxChannels)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state, maxMessageSize, maxChannels]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state, maxMessageSize, maxChannels]() mutable {
         if (m_state == RTCSctpTransportState::Closed)
             return;
 

--- a/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
+++ b/Source/WebCore/Modules/mediastream/UserMediaRequest.cpp
@@ -167,7 +167,7 @@ void UserMediaRequest::allow(CaptureDevice&& audioDevice, CaptureDevice&& videoD
         mediaDevices->willStartMediaCapture(!!audioDevice, !!videoDevice);
 
     m_allowCompletionHandler = WTFMove(completionHandler);
-    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this, audioDevice = WTFMove(audioDevice), videoDevice = WTFMove(videoDevice), deviceIdentifierHashSalt = WTFMove(deviceIdentifierHashSalt)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this, audioDevice = WTFMove(audioDevice), videoDevice = WTFMove(videoDevice), deviceIdentifierHashSalt = WTFMove(deviceIdentifierHashSalt)]() mutable {
         auto callback = [this, protector = makePendingActivity(*this)](auto privateStreamOrError) mutable {
             auto scopeExit = makeScopeExit([completionHandler = WTFMove(m_allowCompletionHandler)]() mutable {
                 completionHandler();

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -279,7 +279,7 @@ rtc::scoped_refptr<LibWebRTCStatsCollector> LibWebRTCMediaEndpoint::createStatsC
 
         Ref peerConnectionBackend = protectedThis->m_peerConnectionBackend.get();
         Ref peerConnection = peerConnectionBackend->connection();
-        peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [promise = WTFMove(promise), rtcReport] {
+        peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [promise = WTFMove(promise), rtcReport] {
             promise->resolve<IDLInterface<RTCStatsReport>>(LibWebRTCStatsCollector::createReport(rtcReport));
         });
     });

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -217,7 +217,7 @@ void Notification::stopResourcesLoader()
 
 void Notification::showSoon()
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
         show();
     });
 }
@@ -344,7 +344,7 @@ void Notification::dispatchClickEvent()
     ASSERT(m_notificationSource != NotificationSource::ServiceWorker);
     ASSERT(!isPersistent());
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
         WindowFocusAllowedIndicator windowFocusAllowed;
         dispatchEvent(Event::create(eventNames().clickEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -472,7 +472,7 @@ void PaymentRequest::closeActivePaymentHandler()
 void PaymentRequest::stop()
 {
     closeActivePaymentHandler();
-    queueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this] {
         settleShowPromise(Exception { ExceptionCode::AbortError });
     });
 }

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
@@ -147,7 +147,7 @@ void PaymentResponse::settleRetryPromise(ExceptionOr<void>&& result)
 
 void PaymentResponse::stop()
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this, pendingActivity = std::exchange(m_pendingActivity, nullptr)] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this, pendingActivity = std::exchange(m_pendingActivity, nullptr)] {
         settleRetryPromise(Exception { ExceptionCode::AbortError });
     });
     m_state = State::Stopped;

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -86,7 +86,7 @@ void RemotePlayback::watchAvailability(Ref<RemotePlaybackAvailabilityCallback>&&
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG(identifier);
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, callback = WTFMove(callback), promise = WTFMove(promise), identifier = identifier] () mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, callback = WTFMove(callback), promise = WTFMove(promise), identifier = identifier] () mutable {
         if (isContextStopped())
             return;
 
@@ -115,7 +115,7 @@ void RemotePlayback::watchAvailability(Ref<RemotePlaybackAvailabilityCallback>&&
         // 8. Fulfill promise with the callbackId and run the following steps in parallel:
         promise->whenSettled([this, protectedThis = Ref { *this }, callbackId] {
             // 8.1 Queue a task to invoke the callback with the current availability for the media element.
-            queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, callbackId, available = m_available] {
+            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, callbackId, available = m_available] {
                 if (isContextStopped())
                     return;
                 auto foundCallback = m_callbackMap.find(callbackId);
@@ -147,7 +147,7 @@ void RemotePlayback::cancelWatchAvailability(std::optional<int32_t> id, Ref<Defe
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG(identifier);
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, id = WTFMove(id), promise = WTFMove(promise), identifier = identifier] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, id = WTFMove(id), promise = WTFMove(promise), identifier = identifier] {
         if (isContextStopped())
             return;
         // 3. If the disableRemotePlayback attribute is present for the media element, reject promise with
@@ -199,7 +199,7 @@ void RemotePlayback::prompt(Ref<DeferredPromise>&& promise)
     auto identifier = LOGIDENTIFIER;
     ALWAYS_LOG(identifier);
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, promise = WTFMove(promise), processingUserGesture = UserGestureIndicator::processingUserGesture(), identifier = identifier] () mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, promise = WTFMove(promise), processingUserGesture = UserGestureIndicator::processingUserGesture(), identifier = identifier] () mutable {
         if (isContextStopped())
             return;
 
@@ -351,7 +351,7 @@ void RemotePlayback::disconnect()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     // 2. Queue a task to run the following steps:
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this] {
         if (isContextStopped())
             return;
 
@@ -429,7 +429,7 @@ void RemotePlayback::availabilityChanged(bool available)
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, available] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, available] {
         if (isContextStopped())
             return;
 

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -135,7 +135,7 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
     ASSERT(m_reportingScope && scriptExecutionContext() == m_reportingScope->scriptExecutionContext());
 
     // Step 4.3.4: Queue a task to § 4.4
-    queueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedThis = Ref { *this }, protectedCallback = Ref { m_callback }] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedThis = Ref { *this }, protectedCallback = Ref { m_callback }] {
         RefPtr context = protectedThis->scriptExecutionContext();
         ASSERT(context);
         if (!context)

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -249,7 +249,7 @@ void WebLockManager::request(const String& name, Options&& options, Ref<WebLockG
 
 void WebLockManager::didCompleteLockRequest(WebLockIdentifier lockIdentifier, bool success)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, weakThis = WeakPtr { *this }, lockIdentifier, success]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, weakThis = WeakPtr { *this }, lockIdentifier, success]() mutable {
         auto request = m_pendingRequests.take(lockIdentifier);
         if (!request.isValid())
             return;
@@ -309,7 +309,7 @@ void WebLockManager::query(Ref<DeferredPromise>&& promise)
         if (!weakThis)
             return;
 
-        weakThis->queueTaskKeepingObjectAlive(*weakThis, TaskSource::DOMManipulation, [promise = WTFMove(promise), snapshot = WTFMove(snapshot)]() mutable {
+        weakThis->legacyQueueTaskKeepingObjectAlive(*weakThis, TaskSource::DOMManipulation, [promise = WTFMove(promise), snapshot = WTFMove(snapshot)]() mutable {
             promise->resolve<IDLDictionary<Snapshot>>(WTFMove(snapshot));
         });
     });

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -313,7 +313,7 @@ void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<Audi
 
     auto p = m_audioDecoder->decodeAsync(audioData.copyRef(), sampleRate());
     p->whenSettled(RunLoop::currentSingleton(), [this, audioData = WTFMove(audioData), activity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise)] (DecodingTaskPromise::Result&& result) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [audioData = WTFMove(audioData), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)]() mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [audioData = WTFMove(audioData), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)]() mutable {
 
             audioData->unpin();
 
@@ -894,7 +894,7 @@ void BaseAudioContext::postTask(Function<void()>&& task)
 {
     ASSERT(isMainThread());
     if (!m_isStopScheduled)
-        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, WTFMove(task));
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, WTFMove(task));
 }
 
 const SecurityOrigin* BaseAudioContext::origin() const

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -299,7 +299,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::encode(Ref<WebCodecsAudioData>&& frame)
         // FIXME: These checks are not yet spec-compliant. See also https://github.com/w3c/webcodecs/issues/716
         if (m_baseConfiguration.numberOfChannels != audioData->numberOfChannels()
             || m_baseConfiguration.sampleRate != audioData->sampleRate()) {
-            queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
+            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
                 closeEncoder(Exception { ExceptionCode::EncodingError, "Input audio buffer is incompatible with codec parameters"_s });
             });
             return WebCodecsControlMessageOutcome::Processed;

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
@@ -73,7 +73,7 @@ void WebCodecsBase::scheduleDequeueEvent()
         return;
 
     m_dequeueEventScheduled = true;
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
         dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
         m_dequeueEventScheduled = false;
     });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h
@@ -36,7 +36,7 @@ void postTaskToCodec(ScriptExecutionContextIdentifier identifier, ThreadSafeWeak
         RefPtr protectedCodec = codec.get();
         if (!protectedCodec)
             return;
-        Codec::queueTaskKeepingObjectAlive(*protectedCodec, TaskSource::MediaElement, [codec = protectedCodec.get(), task = WTFMove(task)] () mutable {
+        Codec::legacyQueueTaskKeepingObjectAlive(*protectedCodec, TaskSource::MediaElement, [codec = protectedCodec.get(), task = WTFMove(task)] () mutable {
             task(*codec);
         });
     });

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -102,7 +102,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
         // 5. Set frame’s active boolean to false.
 
         for (auto& event : inputEvents) {
-            ActiveDOMObject::queueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = Ref { m_session }, event = WTFMove(event)]() {
+            ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = Ref { m_session }, event = WTFMove(event)]() {
                 event->setFrameActive(true);
                 session->dispatchEvent(event.copyRef());
                 event->setFrameActive(false);

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -253,7 +253,7 @@ void WebXRSession::requestReferenceSpace(XRReferenceSpaceType type, RequestRefer
         // 2.1. If the result of running reference space is supported for type and session is false, queue a task to reject promise
         // with a NotSupportedError and abort these steps.
         if (!referenceSpaceIsSupported(type)) {
-            queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [promise = WTFMove(promise)]() mutable {
+            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [promise = WTFMove(promise)]() mutable {
                 promise.reject(Exception { ExceptionCode::NotSupportedError });
             });
             return;
@@ -263,7 +263,7 @@ void WebXRSession::requestReferenceSpace(XRReferenceSpaceType type, RequestRefer
             device->initializeReferenceSpace(type);
 
         // 2.3. Queue a task to run the following steps:
-        queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, type, promise = WTFMove(promise)]() mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, type, promise = WTFMove(promise)]() mutable {
             if (!scriptExecutionContext()) {
                 promise.reject(Exception { ExceptionCode::InvalidStateError });
                 return;
@@ -463,7 +463,7 @@ void WebXRSession::sessionDidInitializeInputSources(Vector<PlatformXR::FrameData
     // https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession
     // 5.4.11 Queue a task to perform the following steps: NOTE: These steps ensure that initial inputsourceschange
     // events occur after the initial session is resolved.
-    queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, inputSources = WTFMove(inputSources)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, inputSources = WTFMove(inputSources)]() mutable {
         //  1. Set session's promise resolved flag to true.
         m_inputInitialized = true;
         //  2. Let sources be any existing input sources attached to session.
@@ -623,7 +623,7 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
         return;
 
     // Queue a task to perform the following steps.
-    queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, frameData = WTFMove(frameData)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, frameData = WTFMove(frameData)]() mutable {
         if (m_ended || m_visibilityState == XRVisibilityState::Hidden)
             return;
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -56,7 +56,6 @@ Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
 Modules/webdatabase/SQLCallbackWrapper.h
-Modules/websockets/WebSocket.cpp
 accessibility/AccessibilityARIAGridRow.cpp
 accessibility/AccessibilityScrollView.cpp
 accessibility/AccessibilityTable.cpp

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -104,8 +104,19 @@ public:
     bool isContextStopped() const;
     bool isAllowedToRunScript() const;
 
+    template<typename T, typename Task>
+    static void queueTaskKeepingObjectAlive(T& object, TaskSource source, Task&& task)
+    {
+        // Calls the template member function outside of lambda init-captures to work around a MSVC bug.
+        auto activity = object.ActiveDOMObject::makePendingActivity(object);
+        object.queueTaskInEventLoop(source, [protectedObject = Ref { object }, activity = WTFMove(activity), task = WTFMove(task)]() mutable {
+            task(protectedObject.get());
+        });
+    }
+
+    // FIXME: Port call sites to queueTaskKeepingObjectAlive() and remove this.
     template<typename T>
-    static void queueTaskKeepingObjectAlive(T& object, TaskSource source, Function<void ()>&& task)
+    static void legacyQueueTaskKeepingObjectAlive(T& object, TaskSource source, Function<void()>&& task)
     {
         // Calls the template member function outside of lambda init-captures to work around a MSVC bug.
         auto activity = object.ActiveDOMObject::makePendingActivity(object);
@@ -114,13 +125,15 @@ public:
         });
     }
 
-    template<typename T>
-    static void queueCancellableTaskKeepingObjectAlive(T& object, TaskSource source, TaskCancellationGroup& cancellationGroup, Function<void()>&& task)
+    template<typename T, typename Task>
+    static void queueCancellableTaskKeepingObjectAlive(T& object, TaskSource source, TaskCancellationGroup& cancellationGroup, Task&& task)
     {
-        CancellableTask cancellableTask(cancellationGroup, WTFMove(task));
+        CancellableTask cancellableTask(cancellationGroup, [task = WTFMove(task), protectedObject = Ref { object }]() mutable {
+            task(protectedObject.get());
+        });
         // Calls the template member function outside of lambda init-captures to work around a MSVC bug.
         auto activity = object.ActiveDOMObject::makePendingActivity(object);
-        object.queueTaskInEventLoop(source, [protectedObject = Ref { object }, activity = WTFMove(activity), cancellableTask = WTFMove(cancellableTask)]() mutable {
+        object.queueTaskInEventLoop(source, [activity = WTFMove(activity), cancellableTask = WTFMove(cancellableTask)]() mutable {
             cancellableTask();
         });
     }

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -249,7 +249,7 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
     if (m_isClosed)
         return;
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [this, message = WTFMove(message)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [this, message = WTFMove(message)]() mutable {
         if (m_isClosed || !scriptExecutionContext())
             return;
 

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -278,7 +278,7 @@ void MessagePort::dispatchMessages()
             }
 
             // Per specification, each MessagePort object has a task source called the port message queue.
-            queueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [this, event = WTFMove(event)] {
+            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [this, event = WTFMove(event)] {
                 dispatchEvent(event.event);
             });
         }

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -230,7 +230,7 @@ void FileReader::enqueueTask(Function<void()>&& task)
     static uint64_t taskIdentifierSeed = 0;
     uint64_t taskIdentifier = ++taskIdentifierSeed;
     m_pendingTasks.add(taskIdentifier, WTFMove(task));
-    queueTaskKeepingObjectAlive(*this, TaskSource::FileReading, [this, pendingActivity = makePendingActivity(*this), taskIdentifier] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::FileReading, [this, pendingActivity = makePendingActivity(*this), taskIdentifier] {
         auto task = m_pendingTasks.take(taskIdentifier);
         if (task && !isContextStopped())
             task();

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -133,7 +133,7 @@ public:
 
     WEBCORE_EXPORT static void setMaxCanvasAreaForTesting(std::optional<size_t>);
 
-    virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
+    virtual void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
 
     bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -66,7 +66,7 @@ public:
 
     void replayDisplayList(GraphicsContext&);
 
-    void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final { };
+    void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final { };
     void dispatchEvent(Event&) final { }
 
     const CSSParserContext& cssParserContext() const final;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -1013,9 +1013,9 @@ bool HTMLCanvasElement::isControlledByOffscreen() const
     return m_context && m_context->isPlaceholder();
 }
 
-void HTMLCanvasElement::queueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
+void HTMLCanvasElement::legacyQueueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(*this, source, WTFMove(task));
+    ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(*this, source, WTFMove(task));
 }
 
 void HTMLCanvasElement::dispatchEvent(Event& event)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -140,7 +140,7 @@ public:
 
     bool isControlledByOffscreen() const;
 
-    void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
+    void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
 
     // ActiveDOMObject.

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -221,7 +221,7 @@ void HTMLTrackElement::scheduleLoad()
 
 void HTMLTrackElement::scheduleTask(Function<void()>&& task)
 {
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)]() mutable {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)]() mutable {
         task();
     });
 }

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -454,9 +454,9 @@ void OffscreenCanvas::reset()
     scheduleCommitToPlaceholderCanvas();
 }
 
-void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
+void OffscreenCanvas::legacyQueueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
 {
-    ActiveDOMObject::queueTaskKeepingObjectAlive(*this, source, WTFMove(task));
+    ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(*this, source, WTFMove(task));
 }
 
 void OffscreenCanvas::dispatchEvent(Event& event)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -146,7 +146,7 @@ public:
 
     void commitToPlaceholderCanvas();
 
-    void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
+    void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
     void dispatchEvent(Event&) final;
     bool isDetached() const { return m_detached; };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5168,7 +5168,7 @@ void WebGLRenderingContextBase::vertexAttribfvImpl(ASCIILiteral functionName, GC
 void WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent()
 {
     // It is safe to capture |this| because we keep the canvas element alive and it owns |this|.
-    canvasBase().queueTaskKeepingObjectAlive(TaskSource::WebGL, [this] {
+    canvasBase().legacyQueueTaskKeepingObjectAlive(TaskSource::WebGL, [this] {
         if (isContextStopped())
             return;
         if (!isContextLost())

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -97,7 +97,7 @@ bool WebGLSync::isSignaled() const
 
 void WebGLSync::scheduleAllowCacheUpdate(WebGLRenderingContextBase& context)
 {
-    context.canvasBase().queueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }]() {
+    context.canvasBase().legacyQueueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }]() {
         protectedThis->m_allowCacheUpdate = true;
     });
 }

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -174,7 +174,7 @@ void TrackListBase::scheduleChangeEvent()
     // selected, the user agent must queue a task to fire a simple event named
     // change at the VideoTrackList object.
     m_isChangeEventScheduled = true;
-    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this] {
         m_isChangeEventScheduled = false;
         dispatchEvent(Event::create(eventNames().changeEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -132,13 +132,13 @@ void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
         return;
     }
     if (auto previousPromise = manager->takeLockPromise()) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [previousPromise = WTFMove(previousPromise)]() mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [previousPromise = WTFMove(previousPromise)]() mutable {
             previousPromise->reject(Exception { ExceptionCode::AbortError, "A new lock request was started"_s });
         });
     }
     manager->setLockPromise(*this, WTFMove(promise));
     manager->lock(lockType, [this, protectedThis = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, exception = WTFMove(exception)]() mutable {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, exception = WTFMove(exception)]() mutable {
             auto* manager = this->manager();
             if (!manager)
                 return;
@@ -263,7 +263,7 @@ void ScreenOrientation::stop()
 
     manager->removeObserver(*this);
     if (manager->lockRequester() == this) {
-        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = manager->takeLockPromise()] {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = manager->takeLockPromise()] {
             promise->reject(Exception { ExceptionCode::AbortError, "Document is no longer fully active"_s });
         });
     }

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -255,7 +255,7 @@ void Worker::reportError(const String& errorMessage)
     if (m_wasTerminated)
         return;
 
-    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, errorMessage] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, errorMessage] {
         if (m_wasTerminated)
             return;
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -190,7 +190,7 @@ void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& m
             return;
 
         auto ports = MessagePort::entanglePorts(context, WTFMove(message.transferredPorts));
-        ActiveDOMObject::queueTaskKeepingObjectAlive(*workerObject, TaskSource::PostedMessageQueue, [worker = Ref { *workerObject }, message = WTFMove(message), userGestureForwarder = WTFMove(userGestureForwarder), ports = WTFMove(ports)] () mutable {
+        ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(*workerObject, TaskSource::PostedMessageQueue, [worker = Ref { *workerObject }, message = WTFMove(message), userGestureForwarder = WTFMove(userGestureForwarder), ports = WTFMove(ports)] () mutable {
             if (!worker->scriptExecutionContext())
                 return;
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -430,7 +430,7 @@ std::optional<ExceptionOr<void>> XMLHttpRequest::prepareToSend()
         if (!m_async)
             return ExceptionOr<void> { Exception { ExceptionCode::NetworkError } };
         m_timeoutTimer.stop();
-        queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
             networkError();
         });
         return ExceptionOr<void> { };
@@ -890,7 +890,7 @@ String XMLHttpRequest::statusText() const
 void XMLHttpRequest::handleCancellation()
 {
     m_exceptionCode = ExceptionCode::AbortError;
-    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, CancellableTask(m_abortErrorGroup, [this] {
+    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, CancellableTask(m_abortErrorGroup, [this] {
         abortError();
     }));
 }
@@ -923,7 +923,7 @@ void XMLHttpRequest::didFail(std::optional<ScriptExecutionContextIdentifier>, co
     if (m_async && m_sendFlag && !m_loadingActivity) {
         m_sendFlag = false;
         m_timeoutTimer.stop();
-        queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
+        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this] {
             networkError();
         });
         return;

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -143,7 +143,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
     m_shouldDeferEventsDueToSuspension = true;
 
     if (m_hasPendingThrottledProgressEvent) {
-        m_target.queueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this] {
+        m_target.legacyQueueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this] {
             flushProgressEvent();
         });
     }
@@ -151,7 +151,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
 
 void XMLHttpRequestProgressEventThrottle::resume()
 {
-    m_target.queueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this] {
+    m_target.legacyQueueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this] {
         m_shouldDeferEventsDueToSuspension = false;
     });
 }

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -80,7 +80,7 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     xrSystem->initializeTrackingAndRendering();
 
     // This is called from the constructor of WebXRSession. Since sessionDidInitializeInputSources()
-    // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we
+    // ends up calling legacyQueueTaskKeepingObjectAlive() which refs the WebXRSession object, we
     // should delay this call after the WebXRSession has finished construction.
     callOnMainRunLoop([this, weakThis = ThreadSafeWeakPtr { *this }]() {
         auto protectedThis = weakThis.get();


### PR DESCRIPTION
#### 01b4cde270584956e84a2caf200480691f4884ce
<pre>
Update ActiveDOMObject::queueTaskKeepingObjectAlive() to play nicely with Safer CPP static analysis
<a href="https://bugs.webkit.org/show_bug.cgi?id=289316">https://bugs.webkit.org/show_bug.cgi?id=289316</a>

Reviewed by Geoffrey Garen.

`ActiveDOMObject::queueTaskKeepingObjectAlive()` keeps `this` alive and therefore, the callers
often capture `this` in the lambda they pass, without additional protection, which is safe.
However, the static analysis has no way to know this. To address the issue,
`queueTaskKeepingObjectAlive()` now passes the protected object as parameter to the lambda
function. As a result, call sites no longer need to capture `this`, which will address static
analysis warnings.

* Source/WTF/wtf/LoggerHelper.h:
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::scheduleStateChangeEvent):
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::match):
(WebCore::DOMCache::matchAll):
(WebCore::DOMCache::addAll):
(WebCore::DOMCache::putWithResponseData):
(WebCore::DOMCache::put):
(WebCore::DOMCache::remove):
(WebCore::DOMCache::keys):
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
(WebCore::MediaKeySession::generateRequest):
(WebCore::MediaKeySession::load):
(WebCore::MediaKeySession::update):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp:
(WebCore::MediaKeySystemAccess::createMediaKeys):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::allow):
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
(WebCore::GamepadHapticActuator::playEffect):
(WebCore::GamepadHapticActuator::reset):
(WebCore::GamepadHapticActuator::stopEffects):
* Source/WebCore/Modules/mediarecorder/MediaRecorder.cpp:
(WebCore::MediaRecorder::startRecording):
(WebCore::MediaRecorder::pauseRecording):
(WebCore::MediaRecorder::resumeRecording):
(WebCore::MediaRecorder::fetchData):
(WebCore::MediaRecorder::handleTrackChange):
(WebCore::MediaRecorder::trackEnded):
* Source/WebCore/Modules/mediastream/ImageCapture.cpp:
(WebCore::ImageCapture::takePhoto):
(WebCore::ImageCapture::getPhotoCapabilities):
(WebCore::ImageCapture::getPhotoSettings):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::applyConstraints):
(WebCore::MediaStreamTrack::trackEnded):
(WebCore::MediaStreamTrack::trackMutedChanged):
(WebCore::MediaStreamTrack::trackConfigurationChanged):
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::createOfferSucceeded):
(WebCore::PeerConnectionBackend::createOfferFailed):
(WebCore::PeerConnectionBackend::createAnswerSucceeded):
(WebCore::PeerConnectionBackend::createAnswerFailed):
(WebCore::PeerConnectionBackend::setLocalDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setLocalDescriptionFailed):
(WebCore::PeerConnectionBackend::setRemoteDescriptionSucceeded):
(WebCore::PeerConnectionBackend::setRemoteDescriptionFailed):
(WebCore::PeerConnectionBackend::iceGatheringStateChanged):
(WebCore::PeerConnectionBackend::addIceCandidate):
(WebCore::PeerConnectionBackend::newICECandidate):
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::create):
(WebCore::RTCDataChannel::didChangeReadyState):
(WebCore::RTCDataChannel::bufferedAmountIsDecreasing):
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
(WebCore::RTCDtlsTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/RTCIceTransport.cpp:
(WebCore::RTCIceTransport::onStateChanged):
(WebCore::RTCIceTransport::onGatheringStateChanged):
(WebCore::RTCIceTransport::onSelectedCandidatePairChanged):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::updateIceGatheringState):
(WebCore::RTCPeerConnection::updateIceConnectionState):
(WebCore::RTCPeerConnection::updateNegotiationNeededFlag):
(WebCore::RTCPeerConnection::scheduleEvent):
(WebCore::RTCPeerConnection::dispatchDataChannelEvent):
* Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp:
(WebCore::RTCSctpTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/UserMediaRequest.cpp:
(WebCore::UserMediaRequest::allow):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::createStatsCollector):
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::showSoon):
(WebCore::Notification::dispatchClickEvent):
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::stop):
* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
(WebCore::PaymentResponse::stop):
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(WebCore::RemotePlayback::watchAvailability):
(WebCore::RemotePlayback::cancelWatchAvailability):
(WebCore::RemotePlayback::prompt):
(WebCore::RemotePlayback::disconnect):
(WebCore::RemotePlayback::availabilityChanged):
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::appendQueuedReportIfCorrectType):
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::didCompleteLockRequest):
(WebCore::WebLockManager::query):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::decodeAudioData):
(WebCore::BaseAudioContext::postTask):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::encode):
* Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp:
(WebCore::WebCodecsBase::scheduleDequeueEvent):
* Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h:
(WebCore::postTaskToCodec):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::failAsynchronously):
(WebCore::WebSocket::didConnect):
(WebCore::WebSocket::didReceiveMessage):
(WebCore::WebSocket::didReceiveBinaryData):
(WebCore::WebSocket::didReceiveMessageError):
(WebCore::WebSocket::didStartClosingHandshake):
(WebCore::WebSocket::didClose):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::update):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::requestReferenceSpace):
(WebCore::WebXRSession::sessionDidInitializeInputSources):
(WebCore::WebXRSession::onFrame):
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::dispatchMessage):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::dispatchMessages):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::enqueueTask):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::legacyQueueTaskKeepingObjectAlive):
(WebCore::HTMLCanvasElement::queueTaskKeepingObjectAlive): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::removedFromAncestor):
(WebCore::HTMLMediaElement::didDetachRenderers):
(WebCore::HTMLMediaElement::scheduleNextSourceChild):
(WebCore::HTMLMediaElement::scheduleResolvePendingPlayPromises):
(WebCore::HTMLMediaElement::scheduleRejectPendingPlayPromises):
(WebCore::HTMLMediaElement::scheduleNotifyAboutPlaying):
(WebCore::HTMLMediaElement::load):
(WebCore::HTMLMediaElement::mediaPlayerReloadAndResumePlaybackIfNeeded):
(WebCore::HTMLMediaElement::selectMediaResource):
(WebCore::HTMLMediaElement::endIgnoringTrackDisplayUpdateRequests):
(WebCore::HTMLMediaElement::mediaPlayerReadyStateChanged):
(WebCore::HTMLMediaElement::setMediaKeys):
(WebCore::HTMLMediaElement::seekWithTolerance):
(WebCore::HTMLMediaElement::finishSeek):
(WebCore::HTMLMediaElement::setVolume):
(WebCore::HTMLMediaElement::layoutSizeChanged):
(WebCore::HTMLMediaElement::scheduleConfigureTextTracks):
(WebCore::HTMLMediaElement::scheduleMediaEngineWasUpdated):
(WebCore::HTMLMediaElement::scheduleUpdatePlayState):
(WebCore::HTMLMediaElement::clearMediaPlayer):
(WebCore::HTMLMediaElement::resume):
(WebCore::HTMLMediaElement::setIsPlayingToWirelessTarget):
(WebCore::HTMLMediaElement::enterFullscreen):
(WebCore::HTMLMediaElement::mediaPlayerBufferedTimeRangesChanged):
(WebCore::HTMLMediaElement::pageScaleFactorChanged):
(WebCore::HTMLMediaElement::scheduleUpdateMediaState):
(WebCore::HTMLMediaElement::isVisibleInViewportChanged):
(WebCore::HTMLMediaElement::scheduleUpdateShouldAutoplay):
(WebCore::HTMLMediaElement::playbackControlsManagerBehaviorRestrictionsTimerFired):
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::scheduleTask):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::legacyQueueTaskKeepingObjectAlive):
(WebCore::OffscreenCanvas::queueTaskKeepingObjectAlive): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::scheduleAllowCacheUpdate):
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::scheduleChangeEvent):
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::reportError):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ready):
(WebCore::ServiceWorkerContainer::getRegistration):
(WebCore::ServiceWorkerContainer::updateRegistrationState):
(WebCore::ServiceWorkerContainer::updateWorkerState):
(WebCore::ServiceWorkerContainer::getRegistrations):
(WebCore::ServiceWorkerContainer::startMessages):
(WebCore::ServiceWorkerContainer::jobFailedWithException):
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
(WebCore::ServiceWorkerContainer::postMessage):
(WebCore::ServiceWorkerContainer::jobResolvedWithUnregistrationResult):
(WebCore::ServiceWorkerContainer::jobFailedLoadingScript):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::prepareToSend):
(WebCore::XMLHttpRequest::handleCancellation):
(WebCore::XMLHttpRequest::didFail):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::suspend):
(WebCore::XMLHttpRequestProgressEventThrottle::resume):
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):

Canonical link: <a href="https://commits.webkit.org/291782@main">https://commits.webkit.org/291782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b406e9cfc168d0b1bb36df9bd72205d17c3a09f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93994 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99002 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96044 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22011 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29085 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10311 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/84906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52075 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9993 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/135/builds/2572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43837 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86704 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80247 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2655 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101043 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92660 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15340 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80114 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19943 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24650 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2016 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14208 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26208 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115310 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20717 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->