### PR TITLE
[WebGPU] Memory barriers in vertex shader validation routines are problematic on M1

### DIFF
--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -177,10 +177,10 @@ Buffer::Buffer(id<MTLBuffer> buffer, uint64_t initialSize, WGPUBufferUsageFlags 
     , m_mappedAtCreation(m_state == State::MappedAtCreation)
 #endif
 {
-    if (m_usage & WGPUBufferUsage_Indirect)
+    if (m_usage & WGPUBufferUsage_Indirect) {
         m_indirectBuffer = device.safeCreateBuffer(sizeof(WebKitMTLDrawPrimitivesIndirectArguments), MTLStorageModeShared);
-    if (m_usage & (WGPUBufferUsage_Indirect | WGPUBufferUsage_Index))
         m_indirectIndexedBuffer = device.safeCreateBuffer(sizeof(WebKitMTLDrawIndexedPrimitivesIndirectArguments), MTLStorageModeShared);
+    }
 }
 
 Buffer::Buffer(Device& device)

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -194,9 +194,15 @@ public:
     id<MTLRenderPipelineState> indirectBufferClampPipeline(NSUInteger rasterSampleCount);
     id<MTLRenderPipelineState> icbCommandClampPipeline(MTLIndexType, NSUInteger rasterSampleCount);
     id<MTLFunction> icbCommandClampFunction(MTLIndexType);
-    id<MTLRenderPipelineState> copyIndexIndirectArgsPipeline(NSUInteger rasterSampleCount);
     id<MTLBuffer> safeCreateBuffer(NSUInteger length, MTLStorageMode, MTLCPUCacheMode = MTLCPUCacheModeDefaultCache, MTLHazardTrackingMode = MTLHazardTrackingModeDefault) const;
     id<MTLBuffer> safeCreateBuffer(NSUInteger) const;
+    template<typename T>
+    id<MTLBuffer> safeCreateBufferWithData(const T& data) const
+    {
+        id<MTLBuffer> buffer = [m_device newBufferWithBytes:static_cast<const void*>(&data) length:sizeof(data) options:MTLResourceStorageModeShared];
+        setOwnerWithIdentity(buffer);
+        return buffer;
+    }
     void loseTheDevice(WGPUDeviceLostReason);
     int bufferIndexForICBContainer() const;
     void setOwnerWithIdentity(id<MTLResource>) const;
@@ -288,9 +294,6 @@ private:
     id<MTLRenderPipelineState> m_icbCommandClampUshortPSO { nil };
     id<MTLRenderPipelineState> m_icbCommandClampUintPSOMS { nil };
     id<MTLRenderPipelineState> m_icbCommandClampUshortPSOMS { nil };
-
-    id<MTLRenderPipelineState> m_copyIndexedIndirectArgsPSO { nil };
-    id<MTLRenderPipelineState> m_copyIndexedIndirectArgsPSOMS { nil };
 
     const Ref<Adapter> m_adapter;
     const ThreadSafeWeakPtr<Instance> m_instance;


### PR DESCRIPTION
#### 8f1919db1fce2079da646cf3a1cc11d50449fcde
<pre>
[WebGPU] Memory barriers in vertex shader validation routines are problematic on M1
<a href="https://bugs.webkit.org/show_bug.cgi?id=289147">https://bugs.webkit.org/show_bug.cgi?id=289147</a>
<a href="https://rdar.apple.com/146219177">rdar://146219177</a>

Reviewed by Tadeu Zagallo.

We were using memory barriers with a single temporary indirect buffer
shared across multiple draw calls. This seemed to work fine on M2 Macs
but results with some command buffer errors on M1 macs (error code = Internal Error).

It appears due to having the barrier on the same indirect buffer many times in a single
render pass encoder.

We can resolve this by replacing the setBytes call with a temporary buffer and use that buffer
instead of the single shared buffer we had previously been using. This will result in very
little or possibly reduced memory usage since now we don&apos;t need to create an indirect
buffer (in addition to the temporary one) for Index buffers.

* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::safeCreateBufferWithData const):
Add helper to create a buffer from byte data. Internally
the data is copied at the call site so we don&apos;t need to worry
about its lifetime.

* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::copyIndexIndirectArgsPipeline): Deleted.
Remove unused code.

* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::clampIndexBufferToValidValues):
Use a temporary buffer instead of the setBytes: call.

* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::Buffer):
We no longer need to create this persistent secondary indirect buffer
for index buffers, only ones which are (also) indirect.

Canonical link: <a href="https://commits.webkit.org/291897@main">https://commits.webkit.org/291897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74afd90df07a1eb4c0439f4cc07445c86c0cacb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98947 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44467 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71678 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29030 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52016 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9938 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43783 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/100986 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/20992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15299 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80691 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21244 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80046 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20030 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1951 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14149 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/20976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26154 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20663 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->