### PR TITLE
Fix handling "url(...) none" as per SVG Paint Server specification

### DIFF
--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -183,9 +183,23 @@ static inline bool isChainableResource(const SVGElement& element, const SVGEleme
     return false;
 }
 
+static inline bool svgPaintTypeHasURL(const SVGPaintType& paintType)
+{
+    switch (paintType) {
+    case SVGPaintType::URI:
+    case SVGPaintType::URINone:
+    case SVGPaintType::URICurrentColor:
+    case SVGPaintType::URIRGBColor:
+        return true;
+    default:
+        break;
+    }
+    return false;
+}
+
 static inline LegacyRenderSVGResourceContainer* paintingResourceFromSVGPaint(TreeScope& treeScope, const SVGPaintType& paintType, const String& paintUri, AtomString& id, bool& hasPendingResource)
 {
-    if (paintType != SVGPaintType::URI && paintType != SVGPaintType::URIRGBColor && paintType != SVGPaintType::URICurrentColor)
+    if (!svgPaintTypeHasURL(paintType))
         return nullptr;
 
     id = SVGURIReference::fragmentIdentifierFromIRIString(paintUri, treeScope.protectedDocumentScope());


### PR DESCRIPTION
#### cdf6c25ed12c5ac722877c974b0a46a9632a7b0f
<pre>
Fix handling &quot;url(...) none&quot; as per SVG Paint Server specification

<a href="https://bugs.webkit.org/show_bug.cgi?id=289319">https://bugs.webkit.org/show_bug.cgi?id=289319</a>
<a href="https://rdar.apple.com/146454258">rdar://146454258</a>

Reviewed by Antoine Quint.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Partial Merge: <a href="https://source.chromium.org/chromium/chromium/src/+/a06aaf2d26a09493ed64b542baa29278a671425e">https://source.chromium.org/chromium/chromium/src/+/a06aaf2d26a09493ed64b542baa29278a671425e</a>

This patch ensures that we consider all paint types with a URI in `paintingResourceFromSVGPaint`
function since currently, we don&apos;t handle `SVGPaintType::URINone`.
We do it by introducing helper function `svgPaintTypeHasURL`.

Web Specification: <a href="https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint">https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint</a>

This change progresses `svg/pservers/reftests/fill-fallback-none-1.svg` but we
cannot enable it due to gradient noise and to enable, we have to add fuzziness
which is under discussion.

* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::svgPaintTypeHasURL):
(WebCore::paintingResourceFromSVGPaint):

Canonical link: <a href="https://commits.webkit.org/291770@main">https://commits.webkit.org/291770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75dbaed74d89dfc5b1347acc0cfc9a081f809def

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3293 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44495 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96018 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71703 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10293 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52048 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9969 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2527 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43811 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101016 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80712 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80073 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19935 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1974 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14177 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26182 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20691 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->