### PR TITLE
StabilityTracer: com.apple.WebKit.GPU at com.apple.WebCore:  void std::__1::map<std::__1::pair<WTF::MediaTime, WTF::MediaTime>, WTF::Ref<WebCore::MediaSample, WTF::RawPtrTraits<WebCore::MediaSample>, WTF::DefaultRefDeref…

### DIFF
--- a/Source/WebCore/Modules/mediasource/SampleMap.cpp
+++ b/Source/WebCore/Modules/mediasource/SampleMap.cpp
@@ -321,6 +321,9 @@ DecodeOrderSampleMap::iterator_range DecodeOrderSampleMap::findSamplesBetweenDec
     auto upper_bound = m_samples.lower_bound(endKey);
     if (lower_bound == upper_bound)
         return { end(), end() };
+    ASSERT(lower_bound != end());
+    if (lower_bound == end())
+        return { begin(), upper_bound };
     return { lower_bound, upper_bound };
 }
 


### PR DESCRIPTION
#### 155378694b4f5b170c3e17dfeb86eb072ed9f544
<pre>
StabilityTracer: com.apple.WebKit.GPU at com.apple.WebCore:  void std::__1::map&lt;std::__1::pair&lt;WTF::MediaTime, WTF::MediaTime&gt;, WTF::Ref&lt;WebCore::MediaSample, WTF::RawPtrTraits&lt;WebCore::MediaSample&gt;, WTF::DefaultRefDeref…
<a href="https://bugs.webkit.org/show_bug.cgi?id=289321">https://bugs.webkit.org/show_bug.cgi?id=289321</a>
<a href="https://rdar.apple.com/129903700">rdar://129903700</a>

Reviewed by Youenn Fablet.

The stack trace seems to indicate that we are attempting to insert a sample
taken from the map with an invalid index.
This is a tentative fix: it appears that we are trying to find a sample
which is the first in the map.
So we detect the nonsensical situation by aborting early should we search for a key with no preceding samples.

In the worse case scenario this will cause later a decoding error which
is likely better than a crash.

* Source/WebCore/Modules/mediasource/SampleMap.cpp:
(WebCore::DecodeOrderSampleMap::findSamplesBetweenDecodeKeys):

Canonical link: <a href="https://commits.webkit.org/291838@main">https://commits.webkit.org/291838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90895bd0bfbabebe64bafd0b8c4d9598b2fc710e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44705 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71837 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29176 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52178 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2711 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44023 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80350 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101232 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21230 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15444 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80840 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20003 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24769 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2129 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14401 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26393 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20901 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22642 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->