### PR TITLE
InstallEvent should be created if the ServiceWorkerInstallEventEnabled flag is true

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-install-event-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-install-event-expected.txt
@@ -1,0 +1,3 @@
+
+PASS InstallEvent and addRoutes
+

--- a/LayoutTests/http/wpt/service-workers/service-worker-install-event.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-install-event.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    const registration = await navigator.serviceWorker.register("service-worker-no-install-event.js");
+    const worker = registration.installing;
+
+    await waitForState(registration.installing, "activated");
+
+    worker.postMessage("test");
+    assert_equals(await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data)), "Has InstallEvent - has addRoutes");
+}, "InstallEvent and addRoutes");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/service-worker-no-install-event-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-no-install-event-expected.txt
@@ -1,0 +1,3 @@
+
+PASS add route when not installing
+

--- a/LayoutTests/http/wpt/service-workers/service-worker-no-install-event.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-no-install-event.html
@@ -1,0 +1,21 @@
+<!doctype html><!-- webkit-test-runner [ ServiceWorkerInstallEventEnabled=false ] -->
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+promise_test(async (test) => {
+    const registration = await navigator.serviceWorker.register("service-worker-no-install-event.js");
+    const worker = registration.installing;
+
+    await waitForState(registration.installing, "activated");
+
+    worker.postMessage("test");
+    assert_equals(await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data)), "No InstallEvent - no addRoutes");
+}, "add route when not installing");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/service-worker-no-install-event.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-no-install-event.js
@@ -1,0 +1,10 @@
+let installEvent;
+oninstall = e => {
+   installEvent = e;
+}
+
+onmessage = e => {
+    let result = self.InstallEvent ? "Has InstallEvent" : "No InstallEvent";
+    result  += installEvent.addRoutes ? " - has addRoutes" : " - no addRoutes"
+    e.source.postMessage(result);
+}

--- a/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThread.cpp
@@ -217,7 +217,7 @@ void ServiceWorkerThread::queueTaskToFireInstallEvent()
     serviceWorkerGlobalScope->eventLoop().queueTask(TaskSource::DOMManipulation, [weakThis = ThreadSafeWeakPtr { *this }, serviceWorkerGlobalScope]() mutable {
         RELEASE_LOG(ServiceWorker, "ServiceWorkerThread::queueTaskToFireInstallEvent firing event for worker %" PRIu64, serviceWorkerGlobalScope->thread().identifier().toUInt64());
 
-        auto installEvent = InstallEvent::create(eventNames().installEvent, { }, ExtendableEvent::IsTrusted::Yes);
+        Ref installEvent = serviceWorkerGlobalScope->settingsValues().serviceWorkerInstallEventEnabled ? Ref<ExtendableEvent> { InstallEvent::create(eventNames().installEvent, { }, ExtendableEvent::IsTrusted::Yes) } : ExtendableEvent::create(eventNames().installEvent, { }, ExtendableEvent::IsTrusted::Yes);
         serviceWorkerGlobalScope->dispatchEvent(installEvent);
 
         installEvent->whenAllExtendLifetimePromisesAreSettled([weakThis = WTFMove(weakThis)](HashSet<Ref<DOMPromise>>&& extendLifetimePromises) mutable {


### PR DESCRIPTION
#### 6f8e26ea3864dcefbad31fee69aea3d1364038db
<pre>
InstallEvent should be created if the ServiceWorkerInstallEventEnabled flag is true
<a href="https://rdar.apple.com/146466029">rdar://146466029</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289325">https://bugs.webkit.org/show_bug.cgi?id=289325</a>

Reviewed by Brady Eidson.

Make use of the flag to instantiate either an ExtendableEvent or an InstallEvent.

* LayoutTests/http/wpt/service-workers/service-worker-install-event-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/service-worker-install-event.html: Added.
* LayoutTests/http/wpt/service-workers/service-worker-no-install-event-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/service-worker-no-install-event.html: Added.
* LayoutTests/http/wpt/service-workers/service-worker-no-install-event.js: Added.
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireInstallEvent):

Canonical link: <a href="https://commits.webkit.org/291834@main">https://commits.webkit.org/291834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09a873cd292119f23200ddbafc0f6258bffddbdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/98979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/21987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29053 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9970 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2528 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43814 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80224 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101019 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15315 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80715 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21275 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80076 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20000 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24619 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/1975 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14180 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26185 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20694 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->