### PR TITLE
[WPE] WPEPlatform: add default accessibility implementation using ATK

### DIFF
--- a/Source/WebKit/WPEPlatform/CMakeLists.txt
+++ b/Source/WebKit/WPEPlatform/CMakeLists.txt
@@ -113,6 +113,24 @@ elseif (USE_LIBDRM)
     list(APPEND WPEPlatform_LIBRARIES LibDRM::LibDRM)
 endif ()
 
+if (USE_ATK)
+    list(APPEND WPEPlatform_SYSTEM_INCLUDE_DIRECTORIES
+        ${ATK_INCLUDE_DIRS}
+    )
+
+    list(APPEND WPEPlatform_LIBRARIES
+        ATK::Bridge
+        ${ATK_LIBRARIES}
+    )
+
+    list(APPEND WPEPlatform_SOURCES
+        ${WEBKIT_DIR}/WPEPlatform/wpe/WPEAccessibilityAtk.cpp
+        ${WEBKIT_DIR}/WPEPlatform/wpe/WPEApplicationAccessibleAtk.cpp
+        ${WEBKIT_DIR}/WPEPlatform/wpe/WPEToplevelAccessibleAtk.cpp
+        ${WEBKIT_DIR}/WPEPlatform/wpe/WPEViewAccessibleAtk.cpp
+    )
+endif ()
+
 if (NOT USE_SYSTEM_MALLOC)
    list(APPEND WPEPlatform_LIBRARIES bmalloc)
 endif ()

--- a/Source/WebKit/WPEPlatform/wpe/WPEAccessibilityAtk.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEAccessibilityAtk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,12 @@
 
 #pragma once
 
-#include "WPEToplevel.h"
-#include "WPEView.h"
-#include <wtf/glib/GRefPtr.h>
-
 #if USE(ATK)
-typedef struct _AtkObject AtkObject;
-#endif
 
-GList* wpeToplevelList();
-void wpeToplevelAddView(WPEToplevel*, WPEView*);
-void wpeToplevelRemoveView(WPEToplevel*, WPEView*);
-GRefPtr<WPEView> wpeToplevelGetView(WPEToplevel*, size_t);
+namespace WPE {
 
+void accessibilityAtkInit();
 
-#if USE(ATK)
-AtkObject* wpeToplevelGetOrCreateAccessibleAtk(WPEToplevel*);
-AtkObject* wpeToplevelGetAccessibleAtk(WPEToplevel*);
-#endif
+} // namespace WPE
+
+#endif // USE(ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEApplicationAccessibleAtk.h"
+
+#if USE(ATK)
+#include "WPEToplevelPrivate.h"
+#include <wtf/Vector.h>
+#include <wtf/glib/GUniquePtr.h>
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEApplicationAccessibleAtkPrivate {
+    Vector<WPEToplevel*> toplevels;
+};
+
+WEBKIT_DEFINE_FINAL_TYPE(WPEApplicationAccessibleAtk, wpe_application_accessible_atk, ATK_TYPE_OBJECT, AtkObject)
+
+static void wpeApplicationAccessibleAtkConstructed(GObject* object)
+{
+    G_OBJECT_CLASS(wpe_application_accessible_atk_parent_class)->constructed(object);
+
+    auto* accessible = WPE_APPLICATION_ACCESSIBLE_ATK(object);
+    GUniquePtr<GList> toplevels(wpeToplevelList());
+    for (GList* iter = toplevels.get(); iter; iter = g_list_next(iter))
+        accessible->priv->toplevels.append(WPE_TOPLEVEL(iter->data));
+}
+
+static void wpeApplicationAccessibleAtkInitialize(AtkObject* atkObject, gpointer userData)
+{
+    ATK_OBJECT_CLASS(wpe_application_accessible_atk_parent_class)->initialize(atkObject, userData);
+
+    atkObject->role = ATK_ROLE_APPLICATION;
+    atkObject->accessible_parent = nullptr;
+}
+
+static gint wpeApplicationAccessibleAtkGetNChildren(AtkObject* atkObject)
+{
+    auto* accessible = WPE_APPLICATION_ACCESSIBLE_ATK(atkObject);
+    return accessible->priv->toplevels.size();
+}
+
+static AtkObject* wpeApplicationAccessibleAtkRefChild(AtkObject* atkObject, int index)
+{
+    auto* accessible = WPE_APPLICATION_ACCESSIBLE_ATK(atkObject);
+    if (index < 0 || static_cast<size_t>(index) >= accessible->priv->toplevels.size())
+        return nullptr;
+
+    auto* toplevel = accessible->priv->toplevels[index];
+    return ATK_OBJECT(g_object_ref(wpeToplevelGetOrCreateAccessibleAtk(toplevel)));
+}
+
+static const char* wpeApplicationAccessibleAtkGetName(AtkObject*)
+{
+    return g_get_prgname();
+}
+
+static void wpe_application_accessible_atk_class_init(WPEApplicationAccessibleAtkClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->constructed = wpeApplicationAccessibleAtkConstructed;
+
+    AtkObjectClass* atkObjectClass = ATK_OBJECT_CLASS(klass);
+    atkObjectClass->initialize = wpeApplicationAccessibleAtkInitialize;
+    atkObjectClass->get_n_children = wpeApplicationAccessibleAtkGetNChildren;
+    atkObjectClass->ref_child = wpeApplicationAccessibleAtkRefChild;
+    atkObjectClass->get_name = wpeApplicationAccessibleAtkGetName;
+    atkObjectClass->get_parent = nullptr;
+}
+
+AtkObject* wpeApplicationAccessibleAtkNew()
+{
+    auto* accessible = ATK_OBJECT(g_object_new(WPE_TYPE_APPLICATION_ACCESSIBLE_ATK, nullptr));
+    atk_object_initialize(accessible, nullptr);
+    return accessible;
+}
+
+void wpeApplicationAccessibleAtkToplevelCreated(WPEApplicationAccessibleAtk* accessible, WPEToplevel* toplevel)
+{
+    accessible->priv->toplevels.append(toplevel);
+    auto* toplevelAccessible = wpeToplevelGetOrCreateAccessibleAtk(toplevel);
+    atk_object_set_parent(toplevelAccessible, ATK_OBJECT(accessible));
+    g_signal_emit_by_name(accessible, "children-changed::add", accessible->priv->toplevels.size() - 1, toplevelAccessible, nullptr);
+}
+
+void wpeApplicationAccessibleAtkToplevelDestroyed(WPEApplicationAccessibleAtk* accessible, WPEToplevel* toplevel)
+{
+    auto* toplevelAccessible = wpeToplevelGetAccessibleAtk(toplevel);
+    if (!toplevelAccessible)
+        return;
+
+    auto index = accessible->priv->toplevels.find(toplevel);
+    if (index == notFound)
+        return;
+
+    accessible->priv->toplevels.remove(index);
+    g_signal_emit_by_name(accessible, "children-changed::remove", index, toplevelAccessible, nullptr);
+    atk_object_set_parent(toplevelAccessible, nullptr);
+}
+
+int wpeApplicationAccessibleAtkGetToplevelIndex(WPEApplicationAccessibleAtk* accessible, WPEToplevel* toplevel)
+{
+    auto index = accessible->priv->toplevels.find(toplevel);
+    return index == notFound ? -1 : index;
+}
+
+#endif // USE(ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,21 @@
 
 #pragma once
 
+#if USE(ATK)
 #include "WPEToplevel.h"
-#include "WPEView.h"
-#include <wtf/glib/GRefPtr.h>
+#include <atk/atk.h>
+#include <glib-object.h>
 
-#if USE(ATK)
-typedef struct _AtkObject AtkObject;
-#endif
+G_BEGIN_DECLS
 
-GList* wpeToplevelList();
-void wpeToplevelAddView(WPEToplevel*, WPEView*);
-void wpeToplevelRemoveView(WPEToplevel*, WPEView*);
-GRefPtr<WPEView> wpeToplevelGetView(WPEToplevel*, size_t);
+#define WPE_TYPE_APPLICATION_ACCESSIBLE_ATK (wpe_application_accessible_atk_get_type())
+G_DECLARE_FINAL_TYPE (WPEApplicationAccessibleAtk, wpe_application_accessible_atk, WPE, APPLICATION_ACCESSIBLE_ATK, AtkObject)
 
+AtkObject* wpeApplicationAccessibleAtkNew();
+void wpeApplicationAccessibleAtkToplevelCreated(WPEApplicationAccessibleAtk*, WPEToplevel*);
+void wpeApplicationAccessibleAtkToplevelDestroyed(WPEApplicationAccessibleAtk*, WPEToplevel*);
+int wpeApplicationAccessibleAtkGetToplevelIndex(WPEApplicationAccessibleAtk*, WPEToplevel*);
 
-#if USE(ATK)
-AtkObject* wpeToplevelGetOrCreateAccessibleAtk(WPEToplevel*);
-AtkObject* wpeToplevelGetAccessibleAtk(WPEToplevel*);
-#endif
+G_END_DECLS
+
+#endif // USE(ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEToplevelAccessibleAtk.h"
+
+#if USE(ATK)
+#include "WPEApplicationAccessibleAtk.h"
+#include "WPEToplevelPrivate.h"
+#include "WPEViewAccessibleAtk.h"
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEToplevelAccessibleAtkPrivate {
+    WPEToplevel* toplevel;
+};
+
+static void wpeToplevelAccessibleAtkComponentInterfaceInit(AtkComponentIface*);
+static void wpeToplevelAccessibleAtkWindowInterfaceInit(AtkWindowIface*);
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WPEToplevelAccessibleAtk, wpe_toplevel_accessible_atk, ATK_TYPE_OBJECT, AtkObject,
+    G_IMPLEMENT_INTERFACE(ATK_TYPE_COMPONENT, wpeToplevelAccessibleAtkComponentInterfaceInit)
+    G_IMPLEMENT_INTERFACE(ATK_TYPE_WINDOW, wpeToplevelAccessibleAtkWindowInterfaceInit))
+
+static void toplevelDestroyedCallback(gpointer userData, GObject*)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(userData);
+    accessible->priv->toplevel = nullptr;
+    atk_object_notify_state_change(ATK_OBJECT(accessible), ATK_STATE_DEFUNCT, TRUE);
+}
+
+static void wpeToplevelAccessibleAtkDispose(GObject* object)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(object);
+    if (accessible->priv->toplevel) {
+        g_object_weak_unref(G_OBJECT(accessible->priv->toplevel), toplevelDestroyedCallback, accessible);
+        accessible->priv->toplevel = nullptr;
+    }
+
+    G_OBJECT_CLASS(wpe_toplevel_accessible_atk_parent_class)->dispose(object);
+}
+
+static void wpeToplevelAccessibleAtkInitialize(AtkObject* atkObject, gpointer data)
+{
+    if (ATK_OBJECT_CLASS(wpe_toplevel_accessible_atk_parent_class)->initialize)
+        ATK_OBJECT_CLASS(wpe_toplevel_accessible_atk_parent_class)->initialize(atkObject, data);
+
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(atkObject);
+    accessible->priv->toplevel = WPE_TOPLEVEL(data);
+    g_object_weak_ref(G_OBJECT(accessible->priv->toplevel), toplevelDestroyedCallback, accessible);
+    atk_object_set_role(atkObject, ATK_ROLE_FRAME);
+}
+
+static AtkStateSet* wpeToplevelAccessibleAtkRefStateSet(AtkObject* atkObject)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(atkObject);
+    AtkStateSet* stateSet = ATK_OBJECT_CLASS(wpe_toplevel_accessible_atk_parent_class)->ref_state_set(atkObject);
+    if (!accessible->priv->toplevel)
+        atk_state_set_add_state(stateSet, ATK_STATE_DEFUNCT);
+    else {
+        atk_state_set_add_state(stateSet, ATK_STATE_FOCUSABLE);
+
+        if (wpe_toplevel_get_state(accessible->priv->toplevel) & WPE_TOPLEVEL_STATE_ACTIVE) {
+            atk_state_set_add_state(stateSet, ATK_STATE_ACTIVE);
+            atk_state_set_add_state(stateSet, ATK_STATE_VISIBLE);
+            atk_state_set_add_state(stateSet, ATK_STATE_SHOWING);
+        }
+    }
+
+    return stateSet;
+}
+
+static gint wpeToplevelAccessibleAtkGetIndexInParent(AtkObject* atkObject)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(atkObject);
+    if (!accessible->priv->toplevel)
+        return -1;
+
+    auto* atkRoot = atk_get_root();
+    if (!WPE_IS_APPLICATION_ACCESSIBLE_ATK(atkRoot))
+        return -1;
+
+    return wpeApplicationAccessibleAtkGetToplevelIndex(WPE_APPLICATION_ACCESSIBLE_ATK(atkRoot), accessible->priv->toplevel);
+}
+
+static gint wpeToplevelAccessibleAtkGetNChildren(AtkObject* atkObject)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(atkObject);
+    if (!accessible->priv->toplevel)
+        return 0;
+
+    return wpe_toplevel_get_n_views(accessible->priv->toplevel);
+}
+
+static AtkObject* wpeToplevelAccessibleAtkRefChild(AtkObject* atkObject, gint index)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(atkObject);
+    if (!accessible->priv->toplevel)
+        return nullptr;
+
+    if (index < 0 || static_cast<unsigned>(index) >= wpe_toplevel_get_n_views(accessible->priv->toplevel))
+        return nullptr;
+
+    auto view = wpeToplevelGetView(accessible->priv->toplevel, index);
+    if (!view)
+        return nullptr;
+
+    auto* viewAccessible = wpe_view_get_accessible(view.get());
+    if (!WPE_IS_VIEW_ACCESSIBLE_ATK(viewAccessible))
+        return nullptr;
+
+    return ATK_OBJECT(g_object_ref(viewAccessible));
+}
+
+static void wpe_toplevel_accessible_atk_class_init(WPEToplevelAccessibleAtkClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->dispose = wpeToplevelAccessibleAtkDispose;
+
+    AtkObjectClass* atkObjectClass = ATK_OBJECT_CLASS(klass);
+    atkObjectClass->initialize = wpeToplevelAccessibleAtkInitialize;
+    atkObjectClass->ref_state_set = wpeToplevelAccessibleAtkRefStateSet;
+    atkObjectClass->get_index_in_parent = wpeToplevelAccessibleAtkGetIndexInParent;
+    atkObjectClass->get_n_children = wpeToplevelAccessibleAtkGetNChildren;
+    atkObjectClass->ref_child = wpeToplevelAccessibleAtkRefChild;
+}
+
+static void wpeToplevelAccessibleAtkGetSize(AtkComponent* atkComponent, gint* width, gint* height)
+{
+    WPEToplevelAccessibleAtk* accessible = WPE_TOPLEVEL_ACCESSIBLE_ATK(atkComponent);
+    if (accessible->priv->toplevel)
+        wpe_toplevel_get_size(accessible->priv->toplevel, width, height);
+}
+
+static void wpeToplevelAccessibleAtkComponentInterfaceInit(AtkComponentIface* interface)
+{
+    interface->get_size = wpeToplevelAccessibleAtkGetSize;
+}
+
+static void wpeToplevelAccessibleAtkWindowInterfaceInit(AtkWindowIface*)
+{
+}
+
+AtkObject* wpeToplevelAccessibleAtkNew(WPEToplevel* toplevel)
+{
+    auto* accessible = ATK_OBJECT(g_object_new(WPE_TYPE_TOPLEVEL_ACCESSIBLE_ATK, nullptr));
+    atk_object_initialize(accessible, toplevel);
+    return accessible;
+}
+
+#endif // USE(ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,18 @@
 
 #pragma once
 
-#include "WPEToplevel.h"
-#include "WPEView.h"
-#include <wtf/glib/GRefPtr.h>
-
 #if USE(ATK)
-typedef struct _AtkObject AtkObject;
-#endif
+#include <atk/atk.h>
+#include <glib-object.h>
+#include <wpe/WPEToplevel.h>
 
-GList* wpeToplevelList();
-void wpeToplevelAddView(WPEToplevel*, WPEView*);
-void wpeToplevelRemoveView(WPEToplevel*, WPEView*);
-GRefPtr<WPEView> wpeToplevelGetView(WPEToplevel*, size_t);
+G_BEGIN_DECLS
 
+#define WPE_TYPE_TOPLEVEL_ACCESSIBLE_ATK (wpe_toplevel_accessible_atk_get_type())
+G_DECLARE_FINAL_TYPE (WPEToplevelAccessibleAtk, wpe_toplevel_accessible_atk, WPE, TOPLEVEL_ACCESSIBLE_ATK, AtkObject)
 
-#if USE(ATK)
-AtkObject* wpeToplevelGetOrCreateAccessibleAtk(WPEToplevel*);
-AtkObject* wpeToplevelGetAccessibleAtk(WPEToplevel*);
-#endif
+AtkObject* wpeToplevelAccessibleAtkNew(WPEToplevel*);
+
+G_END_DECLS
+
+#endif // USE(ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEView.cpp
@@ -39,6 +39,10 @@
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/WTFGType.h>
 
+#if USE(ATK)
+#include "WPEViewAccessibleAtk.h"
+#endif
+
 /**
  * WPEView:
  *
@@ -63,6 +67,10 @@ struct _WPEViewPrivate {
         guint32 time { 0 };
     } lastButtonPress;
     std::optional<GRefPtr<WPEGestureController>> gestureController;
+
+#if USE(ATK)
+    GRefPtr<WPEViewAccessible> accessible;
+#endif
 };
 
 WEBKIT_DEFINE_ABSTRACT_TYPE(WPEView, wpe_view, G_TYPE_OBJECT)
@@ -186,6 +194,15 @@ static void wpeViewDispose(GObject* object)
     G_OBJECT_CLASS(wpe_view_parent_class)->dispose(object);
 }
 
+#if USE(ATK)
+static WPEViewAccessible* wpeViewGetAccessible(WPEView* view)
+{
+    if (!view->priv->accessible)
+        view->priv->accessible = adoptGRef(wpeViewAccessibleAtkNew(view));
+    return view->priv->accessible.get();
+}
+#endif
+
 static void wpe_view_class_init(WPEViewClass* viewClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(viewClass);
@@ -193,6 +210,10 @@ static void wpe_view_class_init(WPEViewClass* viewClass)
     objectClass->get_property = wpeViewGetProperty;
     objectClass->constructed = wpeViewConstructed;
     objectClass->dispose = wpeViewDispose;
+
+#if USE(ATK)
+    viewClass->get_accessible = wpeViewGetAccessible;
+#endif
 
     /**
      * WPEView:display:

--- a/Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2025 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WPEViewAccessibleAtk.h"
+
+#if USE(ATK)
+#include "WPEAccessibilityAtk.h"
+#include <wtf/glib/WTFGType.h>
+
+struct _WPEViewAccessibleAtkPrivate {
+    WPEView* view;
+};
+
+static void wpeViewAccessibleInterfaceInit(WPEViewAccessibleInterface*);
+
+WEBKIT_DEFINE_FINAL_TYPE_WITH_CODE(
+    WPEViewAccessibleAtk, wpe_view_accessible_atk, ATK_TYPE_SOCKET, AtkSocket,
+    G_IMPLEMENT_INTERFACE(WPE_TYPE_VIEW_ACCESSIBLE, wpeViewAccessibleInterfaceInit))
+
+static void viewDestroyedCallback(gpointer userData, GObject*)
+{
+    WPEViewAccessibleAtk* accessible = WPE_VIEW_ACCESSIBLE_ATK(userData);
+    accessible->priv->view = nullptr;
+    atk_object_notify_state_change(ATK_OBJECT(accessible), ATK_STATE_DEFUNCT, TRUE);
+}
+
+static void wpeViewAccessibleAtkDispose(GObject* object)
+{
+    WPEViewAccessibleAtk* accessible = WPE_VIEW_ACCESSIBLE_ATK(object);
+    if (accessible->priv->view) {
+        g_object_weak_unref(G_OBJECT(accessible->priv->view), viewDestroyedCallback, accessible);
+        accessible->priv->view = nullptr;
+    }
+
+    G_OBJECT_CLASS(wpe_view_accessible_atk_parent_class)->dispose(object);
+}
+
+static void wpeViewAccessibleAtkInitialize(AtkObject* atkObject, gpointer data)
+{
+    if (ATK_OBJECT_CLASS(wpe_view_accessible_atk_parent_class)->initialize)
+        ATK_OBJECT_CLASS(wpe_view_accessible_atk_parent_class)->initialize(atkObject, data);
+
+    WPEViewAccessibleAtk* accessible = WPE_VIEW_ACCESSIBLE_ATK(atkObject);
+    accessible->priv->view = WPE_VIEW(data);
+    g_object_weak_ref(G_OBJECT(accessible->priv->view), viewDestroyedCallback, accessible);
+    atk_object_set_role(atkObject, ATK_ROLE_FILLER);
+
+    g_signal_connect_object(accessible->priv->view, "notify::has-focus", G_CALLBACK(+[](WPEViewAccessibleAtk* accessible) {
+        atk_object_notify_state_change(ATK_OBJECT(accessible), ATK_STATE_FOCUSED, wpe_view_get_has_focus(accessible->priv->view));
+    }), accessible, G_CONNECT_SWAPPED);
+    g_signal_connect_object(accessible->priv->view, "notify::visible", G_CALLBACK(+[](WPEViewAccessibleAtk* accessible) {
+        atk_object_notify_state_change(ATK_OBJECT(accessible), ATK_STATE_VISIBLE, wpe_view_get_visible(accessible->priv->view));
+    }), accessible, G_CONNECT_SWAPPED);
+    g_signal_connect_object(accessible->priv->view, "notify::mapped", G_CALLBACK(+[](WPEViewAccessibleAtk* accessible) {
+        atk_object_notify_state_change(ATK_OBJECT(accessible), ATK_STATE_SHOWING, wpe_view_get_mapped(accessible->priv->view));
+    }), accessible, G_CONNECT_SWAPPED);
+}
+
+static AtkStateSet* wpeViewAccessibleAtkRefStateSet(AtkObject* atkObject)
+{
+    WPEViewAccessibleAtk* accessible = WPE_VIEW_ACCESSIBLE_ATK(atkObject);
+    if (!accessible->priv->view) {
+        // If the view is no longer alive, save some remote calls (because of AtkSocket's implementation of ref_state_set())
+        // and just return that this AtkObject is defunct.
+        AtkStateSet* stateSet = atk_state_set_new();
+        atk_state_set_add_state(stateSet, ATK_STATE_DEFUNCT);
+        return stateSet;
+    }
+
+    // Use the implementation of AtkSocket if the view is still alive.
+    AtkStateSet* stateSet = ATK_OBJECT_CLASS(wpe_view_accessible_atk_parent_class)->ref_state_set(atkObject);
+    if (!atk_socket_is_occupied(ATK_SOCKET(atkObject)))
+        atk_state_set_add_state(stateSet, ATK_STATE_TRANSIENT);
+
+    atk_state_set_add_state(stateSet, ATK_STATE_FOCUSABLE);
+    if (wpe_view_get_has_focus(accessible->priv->view))
+        atk_state_set_add_state(stateSet, ATK_STATE_FOCUSED);
+
+    if (wpe_view_get_visible(accessible->priv->view)) {
+        atk_state_set_add_state(stateSet, ATK_STATE_VISIBLE);
+        if (wpe_view_get_mapped(accessible->priv->view))
+            atk_state_set_add_state(stateSet, ATK_STATE_SHOWING);
+    }
+
+    return stateSet;
+}
+
+static gint wpeViewAccessibleAtkGetIndexInParent(AtkObject* atkObject)
+{
+    AtkObject* atkParent = atk_object_get_parent(atkObject);
+    if (!atkParent)
+        return -1;
+
+    guint count = atk_object_get_n_accessible_children(atkParent);
+    for (guint i = 0; i < count; ++i) {
+        AtkObject* child = atk_object_ref_accessible_child(atkParent, i);
+        bool childIsObject = child == atkObject;
+        g_object_unref(child);
+        if (childIsObject)
+            return i;
+    }
+
+    return -1;
+}
+
+static void wpe_view_accessible_atk_class_init(WPEViewAccessibleAtkClass* klass)
+{
+    GObjectClass* objectClass = G_OBJECT_CLASS(klass);
+    objectClass->dispose = wpeViewAccessibleAtkDispose;
+
+    AtkObjectClass* atkObjectClass = ATK_OBJECT_CLASS(klass);
+    atkObjectClass->initialize = wpeViewAccessibleAtkInitialize;
+    atkObjectClass->ref_state_set = wpeViewAccessibleAtkRefStateSet;
+    atkObjectClass->get_index_in_parent = wpeViewAccessibleAtkGetIndexInParent;
+}
+
+static void wpeViewAccessibleAtkBind(WPEViewAccessible* accessible, const char* plugID)
+{
+    atk_socket_embed(ATK_SOCKET(accessible), const_cast<char*>(plugID));
+    atk_object_notify_state_change(ATK_OBJECT(accessible), ATK_STATE_TRANSIENT, FALSE);
+}
+
+static void wpeViewAccessibleInterfaceInit(WPEViewAccessibleInterface* interface)
+{
+    interface->bind = wpeViewAccessibleAtkBind;
+}
+
+WPEViewAccessible* wpeViewAccessibleAtkNew(WPEView* view)
+{
+    g_return_val_if_fail(WPE_IS_VIEW(view), nullptr);
+
+    WPE::accessibilityAtkInit();
+
+    auto* accessible = WPE_VIEW_ACCESSIBLE(g_object_new(WPE_TYPE_VIEW_ACCESSIBLE_ATK, nullptr));
+    atk_object_initialize(ATK_OBJECT(accessible), view);
+    return accessible;
+}
+
+#endif // USE(ATK)

--- a/Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Igalia S.L.
+ * Copyright (C) 2025 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,21 +25,19 @@
 
 #pragma once
 
-#include "WPEToplevel.h"
-#include "WPEView.h"
-#include <wtf/glib/GRefPtr.h>
-
 #if USE(ATK)
-typedef struct _AtkObject AtkObject;
-#endif
+#include <atk/atk.h>
+#include <glib-object.h>
+#include <wpe/WPEView.h>
+#include <wpe/WPEViewAccessible.h>
 
-GList* wpeToplevelList();
-void wpeToplevelAddView(WPEToplevel*, WPEView*);
-void wpeToplevelRemoveView(WPEToplevel*, WPEView*);
-GRefPtr<WPEView> wpeToplevelGetView(WPEToplevel*, size_t);
+G_BEGIN_DECLS
 
+#define WPE_TYPE_VIEW_ACCESSIBLE_ATK (wpe_view_accessible_atk_get_type())
+G_DECLARE_FINAL_TYPE (WPEViewAccessibleAtk, wpe_view_accessible_atk, WPE, VIEW_ACCESSIBLE_ATK, AtkSocket)
 
-#if USE(ATK)
-AtkObject* wpeToplevelGetOrCreateAccessibleAtk(WPEToplevel*);
-AtkObject* wpeToplevelGetAccessibleAtk(WPEToplevel*);
-#endif
+WPEViewAccessible* wpeViewAccessibleAtkNew(WPEView*);
+
+G_END_DECLS
+
+#endif // USE(ATK)


### PR DESCRIPTION
#### f62eb108139f6b7f4205ae6e6a7b72d7f1ab37a8
<pre>
[WPE] WPEPlatform: add default accessibility implementation using ATK
<a href="https://bugs.webkit.org/show_bug.cgi?id=289329">https://bugs.webkit.org/show_bug.cgi?id=289329</a>

Reviewed by Adrian Perez de Castro.

When WebKit is built with ATK and the platform doesn&apos;t implement
WPEView::get_accessible, a default implementation is provided using ATK.

* Source/WebKit/UIProcess/API/wpe/PageClientImpl.cpp:
(WebKit::PageClientImpl::accessible):
* Source/WebKit/UIProcess/API/wpe/WPEWebView.cpp:
(WKWPE::View::~View):
(WKWPE::View::accessible const): Deleted.
* Source/WebKit/UIProcess/API/wpe/WPEWebView.h:
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.cpp:
(WKWPE::ViewLegacy::~ViewLegacy):
(WKWPE::ViewLegacy::accessible const):
* Source/WebKit/UIProcess/API/wpe/WPEWebViewLegacy.h:
* Source/WebKit/UIProcess/wpe/WebPageProxyWPE.cpp:
(WebKit::WebPageProxy::bindAccessibilityTree):
* Source/WebKit/WPEPlatform/CMakeLists.txt:
* Source/WebKit/WPEPlatform/wpe/WPEAccessibilityAtk.cpp: Added.
(WPE::initializeAtkUtil):
(WPE::accessibilityAtkInit):
* Source/WebKit/WPEPlatform/wpe/WPEAccessibilityAtk.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.cpp: Added.
(wpeApplicationAccessibleAtkConstructed):
(wpeApplicationAccessibleAtkInitialize):
(wpeApplicationAccessibleAtkGetNChildren):
(wpeApplicationAccessibleAtkRefChild):
(wpeApplicationAccessibleAtkGetName):
(wpe_application_accessible_atk_class_init):
(wpeApplicationAccessibleAtkNew):
(wpeApplicationAccessibleAtkGetToplevelIndex):
* Source/WebKit/WPEPlatform/wpe/WPEApplicationAccessibleAtk.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.cpp:
(wpeToplevelConstructed):
(wpeToplevelDispose):
(wpe_toplevel_class_init):
(wpeToplevelList):
(wpeToplevelGetView):
(wpeToplevelGetAccessibleAtk):
* Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.cpp: Added.
(toplevelDestroyedCallback):
(wpeToplevelAccessibleAtkDispose):
(wpeToplevelAccessibleAtkInitialize):
(wpeToplevelAccessibleAtkRefStateSet):
(wpeToplevelAccessibleAtkGetIndexInParent):
(wpeToplevelAccessibleAtkGetNChildren):
(wpeToplevelAccessibleAtkRefChild):
(wpe_toplevel_accessible_atk_class_init):
(wpeToplevelAccessibleAtkGetSize):
(wpeToplevelAccessibleAtkComponentInterfaceInit):
(wpeToplevelAccessibleAtkWindowInterfaceInit):
(wpeToplevelAccessibleAtkNew):
* Source/WebKit/WPEPlatform/wpe/WPEToplevelAccessibleAtk.h: Added.
* Source/WebKit/WPEPlatform/wpe/WPEToplevelPrivate.h:
* Source/WebKit/WPEPlatform/wpe/WPEView.cpp:
(wpeViewGetAccessible):
(wpe_view_class_init):
(wpe_view_get_accessible):
* Source/WebKit/WPEPlatform/wpe/WPEView.h:
* Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.cpp: Added.
(viewDestroyedCallback):
(wpeViewAccessibleAtkDispose):
(wpeViewAccessibleAtkInitialize):
(wpeViewAccessibleAtkRefStateSet):
(wpeViewAccessibleAtkGetIndexInParent):
(wpe_view_accessible_atk_class_init):
(wpeViewAccessibleAtkBind):
(wpeViewAccessibleInterfaceInit):
(wpeViewAccessibleAtkNew):
* Source/WebKit/WPEPlatform/wpe/WPEViewAccessibleAtk.h: Added.
* Source/WebKit/WPEPlatform/wpe/wpe-platform.h:
* Tools/MiniBrowser/wpe/main.cpp:
(activate):

Canonical link: <a href="https://commits.webkit.org/292006@main">https://commits.webkit.org/292006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9625d004ae0fec2bfc555489aa021b852b43a050

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99732 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22722 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29549 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97715 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/52582 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44543 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/136/builds/3308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101774 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21741 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21988 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/81527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80623 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25182 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14967 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15194 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26831 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21379 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24848 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->