### PR TITLE
[GTK][WPE] Do not use Chrome UA in YouTube

### DIFF
--- a/Source/WebCore/platform/glib/UserAgentQuirks.cpp
+++ b/Source/WebCore/platform/glib/UserAgentQuirks.cpp
@@ -66,10 +66,6 @@ static bool urlRequiresChromeBrowser(const String& domain, const String& baseDom
     if (baseDomain == "soundcloud.com"_s)
         return true;
 
-    // Seeking in fullscreen Youtube is broken.
-    if (baseDomain == "youtube.com"_s)
-        return true;
-
     // https://webcompat.com/issues/123672
     if (domain == "www.apple.com"_s)
         return true;

--- a/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp
@@ -76,18 +76,26 @@ static void assertUserAgentForURLHasEmptyQuirk(const char* url)
     EXPECT_FALSE(uaString.isNull());
 }
 
-TEST(UserAgentTest, Quirks)
+static void assertUserAgentForURLHasNoQuirk(const char* url)
 {
     // A site with no quirks should return a null String.
-    String uaString = standardUserAgentForURL(URL("http://www.webkit.org/"_s));
+    String uaString = standardUserAgentForURL(URL(String::fromLatin1(url)));
     EXPECT_TRUE(uaString.isNull());
+}
+
+TEST(UserAgentTest, Quirks)
+{
+    assertUserAgentForURLHasNoQuirk("http://www.webkit.org/");
+
+    // We used to have a Chrome quirk for YouTube, added in: https://bugs.webkit.org/show_bug.cgi?id=253877
+    // Removed in: https://bugs.webkit.org/show_bug.cgi?id=289194
+    assertUserAgentForURLHasNoQuirk("http://youtube.com/");
 
     assertUserAgentForURLHasChromeBrowserQuirk("http://typekit.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://typekit.net/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://auth.mayohr.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://bankofamerica.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://soundcloud.com/");
-    assertUserAgentForURLHasChromeBrowserQuirk("http://youtube.com/");
     assertUserAgentForURLHasChromeBrowserQuirk("http://www.apple.com/");
 
     assertUserAgentForURLHasFirefoxBrowserQuirk("http://bugzilla.redhat.com/");


### PR DESCRIPTION
#### a760e1b2e1e09e1f999a48fb77aa87281c991eb8
<pre>
[GTK][WPE] Do not use Chrome UA in YouTube
<a href="https://bugs.webkit.org/show_bug.cgi?id=289194">https://bugs.webkit.org/show_bug.cgi?id=289194</a>

Reviewed by Philippe Normand and Michael Catanzaro.

This patch removes the UA quirk for YouTube. As of writing, this seems
to be enough to make YouTube servers no longer block video content from
WebKitGTK.

Previously WebKitGTK was using a Chrome user-agent string to workaround
this bug: <a href="https://bugs.webkit.org/show_bug.cgi?id=253877">https://bugs.webkit.org/show_bug.cgi?id=253877</a> [GLib] No
render update when seeking outside of network buffer in fullscreen

However, the fullscreen bug seems no longer present in current YouTube
and WebKit, so there is no longer a need for the UA quirk: some sporadic
seek bugs remain, but they seem unrelated to full-screen.

* Source/WebCore/platform/glib/UserAgentQuirks.cpp:
(WebCore::urlRequiresChromeBrowser):
* Tools/TestWebKitAPI/Tests/WebCore/UserAgentQuirks.cpp:
(TestWebKitAPI::TEST(UserAgentTest, Quirks)):

Canonical link: <a href="https://commits.webkit.org/291817@main">https://commits.webkit.org/291817@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eef031a2947a68f422f83d6df257cd2a94e11b06

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/93992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13577 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99000 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44519 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71724 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29071 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/96994 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10308 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84920 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52064 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/9989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2590 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43835 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80244 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101041 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80731 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80093 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14205 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21028 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26206 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20715 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24175 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->