### PR TITLE
service worker addRoutes promise should delay service worker install

### DIFF
--- a/LayoutTests/http/wpt/service-workers/service-worker-add-routes-delay-install-worker.js
+++ b/LayoutTests/http/wpt/service-workers/service-worker-add-routes-delay-install-worker.js
@@ -1,0 +1,23 @@
+let result;
+async function addRoute(e, counter)
+{
+   try {
+     await e.addRoute([{
+       condition: {urlPattern: new URLPattern({pathname: 'direct.txt' + counter})},
+       source: 'network'
+     }]);
+  } catch (exception) {
+    result = "KO:" + exception;
+  }
+
+  if (counter >= 256) {
+    result = "OK";
+    return;
+  }
+
+  addRoute(e, ++counter);
+}
+
+onfetch = e => { };
+onmessage = e => e.source.postMessage(result);
+oninstall = e => addRoute(e, 0);

--- a/LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt
@@ -2,4 +2,5 @@
 PASS Try to register too many routes in one call
 PASS Try to register too many routes incrementally
 PASS add route when not installing
+PASS add route extend installation of service worker
 

--- a/LayoutTests/http/wpt/service-workers/service-worker-routes.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-routes.html
@@ -60,6 +60,18 @@ promise_test(async (test) => {
     worker.postMessage("addRoutes");
     assert_equals(await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data)), "OK");
 }, "add route when not installing");
+
+promise_test(async (test) => {
+    let registration = await navigator.serviceWorker.getRegistration("4");
+    if (registration)
+        await registration.unregister();
+    registration = await navigator.serviceWorker.register("service-worker-add-routes-delay-install-worker.js", { scope : "4" });
+    const worker = registration.installing;
+
+    await waitForState(worker, "activated");
+    worker.postMessage("getResult");
+    assert_equals(await new Promise(resolve => navigator.serviceWorker.onmessage = e => resolve(e.data)), "OK");
+}, "add route extend installation of service worker");
 </script>
 </body>
 </html>

--- a/Source/WebCore/workers/service/InstallEvent.h
+++ b/Source/WebCore/workers/service/InstallEvent.h
@@ -29,6 +29,10 @@
 #include "RouterRule.h"
 #include <wtf/Vector.h>
 
+namespace JSC {
+class JSGlobalObject;
+}
+
 namespace WebCore {
 
 class DeferredPromise;
@@ -43,7 +47,7 @@ public:
     }
     ~InstallEvent();
 
-    void addRoutes(ScriptExecutionContext&, std::variant<RouterRule, Vector<RouterRule>>&&, Ref<DeferredPromise>&&);
+    void addRoutes(JSC::JSGlobalObject&, std::variant<RouterRule, Vector<RouterRule>>&&, Ref<DeferredPromise>&&);
 
 private:
     WEBCORE_EXPORT InstallEvent(const AtomString&, ExtendableEventInit&&, IsTrusted);

--- a/Source/WebCore/workers/service/InstallEvent.idl
+++ b/Source/WebCore/workers/service/InstallEvent.idl
@@ -31,5 +31,5 @@
 ]
 interface InstallEvent : ExtendableEvent {
     constructor([AtomString] DOMString type, optional ExtendableEventInit eventInitDict = {});
-    [CallWith=CurrentScriptExecutionContext] Promise<undefined> addRoutes((RouterRule or sequence<RouterRule>) rules);
+    [CallWith=CurrentGlobalObject] Promise<undefined> addRoutes((RouterRule or sequence<RouterRule>) rules);
 };


### PR DESCRIPTION
#### 67b117b370613a02c92c92026e3ce7a3b4d5e861
<pre>
service worker addRoutes promise should delay service worker install
<a href="https://rdar.apple.com/146482853">rdar://146482853</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=289339">https://bugs.webkit.org/show_bug.cgi?id=289339</a>

Reviewed by Brady Eidson.

As per <a href="https://w3c.github.io/ServiceWorker/#register-router-method">https://w3c.github.io/ServiceWorker/#register-router-method</a>, install cannot happen until addRoutes promises are settled.
Update InstallEvent::addRoutes accordingly.

The added test checks that we can add one route at a time outside of the install event handler without use of waitUntil.

* LayoutTests/http/wpt/service-workers/service-worker-add-routes-delay-install-worker.js: Added.
(async addRoute):
* LayoutTests/http/wpt/service-workers/service-worker-routes-expected.txt:
* LayoutTests/http/wpt/service-workers/service-worker-routes.html:
* Source/WebCore/workers/service/InstallEvent.cpp:
(WebCore::InstallEvent::addRoutes):

Canonical link: <a href="https://commits.webkit.org/292074@main">https://commits.webkit.org/292074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b85894c398e48ffac72b3141a9159008effa341a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99917 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45386 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72384 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29677 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52715 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3402 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44728 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101957 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21930 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/16010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80770 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20178 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25333 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15164 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27023 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->