### PR TITLE
[macOS] MiniBrowser occasionally launches with a giant top inset when Screen Time is enabled

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -1043,6 +1043,7 @@ std::optional<float> PageClientImpl::computeAutomaticTopObscuredInset()
 {
     RetainPtr window = [m_view window];
     if (([window styleMask] & NSWindowStyleMaskFullSizeContentView) && ![window titlebarAppearsTransparent] && ![m_view enclosingScrollView]) {
+        [window updateConstraintsIfNeeded];
         NSRect contentLayoutRectInWebViewCoordinates = [m_view convertRect:[window contentLayoutRect] fromView:nil];
         return std::max<float>(contentLayoutRectInWebViewCoordinates.origin.y, 0);
     }


### PR DESCRIPTION
#### 85714c9125ffb41b802480ea03c80d6243eb806d
<pre>
[macOS] MiniBrowser occasionally launches with a giant top inset when Screen Time is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=289350">https://bugs.webkit.org/show_bug.cgi?id=289350</a>
<a href="https://rdar.apple.com/145900121">rdar://145900121</a>

Reviewed by Wenson Hsieh.

As a preface, all use of the term &quot;constraints&quot; in this commit message refers
to &quot;user&quot; constraints, and not autoresizing mask constraints.

`WKWebView` automatically computes a top content inset using the content layout
rect of its window and converting to its own coordinate space. In the common
case, this inset ends up being the height of the window&apos;s titlebar.

The logic to automatically compute this inset has existed since 152497@main, and
is performed by: scheduling an update, waiting a runloop turn, and finally,
computing the inset.

Updates are scheduled in three cases:
- `WKWebView` initialization
- `-[WKWebView renewGState]`, which generally corresponds to frame changes
- Whenever the containing window&apos;s `contentLayoutRect` changes, using KVO

MiniBrowser&apos;s window style results in the creation of an `NSThemeFrame`, which
is a direct descendant of the `NSWindow`. The `NSThemeFrame`&apos;s
`contentLayoutGuide`&apos;s frame is the window&apos;s `contentLayoutRect`. This is what
is used to compute the top content inset. The `NSThemeFrame` is henceforth
referred to as the &quot;border view&quot;.

With the introduction of Screen Time, an `STWebpageView` is added as a subview
of `WKWebView`, in the first layer tree commit after the first committed load.
`STWebpageView` has an `NSRemoteView` subview, that is added asynchronously
after the `STWebpageView` itself is parented. The remote view is only added
once a reply is received from Screen Time&apos;s view service.

In MiniBrowser, the added remote view is the first view to use Auto Layout. Once
the border view&apos;s view hierarchy contains a view using Auto Layout, AppKit
updates the border view&apos;s layout engine. This update triggers an update to
the border view&apos;s content layout guide&apos;s constraints, and AppKit uses KVO to
notify the observer (`WebViewImpl`) of a change to the window&apos;s
`contentLayoutRect`. In response to the content layout rect change, WebKit
schedules a top constent inset update, as explained above.

Now at this point, there only exists constraints on the border view&apos;s content
layout guide, and the remote view. Importantly, there are not yet any
constraints on the border view itself. The constraints on the border view are
added in the next display link flush. This means that both of the following
scenarios are possible:

Scenario A (good)
1. Top content inset update scheduled due to introduction of Auto Layout.
2. Border view constraints added on display link flush.
3. Top content inset update dispatched on runloop turn.

Scenario B (bad)
1. Top content inset update scheduled due to introduction of Auto Layout.
2. Top content inset update dispatched on runloop turn.
3. Border view constraints added on display link flush.

Scenario A is the &quot;good case&quot;. All the relevant constraints (most importantly,
the border view&apos;s constraints) are in their &quot;final&quot; state, and the correct
content layout rect is observed at the time of top content inset update dispatch.
On the other hand, Scenario B represents the issue: the inset update occurs
with incomplete constraints, ultimately resulting in a top content inset equal
to the height of the window. Additionally, when the border view constraints are
finally added in Scenario B, the border&apos;s view frame and content layout guide
are updated, but AppKit does not report the change via KVO, leaving `WKWebView`
stuck in state. This lack of update is a clear AppKit bug, whereas the timing
issue is less obviously so.

Consequently, the issue can be fixed by ensuring that border view constraints
are present at the time of top content inset update dispatch. This is achieved
by simply calling `-[NSWindow updateConstraintsIfNeeded]`.

Thanks to Jessica Cheung for assisting with the investigation of this issue.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::computeAutomaticTopObscuredInset):

Ensure the window&apos;s and border view&apos;s constraints are up-to-date prior to
accessing the window&apos;s content layout rect. Without this change, there is a
chance that the content layout rect is computed with an incomplete set of
constraints, resulting in an incorrect value, and AppKit failing to notify
clients of an eventually correct value.

This call is a no-op is Auto Layout is not being used.

Canonical link: <a href="https://commits.webkit.org/291818@main">https://commits.webkit.org/291818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67dbf8d9a2d3369d4a04f882ba69d3929e74ab8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44553 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22043 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71749 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29099 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52088 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10013 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43869 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80263 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2671 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101075 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15359 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80755 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80911 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80120 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14240 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15092 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26240 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20749 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22490 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->