### PR TITLE
[Tools][WPE] run-mvt-tests should retry unexpected failures

### DIFF
--- a/Tools/Scripts/run-mvt-tests
+++ b/Tools/Scripts/run-mvt-tests
@@ -73,6 +73,7 @@ def parse_args(argument_list):
     platform.add_argument('--wpe', action='store_const', dest='platform', const='wpe', help='Use the WPE port')
     parser.add_argument("--mvt-instance-address", default="https://mvt.rdkcentral.com", help="MVT instance address to use")
     parser.add_argument("--suite", default=None, choices=TEST_SUITES, help="Suite to run. Default: run all")
+    parser.add_argument("--retry-unexpected-failures", type=int, help="Number of times to retry each unexpected failure.", default=3)
     parser.add_argument('--update-expectations', action='store_true', help='Reset the test expectations with the new results')
     parser.add_argument("--headless", action='store_true', help="Enable headless mode if available")
     parser.add_argument("--browser-name", choices=['MiniBrowser', 'cog'], default='MiniBrowser', help="Select the browser to use (via run-minibrowser). Default: MiniBrowser")
@@ -145,8 +146,14 @@ class MVTWebDriverRunner():
         self.driver.maximize_window()
         self.started = True
 
+    def _suite_has_loaded(self, driver):
+        return driver.execute_script('return typeof globalRunner !== "undefined" && globalRunner !== null && document.readyState == "complete";')
+
     def _suite_has_started(self, driver):
-        return driver.execute_script('return !(typeof globalRunner === "undefined" || globalRunner === null);')
+        return driver.execute_script('return globalRunner.hasOwnProperty("testToRun") && globalRunner.hasOwnProperty("currentTestIdx") && globalRunner.hasOwnProperty("testList");')
+
+    def _have_all_tests_finished(self, driver):
+        return driver.execute_script('return globalRunner.testToRun == 0;')
 
     def _wait_until_suite_has_finished(self, maxwait_secs, suite_name):
         poll_interval_secs = 5
@@ -159,7 +166,7 @@ class MVTWebDriverRunner():
                 i+=1
                 running_test_id = self.driver.execute_script("return globalRunner.currentTestIdx;")
                 total_tests_to_run = self.driver.execute_script("return globalRunner.testList.length;")
-                if total_tests_to_run > 0 and running_test_id==total_tests_to_run:
+                if total_tests_to_run > 0 and running_test_id==total_tests_to_run and self._have_all_tests_finished(self.driver):
                     break
                 if i >= max_loops:
                     raise TimeoutException(f'Timed out waiting for the suite "{suite_name}" to finish after waiting {maxwait_secs} seconds')
@@ -177,10 +184,40 @@ class MVTWebDriverRunner():
         test_url = f"{self.mvt_instance_address}/?test_type={suite}&command=run"
         _log.info(f'Running MVT suite "{suite}" at {test_url}')
         self.driver.get(test_url)
+        WebDriverWait(self.driver, 20).until(self._suite_has_loaded)
         WebDriverWait(self.driver, 20).until(self._suite_has_started)
         self._wait_until_suite_has_finished(3600, suite)
         _log.info(f'MVT suite "{suite}" has finished. Results below:')
-        return self.driver.execute_script("return getMvtTestResults()")
+        return self.driver.execute_script("return getMvtTestResults();")
+
+    def run_test_from_suite(self, test_name, suite, number_repeats):
+        test_results = set()
+        test_url = f"{self.mvt_instance_address}/?test_type={suite}"
+        self.driver.get(test_url)
+        WebDriverWait(self.driver, 20).until(self._suite_has_loaded)
+        test_id = self.driver.execute_script(
+                'for (let s_test_id = 0; s_test_id < window.globalRunner.testList.length; s_test_id++)'
+                    f'if (window.globalRunner.testList[s_test_id].prototype.name == "{test_name}")'
+                        'return s_test_id+1;'
+                'return -1;')
+        if test_id == -1:
+            _log.error(f'Unable to find test_id for test "{test_name}" on suite "{suite}"')
+            return test_results
+        test_url = f"{self.mvt_instance_address}/?test_type={suite}&tests={test_id}&command=run"
+        for test_run in range(1, number_repeats+1):
+            _log.info(f'[Repeat {test_run}/{number_repeats}] Running test "{test_name}" from suite "{suite}" at {test_url}')
+            self.driver.get(test_url)
+            WebDriverWait(self.driver, 20).until(self._suite_has_loaded)
+            WebDriverWait(self.driver, 20).until(self._suite_has_started)
+            WebDriverWait(self.driver, 1000).until(self._have_all_tests_finished)
+            results = self.driver.execute_script("return getMvtTestResults();")
+            assert(results['name'] == suite)
+            assert(len(results['tests']) == 1)
+            assert(results['tests'][0]['name'] == test_name)
+            test_result = results['tests'][0]['status']
+            _log.info(f'Test result: {test_result}')
+            test_results.add(test_result)
+        return test_results
 
     def __del__(self):
         if self.started:
@@ -249,26 +286,26 @@ class MVTResultsExpectationsParser():
             return json.dumps(obj)
 
     def analyze_results(self, data):
-        unexpected_failed = 0
-        expected_failed = 0
-        total_tests = 0
+        unexpected_failed_list = []
+        expected_failed_list = []
+        total_tests_list = []
         for test_entry in data['tests']:
-            total_tests += 1
             test_suite = test_entry['suites_chain']
             test_name = test_entry['name']
             test_result = test_entry['status']
+            total_tests_list.append(test_name)
             if self.should_update_expectations:
                 self._store_test_result_this_run(test_suite, test_name, test_result)
             if self._is_unexpected_failure(test_suite, test_name, test_result):
-                unexpected_failed += 1
+                unexpected_failed_list.append(test_name)
                 _log.warning(f'[UNEXPECTED_FAIL] Test "{test_name}" from "{test_suite}" has unexpected result: {test_result}')
                 _log.info(test_entry['log'])
             elif test_result != 'passed':
                 _log.info(f'[FAIL][EXPECTED] {test_name}')
-                expected_failed += 1
+                expected_failed_list.append(test_name)
             else:
                 _log.info(f'[PASS] {test_name}')
-        return total_tests, unexpected_failed, expected_failed
+        return total_tests_list, unexpected_failed_list, expected_failed_list
 
     def maybe_update_expectations(self):
         if self.should_update_expectations and self._results_this_run:
@@ -289,18 +326,46 @@ def run_mvt_test_suite(args):
     num_suites = len(suites)
     for suite in suites:
         json_results = mvtwebdriver_runner.run_suite(suite)
-        tests_run, unexpected_failures, expected_failures = mvtresultsexpectations_parser.analyze_results(json_results)
-        test_results[suite] = [tests_run, unexpected_failures, expected_failures]
+        tests_run_list, unexpected_failures_list, expected_failures_list = mvtresultsexpectations_parser.analyze_results(json_results)
+        unexpected_failures = len(unexpected_failures_list)
+        tests_run = len(tests_run_list)
+        # Maybe retry unexpected failures
+        if args.retry_unexpected_failures > 0 and unexpected_failures > 0:
+            unexpected_failures_str = "', '".join(unexpected_failures_list)
+            _log.info(f"Retrying {unexpected_failures} unexpected failures: '{unexpected_failures_str}'")
+            # iterate over a copy since we are modifying unexpected_failures_list inside the loop
+            for test_name in list(unexpected_failures_list):
+                repeat_test_results = mvtwebdriver_runner.run_test_from_suite(test_name, suite, args.retry_unexpected_failures)
+                _log.debug(f"Got extra results for {suite}/{test_name}: {repeat_test_results}")
+                for extra_result in repeat_test_results:
+                    if extra_result == 'passed':
+                        _log.info(f'[FLAKY][PASS] {test_name}.')
+                        unexpected_failures_list.remove(test_name)
+                        break
+                    elif not mvtresultsexpectations_parser._is_unexpected_failure(suite, test_name, extra_result):
+                        _log.info(f'[FLAKY][FAIL][EXPECTED] {test_name}')
+                        unexpected_failures_list.remove(test_name)
+                        expected_failures_list.append(test_name)
+                        break
+        # Calculate results of the suite run
+        unexpected_failures = len(unexpected_failures_list)
+        expected_failures = len(expected_failures_list)
+        test_results[suite] = [tests_run_list, unexpected_failures_list, expected_failures_list]
         exit_code = unexpected_failures
         tests_pass = tests_run - unexpected_failures - expected_failures
         suite_summary_header_str = f"[Suite {suite}] Ran {tests_run} tests of which:"
         _log.info('-' * len(suite_summary_header_str))
         _log.info(suite_summary_header_str)
-        _log.info(f"    - {tests_pass} tests passed.")
+        _log.info(f"{'-':>4} {tests_pass} tests passed.")
         if expected_failures > 0:
-            _log.info(f"    - {expected_failures} tests were expected failures.")
+            _log.info(f"{'-':>4} {expected_failures} tests were expected failures:")
+            for test_name in expected_failures_list:
+                _log.info(f"{'':>8}{test_name}")
+
         if unexpected_failures > 0:
-            _log.info(f"    - {unexpected_failures} tests were unexpected failures.")
+            _log.info(f"{'-':>4} {unexpected_failures} tests were unexpected failures:")
+            for test_name in unexpected_failures_list:
+                _log.info(f"{'':>8}{test_name}")
         _log.info('-' * len(suite_summary_header_str) + '\n')
 
     # Print global summary if more than one suite was run
@@ -312,18 +377,18 @@ def run_mvt_test_suite(args):
         total_unexpected_failures = 0
         total_expected_failures = 0
         for suite in test_results:
-            total_tests_run += test_results[suite][0]
-            total_unexpected_failures += test_results[suite][1]
-            total_expected_failures += test_results[suite][2]
+            total_tests_run += len(test_results[suite][0])
+            total_unexpected_failures += len(test_results[suite][1])
+            total_expected_failures += len(test_results[suite][2])
         total_tests_pass = total_tests_run - total_unexpected_failures - total_expected_failures
         suites_str = ", ".join(suites)
         _log.info(f"Executed {num_suites} MVT test suites: {suites_str}")
         _log.info(f"Ran {total_tests_run} tests in total of which:")
-        _log.info(f"    - {total_tests_pass} tests passed.")
+        _log.info(f"{'-':>4} {total_tests_pass} tests passed.")
         if total_expected_failures > 0:
-            _log.info(f"    - {total_expected_failures} tests were expected failures.")
+            _log.info(f"{'-':>4} {total_expected_failures} tests were expected failures.")
         if total_unexpected_failures > 0:
-            _log.info(f"    - {total_unexpected_failures} tests were unexpected failures.")
+            _log.info(f"{'-':>4} {total_unexpected_failures} tests were unexpected failures.")
         exit_code = total_unexpected_failures
 
     mvtresultsexpectations_parser.maybe_update_expectations()


### PR DESCRIPTION
#### 3e12a025ba711af6d7027624fbcc7cc2154ba9f3
<pre>
[Tools][WPE] run-mvt-tests should retry unexpected failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=289349">https://bugs.webkit.org/show_bug.cgi?id=289349</a>

Reviewed by Adrian Perez de Castro.

Some of the MVT tests are randomly flaky, and this is causing issues
on the bot runners due this random unexpected failures.

This patch modifies the runner so each unexpected failure is retried
up to N times (default 3) before marking it as such.

It also improves the conditions to check when the tests have started
or finished. Previously there was a bug detecting that all the tests
finished completely. It also improves the logging to summarize at the
end of each step the names of the tests that failed (expected or not).

* Tools/Scripts/run-mvt-tests:
(parse_args):

Canonical link: <a href="https://commits.webkit.org/292058@main">https://commits.webkit.org/292058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e9a55516ed7562c70d25a2fb30f6e4c7988fb1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44871 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14231 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72001 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29336 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85206 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52323 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10266 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2886 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44189 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101400 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21395 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81004 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80362 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2308 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14628 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15225 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21379 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21066 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->