### PR TITLE
[WebGPU] static assert the size of IndexData in BindableResource.h and the sizes of IndexDataUshort and IndexDataUint in Device.mm

### DIFF
--- a/Source/WebGPU/WebGPU/BindableResource.h
+++ b/Source/WebGPU/WebGPU/BindableResource.h
@@ -84,7 +84,7 @@ struct IndexData {
     uint32_t firstIndex { 0 };
     int32_t baseVertex { 0 };
     uint32_t firstInstance { 0 };
-    MTLPrimitiveType primitiveType { MTLPrimitiveTypeTriangle };
+    uint32_t primitiveType { MTLPrimitiveTypeTriangle };
 };
 
 struct IndexBufferAndIndexData {

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -938,7 +938,7 @@ id<MTLFunction> Device::icbCommandClampFunction(MTLIndexType indexType)
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         options.fastMathEnabled = YES;
         ALLOW_DEPRECATED_DECLARATIONS_END
-        /* NOLINT */ id<MTLLibrary> library = [m_device newLibraryWithSource:@R"(
+        /* NOLINT */ id<MTLLibrary> library = [m_device newLibraryWithSource:[NSString stringWithFormat:@R"(
     using namespace metal;
     struct ICBContainer {
         device uint* outOfBoundsRead [[ id(0) ]];
@@ -968,6 +968,10 @@ id<MTLFunction> Device::icbCommandClampFunction(MTLIndexType indexType)
         uint32_t baseInstance { 0 };
         primitive_type primitiveType { primitive_type::triangle };
     };
+
+    static_assert(sizeof(primitive_type) == sizeof(uint32_t), "API assumes primitive type is sizeof uint32_t");
+    static_assert(sizeof(IndexDataUshort) == %lu, "sizeof(IndexDataUshort) in shader mismatches the API size");
+    static_assert(sizeof(IndexDataUint) == %lu, "sizeof(IndexDataUint) in shader mismatches the API size");
 
     [[vertex]] void vsICB(device const IndexDataUint* indexData [[buffer(0)]],
         device ICBContainer *icb_container [[buffer()" OBJC_STRINGIFY(DEVICE_BUFFER_INDEX_FOR_ICB_CONTAINER) @R"()]],
@@ -1010,7 +1014,7 @@ id<MTLFunction> Device::icbCommandClampFunction(MTLIndexType indexType)
                 data.baseInstance);
         }
 
-    })" /* NOLINT */ options:options error:&error];
+    })", sizeof(IndexData), sizeof(IndexData)] /* NOLINT */ options:options error:&error];
         if (error)
             WTFLogAlways("%@", error);
 

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -706,7 +706,7 @@ void RenderBundleEncoder::storeVertexBufferCountsForValidation(uint32_t indexCou
             .firstIndex = firstIndex,
             .baseVertex = baseVertex,
             .firstInstance = firstInstance,
-            .primitiveType = m_primitiveType,
+            .primitiveType = static_cast<decltype(IndexData::primitiveType)>(m_primitiveType),
         }
     });
 }


### PR DESCRIPTION
#### ae9209cc59f63567bb42f847f28f2994b15ba331
<pre>
[WebGPU] static assert the size of IndexData in BindableResource.h and the sizes of IndexDataUshort and IndexDataUint in Device.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=289221">https://bugs.webkit.org/show_bug.cgi?id=289221</a>
<a href="https://rdar.apple.com/146359797">rdar://146359797</a>

Reviewed by Cameron McCormack.

Add static assertions to ensure data between shaders matches C++
definitions.

Test: existing render bundle tests would immedietly fail with error similar to:
Error Domain=MTLLibraryErrorDomain Code=3 &quot;program_source:33:5: error: static_assert failed due to requirement &apos;sizeof(IndexDataUshort) == 56&apos; &quot;sizeof(IndexDataUshort) in shader mismatches the API size&quot;
    static_assert(sizeof(IndexDataUshort) == 56, &quot;sizeof(IndexDataUshort) in shader mismatches the API size&quot;);
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
program_source:34:5: error: static_assert failed due to requirement &apos;sizeof(IndexDataUint) == 56&apos; &quot;sizeof(IndexDataUint) in shader mismatches the API size&quot;
    static_assert(sizeof(IndexDataUint) == 56, &quot;sizeof(IndexDataUint) in shader mismatches the API size&quot;);

which <a href="https://webgpu.github.io/webgpu-samples/?sample=renderBundles">https://webgpu.github.io/webgpu-samples/?sample=renderBundles</a> illustrates
prior to changing MTLPrimitiveType to a uint32_t

* Source/WebGPU/WebGPU/BindableResource.h:
metal::primitive_type is 4 bytes, while MTLPrimitiveType is sizeof(NSUInteger)
or 8 bytes on macs and phones, so use uint32_t instead to match.

* Source/WebGPU/WebGPU/Device.mm:
Add static assertions to ICB clamp pipeline.

* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::storeVertexBufferCountsForValidation):
add necessary static cast for conversion

Canonical link: <a href="https://commits.webkit.org/291927@main">https://commits.webkit.org/291927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a11a123adab4b75c9f979e9378ac47d9caf5060c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99055 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44574 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71763 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29107 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84931 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10021 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43890 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80270 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101096 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80765 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80133 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20045 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14261 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21083 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26261 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20770 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24230 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->