### PR TITLE
Reduce use of ActiveDOMObject::legacyQueueTaskKeepingObjectAlive()

### DIFF
--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
@@ -67,23 +67,19 @@ void MediaKeySystemAccess::createMediaKeys(Document& document, Ref<DeferredPromi
     // When this method is invoked, the user agent must run the following steps:
     // 1. Let promise be a new promise.
     // 2. Run the following steps in parallel:
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this, weakThis = WeakPtr { *this }, weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, promise = WTFMove(promise)]() mutable {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [weakDocument = WeakPtr<Document, WeakPtrImplWithEventTargetData> { document }, promise = WTFMove(promise)](auto& access) mutable {
         // 2.1. Let configuration be the value of this object's configuration value.
         // 2.2. Let use distinctive identifier be true if the value of configuration's distinctiveIdentifier member is "required" and false otherwise.
-        bool useDistinctiveIdentifier = m_configuration->distinctiveIdentifier == MediaKeysRequirement::Required;
+        bool useDistinctiveIdentifier = access.m_configuration->distinctiveIdentifier == MediaKeysRequirement::Required;
 
         // 2.3. Let persistent state allowed be true if the value of configuration's persistentState member is "required" and false otherwise.
-        bool persistentStateAllowed = m_configuration->persistentState == MediaKeysRequirement::Required;
+        bool persistentStateAllowed = access.m_configuration->persistentState == MediaKeysRequirement::Required;
 
         // 2.4. Load and initialize the Key System implementation represented by this object's cdm implementation value if necessary.
-        m_implementation->loadAndInitialize();
+        access.m_implementation->loadAndInitialize();
 
         // 2.5. Let instance be a new instance of the Key System implementation represented by this object's cdm implementation value.
-        auto instance = m_implementation->createInstance();
+        auto instance = access.m_implementation->createInstance();
         if (!instance) {
             promise->reject(ExceptionCode::InvalidStateError);
             return;
@@ -95,7 +91,7 @@ void MediaKeySystemAccess::createMediaKeys(Document& document, Ref<DeferredPromi
         auto allowDistinctiveIdentifiers = useDistinctiveIdentifier ? CDMInstance::AllowDistinctiveIdentifiers::Yes : CDMInstance::AllowDistinctiveIdentifiers::No;
         auto allowPersistentState = persistentStateAllowed ? CDMInstance::AllowPersistentState::Yes : CDMInstance::AllowPersistentState::No;
 
-        instance->initializeWithConfiguration(*m_configuration, allowDistinctiveIdentifiers, allowPersistentState, [weakDocument = WTFMove(weakDocument), sessionTypes = m_configuration->sessionTypes, implementation = m_implementation.copyRef(), useDistinctiveIdentifier, persistentStateAllowed, instance = instance.releaseNonNull(), promise = WTFMove(promise)] (auto successValue) mutable {
+        instance->initializeWithConfiguration(*access.m_configuration, allowDistinctiveIdentifiers, allowPersistentState, [weakDocument = WTFMove(weakDocument), sessionTypes = access.m_configuration->sessionTypes, implementation = access.m_implementation.copyRef(), useDistinctiveIdentifier, persistentStateAllowed, instance = instance.releaseNonNull(), promise = WTFMove(promise)] (auto successValue) mutable {
             if (successValue == CDMInstance::Failed || !weakDocument) {
                 promise->reject(ExceptionCode::NotAllowedError);
                 return;

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp
@@ -90,9 +90,9 @@ void MediaKeySystemRequest::allow(String&& mediaKeysHashSalt)
     if (!scriptExecutionContext())
         return;
 
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this, mediaKeysHashSalt = WTFMove(mediaKeysHashSalt)] () mutable {
-        if (auto allowCompletionHandler = std::exchange(m_allowCompletionHandler, { }))
-            allowCompletionHandler(WTFMove(mediaKeysHashSalt), WTFMove(m_promise));
+    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [mediaKeysHashSalt = WTFMove(mediaKeysHashSalt)](auto& request) mutable {
+        if (auto allowCompletionHandler = std::exchange(request.m_allowCompletionHandler, { }))
+            allowCompletionHandler(WTFMove(mediaKeysHashSalt), WTFMove(request.m_promise));
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp
@@ -80,18 +80,18 @@ bool RTCDtlsTransport::virtualHasPendingActivity() const
 
 void RTCDtlsTransport::onStateChanged(RTCDtlsTransportState state, Vector<Ref<JSC::ArrayBuffer>>&& certificates)
 {
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state, certificates = WTFMove(certificates)]() mutable {
-        if (m_state == RTCDtlsTransportState::Closed)
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [state, certificates = WTFMove(certificates)](auto& transport) mutable {
+        if (transport.m_state == RTCDtlsTransportState::Closed)
             return;
 
-        if (m_remoteCertificates != certificates)
-            m_remoteCertificates = WTFMove(certificates);
+        if (transport.m_remoteCertificates != certificates)
+            transport.m_remoteCertificates = WTFMove(certificates);
 
-        if (m_state != state) {
-            m_state = state;
-            if (RefPtr connection = m_iceTransport->connection())
+        if (transport.m_state != state) {
+            transport.m_state = state;
+            if (RefPtr connection = transport.m_iceTransport->connection())
                 connection->updateConnectionState();
-            dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+            transport.dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
         }
     });
 }

--- a/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp
@@ -71,17 +71,17 @@ bool RTCSctpTransport::virtualHasPendingActivity() const
 
 void RTCSctpTransport::onStateChanged(RTCSctpTransportState state, std::optional<double> maxMessageSize, std::optional<unsigned short> maxChannels)
 {
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Networking, [this, state, maxMessageSize, maxChannels]() mutable {
-        if (m_state == RTCSctpTransportState::Closed)
+    queueTaskKeepingObjectAlive(*this, TaskSource::Networking, [state, maxMessageSize, maxChannels](auto& transport) mutable {
+        if (transport.m_state == RTCSctpTransportState::Closed)
             return;
 
-        m_maxMessageSize = maxMessageSize;
+        transport.m_maxMessageSize = maxMessageSize;
         if (maxChannels)
-            m_maxChannels = *maxChannels;
+            transport.m_maxChannels = *maxChannels;
 
-        if (m_state != state) {
-            m_state = state;
-            dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+        if (transport.m_state != state) {
+            transport.m_state = state;
+            transport.dispatchEvent(Event::create(eventNames().statechangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
         }
     });
 }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -279,7 +279,7 @@ rtc::scoped_refptr<LibWebRTCStatsCollector> LibWebRTCMediaEndpoint::createStatsC
 
         Ref peerConnectionBackend = protectedThis->m_peerConnectionBackend.get();
         Ref peerConnection = peerConnectionBackend->connection();
-        peerConnection->legacyQueueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [promise = WTFMove(promise), rtcReport] {
+        peerConnection->queueTaskKeepingObjectAlive(peerConnection.get(), TaskSource::Networking, [promise = WTFMove(promise), rtcReport](auto&) {
             promise->resolve<IDLInterface<RTCStatsReport>>(LibWebRTCStatsCollector::createReport(rtcReport));
         });
     });

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -217,8 +217,8 @@ void Notification::stopResourcesLoader()
 
 void Notification::showSoon()
 {
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
-        show();
+    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [](auto& notification) {
+        notification.show();
     });
 }
 
@@ -344,9 +344,9 @@ void Notification::dispatchClickEvent()
     ASSERT(m_notificationSource != NotificationSource::ServiceWorker);
     ASSERT(!isPersistent());
 
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [this] {
+    queueTaskKeepingObjectAlive(*this, TaskSource::UserInteraction, [](auto& notification) {
         WindowFocusAllowedIndicator windowFocusAllowed;
-        dispatchEvent(Event::create(eventNames().clickEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        notification.dispatchEvent(Event::create(eventNames().clickEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });
 }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp
@@ -472,8 +472,8 @@ void PaymentRequest::closeActivePaymentHandler()
 void PaymentRequest::stop()
 {
     closeActivePaymentHandler();
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this] {
-        settleShowPromise(Exception { ExceptionCode::AbortError });
+    queueTaskKeepingObjectAlive(*this, TaskSource::Payment, [](auto& request) {
+        request.settleShowPromise(Exception { ExceptionCode::AbortError });
     });
 }
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
@@ -147,8 +147,8 @@ void PaymentResponse::settleRetryPromise(ExceptionOr<void>&& result)
 
 void PaymentResponse::stop()
 {
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Payment, [this, pendingActivity = std::exchange(m_pendingActivity, nullptr)] {
-        settleRetryPromise(Exception { ExceptionCode::AbortError });
+    queueTaskKeepingObjectAlive(*this, TaskSource::Payment, [pendingActivity = std::exchange(m_pendingActivity, nullptr)](auto& response) {
+        response.settleRetryPromise(Exception { ExceptionCode::AbortError });
     });
     m_state = State::Stopped;
 }

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -135,17 +135,17 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
     ASSERT(m_reportingScope && scriptExecutionContext() == m_reportingScope->scriptExecutionContext());
 
     // Step 4.3.4: Queue a task to § 4.4
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedThis = Ref { *this }, protectedCallback = Ref { m_callback }] {
-        RefPtr context = protectedThis->scriptExecutionContext();
+    queueTaskKeepingObjectAlive(*this, TaskSource::Reporting, [protectedCallback = Ref { m_callback }](auto& observer) {
+        RefPtr context = observer.scriptExecutionContext();
         ASSERT(context);
         if (!context)
             return;
 
         // Step 4.4: Invoke reporting observers with notify list with a copy of global’s registered reporting observer list.
-        auto reports = protectedThis->takeRecords();
+        auto reports = observer.takeRecords();
 
         InspectorInstrumentation::willFireObserverCallback(*context, "ReportingObserver"_s);
-        protectedCallback->handleEvent(reports, protectedThis);
+        protectedCallback->handleEvent(reports, observer);
         InspectorInstrumentation::didFireObserverCallback(*context);
     });
 }

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.cpp
@@ -313,7 +313,7 @@ void BaseAudioContext::decodeAudioData(Ref<ArrayBuffer>&& audioData, RefPtr<Audi
 
     auto p = m_audioDecoder->decodeAsync(audioData.copyRef(), sampleRate());
     p->whenSettled(RunLoop::currentSingleton(), [this, audioData = WTFMove(audioData), activity = makePendingActivity(*this), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise)] (DecodingTaskPromise::Result&& result) mutable {
-        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [audioData = WTFMove(audioData), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)]() mutable {
+        queueTaskKeepingObjectAlive(*this, TaskSource::InternalAsyncTask, [audioData = WTFMove(audioData), successCallback = WTFMove(successCallback), errorCallback = WTFMove(errorCallback), promise = WTFMove(promise), result = WTFMove(result)](auto&) mutable {
 
             audioData->unpin();
 
@@ -894,7 +894,7 @@ void BaseAudioContext::postTask(Function<void()>&& task)
 {
     ASSERT(isMainThread());
     if (!m_isStopScheduled)
-        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, WTFMove(task));
+        queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)](auto&) mutable { task(); });
 }
 
 const SecurityOrigin* BaseAudioContext::origin() const

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -299,8 +299,8 @@ ExceptionOr<void> WebCodecsAudioEncoder::encode(Ref<WebCodecsAudioData>&& frame)
         // FIXME: These checks are not yet spec-compliant. See also https://github.com/w3c/webcodecs/issues/716
         if (m_baseConfiguration.numberOfChannels != audioData->numberOfChannels()
             || m_baseConfiguration.sampleRate != audioData->sampleRate()) {
-            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
-                closeEncoder(Exception { ExceptionCode::EncodingError, "Input audio buffer is incompatible with codec parameters"_s });
+            queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& encoder) mutable {
+                encoder.closeEncoder(Exception { ExceptionCode::EncodingError, "Input audio buffer is incompatible with codec parameters"_s });
             });
             return WebCodecsControlMessageOutcome::Processed;
         }

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp
@@ -73,9 +73,9 @@ void WebCodecsBase::scheduleDequeueEvent()
         return;
 
     m_dequeueEventScheduled = true;
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this]() mutable {
-        dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
-        m_dequeueEventScheduled = false;
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& codecs) mutable {
+        codecs.dispatchEvent(Event::create(eventNames().dequeueEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        codecs.m_dequeueEventScheduled = false;
     });
 }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h
@@ -36,8 +36,8 @@ void postTaskToCodec(ScriptExecutionContextIdentifier identifier, ThreadSafeWeak
         RefPtr protectedCodec = codec.get();
         if (!protectedCodec)
             return;
-        Codec::legacyQueueTaskKeepingObjectAlive(*protectedCodec, TaskSource::MediaElement, [codec = protectedCodec.get(), task = WTFMove(task)] () mutable {
-            task(*codec);
+        Codec::queueTaskKeepingObjectAlive(*protectedCodec, TaskSource::MediaElement, [task = WTFMove(task)](auto& codec) mutable {
+            task(codec);
         });
     });
 }

--- a/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp
@@ -102,7 +102,7 @@ void WebXRInputSourceArray::update(double timestamp, const InputSourceList& inpu
         // 5. Set frame’s active boolean to false.
 
         for (auto& event : inputEvents) {
-            ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = Ref { m_session }, event = WTFMove(event)]() {
+            ActiveDOMObject::queueTaskKeepingObjectAlive(m_session, TaskSource::WebXR, [session = Ref { m_session }, event = WTFMove(event)](auto&) {
                 event->setFrameActive(true);
                 session->dispatchEvent(event.copyRef());
                 event->setFrameActive(false);

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -253,7 +253,7 @@ void WebXRSession::requestReferenceSpace(XRReferenceSpaceType type, RequestRefer
         // 2.1. If the result of running reference space is supported for type and session is false, queue a task to reject promise
         // with a NotSupportedError and abort these steps.
         if (!referenceSpaceIsSupported(type)) {
-            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [promise = WTFMove(promise)]() mutable {
+            queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [promise = WTFMove(promise)](auto&) mutable {
                 promise.reject(Exception { ExceptionCode::NotSupportedError });
             });
             return;
@@ -263,19 +263,19 @@ void WebXRSession::requestReferenceSpace(XRReferenceSpaceType type, RequestRefer
             device->initializeReferenceSpace(type);
 
         // 2.3. Queue a task to run the following steps:
-        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, type, promise = WTFMove(promise)]() mutable {
-            if (!scriptExecutionContext()) {
+        queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [type, promise = WTFMove(promise)](auto& session) mutable {
+            if (!session.scriptExecutionContext()) {
                 promise.reject(Exception { ExceptionCode::InvalidStateError });
                 return;
             }
-            auto& document = downcast<Document>(*scriptExecutionContext());
+            Ref document = downcast<Document>(*session.scriptExecutionContext());
             // 2.4. Create a reference space, referenceSpace, with type and session.
             // https://immersive-web.github.io/webxr/#create-a-reference-space
             RefPtr<WebXRReferenceSpace> referenceSpace;
             if (type == XRReferenceSpaceType::BoundedFloor)
-                referenceSpace = WebXRBoundedReferenceSpace::create(document, Ref { *this }, type);
+                referenceSpace = WebXRBoundedReferenceSpace::create(document, session, type);
             else
-                referenceSpace = WebXRReferenceSpace::create(document, Ref { *this }, type);
+                referenceSpace = WebXRReferenceSpace::create(document, session, type);
 
             // 2.5. Resolve promise with referenceSpace.
             promise.resolve(referenceSpace.releaseNonNull());
@@ -463,17 +463,17 @@ void WebXRSession::sessionDidInitializeInputSources(Vector<PlatformXR::FrameData
     // https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession
     // 5.4.11 Queue a task to perform the following steps: NOTE: These steps ensure that initial inputsourceschange
     // events occur after the initial session is resolved.
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, inputSources = WTFMove(inputSources)]() mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [inputSources = WTFMove(inputSources)](auto& session) mutable {
         //  1. Set session's promise resolved flag to true.
-        m_inputInitialized = true;
+        session.m_inputInitialized = true;
         //  2. Let sources be any existing input sources attached to session.
         //  3. If sources is non-empty, perform the following steps:
         if (!inputSources.isEmpty()) {
-            auto timestamp = (MonotonicTime::now() - m_timeOrigin).milliseconds();
+            auto timestamp = (MonotonicTime::now() - session.m_timeOrigin).milliseconds();
             //  3.1. Set session's list of active XR input sources to sources.
             //  3.2. Fire an XRInputSourcesChangeEvent named inputsourceschange on session with added set to sources.
             //  Note: 3.1 and 3.2 steps are handled inside the update() call.
-            m_inputSources->update(timestamp, inputSources);
+            session.m_inputSources->update(timestamp, inputSources);
         }
     });
 }
@@ -623,18 +623,18 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
         return;
 
     // Queue a task to perform the following steps.
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [this, frameData = WTFMove(frameData)]() mutable {
-        if (m_ended || m_visibilityState == XRVisibilityState::Hidden)
+    queueTaskKeepingObjectAlive(*this, TaskSource::WebXR, [frameData = WTFMove(frameData)](auto& session) mutable {
+        if (session.m_ended || session.m_visibilityState == XRVisibilityState::Hidden)
             return;
 
-        m_frameData = WTFMove(frameData);
+        session.m_frameData = WTFMove(frameData);
         //  1.Let now be the current high resolution time.
-        auto now = (MonotonicTime::now() - m_timeOrigin).milliseconds();
+        auto now = (MonotonicTime::now() - session.m_timeOrigin).milliseconds();
 
-        auto frame = WebXRFrame::create(*this, WebXRFrame::IsAnimationFrame::Yes);
+        Ref frame = WebXRFrame::create(session, WebXRFrame::IsAnimationFrame::Yes);
         //  2.Let frame be session’s animation frame.
         //  3.Set frame’s time to frameTime.
-        frame->setTime(static_cast<DOMHighResTimeStamp>(m_frameData.predictedDisplayTime));
+        frame->setTime(static_cast<DOMHighResTimeStamp>(session.m_frameData.predictedDisplayTime));
 
         // 4. For each view in list of views, set view’s viewport modifiable flag to true.
         // 5. If the active flag of any view in the list of views has changed since the last XR animation frame, update the viewports.
@@ -642,34 +642,34 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
 
         // FIXME: I moved step 7 before 6 because of https://github.com/immersive-web/webxr/issues/1164
         // 7.If session’s pending render state is not null, apply the pending render state.
-        if (m_pendingRenderState)
-            applyPendingRenderState();
+        if (session.m_pendingRenderState)
+            session.applyPendingRenderState();
 
         // 6. If the frame should be rendered for session:
-        if (frameShouldBeRendered() && m_frameData.shouldRender) {
+        if (session.frameShouldBeRendered() && session.m_frameData.shouldRender) {
             // Prepare all layers for render
-            if (isImmersive(m_mode)) {
-                if (m_activeRenderState->baseLayer())
-                    m_activeRenderState->baseLayer()->startFrame(m_frameData);
+            if (isImmersive(session.m_mode)) {
+                if (session.m_activeRenderState->baseLayer())
+                    session.m_activeRenderState->baseLayer()->startFrame(session.m_frameData);
 #if ENABLE(WEBXR_LAYERS)
-                else if (m_activeRenderState->layers().size())
-                    m_activeRenderState->layers()[0]->startFrame(m_frameData);
+                else if (session.m_activeRenderState->layers().size())
+                    session.m_activeRenderState->layers()[0]->startFrame(session.m_frameData);
 #endif
             }
 
             // 6.1.Set session’s list of currently running animation frame callbacks to be session’s list of animation frame callbacks.
             // 6.2.Set session’s list of animation frame callbacks to the empty list.
-            auto callbacks = m_callbacks;
+            auto callbacks = session.m_callbacks;
 
             // 6.3.Set frame’s active boolean to true.
             frame->setActive(true);
 
             // 6.4.Apply frame updates for frame.
-            if (m_inputInitialized)
-                m_inputSources->update(now, m_frameData.inputSources);
+            if (session.m_inputInitialized)
+                session.m_inputSources->update(now, session.m_frameData.inputSources);
 
             tracePoint(WebXRSessionFrameCallbacksStart);
-            minimalUpdateRendering();
+            session.minimalUpdateRendering();
             // 6.5.For each entry in session’s list of currently running animation frame callbacks, in order:
             for (auto& callback : callbacks) {
                 //  6.6.If the entry’s cancelled boolean is true, continue to the next entry.
@@ -684,7 +684,7 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             tracePoint(WebXRSessionFrameCallbacksEnd);
 
             // 6.9.Set session’s list of currently running animation frame callbacks to the empty list.
-            m_callbacks.removeAllMatching([](auto& callback) {
+            session.m_callbacks.removeAllMatching([](auto& callback) {
                 return callback->isFiredOrCancelled();
             });
 
@@ -692,19 +692,19 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             // If the session is ended, m_animationFrame->setActive false is set in shutdown().
             frame->setActive(false);
 
-            if (m_ended)
+            if (session.m_ended)
                 return;
 
             // Submit current frame layers to the device.
             Vector<PlatformXR::Device::Layer> frameLayers;
-            if (isImmersive(m_mode) && m_activeRenderState->baseLayer())
-                frameLayers.append(m_activeRenderState->baseLayer()->endFrame());
+            if (isImmersive(session.m_mode) && session.m_activeRenderState->baseLayer())
+                frameLayers.append(session.m_activeRenderState->baseLayer()->endFrame());
 
-            if (auto device = m_device.get())
+            if (auto device = session.m_device.get())
                 device->submitFrame(WTFMove(frameLayers));
         }
 
-        requestFrameIfNeeded();
+        session.requestFrameIfNeeded();
     });
 }
 

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -46,7 +46,6 @@ Modules/credentialmanagement/CredentialsContainer.cpp
 Modules/encryptedmedia/CDM.cpp
 Modules/encryptedmedia/MediaKeySession.cpp
 Modules/encryptedmedia/MediaKeyStatusMap.cpp
-Modules/encryptedmedia/MediaKeySystemAccess.cpp
 Modules/encryptedmedia/MediaKeySystemRequest.cpp
 Modules/encryptedmedia/MediaKeys.cpp
 Modules/encryptedmedia/legacy/LegacyCDMSessionClearKey.cpp
@@ -1397,7 +1396,6 @@ testing/MockPaymentCoordinator.cpp
 testing/ServiceWorkerInternals.cpp
 testing/js/WebCoreTestSupport.cpp
 workers/DedicatedWorkerGlobalScope.cpp
-workers/Worker.cpp
 workers/WorkerAnimationController.cpp
 workers/WorkerConsoleClient.cpp
 workers/WorkerFontLoadRequest.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -8,8 +8,6 @@ Modules/cache/DOMCache.cpp
 Modules/cache/DOMCacheStorage.cpp
 Modules/cookie-store/CookieStore.cpp
 Modules/encryptedmedia/MediaKeySession.cpp
-Modules/encryptedmedia/MediaKeySystemAccess.cpp
-Modules/encryptedmedia/MediaKeySystemRequest.cpp
 Modules/encryptedmedia/NavigatorEME.cpp
 Modules/entriesapi/DOMFileSystem.cpp
 Modules/entriesapi/FileSystemDirectoryEntry.cpp
@@ -30,19 +28,15 @@ Modules/mediastream/MediaDevices.cpp
 Modules/mediastream/MediaStreamTrack.cpp
 Modules/mediastream/PeerConnectionBackend.cpp
 Modules/mediastream/RTCDataChannel.cpp
-Modules/mediastream/RTCDtlsTransport.cpp
 Modules/mediastream/RTCIceTransport.cpp
 Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpSender.cpp
-Modules/mediastream/RTCSctpTransport.cpp
 Modules/mediastream/UserMediaRequest.cpp
 Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
 Modules/notifications/Notification.cpp
 Modules/paymentrequest/PaymentRequest.cpp
-Modules/paymentrequest/PaymentResponse.cpp
 Modules/push-api/PushDatabase.cpp
 Modules/remoteplayback/RemotePlayback.cpp
-Modules/web-locks/WebLockManager.cpp
 Modules/webaudio/AudioContext.cpp
 Modules/webaudio/AudioWorkletThread.cpp
 Modules/webaudio/BaseAudioContext.cpp
@@ -51,7 +45,6 @@ Modules/webaudio/OfflineAudioDestinationNode.cpp
 Modules/webcodecs/WebCodecsAudioDecoder.cpp
 Modules/webcodecs/WebCodecsAudioEncoder.cpp
 Modules/webcodecs/WebCodecsBase.cpp
-Modules/webcodecs/WebCodecsUtilities.h
 Modules/webcodecs/WebCodecsVideoDecoder.cpp
 Modules/webcodecs/WebCodecsVideoEncoder.cpp
 Modules/webdatabase/DatabaseThread.cpp
@@ -76,7 +69,6 @@ css/CSSVariableReferenceValue.cpp
 css/SelectorChecker.cpp
 css/StyleRule.cpp
 css/parser/CSSParserImpl.cpp
-dom/BroadcastChannel.cpp
 dom/ContainerNode.cpp
 dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
@@ -103,7 +95,6 @@ html/canvas/GPUCanvasContextCocoa.mm
 html/canvas/WebGLRenderingContextBase.cpp
 html/track/LoadableTextTrack.cpp
 html/track/TrackBase.cpp
-html/track/TrackListBase.cpp
 html/track/VTTCue.cpp
 inspector/InspectorOverlay.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp
@@ -167,4 +158,3 @@ workers/service/ExtendableEvent.cpp
 workers/service/ServiceWorkerContainer.cpp
 workers/service/ServiceWorkerGlobalScope.cpp
 workers/shared/SharedWorkerObjectConnection.cpp
-xml/XMLHttpRequest.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -79,7 +79,6 @@ Modules/webaudio/WaveShaperDSPKernel.cpp
 Modules/webaudio/WaveShaperNode.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/PublicKeyCredential.cpp
-Modules/webcodecs/WebCodecsUtilities.h
 Modules/webcodecs/WebCodecsVideoFrameAlgorithms.cpp
 Modules/webdatabase/ChangeVersionWrapper.cpp
 Modules/webdatabase/Database.cpp

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -278,8 +278,8 @@ void MessagePort::dispatchMessages()
             }
 
             // Per specification, each MessagePort object has a task source called the port message queue.
-            legacyQueueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [this, event = WTFMove(event)] {
-                dispatchEvent(event.event);
+            queueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [event = WTFMove(event)](auto& port) {
+                port.dispatchEvent(event.event);
             });
         }
     };

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -230,9 +230,9 @@ void FileReader::enqueueTask(Function<void()>&& task)
     static uint64_t taskIdentifierSeed = 0;
     uint64_t taskIdentifier = ++taskIdentifierSeed;
     m_pendingTasks.add(taskIdentifier, WTFMove(task));
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::FileReading, [this, pendingActivity = makePendingActivity(*this), taskIdentifier] {
-        auto task = m_pendingTasks.take(taskIdentifier);
-        if (task && !isContextStopped())
+    queueTaskKeepingObjectAlive(*this, TaskSource::FileReading, [taskIdentifier](auto& reader) {
+        auto task = reader.m_pendingTasks.take(taskIdentifier);
+        if (task && !reader.isContextStopped())
             task();
     });
 }

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -133,7 +133,7 @@ public:
 
     WEBCORE_EXPORT static void setMaxCanvasAreaForTesting(std::optional<size_t>);
 
-    virtual void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
+    virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
 
     bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -66,7 +66,7 @@ public:
 
     void replayDisplayList(GraphicsContext&);
 
-    void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final { };
+    void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) final { };
     void dispatchEvent(Event&) final { }
 
     const CSSParserContext& cssParserContext() const final;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -1013,9 +1013,11 @@ bool HTMLCanvasElement::isControlledByOffscreen() const
     return m_context && m_context->isPlaceholder();
 }
 
-void HTMLCanvasElement::legacyQueueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
+void HTMLCanvasElement::queueTaskKeepingObjectAlive(TaskSource source, Function<void(CanvasBase&)>&& task)
 {
-    ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(*this, source, WTFMove(task));
+    ActiveDOMObject::queueTaskKeepingObjectAlive(*this, source, [task = WTFMove(task)](auto& element) mutable {
+        task(element);
+    });
 }
 
 void HTMLCanvasElement::dispatchEvent(Event& event)

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -140,7 +140,7 @@ public:
 
     bool isControlledByOffscreen() const;
 
-    void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
+    void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) final;
     void dispatchEvent(Event&) final;
 
     // ActiveDOMObject.

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -221,7 +221,7 @@ void HTMLTrackElement::scheduleLoad()
 
 void HTMLTrackElement::scheduleTask(Function<void()>&& task)
 {
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)]() mutable {
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [task = WTFMove(task)](auto&) mutable {
         task();
     });
 }

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -454,9 +454,11 @@ void OffscreenCanvas::reset()
     scheduleCommitToPlaceholderCanvas();
 }
 
-void OffscreenCanvas::legacyQueueTaskKeepingObjectAlive(TaskSource source, Function<void()>&& task)
+void OffscreenCanvas::queueTaskKeepingObjectAlive(TaskSource source, Function<void(CanvasBase&)>&& task)
 {
-    ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(*this, source, WTFMove(task));
+    ActiveDOMObject::queueTaskKeepingObjectAlive(*this, source, [task = WTFMove(task)](auto& canvas) mutable {
+        task(canvas);
+    });
 }
 
 void OffscreenCanvas::dispatchEvent(Event& event)

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -146,7 +146,7 @@ public:
 
     void commitToPlaceholderCanvas();
 
-    void legacyQueueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
+    void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) final;
     void dispatchEvent(Event&) final;
     bool isDetached() const { return m_detached; };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5168,7 +5168,7 @@ void WebGLRenderingContextBase::vertexAttribfvImpl(ASCIILiteral functionName, GC
 void WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent()
 {
     // It is safe to capture |this| because we keep the canvas element alive and it owns |this|.
-    canvasBase().legacyQueueTaskKeepingObjectAlive(TaskSource::WebGL, [this] {
+    canvasBase().queueTaskKeepingObjectAlive(TaskSource::WebGL, [this](auto&) {
         if (isContextStopped())
             return;
         if (!isContextLost())

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -97,7 +97,7 @@ bool WebGLSync::isSignaled() const
 
 void WebGLSync::scheduleAllowCacheUpdate(WebGLRenderingContextBase& context)
 {
-    context.canvasBase().legacyQueueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }]() {
+    context.canvasBase().queueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }](auto&) {
         protectedThis->m_allowCacheUpdate = true;
     });
 }

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -174,9 +174,9 @@ void TrackListBase::scheduleChangeEvent()
     // selected, the user agent must queue a task to fire a simple event named
     // change at the VideoTrackList object.
     m_isChangeEventScheduled = true;
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [this] {
-        m_isChangeEventScheduled = false;
-        dispatchEvent(Event::create(eventNames().changeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+    queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [](auto& trackList) {
+        trackList.m_isChangeEventScheduled = false;
+        trackList.dispatchEvent(Event::create(eventNames().changeEvent, Event::CanBubble::No, Event::IsCancelable::No));
     });
 }
 

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -132,14 +132,14 @@ void ScreenOrientation::lock(LockType lockType, Ref<DeferredPromise>&& promise)
         return;
     }
     if (auto previousPromise = manager->takeLockPromise()) {
-        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [previousPromise = WTFMove(previousPromise)]() mutable {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [previousPromise = WTFMove(previousPromise)](auto&) mutable {
             previousPromise->reject(Exception { ExceptionCode::AbortError, "A new lock request was started"_s });
         });
     }
     manager->setLockPromise(*this, WTFMove(promise));
     manager->lock(lockType, [this, protectedThis = makePendingActivity(*this)](std::optional<Exception>&& exception) mutable {
-        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, exception = WTFMove(exception)]() mutable {
-            auto* manager = this->manager();
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [exception = WTFMove(exception)](auto& orientation) mutable {
+            auto* manager = orientation.manager();
             if (!manager)
                 return;
 
@@ -263,7 +263,7 @@ void ScreenOrientation::stop()
 
     manager->removeObserver(*this);
     if (manager->lockRequester() == this) {
-        legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = manager->takeLockPromise()] {
+        queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [promise = manager->takeLockPromise()](auto&) {
             promise->reject(Exception { ExceptionCode::AbortError, "Document is no longer fully active"_s });
         });
     }

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -255,14 +255,14 @@ void Worker::reportError(const String& errorMessage)
     if (m_wasTerminated)
         return;
 
-    legacyQueueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [this, errorMessage] {
-        if (m_wasTerminated)
+    queueTaskKeepingObjectAlive(*this, TaskSource::DOMManipulation, [errorMessage](auto& worker) {
+        if (worker.m_wasTerminated)
             return;
 
-        auto event = Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No);
-        AbstractWorker::dispatchEvent(event);
-        if (!event->defaultPrevented() && scriptExecutionContext())
-            scriptExecutionContext()->addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Error, errorMessage));
+        Ref event = Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No);
+        worker.AbstractWorker::dispatchEvent(event);
+        if (!event->defaultPrevented() && worker.scriptExecutionContext())
+            worker.scriptExecutionContext()->addConsoleMessage(makeUnique<Inspector::ConsoleMessage>(MessageSource::JS, MessageType::Log, MessageLevel::Error, errorMessage));
     });
 }
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -190,7 +190,7 @@ void WorkerMessagingProxy::postMessageToWorkerObject(MessageWithMessagePorts&& m
             return;
 
         auto ports = MessagePort::entanglePorts(context, WTFMove(message.transferredPorts));
-        ActiveDOMObject::legacyQueueTaskKeepingObjectAlive(*workerObject, TaskSource::PostedMessageQueue, [worker = Ref { *workerObject }, message = WTFMove(message), userGestureForwarder = WTFMove(userGestureForwarder), ports = WTFMove(ports)] () mutable {
+        ActiveDOMObject::queueTaskKeepingObjectAlive(*workerObject, TaskSource::PostedMessageQueue, [worker = Ref { *workerObject }, message = WTFMove(message), userGestureForwarder = WTFMove(userGestureForwarder), ports = WTFMove(ports)](auto&) mutable {
             if (!worker->scriptExecutionContext())
                 return;
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -143,7 +143,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
     m_shouldDeferEventsDueToSuspension = true;
 
     if (m_hasPendingThrottledProgressEvent) {
-        m_target.legacyQueueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this] {
+        m_target.queueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this](auto&) {
             flushProgressEvent();
         });
     }
@@ -151,7 +151,7 @@ void XMLHttpRequestProgressEventThrottle::suspend()
 
 void XMLHttpRequestProgressEventThrottle::resume()
 {
-    m_target.legacyQueueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this] {
+    m_target.queueTaskKeepingObjectAlive(m_target, TaskSource::Networking, [this](auto&) {
         m_shouldDeferEventsDueToSuspension = false;
     });
 }

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -80,7 +80,7 @@ void XRDeviceProxy::initializeTrackingAndRendering(const WebCore::SecurityOrigin
     xrSystem->initializeTrackingAndRendering();
 
     // This is called from the constructor of WebXRSession. Since sessionDidInitializeInputSources()
-    // ends up calling legacyQueueTaskKeepingObjectAlive() which refs the WebXRSession object, we
+    // ends up calling queueTaskKeepingObjectAlive() which refs the WebXRSession object, we
     // should delay this call after the WebXRSession has finished construction.
     callOnMainRunLoop([this, weakThis = ThreadSafeWeakPtr { *this }]() {
         auto protectedThis = weakThis.get();


### PR DESCRIPTION
#### 43c78d5a07dc6af3c451208a16f94632a6f52bf0
<pre>
Reduce use of ActiveDOMObject::legacyQueueTaskKeepingObjectAlive()
<a href="https://bugs.webkit.org/show_bug.cgi?id=289357">https://bugs.webkit.org/show_bug.cgi?id=289357</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp:
(WebCore::MediaKeySystemAccess::createMediaKeys):
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemRequest.cpp:
(WebCore::MediaKeySystemRequest::allow):
* Source/WebCore/Modules/mediastream/RTCDtlsTransport.cpp:
(WebCore::RTCDtlsTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/RTCSctpTransport.cpp:
(WebCore::RTCSctpTransport::onStateChanged):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp:
(WebCore::LibWebRTCMediaEndpoint::createStatsCollector):
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::showSoon):
(WebCore::Notification::dispatchClickEvent):
* Source/WebCore/Modules/paymentrequest/PaymentRequest.cpp:
(WebCore::PaymentRequest::stop):
* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
(WebCore::PaymentResponse::stop):
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::appendQueuedReportIfCorrectType):
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::didCompleteLockRequest):
(WebCore::WebLockManager::query):
* Source/WebCore/Modules/webaudio/BaseAudioContext.cpp:
(WebCore::BaseAudioContext::decodeAudioData):
(WebCore::BaseAudioContext::postTask):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::encode):
* Source/WebCore/Modules/webcodecs/WebCodecsBase.cpp:
(WebCore::WebCodecsBase::scheduleDequeueEvent):
* Source/WebCore/Modules/webcodecs/WebCodecsUtilities.h:
(WebCore::postTaskToCodec):
* Source/WebCore/Modules/webxr/WebXRInputSourceArray.cpp:
(WebCore::WebXRInputSourceArray::update):
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::requestReferenceSpace):
(WebCore::WebXRSession::sessionDidInitializeInputSources):
(WebCore::WebXRSession::onFrame):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::dispatchMessage):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::dispatchMessages):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::enqueueTask):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::queueTaskKeepingObjectAlive):
(WebCore::HTMLCanvasElement::legacyQueueTaskKeepingObjectAlive): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::scheduleTask):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::queueTaskKeepingObjectAlive):
(WebCore::OffscreenCanvas::legacyQueueTaskKeepingObjectAlive): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::scheduleAllowCacheUpdate):
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::scheduleChangeEvent):
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::ScreenOrientation::lock):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::reportError):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::ready):
(WebCore::ServiceWorkerContainer::getRegistration):
(WebCore::ServiceWorkerContainer::updateRegistrationState):
(WebCore::ServiceWorkerContainer::updateWorkerState):
(WebCore::ServiceWorkerContainer::getRegistrations):
(WebCore::ServiceWorkerContainer::startMessages):
(WebCore::ServiceWorkerContainer::jobFailedWithException):
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
(WebCore::ServiceWorkerContainer::postMessage):
(WebCore::ServiceWorkerContainer::jobResolvedWithUnregistrationResult):
(WebCore::ServiceWorkerContainer::jobFailedLoadingScript):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::prepareToSend):
(WebCore::XMLHttpRequest::handleCancellation):
(WebCore::XMLHttpRequest::didFail):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::suspend):
(WebCore::XMLHttpRequestProgressEventThrottle::resume):
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::initializeTrackingAndRendering):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43c78d5a07dc6af3c451208a16f94632a6f52bf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94134 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99145 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71802 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29144 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84981 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52143 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10080 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2667 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43979 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80317 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101186 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21186 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80805 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21438 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19989 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24732 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14348 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20857 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24317 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22598 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->