### PR TITLE
[iOS] New line with English keyboard remains right-aligned after pasting right-aligned Arabic paragraph

### DIFF
--- a/LayoutTests/editing/input/ios/update-text-alignment-after-inserting-newline-expected.txt
+++ b/LayoutTests/editing/input/ios/update-text-alignment-after-inserting-newline-expected.txt
@@ -1,0 +1,13 @@
+Verifies that switching to an LTR input mode and then pressing Return automatically sets the base writing direction to LTR in a new left-aligned paragraph
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS editorCenter.x is > caretRect.left
+PASS successfullyParsed is true
+
+TEST COMPLETE
+عنوان بريدي الإلكتروني هو foo@me.com. أرسل لي تحديثًا عند وصولك إلى المطار
+
+
+

--- a/LayoutTests/editing/input/ios/update-text-alignment-after-inserting-newline.html
+++ b/LayoutTests/editing/input/ios/update-text-alignment-after-inserting-newline.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<style>
+body, html {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    font-family: system-ui;
+}
+
+.editor {
+    width: 300px;
+    height: 300px;
+    border: 1px solid lightgray;
+}
+</style>
+</head>
+<body>
+    <div contenteditable dir="rtl" class="editor">
+        <p style="text-align: right;">عنوان بريدي الإلكتروني هو foo@me.com. أرسل لي تحديثًا عند وصولك إلى المطار</p>
+    </div>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Verifies that switching to an LTR input mode and then pressing Return automatically sets the base writing direction to LTR in a new left-aligned paragraph");
+
+    const editor = document.querySelector(".editor");
+
+    async function doAfterInputEvent(callback) {
+        await UIHelper.callFunctionAndWaitForEvent(callback, editor, "input");
+    }
+
+    await UIHelper.activateElementAndWaitForInputSession(editor);
+    await UIHelper.setKeyboardInputModeIdentifier("en_US");
+
+    await doAfterInputEvent(async () => await UIHelper.enterText("\n"));
+    await UIHelper.ensurePresentationUpdate();
+    caretRect = await UIHelper.getUICaretViewRect();
+    editorCenter = UIHelper.midPointOfRect(editor.getBoundingClientRect());
+
+    shouldBeGreaterThan("editorCenter.x", "caretRect.left");
+
+    editor.blur();
+    await UIHelper.waitForKeyboardToHide();
+    finishJSTest();
+});
+</script>
+</html>

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -463,10 +463,10 @@ public:
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT void confirmMarkedText();
     WEBCORE_EXPORT void setTextAsChildOfElement(String&&, Element&);
-    WEBCORE_EXPORT void setTextAlignmentForChangedBaseWritingDirection(WritingDirection);
     WEBCORE_EXPORT void insertDictationPhrases(Vector<Vector<String>>&& dictationPhrases, id metadata);
     WEBCORE_EXPORT void setDictationPhrasesAsChildOfElement(const Vector<Vector<String>>& dictationPhrases, id metadata, Element&);
 #endif
+    WEBCORE_EXPORT void setTextAlignmentForChangedBaseWritingDirection(WritingDirection);
     
     enum class KillRingInsertionMode { PrependText, AppendText };
     void addRangeToKillRing(const SimpleRange&, KillRingInsertionMode);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7100,8 +7100,10 @@ void WebPage::insertTextAsync(const String& text, const EditingRange& replacemen
         return { direction == TextDirection::LTR ? WritingDirection::LeftToRight : WritingDirection::RightToLeft };
     }();
 
-    if (baseWritingDirectionFromInputMode)
+    if (baseWritingDirectionFromInputMode) {
         editor->setBaseWritingDirection(*baseWritingDirectionFromInputMode);
+        editor->setTextAlignmentForChangedBaseWritingDirection(*baseWritingDirectionFromInputMode);
+    }
 
     if (focusedElement && options.shouldSimulateKeyboardInput) {
         focusedElement->dispatchEvent(Event::create(eventNames().keyupEvent, Event::CanBubble::Yes, Event::IsCancelable::Yes));


### PR DESCRIPTION
#### 719ce9eaf771e8f44e19e3e4afc32194feb51f14
<pre>
[iOS] New line with English keyboard remains right-aligned after pasting right-aligned Arabic paragraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=289360">https://bugs.webkit.org/show_bug.cgi?id=289360</a>
<a href="https://rdar.apple.com/144986653">rdar://144986653</a>

Reviewed by Abrar Rahman Protyasha.

For platform consistency, when inserting a new paragraph using an LTR (or RTL) input mode, the new
parapraph should be both left-aligned and LTR (or right-aligned and RTL), respectively. We currently
only set the base writing direction, but don&apos;t adjust the alignment, which (for instance) may result
in the user inserting LTR text in a right-aligned paragraph after starting a new paragraph with an
English keyboard, if the selection was at the end of a right-aligned RTL paragraph.

To fix this, we move `Editor::setTextAlignmentForChangedBaseWritingDirection`, an existing helper
method, into platform-agnostic code so that we can invoke it from `WebPage::insertTextAsync`, if
the base writing direction is changed after inserting a newline.

* LayoutTests/editing/input/ios/update-text-alignment-after-inserting-newline-expected.txt: Added.
* LayoutTests/editing/input/ios/update-text-alignment-after-inserting-newline.html: Added.

Add a new layout test to exercise the change.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::setTextAlignmentForChangedBaseWritingDirection):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::setTextAlignmentForChangedBaseWritingDirection): Deleted.

Move this helper method out of iOS-specific code, and into `Editor.cpp`.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::insertTextAsync):

See above for more details.

Canonical link: <a href="https://commits.webkit.org/291820@main">https://commits.webkit.org/291820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe60452093a3f5734ba5eeba8d2d469ac57d4223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13679 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99103 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71784 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29130 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10368 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52125 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10052 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2634 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80298 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101142 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21144 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80791 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80960 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80166 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19987 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14306 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26307 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->