### PR TITLE
Remove unnecessary isolated copy in CacheStorageCache

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp
@@ -38,7 +38,6 @@ CacheStorageRecordInformation::CacheStorageRecordInformation(NetworkCache::Key&&
     , m_hasVaryStar(hasVaryStar)
     , m_varyHeaders(WTFMove(varyHeaders))
 {
-    RELEASE_ASSERT(!m_url.string().impl()->isAtom());
 }
 
 void CacheStorageRecordInformation::updateVaryHeaders(const WebCore::ResourceRequest& request, const WebCore::ResourceResponse::CrossThreadData& response)
@@ -86,12 +85,6 @@ CacheStorageRecordInformation CacheStorageRecordInformation::isolatedCopy() cons
         m_hasVaryStar,
         crossThreadCopy(m_varyHeaders)
     };
-}
-
-void CacheStorageRecordInformation::setURL(URL&& url)
-{
-    RELEASE_ASSERT(!url.string().impl()->isAtom());
-    m_url = WTFMove(url);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h
@@ -48,12 +48,12 @@ public:
     bool hasVaryStar() const { return m_hasVaryStar; }
     const HashMap<String, String>& varyHeaders() const { return m_varyHeaders; }
 
-    void setKey(NetworkCache::Key&& key) { m_key = WTFMove(key); }
+    void setKey(const NetworkCache::Key& key) { m_key = key; }
     void setSize(uint64_t size) { m_size = size; }
     void setIdentifier(uint64_t identifier) { m_identifier = identifier; }
     void setUpdateResponseCounter(double updateResponseCounter) { m_updateResponseCounter = updateResponseCounter; }
     void setInsertionTime(double insertionTime) { m_insertionTime = insertionTime; }
-    void setURL(URL&&);
+    void setURL(const URL& url) { m_url = url; }
 
 private:
     NetworkCache::Key m_key;


### PR DESCRIPTION
#### 7f3aeee4a6ba1745b5e4946a1f540bbdfa8f5ca8
<pre>
Remove unnecessary isolated copy in CacheStorageCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=289362">https://bugs.webkit.org/show_bug.cgi?id=289362</a>
<a href="https://rdar.apple.com/146503129">rdar://146503129</a>

Reviewed by Chris Dumez and Per Arne Vollan.

We used to make isolated copy for URL due to an unidentified crash. The crash is confirmed to be fixed by 289347@main,
so we can drop it and the assertions added to debug the issue.

* Source/WebKit/NetworkProcess/storage/CacheStorageCache.cpp:
(WebKit::CacheStorageCache::open):
(WebKit::CacheStorageCache::retrieveRecords):
(WebKit::CacheStorageCache::findExistingRecord):
(WebKit::CacheStorageCache::putRecordsAfterQuotaCheck):
(WebKit::CacheStorageCache::putRecordsInStore):
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.cpp:
(WebKit::CacheStorageRecordInformation::CacheStorageRecordInformation):
(WebKit::CacheStorageRecordInformation::setURL): Deleted.
* Source/WebKit/NetworkProcess/storage/CacheStorageRecord.h:
(WebKit::CacheStorageRecordInformation::setKey):
(WebKit::CacheStorageRecordInformation::setURL):

Canonical link: <a href="https://commits.webkit.org/291908@main">https://commits.webkit.org/291908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a7dcf369f48865be81cb41b041597794244a0f1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44600 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71774 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29117 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52113 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10039 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43916 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80287 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101123 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15388 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80781 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21377 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80952 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80151 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20037 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24699 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2065 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14287 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26288 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20796 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24256 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->