### PR TITLE
[JSC] Optimize DataView.prototype.byteLength handling in JIT

### DIFF
--- a/JSTests/microbenchmarks/dataview-byte-length-small-array.js
+++ b/JSTests/microbenchmarks/dataview-byte-length-small-array.js
@@ -1,0 +1,17 @@
+
+const b = new ArrayBuffer(16);
+const v1 = new DataView(b);
+const v2 = new DataView(b);
+const v3 = new DataView(b);
+const v4 = new DataView(b);
+
+function test(v1, v2, v3, v4) {
+    return v1.byteLength + v2.byteLength + v3.byteLength + v4.byteLength;
+}
+noInline(test);
+
+
+for (let i = 0; i < 1e6; i++) {
+    if (test(v1, v2, v3, v4) != 16 * 4)
+        throw new Error("bad");
+}

--- a/JSTests/stress/dataview-byte-length-large-array-oob-baseline.js
+++ b/JSTests/stress/dataview-byte-length-large-array-oob-baseline.js
@@ -1,0 +1,31 @@
+
+function test(v) {
+    return v.byteLength;
+}
+noInline(test);
+noDFG(test);
+
+let oneGiga = 1024 * 1024 * 1024;
+let twoGigs = 2 * oneGiga;
+let fourGigs = 4 * oneGiga;
+
+const buffer = new ArrayBuffer(fourGigs, { maxByteLength: fourGigs });
+const view = new DataView(buffer, 2, twoGigs);
+
+testLoopCount = 100;
+for (let i = 0; i < testLoopCount; i++) {
+    if (i == testLoopCount - 1) {
+        buffer.resize(1);
+        let didThrow = false;
+        try {
+            test(view);
+        } catch (e) {
+            didThrow = true;
+        }
+        if (!didThrow)
+            throw new Error("bad")
+    } else {
+        if (test(view) != twoGigs)
+            throw new Error("bad");
+    }
+}

--- a/JSTests/stress/dataview-byte-length-large-array-oob.js
+++ b/JSTests/stress/dataview-byte-length-large-array-oob.js
@@ -1,0 +1,29 @@
+
+function test(v) {
+    return v.byteLength;
+}
+noInline(test);
+
+let oneGiga = 1024 * 1024 * 1024;
+let twoGigs = 2 * oneGiga;
+let fourGigs = 4 * oneGiga;
+
+const buffer = new ArrayBuffer(fourGigs, { maxByteLength: fourGigs });
+const view = new DataView(buffer, 2, twoGigs);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i == testLoopCount - 1) {
+        buffer.resize(1);
+        let didThrow = false;
+        try {
+            test(view);
+        } catch (e) {
+            didThrow = true;
+        }
+        if (!didThrow)
+            throw new Error("bad")
+    } else {
+        if (test(view) != twoGigs)
+            throw new Error("bad");
+    }
+}

--- a/JSTests/stress/dataview-byte-length-large-array.js
+++ b/JSTests/stress/dataview-byte-length-large-array.js
@@ -1,0 +1,15 @@
+
+function test(v) {
+    return v.byteLength;
+}
+noInline(test);
+
+let oneGiga = 1024 * 1024 * 1024;
+let fourGigs = 4 * oneGiga;
+const b = new ArrayBuffer(fourGigs);
+const v = new DataView(b);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (test(v) != fourGigs)
+        throw new Error("bad");
+}

--- a/JSTests/stress/dataview-byte-length-small-array-oob-baseline.js
+++ b/JSTests/stress/dataview-byte-length-small-array-oob-baseline.js
@@ -1,0 +1,27 @@
+
+function test(v) {
+    return v.byteLength;
+}
+noInline(test);
+noDFG(test);
+
+const buffer = new ArrayBuffer(16, { maxByteLength: 32 });
+const view = new DataView(buffer, 8, 8);
+
+testLoopCount = 100
+for (let i = 0; i < testLoopCount; i++) {
+    if (i == testLoopCount - 1) {
+        buffer.resize(4);
+        let didThrow = false;
+        try {
+            test(view);
+        } catch (e) {
+            didThrow = true;
+        }
+        if (!didThrow)
+            throw new Error("bad")
+    } else {
+        if (test(view) != 8)
+            throw new Error("bad");
+    }
+}

--- a/JSTests/stress/dataview-byte-length-small-array-oob.js
+++ b/JSTests/stress/dataview-byte-length-small-array-oob.js
@@ -1,0 +1,25 @@
+
+function test(v) {
+    return v.byteLength;
+}
+noInline(test);
+
+const buffer = new ArrayBuffer(16, { maxByteLength: 32 });
+const view = new DataView(buffer, 8, 8);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i == testLoopCount - 1) {
+        buffer.resize(4);
+        let didThrow = false;
+        try {
+            test(view);
+        } catch (e) {
+            didThrow = true;
+        }
+        if (!didThrow)
+            throw new Error("bad")
+    } else {
+        if (test(view) != 8)
+            throw new Error("bad");
+    }
+}

--- a/JSTests/stress/dataview-byte-length-small-array.js
+++ b/JSTests/stress/dataview-byte-length-small-array.js
@@ -1,0 +1,13 @@
+
+function test(v) {
+    return v.byteLength;
+}
+noInline(test);
+
+const b = new ArrayBuffer(16);
+const v = new DataView(b);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (test(v) != 16)
+        throw new Error("bad");
+}

--- a/LayoutTests/inspector/model/remote-object/object-expected.txt
+++ b/LayoutTests/inspector/model/remote-object/object-expected.txt
@@ -330,14 +330,14 @@ EXPRESSION: new DataView(new ArrayBuffer(16))
         "_value": "ArrayBuffer"
       },
       {
-        "_name": "byteLength",
-        "_type": "number",
-        "_value": "16"
-      },
-      {
         "_name": "byteOffset",
         "_type": "number",
         "_value": "0"
+      },
+      {
+        "_name": "byteLength",
+        "_type": "number",
+        "_value": "16"
       }
     ],
     "_entries": null

--- a/Source/JavaScriptCore/bytecode/GetByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.cpp
@@ -94,6 +94,15 @@ inline bool GetByVariant::canMergeIntrinsicStructures(const GetByVariant& other)
         return logElementSize(thisType) == logElementSize(otherType);
     }
 
+    case DataViewByteLengthIntrinsic: {
+#if ASSERT_ENABLED
+        TypedArrayType thisType = typedArrayType((*m_structureSet.begin())->typeInfo().type());
+        TypedArrayType otherType = typedArrayType((*other.m_structureSet.begin())->typeInfo().type());
+        ASSERT(thisType == TypeDataView && otherType == TypeDataView);
+#endif
+        return true;
+    }
+
     default:
         return true;
     }

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp
@@ -51,6 +51,7 @@ bool IntrinsicGetterAccessCase::doesCalls() const
     case TypedArrayByteOffsetIntrinsic:
     case TypedArrayByteLengthIntrinsic:
     case TypedArrayLengthIntrinsic:
+    case DataViewByteLengthIntrinsic:
         return isResizableOrGrowableSharedTypedArrayIncludingDataView(structure()->classInfoForCells());
     default:
         return false;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4209,6 +4209,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case DataViewGetByteLengthAsInt52:
+        setNonCellTypeForNode(node, SpecInt52Any);
+        break;
+
+    case DataViewGetByteLength:
     case GetVectorLength: {
         setNonCellTypeForNode(node, SpecInt32Only);
         break;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -145,6 +145,8 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case EnumeratorInByVal:
         case EnumeratorHasOwnProperty:
         case GetIndexedPropertyStorage:
+        case DataViewGetByteLength:
+        case DataViewGetByteLengthAsInt52:
         case GetArrayLength:
         case GetUndetachedTypeArrayLength:
         case GetTypedArrayLengthAsInt52:
@@ -1611,6 +1613,18 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
                 def(HeapLocation(ArrayLengthLoc, MiscFields, node->child1()), LazyNode(node));
             return;
         }
+    }
+
+    case DataViewGetByteLength:
+    case DataViewGetByteLengthAsInt52: {
+        read(MiscFields);
+        if (node->mayBeResizableOrGrowableSharedArrayBuffer())
+            write(MiscFields);
+        else {
+            auto location = node->op() == DataViewGetByteLength ? DataViewByteLengthLoc : DataViewByteLengthAsInt52Loc;
+            def(HeapLocation(location, MiscFields, node->child1()), LazyNode(node));
+        }
+        return;
     }
 
     case GetUndetachedTypeArrayLength: {

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -297,6 +297,8 @@ bool doesGC(Graph& graph, Node* node)
     case Construct:
     case ConstructForwardVarargs:
     case ConstructVarargs:
+    case DataViewGetByteLength:
+    case DataViewGetByteLengthAsInt52:
     case DefineDataProperty:
     case DefineAccessorProperty:
     case DeleteById:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2465,6 +2465,12 @@ private:
             break;
         }
 
+        case DataViewGetByteLength:
+        case DataViewGetByteLengthAsInt52: {
+            fixEdge<DataViewObjectUse>(node->child1());
+            break;
+        }
+
         case GetTypedArrayByteOffsetAsInt52: {
             ArrayMode arrayMode = node->arrayMode().refine(m_graph, node, node->child1()->prediction(), ArrayMode::unusedIndexSpeculatedType);
             if (arrayMode.type() == Array::Generic)

--- a/Source/JavaScriptCore/dfg/DFGHeapLocation.h
+++ b/Source/JavaScriptCore/dfg/DFGHeapLocation.h
@@ -35,11 +35,13 @@ namespace JSC { namespace DFG {
 
 enum LocationKind {
     InvalidLocationKind,
-    
+
     ArrayLengthLoc,
     ArrayMaskLoc,
     VectorLengthLoc,
     ButterflyLoc,
+    DataViewByteLengthLoc,
+    DataViewByteLengthAsInt52Loc,
     CheckTypeInfoFlagsLoc,
     OverridesHasInstanceLoc,
     ClosureVariableLoc,

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1516,7 +1516,8 @@ private:
             }
             break;
         }
-            
+
+        case DataViewGetByteLength:
         case GetArrayLength:
         case GetVectorLength:
         case GetUndetachedTypeArrayLength: {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -2622,6 +2622,12 @@ public:
         return true;
     }
 
+    bool mayBeResizableOrGrowableSharedArrayBuffer()
+    {
+        ASSERT(op() == DataViewGetByteLength || op() == DataViewGetByteLengthAsInt52);
+        return m_opInfo.as<bool>();
+    }
+
     bool hasECMAMode()
     {
         switch (op()) {

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -613,6 +613,8 @@ namespace JSC { namespace DFG {
     macro(DataViewGetInt, NodeMustGenerate | NodeResultJS) /* The gets are must generate for now because they do bounds checks */ \
     macro(DataViewGetFloat, NodeMustGenerate | NodeResultDouble) \
     macro(DataViewSet, NodeMustGenerate | NodeMustGenerate | NodeHasVarArgs) \
+    macro(DataViewGetByteLength, NodeResultInt32) \
+    macro(DataViewGetByteLengthAsInt52, NodeResultInt52) \
     /* Date access */ \
     macro(DateGetInt32OrNaN, NodeResultJS) \
     macro(DateGetTime, NodeResultDouble) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1149,6 +1149,7 @@ private:
             break;
         }
 
+        case DataViewGetByteLength:
         case GetTypedArrayByteOffset:
         case GetArrayLength:
         case GetUndetachedTypeArrayLength:
@@ -1157,6 +1158,7 @@ private:
             break;
         }
 
+        case DataViewGetByteLengthAsInt52:
         case GetTypedArrayLengthAsInt52:
         case GetTypedArrayByteOffsetAsInt52: {
             setPrediction(SpecInt52Any);

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -414,7 +414,13 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ArrayPush:
         return node->arrayMode().alreadyChecked(graph, node, state.forNode(graph.varArgChild(node, 1)));
 
+    case DataViewGetByteLength:
+    case DataViewGetByteLengthAsInt52:
+        return !(state.forNode(node->child1()).m_type & ~(SpecDataViewObject));
+
     case CheckDetached:
+        return !(state.forNode(node->child1()).m_type & ~(SpecTypedArrayView | SpecDataViewObject));
+
     case GetTypedArrayByteOffset:
     case GetTypedArrayByteOffsetAsInt52:
         return !(state.forNode(node->child1()).m_type & ~(SpecTypedArrayView));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1552,6 +1552,10 @@ public:
 #if USE(LARGE_TYPED_ARRAYS)
     void compileGetTypedArrayLengthAsInt52(Node*);
 #endif
+    void compileDataViewGetByteLength(Node*);
+#if USE(LARGE_TYPED_ARRAYS)
+    void compileDataViewGetByteLengthAsInt52(Node*);
+#endif
 
     void compileCheckTypeInfoFlags(Node*);
     void compileCheckIdent(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3430,6 +3430,11 @@ void SpeculativeJIT::compile(Node* node)
         compileGetArrayLength(node);
         break;
 
+    case DataViewGetByteLength:
+        compileDataViewGetByteLength(node);
+        break;
+
+    case DataViewGetByteLengthAsInt52:
     case GetTypedArrayLengthAsInt52:
         // We do not support typed arrays larger than 2GB on 32-bit platforms.
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -473,6 +473,8 @@ inline CapabilityLevel canCompile(Node* node)
     case CreatePromise:
     case CreateGenerator:
     case CreateAsyncGenerator:
+    case DataViewGetByteLength:
+    case DataViewGetByteLengthAsInt52:
     case DataViewGetInt:
     case DataViewGetFloat:
     case DataViewSet:

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -1210,10 +1210,12 @@ public:
 #if USE(JSVALUE64)
     JumpList branchIfResizableOrGrowableSharedTypedArrayIsOutOfBounds(GPRReg baseGPR, GPRReg scratchGPR, GPRReg scratch2GPR, std::optional<TypedArrayType>);
     void loadTypedArrayByteLength(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, TypedArrayType);
+    std::tuple<Jump, JumpList> loadDataViewByteLength(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, TypedArrayType);
     void loadTypedArrayLength(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, std::optional<TypedArrayType>);
 #else
     JumpList branchIfResizableOrGrowableSharedTypedArrayIsOutOfBounds(GPRReg, GPRReg, GPRReg, std::optional<TypedArrayType>) { return { }; }
     void loadTypedArrayByteLength(GPRReg, GPRReg, GPRReg, GPRReg, TypedArrayType) { }
+    std::tuple<Jump, JumpList> loadDataViewByteLength(GPRReg, GPRReg, GPRReg, GPRReg, TypedArrayType) { return { }; };
     void loadTypedArrayLength(GPRReg, GPRReg, GPRReg, GPRReg, std::optional<TypedArrayType>) { }
 #endif
 
@@ -2137,7 +2139,8 @@ protected:
     void copyCalleeSavesToEntryFrameCalleeSavesBufferImpl(GPRReg calleeSavesBuffer);
 
     enum class TypedArrayField { Length, ByteLength };
-    void loadTypedArrayByteLengthImpl(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, std::optional<TypedArrayType>, TypedArrayField);
+    std::tuple<Jump, JumpList> loadTypedArrayByteLengthImpl(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, std::optional<TypedArrayType>, TypedArrayField);
+    void loadTypedArrayByteLengthCommonImpl(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, std::optional<TypedArrayType>, TypedArrayField);
 
     CodeBlock* const m_codeBlock;
     CodeBlock* const m_baselineCodeBlock;

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -195,6 +195,7 @@ namespace JSC {
     /* Getter intrinsics. */ \
     macro(TypedArrayLengthIntrinsic) \
     macro(TypedArrayByteLengthIntrinsic) \
+    macro(DataViewByteLengthIntrinsic) \
     macro(TypedArrayByteOffsetIntrinsic) \
     macro(UnderscoreProtoIntrinsic) \
     macro(SpeciesGetterIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp
@@ -62,7 +62,6 @@ namespace JSC {
   setBigInt64           dataViewProtoFuncSetBigInt64         DontEnum|Function       2
   setBigUint64          dataViewProtoFuncSetBigUint64        DontEnum|Function       2
   buffer                dataViewProtoGetterBuffer            DontEnum|ReadOnly|CustomAccessor
-  byteLength            dataViewProtoGetterByteLength        DontEnum|ReadOnly|CustomAccessor
   byteOffset            dataViewProtoGetterByteOffset        DontEnum|ReadOnly|CustomAccessor
 @end
 */
@@ -89,8 +88,8 @@ static JSC_DECLARE_HOST_FUNCTION(dataViewProtoFuncSetFloat32);
 static JSC_DECLARE_HOST_FUNCTION(dataViewProtoFuncSetFloat64);
 static JSC_DECLARE_HOST_FUNCTION(dataViewProtoFuncSetBigInt64);
 static JSC_DECLARE_HOST_FUNCTION(dataViewProtoFuncSetBigUint64);
+static JSC_DECLARE_HOST_FUNCTION(dataViewProtoGetterByteLength);
 static JSC_DECLARE_CUSTOM_GETTER(dataViewProtoGetterBuffer);
-static JSC_DECLARE_CUSTOM_GETTER(dataViewProtoGetterByteLength);
 static JSC_DECLARE_CUSTOM_GETTER(dataViewProtoGetterByteOffset);
 
 }
@@ -109,20 +108,22 @@ JSDataViewPrototype::JSDataViewPrototype(VM& vm, Structure* structure)
 {
 }
 
-JSDataViewPrototype* JSDataViewPrototype::create(VM& vm, Structure* structure)
+JSDataViewPrototype* JSDataViewPrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)
 {
     JSDataViewPrototype* prototype =
         new (NotNull, allocateCell<JSDataViewPrototype>(vm))
         JSDataViewPrototype(vm, structure);
-    prototype->finishCreation(vm);
+    prototype->finishCreation(vm, globalObject);
     return prototype;
 }
 
-void JSDataViewPrototype::finishCreation(VM& vm)
+void JSDataViewPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+
+    JSC_NATIVE_INTRINSIC_GETTER_WITHOUT_TRANSITION(vm.propertyNames->byteLength, dataViewProtoGetterByteLength, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly, DataViewByteLengthIntrinsic);
 }
 
 Structure* JSDataViewPrototype::createStructure(
@@ -234,13 +235,13 @@ JSC_DEFINE_CUSTOM_GETTER(dataViewProtoGetterBuffer, (JSGlobalObject* globalObjec
     RELEASE_AND_RETURN(scope, JSValue::encode(view->possiblySharedJSBuffer(globalObject)));
 }
 
-JSC_DEFINE_CUSTOM_GETTER(dataViewProtoGetterByteLength, (JSGlobalObject* globalObject, EncodedJSValue thisValue, PropertyName))
+JSC_DEFINE_HOST_FUNCTION(dataViewProtoGetterByteLength, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    JSDataView* view = jsDynamicCast<JSDataView*>(JSValue::decode(thisValue));
-    if (!view)
+    JSDataView* view = jsDynamicCast<JSDataView*>(callFrame->thisValue());
+    if (UNLIKELY(!view))
         return throwVMTypeError(globalObject, scope, "DataView.prototype.byteLength expects |this| to be a DataView object"_s);
 
     IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;

--- a/Source/JavaScriptCore/runtime/JSDataViewPrototype.h
+++ b/Source/JavaScriptCore/runtime/JSDataViewPrototype.h
@@ -41,7 +41,7 @@ public:
         return &vm.plainObjectSpace();
     }
 
-    static JSDataViewPrototype* create(VM&, Structure*);
+    static JSDataViewPrototype* create(VM&, JSGlobalObject*, Structure*);
     
     DECLARE_INFO;
     
@@ -49,7 +49,7 @@ public:
 
 private:
     JSDataViewPrototype(VM&, Structure*);
-    void finishCreation(VM&);
+    void finishCreation(VM&, JSGlobalObject*);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -982,7 +982,7 @@ void JSGlobalObject::init(VM& vm)
     
     m_typedArrayDataView.initLater(
         [] (LazyClassStructure::Initializer& init) {
-            init.setPrototype(JSDataViewPrototype::create(init.vm, JSDataViewPrototype::createStructure(init.vm, init.global, init.global->m_objectPrototype.get())));
+            init.setPrototype(JSDataViewPrototype::create(init.vm, init.global, JSDataViewPrototype::createStructure(init.vm, init.global, init.global->m_objectPrototype.get())));
             init.setStructure(JSDataView::createStructure(init.vm, init.global, init.prototype));
             init.setConstructor(JSDataViewConstructor::create(init.vm, init.global, JSDataViewConstructor::createStructure(init.vm, init.global, init.global->m_functionPrototype.get()), init.prototype, "DataView"_s));
             init.global->typedArrayStructure(TypeDataView, /* isResizableOrGrowableShared */ true); /* Initialize resizable Structure too */


### PR DESCRIPTION
#### e6f31f64c264e758f2f357b83e71dd404d6c8f73
<pre>
[JSC] Optimize DataView.prototype.byteLength handling in JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=289365">https://bugs.webkit.org/show_bug.cgi?id=289365</a>
<a href="https://rdar.apple.com/146511506">rdar://146511506</a>

Reviewed by Yusuke Suzuki.

Introduced DataViewByteLengthIntrinsic to improve inline caching and JIT
optimizations for DataView.prototype.byteLength. With this change, the
byteLength property’s order is rearranged in the DataView property table.
Consequently, object-expected.txt has been updated accordingly.

MicroBenchmarks Results:

                                           without                     with

dataview-byte-length-small-array       14.7764+-0.0405     ^      4.6604+-0.0182        ^ definitely 2.8164x faster

* JSTests/microbenchmarks/dataview-byte-length-small-array.js: Added.
(test):
* JSTests/stress/dataview-byte-length-large-array-oob.js: Added.
(test):
(i.i.testLoopCount.1.catch):
* JSTests/stress/dataview-byte-length-large-array.js: Added.
(test):
* JSTests/stress/dataview-byte-length-small-array-oob.js: Added.
(test):
(i.i.testLoopCount.1.catch):
* JSTests/stress/dataview-byte-length-small-array.js: Added.
(test):
* Source/JavaScriptCore/assembler/AbortReason.h:
* Source/JavaScriptCore/bytecode/GetByVariant.cpp:
(JSC::GetByVariant::canMergeIntrinsicStructures const):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::canEmitIntrinsicGetter):
(JSC::InlineCacheCompiler::emitIntrinsicGetter):
* Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.cpp:
(JSC::IntrinsicGetterAccessCase::doesCalls const):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArrayMode.cpp:
(JSC::DFG::ArrayMode::alreadyChecked const):
(JSC::DFG::toTypedArrayType):
(JSC::DFG::toArrayType):
* Source/JavaScriptCore/dfg/DFGArrayMode.h:
(JSC::DFG::ArrayMode::isSomeTypedArrayViewOrDataView const):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicGetter):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileGetByVal):
(JSC::DFG::SpeculativeJIT::compileGetTypedArrayLengthAsInt52):
(JSC::DFG::SpeculativeJIT::compilePutByVal):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::typedArrayLength):
(JSC::FTL::DFG::LowerDFGToB3::compileGetArrayLength):
(JSC::FTL::DFG::LowerDFGToB3::compileGetTypedArrayLengthAsInt52):
(JSC::FTL::DFG::LowerDFGToB3::compileGetByValImpl):
(JSC::FTL::DFG::LowerDFGToB3::compilePutByVal):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::loadTypedArrayByteLengthImpl):
(JSC::AssemblyHelpers::loadTypedArrayByteLengthCommonImpl):
(JSC::AssemblyHelpers::loadTypedArrayByteLength):
(JSC::AssemblyHelpers::loadDataViewByteLength):
(JSC::AssemblyHelpers::loadTypedArrayLength):
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
(JSC::AssemblyHelpers::loadDataViewByteLength):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSDataViewPrototype.cpp:
(JSC::JSDataViewPrototype::create):
(JSC::JSDataViewPrototype::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSDataViewPrototype.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):

Canonical link: <a href="https://commits.webkit.org/291993@main">https://commits.webkit.org/291993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/165a7158cb69e9d3fd9b9df27630d2aeb50f2120

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14152 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45075 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72163 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29476 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85379 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52494 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3081 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44399 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87241 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80670 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3187 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101623 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93207 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21616 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81162 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81402 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20108 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2476 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14835 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26722 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115874 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21272 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23010 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->