### PR TITLE
Address more Safer CPP failures in WebKit/UIProcess/Cocoa

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -137,12 +137,6 @@ UIProcess/BackgroundProcessResponsivenessTimer.cpp
 UIProcess/Cocoa/GroupActivities/GroupActivitiesCoordinator.mm
 UIProcess/Cocoa/LegacyDownloadClient.mm
 UIProcess/Cocoa/ModelElementControllerCocoa.mm
-UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
-UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
-UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
-UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
-UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
-UIProcess/Cocoa/WKEditCommand.mm
 UIProcess/Extensions/Cocoa/WebExtensionActionCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionCommandCocoa.mm
 UIProcess/Extensions/Cocoa/WebExtensionURLSchemeHandlerCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -23,7 +23,6 @@ UIProcess/API/Cocoa/WKWebViewTesting.mm
 UIProcess/API/Cocoa/_WKDataTask.mm
 UIProcess/API/Cocoa/_WKDownload.mm
 UIProcess/Cocoa/GroupActivities/GroupActivitiesSessionNotifier.mm
-UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
 UIProcess/mac/WebContextMenuProxyMac.mm
 UIProcess/mac/WebViewImpl.mm
 WebProcess/Automation/WebAutomationSessionProxy.cpp

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -47,8 +47,10 @@ NavigationSOAuthorizationSession::~NavigationSOAuthorizationSession()
 {
     if (m_callback)
         m_callback(true);
-    if (state() == State::Waiting && page())
-        page()->removeDidMoveToWindowObserver(*this);
+    if (state() == State::Waiting) {
+        if (RefPtr page = this->page())
+            page->removeDidMoveToWindowObserver(*this);
+    }
 }
 
 void NavigationSOAuthorizationSession::shouldStartInternal()
@@ -63,7 +65,7 @@ void NavigationSOAuthorizationSession::shouldStartInternal()
         setState(State::Waiting);
         page->addDidMoveToWindowObserver(*this);
         ASSERT(page->mainFrame());
-        m_waitingPageActiveURL = page->pageLoadState().activeURL();
+        m_waitingPageActiveURL = page->protectedPageLoadState()->activeURL();
         return;
     }
     start();
@@ -88,7 +90,7 @@ bool NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting() con
 {
     AUTHORIZATIONSESSION_RELEASE_LOG("pageActiveURLDidChangeDuringWaiting");
     RefPtr page = this->page();
-    return !page || page->pageLoadState().activeURL() != m_waitingPageActiveURL;
+    return !page || page->protectedPageLoadState()->activeURL() != m_waitingPageActiveURL;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm
@@ -194,7 +194,7 @@ void PopUpSOAuthorizationSession::initSecretWebView()
     [m_secretWebView setUIDelegate:m_secretDelegate.get()];
     [m_secretWebView setNavigationDelegate:m_secretDelegate.get()];
 
-    RELEASE_ASSERT(!m_secretWebView->_page->preferences().isExtensibleSSOEnabled());
+    RELEASE_ASSERT(!m_secretWebView->_page->protectedPreferences()->isExtensibleSSOEnabled());
     WTFLogAlways("SecretWebView is created.");
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm
@@ -180,9 +180,9 @@ bool SubFrameSOAuthorizationSession::shouldInterruptLoadForCSPFrameAncestorsOrXF
     Vector<Ref<SecurityOrigin>> frameAncestorOrigins;
 
     ASSERT(navigationAction());
-    if (auto* targetFrame = navigationAction()->targetFrame()) {
+    if (RefPtr targetFrame = navigationAction()->targetFrame()) {
         if (auto parentFrameHandle = targetFrame->parentFrameHandle()) {
-            for (auto* parent = WebFrameProxy::webFrame(parentFrameHandle->frameID()); parent; parent = parent->parentFrame())
+            for (RefPtr parent = WebFrameProxy::webFrame(parentFrameHandle->frameID()); parent; parent = parent->parentFrame())
                 frameAncestorOrigins.append(SecurityOrigin::create(parent->url()));
         }
     }

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm
@@ -43,7 +43,8 @@
 {
     ASSERT(RunLoop::isMain() && completion);
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization (authorization = %p, _session = %p)", authorization, _session.get());
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization: No session, so completing with NO as success state.");
         ASSERT_NOT_REACHED();
         completion(NO, nil);
@@ -57,7 +58,7 @@
     }
 
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization: presentingViewController %p", viewController);
-    _session->presentViewController(viewController, completion);
+    session->presentViewController(viewController, completion);
 }
 
 - (void)authorizationDidNotHandle:(SOAuthorization *)authorization
@@ -65,26 +66,28 @@
     ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidNotHandle: (authorization = %p, _session = %p)", authorization, _session.get());
     LOG_ERROR("Could not handle AppSSO.");
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidNotHandle: No session, so returning early.");
         ASSERT_NOT_REACHED();
         return;
     }
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidNotHandle: Falling back to web path.");
-    _session->fallBackToWebPath();
+    session->fallBackToWebPath();
 }
 
 - (void)authorizationDidCancel:(SOAuthorization *)authorization
 {
     ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidCancel: (authorization = %p, _session = %p)", authorization, _session.get());
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidCancel: No session, so returning early.");
         ASSERT_NOT_REACHED();
         return;
     }
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidCancel: Aborting session.");
-    _session->abort();
+    session->abort();
 }
 
 - (void)authorizationDidComplete:(SOAuthorization *)authorization
@@ -92,13 +95,14 @@
     ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidComplete: (authorization = %p, _session = %p)", authorization, _session.get());
     LOG_ERROR("Complete AppSSO without any data.");
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidComplete: No session, so returning early.");
         ASSERT_NOT_REACHED();
         return;
     }
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorizationDidComplete: Falling back to web path.");
-    _session->fallBackToWebPath();
+    session->fallBackToWebPath();
 }
 
 - (void)authorization:(SOAuthorization *)authorization didCompleteWithHTTPAuthorizationHeaders:(NSDictionary *)httpAuthorizationHeaders
@@ -106,26 +110,28 @@
     ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithHTTPAuthorizationHeaders: (authorization = %p, _session = %p)", authorization, _session.get());
     LOG_ERROR("Complete AppSSO with unexpected callback.");
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithHTTPAuthorizationHeaders: No session, so returning early.");
         ASSERT_NOT_REACHED();
         return;
     }
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithHTTPAuthorizationHeaders: Falling back to web path.");
-    _session->fallBackToWebPath();
+    session->fallBackToWebPath();
 }
 
 - (void)authorization:(SOAuthorization *)authorization didCompleteWithHTTPResponse:(NSHTTPURLResponse *)httpResponse httpBody:(NSData *)httpBody
 {
     ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithHTTPResponse: (authorization = %p, _session = %p)", authorization, _session.get());
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithHTTPResponse: No session, so returning early.");
         ASSERT_NOT_REACHED();
         return;
     }
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithHTTPResponse: Completing.");
-    _session->complete(httpResponse, httpBody);
+    session->complete(httpResponse, httpBody);
 }
 
 - (void)authorization:(SOAuthorization *)authorization didCompleteWithError:(NSError *)error
@@ -134,23 +140,24 @@
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: (authorization = %p, _session = %p)", authorization, _session.get());
     if (error.code)
         LOG_ERROR("Could not complete AppSSO operation. Error: %d", error.code);
-    if (!_session) {
+    RefPtr session = _session;
+    if (!session) {
         WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: No session, so returning early.");
         ASSERT_NOT_REACHED();
         return;
     }
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("authorization:didCompleteWithError: Falling back to web path.");
-    _session->fallBackToWebPath();
+    session->fallBackToWebPath();
 }
 
 - (void)setSession:(RefPtr<WebKit::SOAuthorizationSession>&&)session
 {
     RELEASE_ASSERT(RunLoop::isMain());
     WKSOAUTHORIZATIONDELEGATE_RELEASE_LOG("setSession: (existing session = %p, new session = %p)", _session.get(), session.get());
-    _session = WTFMove(session);
+    _session = session.copyRef();
 
-    if (_session)
-        _session->shouldStart();
+    if (session)
+        session->shouldStart();
 }
 @end
 

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm
@@ -158,7 +158,7 @@ bool UserMediaPermissionRequestManagerProxy::permittedToCaptureVideo()
 #if ENABLE(MEDIA_STREAM)
 void UserMediaPermissionRequestManagerProxy::requestSystemValidation(const WebPageProxy& page, UserMediaPermissionRequestProxy& request, CompletionHandler<void(bool)>&& callback)
 {
-    if (page.preferences().mockCaptureDevicesEnabled()) {
+    if (page.protectedPreferences()->mockCaptureDevicesEnabled()) {
         callback(true);
         return;
     }

--- a/Source/WebKit/UIProcess/Cocoa/WKEditCommand.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKEditCommand.mm
@@ -52,13 +52,13 @@
 - (void)undoEditing:(id)sender
 {
     ASSERT([sender isKindOfClass:WKEditCommand.class]);
-    [sender command].unapply();
+    Ref { [sender command] }->unapply();
 }
 
 - (void)redoEditing:(id)sender
 {
     ASSERT([sender isKindOfClass:WKEditCommand.class]);
-    [sender command].reapply();
+    Ref { [sender command] }->reapply();
 }
 
 @end


### PR DESCRIPTION
#### 27dba1b6f4d22a9ebaeeaf753044801e77279705
<pre>
Address more Safer CPP failures in WebKit/UIProcess/Cocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=289366">https://bugs.webkit.org/show_bug.cgi?id=289366</a>

Reviewed by Darin Adler.

* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
(WebKit::NavigationSOAuthorizationSession::~NavigationSOAuthorizationSession):
(WebKit::NavigationSOAuthorizationSession::shouldStartInternal):
(WebKit::NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting const):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/PopUpSOAuthorizationSession.mm:
(WebKit::PopUpSOAuthorizationSession::initSecretWebView):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::continueStartAfterGetAuthorizationHints):
(WebKit::SOAuthorizationSession::complete):
(WebKit::SOAuthorizationSession::presentViewController):
(WebKit::SOAuthorizationSession::dismissViewController):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SubFrameSOAuthorizationSession.mm:
(WebKit::SubFrameSOAuthorizationSession::shouldInterruptLoadForCSPFrameAncestorsOrXFrameOptions):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/WKSOAuthorizationDelegate.mm:
(-[WKSOAuthorizationDelegate authorization:presentViewController:withCompletion:]):
(-[WKSOAuthorizationDelegate authorizationDidNotHandle:]):
(-[WKSOAuthorizationDelegate authorizationDidCancel:]):
(-[WKSOAuthorizationDelegate authorizationDidComplete:]):
(-[WKSOAuthorizationDelegate authorization:didCompleteWithHTTPAuthorizationHeaders:]):
(-[WKSOAuthorizationDelegate authorization:didCompleteWithHTTPResponse:httpBody:]):
(-[WKSOAuthorizationDelegate authorization:didCompleteWithError:]):
(-[WKSOAuthorizationDelegate setSession:]):
* Source/WebKit/UIProcess/Cocoa/UserMediaPermissionRequestManagerProxy.mm:
(WebKit::UserMediaPermissionRequestManagerProxy::requestSystemValidation):
* Source/WebKit/UIProcess/Cocoa/WKEditCommand.mm:
(-[WKEditorUndoTarget undoEditing:]):
(-[WKEditorUndoTarget redoEditing:]):

Canonical link: <a href="https://commits.webkit.org/291824@main">https://commits.webkit.org/291824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/940390a848fdb27864e4fa31d437a6531ff99242

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44620 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/13980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71785 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29131 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84959 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52126 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10053 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43936 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101143 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21145 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15398 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80792 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/80959 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80167 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24713 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2071 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14307 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15094 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21129 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26308 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20816 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->