### PR TITLE
REGRESSION(291652@main): accessibility-node-memory-management.html is timing out

### DIFF
--- a/LayoutTests/accessibility/accessibility-node-memory-management-expected.txt
+++ b/LayoutTests/accessibility/accessibility-node-memory-management-expected.txt
@@ -1,15 +1,7 @@
 This test makes sure that AccessibilityNodeObjects are properly detached when the node they point to is deleted.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: axButton.role === detachedRole
 
-
-Button role: AXRole: AXButton
-Button role after being detached: AXRole:
-PASS buttonRole != detachedRole is true
-Canvas button role: AXRole: AXButton
-PASS canvasButtonRole is buttonRole
-Canvas button role after being detached: AXRole:
-PASS detachedCanvasButtonRole is detachedRole
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/accessibility-node-memory-management.html
+++ b/LayoutTests/accessibility/accessibility-node-memory-management.html
@@ -2,41 +2,47 @@
 <html>
 <head>
 <script src="../resources/accessibility-helper.js"></script>
-<script src="../resources/js-test-pre.js"></script>
+<script src="../resources/js-test.js"></script>
 </head>
 <body>
 
 <canvas id="canvas" tabindex="-1"></canvas>
 
-<p id="description"></p>
-<div id="console"></div>
-
 <script>
-    description("This test makes sure that AccessibilityNodeObjects are properly detached when the node they point to is deleted.");
+var output = "This test makes sure that AccessibilityNodeObjects are properly detached when the node they point to is deleted.\n\n";
 
-    if (window.testRunner && window.accessibilityController) {
-        window.jsTestIsAsync = true;
-        testRunner.dumpAsText();
 
-        // Create an ordinary button on the page, focus it and get its accessibility role.
-        var button = document.createElement('button');
-        document.body.appendChild(button);
-        button.focus();
+if (window.testRunner && window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        axButton = accessibilityController.focusedElement;
-        buttonRole = axButton.role;
-        debug("Button role: " + buttonRole);
+    var canvas = document.getElementById("canvas");
+    // Create an ordinary button on the page, focus it and get its accessibility role.
+    var button = document.createElement("button");
+    document.body.appendChild(button);
+    button.focus();
+
+    var detachedRole = null;
+    var buttonRole = null;
+    var axCanvas = null;
+    setTimeout(async function() {
+        await waitFor(() => {
+            axButton = accessibilityController.focusedElement;
+            if (!axButton)
+                return false;
+            buttonRole = axButton.role;
+            return buttonRole.toLowerCase().includes("button");
+        });
 
         // Now remove the button from the tree and get the role of the detached accessibility object.
         document.body.removeChild(button);
-        detachedRole = axButton.role;
-        debug("Button role after being detached: " + detachedRole);
-        shouldBeTrue("buttonRole != detachedRole");
+        await waitFor(() => {
+            detachedRole = axButton.role;
+            return detachedRole !== buttonRole;
+        });
 
         // This time create a button that's a child of a canvas element. It will be focusable but not rendered.
         // In particular, this will create an AccessibilityNodeObject rather than an AccessibilityRenderObject.
-        var canvas = document.getElementById('canvas');
-        button = document.createElement('button');
+        button = document.createElement("button");
         canvas.appendChild(button);
 
         // Note: Focusing the button and using that to get its accessibility object creates an extra
@@ -44,34 +50,26 @@
         // canvas and get its first child.
         canvas.focus();
 
-        var axCanvas = null;
-        setTimeout(async function() {
-            await waitFor(() => {
-                axCanvas = accessibilityController.focusedElement;
-                return axCanvas.childrenCount > 0;
-            });
-            axButton = axCanvas.childAtIndex(0);
-            canvasButtonRole = axButton.role;
-            debug("Canvas button role: " + canvasButtonRole);
-            shouldBe("canvasButtonRole", "buttonRole");
+        await waitFor(() => {
+            axCanvas = accessibilityController.accessibleElementById("canvas");
+            axButton = axCanvas?.childAtIndex(0);
+            return axButton && axButton.role === buttonRole;
+        });
 
-            // Now delete the last reference to the button.
-            canvas.removeChild(button);
-            // Explicitly run garbage collection now. Since there are no more references to the button,
-            // it will be destroyed.
-            gc();
+        // Now delete the last reference to the button.
+        canvas.removeChild(button);
+        // Explicitly run garbage collection now. Since there are no more references to the button,
+        // it will be destroyed.
+        gc();
 
-            // Ensure that the accessibility object is detached by checking its role.
-            detachedCanvasButtonRole = axButton.role;
-            debug("Canvas button role after being detached: " + detachedCanvasButtonRole);
-            shouldBe("detachedCanvasButtonRole", "detachedRole");
+        // Ensure that the accessibility object is detached by checking its role.
+        detachedCanvasButtonRole = axButton.role;
+        output += await expectAsync("axButton.role", "detachedRole");
 
-            finishJSTest();
-        }, 0);
-    }
-
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
-
-<script src="../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/glib/accessibility/accessibility-node-memory-management-expected.txt
+++ b/LayoutTests/platform/glib/accessibility/accessibility-node-memory-management-expected.txt
@@ -1,15 +1,7 @@
 This test makes sure that AccessibilityNodeObjects are properly detached when the node they point to is deleted.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+PASS: axButton.role === detachedRole
 
-
-Button role: AXRole: AXButton
-Button role after being detached: AXRole: AXInvalid
-PASS buttonRole != detachedRole is true
-Canvas button role: AXRole: AXButton
-PASS canvasButtonRole is buttonRole
-Canvas button role after being detached: AXRole: AXInvalid
-PASS detachedCanvasButtonRole is detachedRole
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2031,8 +2031,6 @@ webkit.org/b/289254 [ Debug ] imported/w3c/web-platform-tests/mediacapture-strea
 
 webkit.org/b/289284 fast/canvas/image-buffer-resource-limits.html [ Pass Timeout Crash ]
 
-webkit.org/b/289287 [ Release ] accessibility/accessibility-node-memory-management.html [ Timeout ]
-
 webkit.org/b/289347 [ arm64 ] http/tests/site-isolation/fullscreen.html [ Pass Failure ]
 
 # webkit.org/b/289298 [ macOS wk2 Release ] 3x imported/w3c/web-platform-tests/css/css-conditional/container-queries/canvas-as-container-00*.html are flaky failures.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1574,9 +1574,6 @@ webkit.org/b/215450 imported/w3c/web-platform-tests/media-source/mediasource-cha
 # <rdar://problem/59785942> [ iOS macOS ] imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-blocked.sub.html is flaky failing
 imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-blocked.sub.html [ Pass Failure ]
 
-# <rdar://problem/60173203> [ Mac ] accessibility/accessibility-node-memory-management.html is flaky failing and crashing.
-accessibility/accessibility-node-memory-management.html [ Pass Failure Crash ]
-
 # <rdar://problem/60290943> [ Mac ] inspector/unit-tests/test-harness-expect-functions.html is flaky crashing.
 inspector/unit-tests/test-harness-expect-functions.html [ Pass Crash ]
 

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2877,15 +2877,11 @@ void AXObjectCache::handleAttributeChange(Element* element, const QualifiedName&
         postNotification(element, AXNotification::LiveRegionStatusChanged);
 
 #if PLATFORM(MAC)
-        if (m_sortedIDListsInitialized) {
-            // Once the sorted ID lists have been initialized for the first time, we rely
-            // on handling these dynamic updates to keep them up-to-date.
-            if (RefPtr object = getOrCreate(element)) {
-                if (object->supportsLiveRegion())
-                    addSortedObject(*object, PreSortedObjectType::LiveRegion);
-                else
-                    removeLiveRegion(*object);
-            }
+        if (RefPtr object = getOrCreate(element)) {
+            if (object->supportsLiveRegion())
+                addSortedObject(*object, PreSortedObjectType::LiveRegion);
+            else
+                removeLiveRegion(*object);
         }
 #endif // PLATFORM(MAC)
     }

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -607,8 +607,8 @@ public:
 #endif
 
 #if PLATFORM(MAC)
-    AXCoreObject::AccessibilityChildrenVector sortedLiveRegions() const;
-    AXCoreObject::AccessibilityChildrenVector sortedNonRootWebAreas() const;
+    AXCoreObject::AccessibilityChildrenVector sortedLiveRegions();
+    AXCoreObject::AccessibilityChildrenVector sortedNonRootWebAreas();
     void addSortedObject(AccessibilityObject&, PreSortedObjectType);
     void removeLiveRegion(AccessibilityObject&);
     void initializeSortedIDLists();

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -170,6 +170,8 @@ RefPtr<AXIsolatedTree> AXIsolatedTree::create(AXObjectCache& axObjectCache)
     if (axFocus)
         tree->setFocusedNodeID(axFocus->objectID());
     tree->setSelectedTextMarkerRange(document->selection().selection());
+    tree->setInitialSortedLiveRegions(axIDs(axObjectCache.sortedLiveRegions()));
+    tree->setInitialSortedNonRootWebAreas(axIDs(axObjectCache.sortedNonRootWebAreas()));
     tree->updateLoadingProgress(axObjectCache.loadingProgress());
 
     const auto relations = axObjectCache.relations();
@@ -1082,6 +1084,20 @@ AXCoreObject::AccessibilityChildrenVector AXIsolatedTree::sortedNonRootWebAreas(
 {
     ASSERT(!isMainThread());
     return objectsForIDs(m_sortedNonRootWebAreaIDs);
+}
+
+void AXIsolatedTree::setInitialSortedLiveRegions(Vector<AXID> liveRegionIDs)
+{
+    ASSERT(isMainThread());
+
+    m_sortedLiveRegionIDs = WTFMove(liveRegionIDs);
+}
+
+void AXIsolatedTree::setInitialSortedNonRootWebAreas(Vector<AXID> webAreaIDs)
+{
+    ASSERT(isMainThread());
+
+    m_sortedNonRootWebAreaIDs = WTFMove(webAreaIDs);
 }
 
 std::optional<AXID> AXIsolatedTree::focusedNodeID()

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -487,6 +487,10 @@ public:
 
     void sortedLiveRegionsDidChange(Vector<AXID>);
     void sortedNonRootWebAreasDidChange(Vector<AXID>);
+
+    void setInitialSortedLiveRegions(Vector<AXID>);
+    void setInitialSortedNonRootWebAreas(Vector<AXID>);
+
     void queueNodeUpdate(AXID, const NodeUpdateOptions&);
     void queueNodeRemoval(const AccessibilityObject&);
     void processQueuedNodeUpdates();


### PR DESCRIPTION
#### c0673b1cf7b66732ed2b9633586e35bd31f53003
<pre>
REGRESSION(291652@main): accessibility-node-memory-management.html is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=289371">https://bugs.webkit.org/show_bug.cgi?id=289371</a>
<a href="https://rdar.apple.com/146514331">rdar://146514331</a>

Reviewed by Chris Fleizach.

291652@main caused this test to regress only because it changed the timing on when the accessibility tree is built
after a focus change, exposing an existing bug where depending on the interleaving and timing of the recomputation of
is-ignored and handling children-changed, we can compute the wrong accessibility tree.

We could fix this, but really don&apos;t need to with the enablement of ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), which
makes us immune to these minor timing differences.

This commit rewrites accessibility-node-memory-management.html to a more modern style that is properly async considering
the dynamic page changes from JS it performs.

In the process of trying to understand how 291652@main caused this issue, I ended up polishing the change up a bit more.
With this commit:

  - We now only initializeSortedIDLists and maintain these eagerly sorted lists when an AT actually needs them. This
    avoids incurring a cost for ATs that will never need these, like Hover Text.

  - We now properly initalize the isolated tree the sorted lists upon creation, rather than creating a tree and waiting
    for them to be synced over, causing a short period where clients can make requests to the tree but the state is
    missing.

  - onDocumentRenderTreeCreation now starts the cache-update timer if it&apos;s not active. This is pretty important
    considering this list is processed as part of performDeferredCacheUpdate.

* LayoutTests/accessibility/accessibility-node-memory-management-expected.txt:
* LayoutTests/accessibility/accessibility-node-memory-management.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::handleAttributeChange):
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::create):
(WebCore::AXIsolatedTree::setInitialSortedLiveRegions):
(WebCore::AXIsolatedTree::setInitialSortedNonRootWebAreas):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::onDocumentRenderTreeCreation):
(WebCore::AXObjectCache::platformPerformDeferredCacheUpdate):
(WebCore::AXObjectCache::sortedLiveRegions):
(WebCore::AXObjectCache::sortedNonRootWebAreas):
(WebCore::AXObjectCache::addSortedObject):
(WebCore::AXObjectCache::removeLiveRegion):
(WebCore::AXObjectCache::initializeSortedIDLists):
(WebCore::AXObjectCache::sortedLiveRegions const): Deleted.
(WebCore::AXObjectCache::sortedNonRootWebAreas const): Deleted.

Canonical link: <a href="https://commits.webkit.org/291832@main">https://commits.webkit.org/291832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbc0b31b007d8496383e0d53f4201ead621b8218

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96196 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29150 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97148 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10397 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84991 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52150 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10088 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2679 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43991 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2769 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101199 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80813 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80194 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/19995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24740 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14360 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21182 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20869 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->