### PR TITLE
Address Safer CPP warnings in VTTRegion

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -788,7 +788,6 @@ html/track/TextTrack.cpp
 html/track/TextTrackCue.cpp
 html/track/TrackBase.cpp
 html/track/VTTCue.cpp
-html/track/VTTRegion.cpp
 html/track/VideoTrack.cpp
 html/track/WebVTTParser.cpp
 inspector/CommandLineAPIModule.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -427,7 +427,6 @@ html/track/TextTrackCueGeneric.cpp
 html/track/TextTrackList.cpp
 html/track/TrackBase.cpp
 html/track/VTTCue.cpp
-html/track/VTTRegion.cpp
 html/track/VideoTrackList.cpp
 inspector/CommandLineAPIHost.cpp
 inspector/DOMPatchSupport.cpp

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4830,6 +4830,11 @@ DOMTokenList& Element::classList()
     return *data.classList();
 }
 
+Ref<DOMTokenList> Element::protectedClassList()
+{
+    return classList();
+}
+
 SpaceSplitString Element::partNames() const
 {
     return hasRareData() ? elementRareData()->partNames() : SpaceSplitString();

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -593,6 +593,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Element*> closest(const String& selectors);
 
     WEBCORE_EXPORT DOMTokenList& classList();
+    WEBCORE_EXPORT Ref<DOMTokenList> protectedClassList();
 
     SpaceSplitString partNames() const;
     DOMTokenList& part();

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -269,13 +269,13 @@ void VTTRegion::displayLastTextTrackCueBox()
 
     // If it's a scrolling region, add the scrolling class.
     if (scroll() == ScrollSetting::Up)
-        m_cueContainer->classList().add(textTrackCueContainerScrollingClass());
+        m_cueContainer->protectedClassList()->add(textTrackCueContainerScrollingClass());
 
     float regionBottom = m_regionDisplayTree->boundingClientRect().maxY();
 
     // Find first cue that is not entirely displayed and scroll it upwards.
-    for (auto& child : childrenOfType<Element>(*m_cueContainer)) {
-        auto rect = child.boundingClientRect();
+    for (Ref child : childrenOfType<Element>(*m_cueContainer)) {
+        auto rect = child->boundingClientRect();
         float childTop = rect.y();
         float childBottom = rect.maxY();
 
@@ -299,7 +299,7 @@ void VTTRegion::willRemoveTextTrackCueBox(VTTCueBox* box)
 
     double boxHeight = box->boundingClientRect().height();
 
-    m_cueContainer->classList().remove(textTrackCueContainerScrollingClass());
+    m_cueContainer->protectedClassList()->remove(textTrackCueContainerScrollingClass());
 
     m_currentTop += boxHeight;
     m_cueContainer->setInlineStyleProperty(CSSPropertyTop, m_currentTop, CSSUnitType::CSS_PX);
@@ -308,7 +308,7 @@ void VTTRegion::willRemoveTextTrackCueBox(VTTCueBox* box)
 HTMLDivElement& VTTRegion::getDisplayTree()
 {
     if (!m_regionDisplayTree) {
-        m_regionDisplayTree = HTMLDivElement::create(downcast<Document>(*scriptExecutionContext()));
+        lazyInitialize(m_regionDisplayTree, HTMLDivElement::create(*protectedDocument()));
         m_regionDisplayTree->setUserAgentPart(UserAgentParts::webkitMediaTextTrackRegion());
         m_recalculateStyles = true;
     }
@@ -331,7 +331,7 @@ void VTTRegion::prepareRegionDisplayTree()
     // The cue container is used to wrap the cues and it is the object which is
     // gradually scrolled out as multiple cues are appended to the region.
     if (!m_cueContainer) {
-        m_cueContainer = HTMLDivElement::create(downcast<Document>(*scriptExecutionContext()));
+        lazyInitialize(m_cueContainer, HTMLDivElement::create(*protectedDocument()));
         m_cueContainer->setUserAgentPart(UserAgentParts::webkitMediaTextTrackRegionContainer());
         m_regionDisplayTree->appendChild(*m_cueContainer);
     }
@@ -399,6 +399,11 @@ void VTTRegion::scrollTimerFired()
 
     stopTimer();
     displayLastTextTrackCueBox();
+}
+
+RefPtr<Document> VTTRegion::protectedDocument() const
+{
+    return downcast<Document>(protectedScriptExecutionContext());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -117,6 +117,8 @@ private:
 
     static const AtomString& textTrackCueContainerScrollingClass();
 
+    RefPtr<Document> protectedDocument() const;
+
     String m_id;
     String m_settings;
 
@@ -130,8 +132,8 @@ private:
 
     // The cue container is the container that is scrolled up to obtain the
     // effect of scrolling cues when this is enabled for the regions.
-    RefPtr<HTMLDivElement> m_cueContainer;
-    RefPtr<HTMLDivElement> m_regionDisplayTree;
+    const RefPtr<HTMLDivElement> m_cueContainer;
+    const RefPtr<HTMLDivElement> m_regionDisplayTree;
 
     // Keep track of the current numeric value of the css "top" property.
     double m_currentTop { 0 };


### PR DESCRIPTION
#### a211c58c1873e2a9dbb6a133c8b19608ffd3c6cf
<pre>
Address Safer CPP warnings in VTTRegion
<a href="https://bugs.webkit.org/show_bug.cgi?id=289373">https://bugs.webkit.org/show_bug.cgi?id=289373</a>
<a href="https://rdar.apple.com/146516346">rdar://146516346</a>

Reviewed by Chris Dumez.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::protectedClassList):
* Source/WebCore/dom/Element.h:
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::displayLastTextTrackCueBox):
(WebCore::VTTRegion::willRemoveTextTrackCueBox):
(WebCore::VTTRegion::getDisplayTree):
(WebCore::VTTRegion::prepareRegionDisplayTree):
(WebCore::VTTRegion::protectedDocument const):
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/html/track/VTTRegion.h:

Canonical link: <a href="https://commits.webkit.org/292029@main">https://commits.webkit.org/292029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89a648cc998c4d61c200593384fa54fd2fb2f37c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14329 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4161 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14605 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22748 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72276 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29580 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97740 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10880 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52607 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10572 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3248 "Failed to checkout and rebase branch from PR 42114") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44568 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101799 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21768 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15890 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22016 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81563 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/80656 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25203 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15001 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21745 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26858 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23145 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->