### PR TITLE
ComplexTextController: Rename "m_font": it is a FontCascade and not a Font

### DIFF
--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -201,7 +201,7 @@ private:
 
     SingleThreadWeakHashSet<const Font>* m_fallbackFonts { nullptr };
 
-    const FontCascade& m_font;
+    const FontCascade& m_fontCascade;
     const TextRun& m_run;
 
     unsigned m_currentCharacter { 0 };

--- a/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
+++ b/Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp
@@ -312,7 +312,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
         return;
     }
 
@@ -365,7 +365,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 
     hb_font_make_immutable(harfBuzzFont.get());
 
-    auto features = fontFeatures(m_font, fontPlatformData);
+    auto features = fontFeatures(m_fontCascade, fontPlatformData);
     HbUniquePtr<hb_buffer_t> buffer(hb_buffer_create());
     if (fontPlatformData.orientation() == FontOrientation::Vertical)
         hb_buffer_set_script(buffer.get(), findScriptForVerticalGlyphSubstitution(face.get()));

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -155,7 +155,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade.primaryFont(), characters, stringLocation, 0, characters.size(), m_run.ltr()));
         return;
     }
 
@@ -183,7 +183,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     const hb_feature_t* featuresData = features.isEmpty() ? nullptr : features.data();
     unsigned featuresSize = features.size();
     Vector<hb_feature_t> featuresWithKerning;
-    if (!m_font.enableKerning()) {
+    if (!m_fontCascade.enableKerning()) {
         featuresWithKerning.reserveInitialCapacity(featuresSize + 1);
         featuresWithKerning.append({ HB_TAG('k', 'e', 'r', 'n'), 0, 0, static_cast<unsigned>(-1) });
         featuresWithKerning.appendVector(features);
@@ -198,7 +198,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     // According to <https://datatracker.ietf.org/doc/html/rfc5646#section-2.1>
     // "the language tags described in this document are sequences of characters
     // from the US-ASCII [ISO646] repertoire.".
-    auto language = hb_language_from_string(m_font.fontDescription().computedLocale().string().ascii().data(), -1);
+    auto language = hb_language_from_string(m_fontCascade.fontDescription().computedLocale().string().ascii().data(), -1);
 
     for (unsigned i = 0; i < runCount; ++i) {
         hb_buffer_set_language(buffer.get(), language);

--- a/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
+++ b/Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp
@@ -173,7 +173,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
 {
     if (!font) {
         // Create a run of missing glyphs from the primary font.
-        m_complexTextRuns.append(ComplexTextRun::create(m_font.primaryFont(), cp, stringLocation, 0, cp.size(), m_run.ltr()));
+        m_complexTextRuns.append(ComplexTextRun::create(m_fontCascade.primaryFont(), cp, stringLocation, 0, cp.size(), m_run.ltr()));
         return;
     }
 


### PR DESCRIPTION
#### a6bb5ab269c13caaa671652a946b2d6dbf89cbb2
<pre>
ComplexTextController: Rename &quot;m_font&quot;: it is a FontCascade and not a Font
<a href="https://bugs.webkit.org/show_bug.cgi?id=289374">https://bugs.webkit.org/show_bug.cgi?id=289374</a>
<a href="https://rdar.apple.com/146517164">rdar://146517164</a>

Reviewed by Sammy Gill.

&quot;m_font&quot; of ComplexTextController is a FontCascade object and not a Font object.
This is specially misleading because it is used along
&quot;font&quot; which is an actual &quot;Font&quot; object.

Also, &quot;m_font&quot; of ComplexTextController::ComplexRun is still a Font, which it
makes it hard for distinguish it.

* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::TextLayout::isNeeded):
(WebCore::TextLayout::TextLayout):
(WebCore::TextLayout::width):
(WebCore::ComplexTextController::ComplexTextController):
(WebCore::ComplexTextController::collectComplexTextRuns):
(WebCore::ComplexTextController::advance):
(WebCore::ComplexTextController::adjustGlyphsAndAdvances):
* Source/WebCore/platform/graphics/ComplexTextController.h:
* Source/WebCore/platform/graphics/coretext/ComplexTextControllerCoreText.mm:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/harfbuzz/ComplexTextControllerHarfBuzz.cpp:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
* Source/WebCore/platform/graphics/win/ComplexTextControllerUniscribe.cpp:
(WebCore::ComplexTextController::collectComplexTextRunsForCharacters):

Canonical link: <a href="https://commits.webkit.org/291836@main">https://commits.webkit.org/291836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c38ce74f04b5d376b139f7216116775bd9525a84

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44679 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96202 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14039 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22169 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29158 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10405 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84999 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2688 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43997 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80329 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101205 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21204 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80821 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-view-transitions/active-view-transition-type-on-non-root.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81016 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80203 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20002 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24749 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2106 "Found 2 new test failures: svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-default-context.svg svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-ltr-context.svg (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14366 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21188 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26367 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20875 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24335 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22616 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->