### PR TITLE
Address more Safer CPP failures in WebCore/platform/network

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -119,7 +119,6 @@ platform/mac/ScrollbarThemeMac.mm
 platform/mac/ScrollbarsControllerMac.mm
 platform/mac/SerializedPlatformDataCueMac.mm
 platform/mac/WebCoreFullScreenWindow.mm
-platform/network/BlobResourceHandle.cpp
 rendering/BidiRun.cpp
 rendering/BidiRun.h
 rendering/RenderAncestorIterator.h

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1096,12 +1096,6 @@ platform/mock/MockRealtimeVideoSource.cpp
 platform/mock/RTCNotifiersMock.cpp
 platform/mock/TimerEventBasedMock.h
 platform/mock/mediasource/MockMediaSourcePrivate.cpp
-platform/network/BlobData.cpp
-platform/network/BlobRegistryImpl.cpp
-platform/network/BlobResourceHandle.cpp
-platform/network/DataURLDecoder.cpp
-platform/network/FormData.cpp
-platform/network/NetworkLoadMetrics.cpp
 platform/network/SynchronousLoaderClient.cpp
 platform/network/mac/ResourceHandleMac.mm
 platform/network/mac/WebCoreResourceHandleAsOperationQueueDelegate.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -598,8 +598,6 @@ platform/mac/WidgetMac.mm
 platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
 platform/mock/MockRealtimeMediaSourceCenter.cpp
 platform/mock/MockRealtimeVideoSource.cpp
-platform/network/BlobRegistryImpl.cpp
-platform/network/FormData.cpp
 platform/text/BidiContext.cpp
 platform/text/BidiResolver.h
 plugins/DOMPluginArray.cpp

--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -53,7 +53,7 @@ long long BlobDataItem::length() const
         ASSERT_NOT_REACHED();
         return m_length;
     case Type::File:
-        return m_file->size();
+        return protectedFile()->size();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/network/BlobData.h
+++ b/Source/WebCore/platform/network/BlobData.h
@@ -53,6 +53,7 @@ public:
 
     // For Data type.
     DataSegment* data() const { return m_data.get(); }
+    RefPtr<DataSegment> protectedData() const { return m_data; }
 
     // For File type.
     BlobDataFileReference* file() const { return m_file.get(); }

--- a/Source/WebCore/platform/network/BlobRegistryImpl.h
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.h
@@ -55,7 +55,8 @@ class WEBCORE_EXPORT BlobRegistryImpl {
 public:
     virtual ~BlobRegistryImpl();
 
-    BlobData* getBlobDataFromURL(const URL&, const std::optional<SecurityOriginData>& topOrigin = std::nullopt) const;
+    BlobData* blobDataFromURL(const URL&, const std::optional<SecurityOriginData>& topOrigin = std::nullopt) const;
+    RefPtr<BlobData> protectedBlobDataFromURL(const URL&, const std::optional<SecurityOriginData>& topOrigin = std::nullopt) const;
 
     Ref<ResourceHandle> createResourceHandle(const ResourceRequest&, ResourceHandleClient*);
 

--- a/Source/WebCore/platform/network/BlobResourceHandle.h
+++ b/Source/WebCore/platform/network/BlobResourceHandle.h
@@ -64,6 +64,8 @@ public:
         MethodNotAllowed = 5
     };
 
+    bool isBlobResourceHandle() const final { return true; }
+
 private:
     BlobResourceHandle(BlobData*, const ResourceRequest&, ResourceHandleClient*, bool async);
     virtual ~BlobResourceHandle();
@@ -120,3 +122,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::BlobResourceHandle)
+    static bool isType(const WebCore::ResourceHandle& handle) { return handle.isBlobResourceHandle(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -63,7 +63,7 @@ static bool shouldRemoveFragmentIdentifier(const String& mediaType)
 #endif
 }
 
-static WorkQueue& decodeQueue()
+static WorkQueue& decodeQueueSingleton()
 {
     static NeverDestroyed<Ref<WorkQueue>> queue(WorkQueue::create("org.webkit.DataURLDecoder"_s, WorkQueue::QOS::UserInitiated));
     return queue.get();
@@ -177,7 +177,7 @@ void decode(const URL& url, const ScheduleContext& scheduleContext, ShouldValida
 {
     ASSERT(url.protocolIsData());
 
-    decodeQueue().dispatch([decodeTask = createDecodeTask(url, scheduleContext, shouldValidatePadding, WTFMove(completionHandler))]() mutable {
+    decodeQueueSingleton().dispatch([decodeTask = createDecodeTask(url, scheduleContext, shouldValidatePadding, WTFMove(completionHandler))]() mutable {
         auto result = decodeSynchronously(*decodeTask);
 
 #if USE(COCOA_EVENT_LOOP)

--- a/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
+++ b/Source/WebCore/platform/network/NetworkLoadMetrics.cpp
@@ -161,8 +161,8 @@ NetworkLoadMetrics NetworkLoadMetrics::isolatedCopy() const
     copy.responseBodyBytesReceived = responseBodyBytesReceived;
     copy.responseBodyDecodedSize = responseBodyDecodedSize;
 
-    if (additionalNetworkLoadMetricsForWebInspector)
-        copy.additionalNetworkLoadMetricsForWebInspector = additionalNetworkLoadMetricsForWebInspector->isolatedCopy();
+    if (RefPtr metrics = additionalNetworkLoadMetricsForWebInspector)
+        copy.additionalNetworkLoadMetricsForWebInspector = metrics->isolatedCopy();
 
     return copy;
 }

--- a/Source/WebCore/platform/network/ResourceHandle.h
+++ b/Source/WebCore/platform/network/ResourceHandle.h
@@ -99,6 +99,8 @@ public:
     void receivedRequestToPerformDefaultHandling(const AuthenticationChallenge&) override;
     void receivedChallengeRejection(const AuthenticationChallenge&) override;
 
+    virtual bool isBlobResourceHandle() const { return false; }
+
 #if PLATFORM(COCOA)
     bool tryHandlePasswordBasedAuthentication(const AuthenticationChallenge&);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp
@@ -77,7 +77,7 @@ NetworkDataTaskBlob::NetworkDataTaskBlob(NetworkSession& session, NetworkDataTas
         RELEASE_LOG(Network, "Got request for blob without topOrigin but request specifies firstPartyForCookies");
         topOriginData = SecurityOriginData::fromURLWithoutStrictOpaqueness(request.firstPartyForCookies());
     }
-    m_blobData = session.blobRegistry().getBlobDataFromURL(request.url(), topOriginData);
+    m_blobData = session.blobRegistry().blobDataFromURL(request.url(), topOriginData);
 
     LOG(NetworkSession, "%p - Created NetworkDataTaskBlob for %s", this, request.url().string().utf8().data());
 }


### PR DESCRIPTION
#### d40cc36b2f9e298f97f1ca8366799f5dedd1ffc7
<pre>
Address more Safer CPP failures in WebCore/platform/network
<a href="https://bugs.webkit.org/show_bug.cgi?id=289390">https://bugs.webkit.org/show_bug.cgi?id=289390</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/platform/network/BlobData.cpp:
(WebCore::BlobDataItem::length const):
* Source/WebCore/platform/network/BlobData.h:
(WebCore::BlobDataItem::protectedData const):
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::loadBlobResourceSynchronously):
(WebCore::BlobRegistryImpl::createResourceHandle):
(WebCore::BlobRegistryImpl::appendStorageItems):
(WebCore::registryQueueSingleton):
(WebCore::BlobRegistryImpl::createDataSegment):
(WebCore::BlobRegistryImpl::registerInternalBlobURL):
(WebCore::BlobRegistryImpl::registerBlobURLOptionallyFileBacked):
(WebCore::BlobRegistryImpl::registerInternalBlobURLForSlice):
(WebCore::BlobRegistryImpl::blobDataFromURL const):
(WebCore::BlobRegistryImpl::protectedBlobDataFromURL const):
(WebCore::BlobRegistryImpl::blobType):
(WebCore::BlobRegistryImpl::blobSize):
(WebCore::blobUtilityQueueSingleton):
(WebCore::BlobRegistryImpl::populateBlobsForFileWriting):
(WebCore::writeFilePathsOrDataBuffersToFile):
(WebCore::BlobRegistryImpl::writeBlobsToTemporaryFilesForIndexedDB):
(WebCore::BlobRegistryImpl::filesInBlob const):
(WebCore::BlobRegistryImpl::getBlobDataFromURL const): Deleted.
(WebCore::blobUtilityQueue): Deleted.
* Source/WebCore/platform/network/BlobRegistryImpl.h:
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::getSizeForNext):
(WebCore::BlobResourceHandle::readDataSync):
(WebCore::BlobResourceHandle::readFileSync):
(WebCore::BlobResourceHandle::readDataAsync):
(WebCore::BlobResourceHandle::readFileAsync):
* Source/WebCore/platform/network/BlobResourceHandle.h:
(isType):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::decodeQueueSingleton):
(WebCore::DataURLDecoder::decode):
(WebCore::DataURLDecoder::decodeQueue): Deleted.
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::FormData::appendMultiPartKeyValuePairItems):
(WebCore::appendBlobResolved):
* Source/WebCore/platform/network/NetworkLoadMetrics.cpp:
(WebCore::NetworkLoadMetrics::isolatedCopy const):
* Source/WebCore/platform/network/ResourceHandle.h:
(WebCore::ResourceHandle::isBlobResourceHandle const):
* Source/WebKit/NetworkProcess/NetworkDataTaskBlob.cpp:
(WebKit::NetworkDataTaskBlob::NetworkDataTaskBlob):

Canonical link: <a href="https://commits.webkit.org/291842@main">https://commits.webkit.org/291842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c73a1ff8504139a556fca0c0e7b0e9f1c127be66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99162 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44678 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96201 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71816 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29157 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10404 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/84996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52157 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10095 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2685 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/43996 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101204 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21455 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80201 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24747 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14365 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15104 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21187 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26366 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20874 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24334 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->