### PR TITLE
[Async scrolling] Programmatic scrolls can cause missing tiles and offset hit-testing

### DIFF
--- a/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-hit-test-expected.txt
+++ b/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-hit-test-expected.txt
@@ -1,0 +1,5 @@
+PASS clickCount is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-hit-test.html
+++ b/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-hit-test.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .spacer {
+            height: 4000px;
+            width: 10px;
+            background-color: silver;
+        }
+        
+        .target {
+            margin-top: 120px;
+            height: 50px;
+            width: 300px;
+            background-color: green;
+        }
+        
+        .target:active {
+            background-color: orange;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script src="../../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        let clickCount = 0;
+        async function scrollTest()
+        {
+            const scroller = document.getElementById("scroller");
+
+            await UIHelper.startMonitoringWheelEvents();
+            eventSender.mouseMoveTo(100, 100);
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -2, "began", "none");
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -15, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "begin");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -20, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -20, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -20, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, -10, "none", "continue");
+
+            window.scrollTo(0, 100);
+
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
+
+            await UIHelper.waitForScrollCompletion();
+            await doClick();
+            
+            shouldBe('clickCount', '1');
+
+            finishJSTest();
+        }
+        
+        async function doClick()
+        {
+            if (!window.eventSender)
+                return;
+
+            eventSender.mouseMoveTo(100, 25);
+            eventSender.mouseDown();
+            await UIHelper.delayFor(20);
+            eventSender.mouseUp();
+        }
+        
+        function targetClicked()
+        {
+            ++clickCount;
+        }
+
+        window.addEventListener('load', () => {
+            const scroller = document.getElementById("scroller");
+
+            if (!window.eventSender) {
+                setTimeout(scrollTest, 0);
+                return;
+            }
+
+            testRunner.waitUntilDone();
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="target" onclick="targetClicked()"></div>
+    <div id="console"></div>
+    <div class="spacer"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-missing-tiles-expected.html
+++ b/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-missing-tiles-expected.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .list {
+            width: 400px;
+            height: 400px;
+            display: flex;
+            flex-flow: row nowrap;
+            overflow-x: scroll;
+            overflow-y: hidden;
+            border: 1px solid black;
+            padding: 0;
+            margin: 0;
+        }
+
+        .list li {
+            flex: none;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+            list-style-type: none;
+        }
+    </style>
+</head>
+<body>
+    <ul id="scroller" class="list">
+      <li style="background: #ff0;">test</li>
+      <li style="background: #0f0;">test</li>
+      <li style="background: #0ff;">test</li>
+      <li style="background: #00f;">test</li>
+      <li style="background: #f0f;">test</li>
+      <li style="background: #f00;">test</li>
+      <li style="background: #ff0;">test</li>
+      <li style="background: #0f0;">test</li>
+      <li style="background: #0ff;">test</li>
+      <li style="background: #00f;">test</li>
+      <li style="background: #f0f;">test</li>
+      <li style="background: #f00;">test</li>
+    </ul>
+    <div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-missing-tiles.html
+++ b/LayoutTests/fast/scrolling/mac/momentum-then-programmatic-missing-tiles.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        .list {
+            width: 400px;
+            height: 400px;
+            display: flex;
+            flex-flow: row nowrap;
+            overflow-x: scroll;
+            overflow-y: hidden;
+            border: 1px solid black;
+            padding: 0;
+            margin: 0;
+        }
+
+        .list li {
+            flex: none;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            margin: 0;
+            list-style-type: none;
+        }
+    </style>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        async function scrollTest()
+        {
+            const scroller = document.getElementById("scroller");
+
+            await UIHelper.startMonitoringWheelEvents();
+            eventSender.mouseMoveTo(100, 100);
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-2, 0, "began", "none");
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-15, 0, "changed", "none");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "ended", "none");
+
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "begin");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-10, 0, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "none", "continue");
+            await UIHelper.renderingUpdate();
+
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-20, 0, "none", "continue");
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(-10, 0, "none", "continue");
+
+            scroller.scrollTo(0, 0);
+
+            await UIHelper.renderingUpdate();
+            eventSender.mouseScrollByWithWheelAndMomentumPhases(0, 0, "none", "end");
+
+            await UIHelper.waitForScrollCompletion();
+
+            await UIHelper.renderingUpdate();
+            testRunner.notifyDone();
+        }
+
+        window.addEventListener('load', () => {
+            const scroller = document.getElementById("scroller");
+
+            if (!window.eventSender) {
+                setTimeout(scrollTest, 0);
+                return;
+            }
+
+            testRunner.waitUntilDone();
+
+            setTimeout(scrollTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <ul id="scroller" class="list">
+      <li style="background: #ff0;">test</li>
+      <li style="background: #0f0;">test</li>
+      <li style="background: #0ff;">test</li>
+      <li style="background: #00f;">test</li>
+      <li style="background: #f0f;">test</li>
+      <li style="background: #f00;">test</li>
+      <li style="background: #ff0;">test</li>
+      <li style="background: #0f0;">test</li>
+      <li style="background: #0ff;">test</li>
+      <li style="background: #00f;">test</li>
+      <li style="background: #f0f;">test</li>
+      <li style="background: #f00;">test</li>
+    </ul>
+    <div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/dirty-contents-reselect-anchor.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/dirty-contents-reselect-anchor.tentative-expected.txt
@@ -1,4 +1,4 @@
 Scroll target
 
-FAIL Scroll anchor is re-selected after adjustment if there are dirty descendants at selection time assert_equals: Scroll position should've been preserved expected 1207.34375 but got 0.34375
+PASS Scroll anchor is re-selected after adjustment if there are dirty descendants at selection time
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3674,7 +3674,6 @@ webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrolle
 webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-after-snap.html [ Skip ]
 webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scrollIntoView.html?include=subframe-inline-end-block-end-behavior-auto [ Skip ]
 webkit.org/b/296195 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-scrollIntoView.html?include=subframe-inline-start-block-start-behavior-smooth [ Skip ]
-webkit.org/b/307555 imported/w3c/web-platform-tests/dom/events/scrolling/scrollend-event-fired-for-programmatic-scroll.html?include=root-scrollBy-smooth [ Failure ]
 
 webkit.org/b/231337 imported/w3c/web-platform-tests/xhr/send-timeout-events.htm [ Pass Failure ]
 
@@ -4640,9 +4639,6 @@ fast/forms/ios/show-file-upload-context-menu-above-keyboard.html [ Pass ]
 # rdar://110034620 (REGRESSION ( iOS17 ): [ iOS17 ] compositing/clipping/nested-overflow-with-border-radius.html is a consistent image failure)
 compositing/clipping/nested-overflow-with-border-radius.html [ ImageOnlyFailure ]
 
-# rdar://104451028 (REGRESSION (iOS17 ): [ iOS17 ] fast/scrolling/keyboard-scrolling-distance-pageDown.html is a consistent timeout)
-fast/scrolling/keyboard-scrolling-distance-pageDown.html [ Timeout ]
-
 # rdar://104460194 (REGRESSION (iOS17 Sonoma23A177 ): [ iOS17 Sonoma ] fast/box-shadow/inset-box-shadow-fractional-radius.html is a consistent image failure)
 fast/box-shadow/inset-box-shadow-fractional-radius.html [ ImageOnlyFailure ]
 
@@ -4699,7 +4695,6 @@ fast/borders/hidpi-border-painting-groove.html [ ImageOnlyFailure ]
 fast/borders/hidpi-border-painting-ridge.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/white-space/textarea-pre-wrap-013.html [ ImageOnlyFailure ]
 editing/spelling/editing-word-with-marker-1.html [ Failure ]
-fast/scrolling/ios/body-overflow-hidden-height-100-percent-keyboard.html [ Failure ]
 http/wpt/webcodecs/videoFrame-colorSpace.html [ Failure ]
 http/wpt/webcodecs/webcodecs-gc.html [ Failure ]
 http/wpt/webrtc/video-script-transform-keyframe-only.html [ Failure ]

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -188,7 +188,7 @@ private:
     void updateEventTrackingRegions(FrameIdentifier rootFrameID);
     
     void applyScrollPositionUpdate(ScrollUpdate&&, ScrollType, ViewportRectStability);
-    void updateScrollPositionAfterAsyncScroll(ScrollUpdate&&, ScrollType, ViewportRectStability);
+    void updateScrollPositionAfterAsyncScroll(ScrollingNodeID, FloatPoint, std::optional<FloatPoint> layoutViewportOrigin, ScrollingLayerPositionAction, ScrollType, ViewportRectStability);
     void animatedScrollWillStartForNode(ScrollingNodeID);
     void animatedScrollDidEndForNode(ScrollingNodeID);
     void wheelEventScrollWillStartForNode(ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -67,6 +67,12 @@ using PlatformDisplayID = uint32_t;
 
 enum class EventTargeting : uint8_t { NodeOnly, Propagate };
 
+enum class RequestsScrollHandling : uint8_t {
+    Unhandled,
+    Handled,
+    Delayed
+};
+
 class ScrollingTree : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingTree> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ScrollingTree, WEBCORE_EXPORT);
     friend class ScrollingTreeLatchingController;
@@ -135,13 +141,12 @@ public:
     virtual void scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode&) { }
     virtual void scrollingTreeNodeWillStartWheelEventScroll(ScrollingTreeScrollingNode&) { }
     virtual void scrollingTreeNodeDidStopWheelEventScroll(ScrollingTreeScrollingNode&) { }
-    virtual void scrollingTreeNodeDidStopProgrammaticScroll(ScrollingTreeScrollingNode&) { }
 
     // Called for requested scroll position updates. Returns true if handled.
-    virtual bool scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) { return false; }
+    virtual RequestsScrollHandling scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) { return RequestsScrollHandling::Unhandled; }
     virtual bool scrollingTreeNodeRequestsKeyboardScroll(ScrollingNodeID, const RequestedKeyboardScrollData&) { return false; }
 
-    virtual void didHandleScrollRequestForNode(ScrollingNodeID, FloatPoint, ScrollRequestIdentifier) { }
+    virtual void didHandleScrollRequestForNode(ScrollingNodeID, ScrollRequestType, FloatPoint, ShouldFireScrollEnd, Markable<ScrollRequestIdentifier>) { }
 
     // Delegated scrolling/zooming has caused the viewport to change, so update viewport-constrained layers
     WEBCORE_EXPORT void mainFrameViewportChangedViaDelegatedScrolling(const FloatPoint& scrollPosition, const WebCore::FloatRect& layoutViewport, double scale);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -78,7 +78,9 @@ protected:
     void scrollingTreeNodeDidStopAnimatedScroll(ScrollingTreeScrollingNode&) override;
     void scrollingTreeNodeWillStartWheelEventScroll(ScrollingTreeScrollingNode&) override;
     void scrollingTreeNodeDidStopWheelEventScroll(ScrollingTreeScrollingNode&) override;
-    bool scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) override WTF_REQUIRES_LOCK(m_treeLock);
+    void didHandleScrollRequestForNode(ScrollingNodeID, ScrollRequestType, FloatPoint, ShouldFireScrollEnd, Markable<ScrollRequestIdentifier>) override;
+
+    RequestsScrollHandling scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&) override WTF_REQUIRES_LOCK(m_treeLock);
     bool scrollingTreeNodeRequestsKeyboardScroll(ScrollingNodeID, const RequestedKeyboardScrollData&) override WTF_REQUIRES_LOCK(m_treeLock);
 
     void addPendingScrollUpdateWithDeferReason(ScrollUpdate&&, WheelEventTestMonitor::DeferReason);
@@ -127,7 +129,7 @@ private:
     void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
     void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
 
-    void scrollingTreeNodeScrollUpdated(ScrollingTreeScrollingNode&, const ScrollUpdateType&);
+    void scrollingTreeNodeScrollUpdated(ScrollingTreeScrollingNode&, ScrollUpdateType);
 
     void didAddPendingScrollUpdate() override;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2800,12 +2800,10 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] enum class WebCore::ScrollUpdateType : uint8_t {
     PositionUpdate,
-    ScrollRequestResponse,
     AnimatedScrollWillStart,
     AnimatedScrollDidEnd,
     WheelEventScrollWillStart,
     WheelEventScrollDidEnd,
-    ProgrammaticScrollDidEnd,
 };
 
 header: <WebCore/ScrollingCoordinatorTypes.h>
@@ -2816,13 +2814,27 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
 };
 
 header: <WebCore/ScrollingCoordinatorTypes.h>
+[CustomHeader] enum class WebCore::ShouldFireScrollEnd : bool;
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[CustomHeader] struct WebCore::ScrollUpdateData {
+    WebCore::ScrollUpdateType updateType;
+    WebCore::ScrollingLayerPositionAction updateLayerPositionAction;
+    std::optional<WebCore::FloatPoint> layoutViewportOrigin;
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
+[CustomHeader] struct WebCore::ScrollRequestResponseData {
+    WebCore::ScrollRequestType requestType;
+    Markable<WebCore::ScrollRequestIdentifier> responseIdentifier;
+};
+
+header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] struct WebCore::ScrollUpdate {
     WebCore::ScrollingNodeID nodeID;
     WebCore::FloatPoint scrollPosition;
-    std::optional<WebCore::FloatPoint> layoutViewportOrigin;
-    WebCore::ScrollUpdateType updateType;
-    WebCore::ScrollingLayerPositionAction updateLayerPositionAction;
-    Markable<WebCore::ScrollRequestIdentifier> responseIdentifier;
+    WebCore::ShouldFireScrollEnd shouldFireScrollEnd;
+    Variant<WebCore::ScrollUpdateData, WebCore::ScrollRequestResponseData> data;
 };
 
 header: <WebCore/ScrollingCoordinatorTypes.h>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -88,7 +88,7 @@ public:
     }
 
     // Inform the web process that the scroll position changed (called from the scrolling tree)
-    virtual bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&);
+    virtual WebCore::RequestsScrollHandling scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&);
     virtual bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&);
 
     void scrollingThreadAddedPendingUpdate();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -73,11 +73,10 @@ public:
     void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction = WebCore::ScrollingLayerPositionAction::Sync) override;
     void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingTreeScrollingNode&) override;
     void scrollingTreeNodeDidStopWheelEventScroll(WebCore::ScrollingTreeScrollingNode&) override;
-    bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
+    WebCore::RequestsScrollHandling scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;
-    void scrollingTreeNodeDidStopProgrammaticScroll(WebCore::ScrollingTreeScrollingNode&) override;
 
-    void didHandleScrollRequestForNode(WebCore::ScrollingNodeID, WebCore::FloatPoint scrollPosition, WebCore::ScrollRequestIdentifier) override;
+    void didHandleScrollRequestForNode(WebCore::ScrollingNodeID, WebCore::ScrollRequestType, WebCore::FloatPoint scrollPosition, WebCore::ShouldFireScrollEnd, Markable<WebCore::ScrollRequestIdentifier>) override;
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -48,7 +48,7 @@ private:
     void handleWheelEvent(const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges) override;
     void wheelEventHandlingCompleted(const WebCore::PlatformWheelEvent&, std::optional<WebCore::ScrollingNodeID>, std::optional<WebCore::WheelScrollGestureState>, bool wasHandled) override;
 
-    bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
+    WebCore::RequestsScrollHandling scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;
     void hasNodeWithAnimatedScrollChanged(bool) override;
     void setRubberBandingInProgressForNode(WebCore::ScrollingNodeID, bool isRubberBanding) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -80,10 +80,10 @@ void RemoteScrollingCoordinatorProxyMac::wheelEventHandlingCompleted(const Platf
     m_eventDispatcher->wheelEventHandlingCompleted(wheelEvent, scrollingNodeID, gestureState, wasHandled);
 }
 
-bool RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&)
+RequestsScrollHandling RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeRequestsScroll(ScrollingNodeID, const RequestedScrollData&)
 {
     // Unlike iOS, we handle scrolling requests for the main frame in the same way we handle them for subscrollers.
-    return false;
+    return RequestsScrollHandling::Unhandled;
 }
 
 bool RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeRequestsKeyboardScroll(ScrollingNodeID, const RequestedKeyboardScrollData&)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -65,8 +65,7 @@ private:
     void scrollingTreeNodeDidScroll(WebCore::ScrollingTreeScrollingNode&, WebCore::ScrollingLayerPositionAction) override;
     void scrollingTreeNodeDidStopAnimatedScroll(WebCore::ScrollingTreeScrollingNode&) override;
     void scrollingTreeNodeDidStopWheelEventScroll(WebCore::ScrollingTreeScrollingNode&) override;
-    void scrollingTreeNodeDidStopProgrammaticScroll(WebCore::ScrollingTreeScrollingNode&) override;
-    bool scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
+    WebCore::RequestsScrollHandling scrollingTreeNodeRequestsScroll(WebCore::ScrollingNodeID, const WebCore::RequestedScrollData&) override;
     bool scrollingTreeNodeRequestsKeyboardScroll(WebCore::ScrollingNodeID, const WebCore::RequestedKeyboardScrollData&) override;
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) override;
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -224,9 +224,11 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidScroll(ScrollingTreeScrollingNo
     auto scrollUpdate = ScrollUpdate {
         .nodeID = node.scrollingNodeID(),
         .scrollPosition = node.currentScrollPosition(),
-        .layoutViewportOrigin = layoutViewportOrigin,
-        .updateType = ScrollUpdateType::PositionUpdate,
-        .updateLayerPositionAction = action,
+        .data = ScrollUpdateData {
+            .updateType = ScrollUpdateType::PositionUpdate,
+            .updateLayerPositionAction = action,
+            .layoutViewportOrigin = layoutViewportOrigin,
+        }
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
 }
@@ -236,8 +238,9 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll(ScrollingTre
     auto scrollUpdate = ScrollUpdate {
         .nodeID = node.scrollingNodeID(),
         .scrollPosition = { },
-        .layoutViewportOrigin = { },
-        .updateType = ScrollUpdateType::AnimatedScrollDidEnd,
+        .data = ScrollUpdateData {
+            .updateType = ScrollUpdateType::AnimatedScrollDidEnd,
+        }
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
 }
@@ -249,19 +252,9 @@ void RemoteScrollingTreeMac::scrollingTreeNodeDidStopWheelEventScroll(WebCore::S
     auto scrollUpdate = ScrollUpdate {
         .nodeID = node.scrollingNodeID(),
         .scrollPosition = { },
-        .layoutViewportOrigin = { },
-        .updateType = ScrollUpdateType::WheelEventScrollDidEnd,
-    };
-    addPendingScrollUpdate(WTF::move(scrollUpdate));
-}
-
-void RemoteScrollingTreeMac::scrollingTreeNodeDidStopProgrammaticScroll(WebCore::ScrollingTreeScrollingNode& node)
-{
-    auto scrollUpdate = ScrollUpdate {
-        .nodeID = node.scrollingNodeID(),
-        .scrollPosition = { },
-        .layoutViewportOrigin = { },
-        .updateType = ScrollUpdateType::ProgrammaticScrollDidEnd,
+        .data = ScrollUpdateData {
+            .updateType = ScrollUpdateType::WheelEventScrollDidEnd,
+        }
     };
     addPendingScrollUpdate(WTF::move(scrollUpdate));
 }
@@ -280,14 +273,14 @@ void RemoteScrollingTreeMac::didAddPendingScrollUpdate()
     });
 }
 
-bool RemoteScrollingTreeMac::scrollingTreeNodeRequestsScroll(ScrollingNodeID nodeID, const RequestedScrollData& request)
+RequestsScrollHandling RemoteScrollingTreeMac::scrollingTreeNodeRequestsScroll(ScrollingNodeID nodeID, const RequestedScrollData& request)
 {
     if (isAnimatedUpdate(request.requestType)) {
         ASSERT(m_treeLock.isLocked());
         m_nodesWithPendingScrollAnimations.set(nodeID, request);
-        return true;
+        return RequestsScrollHandling::Handled;
     }
-    return false;
+    return RequestsScrollHandling::Unhandled;
 }
 
 bool RemoteScrollingTreeMac::scrollingTreeNodeRequestsKeyboardScroll(ScrollingNodeID nodeID, const RequestedKeyboardScrollData& request)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h
@@ -111,7 +111,11 @@ private:
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveScrollSnap;
     HashSet<WebCore::ScrollingNodeID> m_nodesWithActiveUserScrolls;
 
-    HashMap<WebCore::ScrollingNodeID, WebCore::ScrollRequestIdentifier> m_scrollRequestsPendingResponse;
+    struct PendingScrollResponseInfo {
+        Markable<WebCore::ScrollRequestIdentifier> identifier;
+        bool pendingScrollEnd { false };
+    };
+    HashMap<WebCore::ScrollingNodeID, PendingScrollResponseInfo> m_scrollRequestsPendingResponse;
 
     NodeAndGestureState m_currentWheelGestureInfo;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3788,8 +3788,11 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
         auto scrollUpdate = ScrollUpdate {
             .nodeID = *mainFrameScrollingNodeID,
             .scrollPosition = scrollPosition,
-            .layoutViewportOrigin = visibleContentRectUpdateInfo.layoutViewportRect().location(),
-            .updateLayerPositionAction = layerAction,
+            .data = ScrollUpdateData {
+                .updateType = ScrollUpdateType::PositionUpdate,
+                .updateLayerPositionAction = layerAction,
+                .layoutViewportOrigin = visibleContentRectUpdateInfo.layoutViewportRect().location()
+            }
         };
 
         // We don't actually know that these are user scrolls; we get here for all kinds of state changes.
@@ -3799,8 +3802,9 @@ void WebPage::updateVisibleContentRects(const VisibleContentRectUpdateInfo& visi
             auto scrollUpdate = ScrollUpdate {
                 .nodeID = *frameView->scrollingNodeID(),
                 .scrollPosition = { },
-                .layoutViewportOrigin = { },
-                .updateType = ScrollUpdateType::WheelEventScrollDidEnd,
+                .data = ScrollUpdateData {
+                    .updateType = ScrollUpdateType::WheelEventScrollDidEnd,
+                }
             };
             scrollingCoordinator->applyScrollUpdate(WTF::move(scrollUpdate), ScrollType::User);
         }


### PR DESCRIPTION
#### e8697834ad4b3d036032823f29b7d4329ffb45ec
<pre>
[Async scrolling] Programmatic scrolls can cause missing tiles and offset hit-testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=262287">https://bugs.webkit.org/show_bug.cgi?id=262287</a>
<a href="https://rdar.apple.com/116205365">rdar://116205365</a>

Reviewed by Alan Baradlay and Abrar Rahman Protyasha.

This change fixes some long-standing issues with asynchronous scrolling, where
UI and web processes could be left with different scroll positions when both
user and programmatic scrolling was happening at the same time. This could result
in bad tile coverage (missing content), and offset hit-testing.

The fundamental problem was that IPC message for programmatic scrolling, from
web to UI process, could overlap with messages in the other direction for user
scrolling; the messages would pass like ships in the night, with no final
reconciliation step.

307867@main introduced the concept of `ScrollRequestIdentifier`. This change
makes use of those identifiers to ensure that the web process is updated with
the correct scroll position via a message from the UI process back to the web
process. Every programmatic scroll IPC now triggers a response message, which
returns the originating identifier. This allows `RemoteScrollingCoordinator` in
the web process to know when there&apos;s programmatic scroll in flight. When there
is, we have to ignore user scrolls, because they will contain a scroll position
that is stale relative to the current web process scroll position. With multiple
programmatic scrolls in a row, we also have to ignore the response for the same
reason. We need to take care to fire `scrollend` when necessary.

ScrollUpdate now has a data member with two variants; one for responses to
programmatic scrolls (`ScrollRequestResponseData`) and one for other messages
from UI to web process.

We actually apply the scroll position in `RemoteScrollingCoordinator::scrollUpdateForNode()`,
to handle the case where the web process sent a &quot;delta&quot; scroll (e.g. for scroll
anchoring or `scrollBy`); the response will contain the most recent UI-side scroll
position with the delta applied.

There was already a `ProgrammaticScrollDidEnd` sent back to the web process; now
that we always send `ScrollRequestResponse` updates back, use that to trigger
`scrollend` via a `ShouldFireScrollEnd` member on ScrollUpdate.
`scrollingTreeNodeDidStopProgrammaticScroll` is no longer needed.

`scrollingTreeNodeRequestsScroll()` has to distinguish between &quot;scrolling tree
handled it for animated scroll&quot;, and &quot;scrolling tree delayed handling for
delegated scrolling&quot; so add `RequestsScrollHandling` to indicate that.

The changes in `ScrollingTreeScrollingNode::handleScrollPositionRequest()` and
`RemoteScrollingCoordinatorProxy::adjustMainFrameDelegatedScrollPosition()` are
needed to handle the iOS-specific behavior, seen in `RemoteLayerTreeDrawingAreaProxy::commitLayerTreeTransaction()`,
where the application of the `requestedScroll` is delayed until after layer tree
commit; `didHandleScrollRequestForNode()` needs to be called once the final scroll
position has been computed (this is tested by existing tests).

Tests: fast/scrolling/mac/momentum-then-programmatic-hit-test.html
       fast/scrolling/mac/momentum-then-programmatic-missing-tiles.html

* LayoutTests/fast/scrolling/mac/momentum-then-programmatic-hit-test-expected.txt: Added.
* LayoutTests/fast/scrolling/mac/momentum-then-programmatic-hit-test.html: Added.
* LayoutTests/fast/scrolling/mac/momentum-then-programmatic-missing-tiles-expected.html: Added.
* LayoutTests/fast/scrolling/mac/momentum-then-programmatic-missing-tiles.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/dirty-contents-reselect-anchor.tentative-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
(WebCore::AsyncScrollingCoordinator::synchronizeStateFromScrollingTree):
(WebCore::AsyncScrollingCoordinator::applyScrollPositionUpdate):
(WebCore::AsyncScrollingCoordinator::updateScrollPositionAfterAsyncScroll):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::ScrollUpdate::canMerge const):
(WebCore::ScrollUpdate::merge):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::ScrollUpdate::canMerge const): Deleted.
(WebCore::ScrollUpdate::merge): Deleted.
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::scrollingTreeNodeDidStopWheelEventScroll):
(WebCore::ScrollingTree::scrollingTreeNodeRequestsScroll):
(WebCore::ScrollingTree::didHandleScrollRequestForNode):
(WebCore::ScrollingTree::scrollingTreeNodeDidStopProgrammaticScroll): Deleted.
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
(WebCore::ScrollingTreeScrollingNode::didStopProgrammaticScroll): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::scrollingTreeNodeRequestsScroll):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeDidScroll):
(WebCore::ThreadedScrollingTree::didHandleScrollRequestForNode):
(WebCore::ThreadedScrollingTree::scrollingTreeNodeScrollUpdated):
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::adjustMainFrameDelegatedScrollPosition):
(WebKit::RemoteScrollingCoordinatorProxy::sendScrollingTreeNodeUpdate):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeRequestsScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopWheelEventScroll):
(WebKit::RemoteScrollingTree::scrollingTreeNodeRequestsScroll):
(WebKit::RemoteScrollingTree::didHandleScrollRequestForNode):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidStopProgrammaticScroll): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeRequestsScroll):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopAnimatedScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopWheelEventScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeRequestsScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidStopProgrammaticScroll): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::willSendScrollPositionRequest):
(WebKit::RemoteScrollingCoordinator::scrollUpdateForNode):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::updateVisibleContentRects):

Canonical link: <a href="https://commits.webkit.org/308215@main">https://commits.webkit.org/308215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eaafaf67d16c70cc4b4bacabaa35d6b59592e4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19473 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/13005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155460 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8b1e4e7-c423-484b-89da-162335e9a431) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19932 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19374 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/113104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e6baf8c-058b-4cfe-8bd7-48f55b825556) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149755 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/15361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93849 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98e27097-4061-4463-b719-bd46a9a030eb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2904 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157792 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/937 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16194 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121325 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31080 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19284 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/131520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/16936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18890 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/82645 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18620 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18771 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->