### PR TITLE
Address safer CPP failures in WebCore/platform/audio/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -981,15 +981,6 @@ platform/ShareableResource.cpp
 platform/animation/AcceleratedEffectValues.cpp
 platform/animation/Animation.cpp
 platform/animation/AnimationList.cpp
-platform/audio/AudioResampler.cpp
-platform/audio/HRTFDatabaseLoader.cpp
-platform/audio/MultiChannelResampler.cpp
-platform/audio/PlatformMediaSessionManager.cpp
-platform/audio/PushPullFIFO.cpp
-platform/audio/Reverb.cpp
-platform/audio/ReverbConvolver.cpp
-platform/audio/cocoa/AudioFileReaderCocoa.cpp
-platform/audio/cocoa/AudioSampleDataSource.mm
 platform/cocoa/DragImageCocoa.mm
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm

--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -115,9 +115,6 @@ page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ThreadedScrollingCoordinator.cpp
 page/scrolling/mac/ScrollerPairMac.mm
 platform/Timer.h
-platform/audio/HRTFDatabaseLoader.cpp
-platform/audio/PlatformMediaSessionManager.cpp
-platform/audio/cocoa/AudioSampleBufferConverter.mm
 platform/encryptedmedia/CDMProxy.cpp
 platform/encryptedmedia/clearkey/CDMClearKey.cpp
 platform/graphics/avfoundation/InbandTextTrackPrivateAVF.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -560,7 +560,6 @@ platform/ThreadGlobalData.cpp
 platform/ThreadGlobalData.h
 platform/animation/AcceleratedEffect.cpp
 platform/animation/AcceleratedEffectValues.cpp
-platform/audio/AudioBus.cpp
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/graphics/ComplexTextController.cpp

--- a/Source/WebCore/platform/audio/AudioBus.cpp
+++ b/Source/WebCore/platform/audio/AudioBus.cpp
@@ -530,7 +530,7 @@ RefPtr<AudioBus> AudioBus::createBySampleRateConverting(const AudioBus* sourceBu
     }
 
     // First, mix to mono (if necessary) then sample-rate convert.
-    const AudioBus* resamplerSourceBus;
+    RefPtr<const AudioBus> resamplerSourceBus;
     RefPtr<AudioBus> mixedMonoBus;
     if (mixToMono) {
         mixedMonoBus = AudioBus::createByMixingToMono(sourceBus);

--- a/Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp
+++ b/Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp
@@ -97,8 +97,9 @@ void HRTFDatabaseLoader::loadAsynchronously()
     
     if (!m_hrtfDatabase.get() && !m_databaseLoaderThread) {
         // Start the asynchronous database loading process.
-        m_databaseLoaderThread = Thread::create("HRTF database loader"_s, [this] {
-            load();
+        m_databaseLoaderThread = Thread::create("HRTF database loader"_s, [weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->load();
         });
     }
 }
@@ -113,8 +114,8 @@ void HRTFDatabaseLoader::waitForLoaderThreadCompletion()
     Locker locker { m_threadLock };
     
     // waitForThreadCompletion() should not be called twice for the same thread.
-    if (m_databaseLoaderThread)
-        m_databaseLoaderThread->waitForCompletion();
+    if (RefPtr thread = m_databaseLoaderThread)
+        thread->waitForCompletion();
     m_databaseLoaderThread = nullptr;
 }
 

--- a/Source/WebCore/platform/audio/HRTFDatabaseLoader.h
+++ b/Source/WebCore/platform/audio/HRTFDatabaseLoader.h
@@ -32,15 +32,15 @@
 #include "HRTFDatabase.h"
 #include <memory>
 #include <wtf/Lock.h>
-#include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Threading.h>
 
 namespace WebCore {
 
 // HRTFDatabaseLoader will asynchronously load the default HRTFDatabase in a new thread.
 
-class HRTFDatabaseLoader : public RefCounted<HRTFDatabaseLoader> {
+class HRTFDatabaseLoader : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<HRTFDatabaseLoader, WTF::DestructionThread::Main> {
 public:
     // Lazily creates a HRTFDatabaseLoader (if not already created) for the given sample-rate
     // and starts loading asynchronously (when created the first time).

--- a/Source/WebCore/platform/audio/MultiChannelResampler.h
+++ b/Source/WebCore/platform/audio/MultiChannelResampler.h
@@ -61,7 +61,7 @@ private:
     unsigned m_numberOfChannels;
     size_t m_outputFramesReady { 0 };
     Function<void(AudioBus*, size_t framesToProcess)> m_provideInput;
-    RefPtr<AudioBus> m_multiChannelBus;
+    const RefPtr<AudioBus> m_multiChannelBus;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp
@@ -229,7 +229,7 @@ void PlatformMediaSessionManager::addSession(PlatformMediaSession& session)
 #endif
 
 #if !RELEASE_LOG_DISABLED && (ENABLE(VIDEO) || ENABLE(WEB_AUDIO))
-    m_logger->addLogger(session.logger());
+    m_logger->addLogger(session.protectedLogger());
 #endif
 
     scheduleUpdateSessionState();
@@ -256,7 +256,7 @@ void PlatformMediaSessionManager::removeSession(PlatformMediaSession& session)
         maybeDeactivateAudioSession();
 
 #if !RELEASE_LOG_DISABLED && (ENABLE(VIDEO) || ENABLE(WEB_AUDIO))
-    m_logger->removeLogger(session.logger());
+    m_logger->removeLogger(session.protectedLogger());
 #endif
 
     scheduleUpdateSessionState();
@@ -532,7 +532,7 @@ void PlatformMediaSessionManager::sessionCanProduceAudioChanged()
         return;
 
     m_alreadyScheduledSessionStatedUpdate = true;
-    enqueueTaskOnMainThread([this] {
+    enqueueTaskOnMainThread([this, protectedThis = Ref { *this }] {
         m_alreadyScheduledSessionStatedUpdate = false;
         maybeActivateAudioSession();
         updateSessionState();
@@ -726,7 +726,7 @@ void PlatformMediaSessionManager::scheduleUpdateSessionState()
         return;
 
     m_hasScheduledSessionStateUpdate = true;
-    enqueueTaskOnMainThread([this] {
+    enqueueTaskOnMainThread([this, protectedThis = Ref { * this }] {
         updateSessionState();
         m_hasScheduledSessionStateUpdate = false;
     });
@@ -739,7 +739,7 @@ void PlatformMediaSessionManager::maybeDeactivateAudioSession()
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, "tried to set inactive AudioSession");
-    AudioSession::sharedSession().tryToSetActive(false);
+    AudioSession::protectedSharedSession()->tryToSetActive(false);
     m_becameActive = false;
 #endif
 }
@@ -752,7 +752,7 @@ bool PlatformMediaSessionManager::maybeActivateAudioSession()
         return true;
     }
 
-    m_becameActive = AudioSession::sharedSession().tryToSetActive(true);
+    m_becameActive = AudioSession::protectedSharedSession()->tryToSetActive(true);
     ALWAYS_LOG(LOGIDENTIFIER, m_becameActive ? "successfully activated" : "failed to activate", " AudioSession");
     return m_becameActive;
 #else

--- a/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
+++ b/Source/WebCore/platform/audio/PlatformMediaSessionManager.h
@@ -284,7 +284,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     UniqueRef<Timer> m_stateLogTimer;
-    Ref<AggregateLogger> m_logger;
+    const Ref<AggregateLogger> m_logger;
 #endif
 };
 

--- a/Source/WebCore/platform/audio/PushPullFIFO.cpp
+++ b/Source/WebCore/platform/audio/PushPullFIFO.cpp
@@ -34,9 +34,9 @@ namespace WebCore {
 
 PushPullFIFO::PushPullFIFO(unsigned numberOfChannels, size_t fifoLength)
     : m_fifoLength(fifoLength)
+    , m_fifoBus(AudioBus::create(numberOfChannels, m_fifoLength))
 {
     ASSERT(m_fifoLength <= maxFIFOLength);
-    m_fifoBus = AudioBus::create(numberOfChannels, m_fifoLength);
 }
 
 PushPullFIFO::~PushPullFIFO() = default;

--- a/Source/WebCore/platform/audio/PushPullFIFO.h
+++ b/Source/WebCore/platform/audio/PushPullFIFO.h
@@ -67,7 +67,7 @@ private:
     // The size of the FIFO.
     const size_t m_fifoLength = 0;
 
-    RefPtr<AudioBus> m_fifoBus;
+    const RefPtr<AudioBus> m_fifoBus;
 
     // The number of frames in the FIFO actually available for pulling.
     size_t m_framesAvailable { 0 };

--- a/Source/WebCore/platform/audio/Reverb.cpp
+++ b/Source/WebCore/platform/audio/Reverb.cpp
@@ -194,8 +194,9 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         const AudioChannel* sourceChannelR = sourceBus->channel(1);
         AudioChannel* destinationChannelR = destinationBus->channel(1);
 
-        AudioChannel* tempChannelL = m_tempBuffer->channel(0);
-        AudioChannel* tempChannelR = m_tempBuffer->channel(1);
+        RefPtr tempBuffer = m_tempBuffer;
+        AudioChannel* tempChannelL = tempBuffer->channel(0);
+        AudioChannel* tempChannelR = tempBuffer->channel(1);
 
         // Process left virtual source
         m_convolvers[0]->process(sourceChannelL, destinationChannelL, framesToProcess);
@@ -205,15 +206,16 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         m_convolvers[2]->process(sourceChannelR, tempChannelL, framesToProcess);
         m_convolvers[3]->process(sourceChannelR, tempChannelR, framesToProcess);
 
-        destinationBus->sumFrom(*m_tempBuffer);
+        destinationBus->sumFrom(*tempBuffer);
     } else if (numInputChannels == 1 && numberOfResponseChannels == 4 && numOutputChannels == 2) {
         // Case 3: 1 -> 4 -> 2 (Processing mono with "True" stereo impulse
         // response) This is an inefficient use of a four-channel impulse
         // response, but we should handle the case.
         AudioChannel* destinationChannelR = destinationBus->channel(1);
 
-        AudioChannel* tempChannelL = m_tempBuffer->channel(0);
-        AudioChannel* tempChannelR = m_tempBuffer->channel(1);
+        RefPtr tempBuffer = m_tempBuffer;
+        AudioChannel* tempChannelL = tempBuffer->channel(0);
+        AudioChannel* tempChannelR = tempBuffer->channel(1);
 
         // Process left virtual source
         m_convolvers[0]->process(sourceChannelL, destinationChannelL, framesToProcess);
@@ -223,7 +225,7 @@ void Reverb::process(const AudioBus* sourceBus, AudioBus* destinationBus, size_t
         m_convolvers[2]->process(sourceChannelL, tempChannelL, framesToProcess);
         m_convolvers[3]->process(sourceChannelL, tempChannelR, framesToProcess);
 
-        destinationBus->sumFrom(*m_tempBuffer);
+        destinationBus->sumFrom(*tempBuffer);
     } else {
         ASSERT_NOT_REACHED();
         destinationBus->zero();

--- a/Source/WebCore/platform/audio/ReverbConvolver.cpp
+++ b/Source/WebCore/platform/audio/ReverbConvolver.cpp
@@ -122,9 +122,9 @@ ReverbConvolver::ReverbConvolver(AudioChannel* impulseResponse, size_t renderSli
     // Start up background thread
     // FIXME: would be better to up the thread priority here.  It doesn't need to be real-time, but higher than the default...
     if (this->useBackgroundThreads() && m_backgroundStages.size() > 0) {
-        m_backgroundThread = Thread::create("convolution background thread"_s, [this] {
+        lazyInitialize(m_backgroundThread, Thread::create("convolution background thread"_s, [this] {
             backgroundThreadEntry();
-        }, ThreadType::Audio);
+        }, ThreadType::Audio));
     }
 }
 

--- a/Source/WebCore/platform/audio/ReverbConvolver.h
+++ b/Source/WebCore/platform/audio/ReverbConvolver.h
@@ -86,7 +86,7 @@ private:
 
     // Background thread and synchronization
     bool m_useBackgroundThreads;
-    RefPtr<Thread> m_backgroundThread;
+    const RefPtr<Thread> m_backgroundThread;
     bool m_wantsToExit { false };
     bool m_moreInputBuffered { false };
     mutable Lock m_backgroundThreadLock;

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -132,12 +132,12 @@ class AudioFileReaderWebMData {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(AudioFileReaderWebMData);
 
 public:
-    Ref<SharedBuffer> m_buffer;
+    const Ref<SharedBuffer> m_buffer;
 #if ENABLE(MEDIA_SOURCE)
-    Ref<AudioTrackPrivateWebM> m_track;
+    const Ref<AudioTrackPrivateWebM> m_track;
 #endif
     MediaTime m_duration;
-    Vector<Ref<MediaSampleAVFObjC>> m_samples;
+    const Vector<Ref<MediaSampleAVFObjC>> m_samples;
 };
 
 AudioFileReader::AudioFileReader(std::span<const uint8_t> data)


### PR DESCRIPTION
#### 0186628742eff5ebe5e62826d31609b51cd581d2
<pre>
Address safer CPP failures in WebCore/platform/audio/
<a href="https://bugs.webkit.org/show_bug.cgi?id=289394">https://bugs.webkit.org/show_bug.cgi?id=289394</a>

Reviewed by Brady Eidson.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/platform/audio/AudioBus.cpp:
(WebCore::AudioBus::createBySampleRateConverting):
* Source/WebCore/platform/audio/AudioResampler.cpp:
(WebCore::AudioResampler::AudioResampler):
(WebCore::m_sourceBus):
(WebCore::AudioResampler::process):
* Source/WebCore/platform/audio/HRTFDatabaseLoader.cpp:
(WebCore::HRTFDatabaseLoader::loadAsynchronously):
(WebCore::HRTFDatabaseLoader::waitForLoaderThreadCompletion):
* Source/WebCore/platform/audio/HRTFDatabaseLoader.h:
* Source/WebCore/platform/audio/MultiChannelResampler.h:
* Source/WebCore/platform/audio/PlatformMediaSessionManager.cpp:
(WebCore::PlatformMediaSessionManager::addSession):
(WebCore::PlatformMediaSessionManager::removeSession):
(WebCore::PlatformMediaSessionManager::sessionCanProduceAudioChanged):
(WebCore::PlatformMediaSessionManager::scheduleUpdateSessionState):
(WebCore::PlatformMediaSessionManager::maybeDeactivateAudioSession):
(WebCore::PlatformMediaSessionManager::maybeActivateAudioSession):
* Source/WebCore/platform/audio/PlatformMediaSessionManager.h:
* Source/WebCore/platform/audio/PushPullFIFO.cpp:
(WebCore::PushPullFIFO::PushPullFIFO):
* Source/WebCore/platform/audio/PushPullFIFO.h:
* Source/WebCore/platform/audio/Reverb.cpp:
(WebCore::Reverb::process):
* Source/WebCore/platform/audio/ReverbConvolver.cpp:
(WebCore::ReverbConvolver::ReverbConvolver):
* Source/WebCore/platform/audio/ReverbConvolver.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp:
* Source/WebCore/platform/audio/cocoa/AudioSampleBufferConverter.mm:
(WebCore::AudioSampleBufferConverter::drain):
(WebCore::AudioSampleBufferConverter::initAudioConverterForSourceFormatDescription):
* Source/WebCore/platform/audio/cocoa/AudioSampleDataSource.mm:
(WebCore::AudioSampleDataSource::pushSamplesInternal):
(WebCore::AudioSampleDataSource::pullSamplesInternal):

Canonical link: <a href="https://commits.webkit.org/291850@main">https://commits.webkit.org/291850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f68a6641d360605cfdd0e4c75559bf0d1b5b895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94186 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71845 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29187 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97188 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10436 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52186 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2722 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44031 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2812 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101241 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80850 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80232 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24778 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14414 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15110 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26401 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20909 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24369 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22650 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->