### PR TITLE
Further optimize performMicrotaskCheckpoint

### DIFF
--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -193,7 +193,7 @@ public:
 
     DECLARE_VISIT_AGGREGATE;
 
-    inline void performMicrotaskCheckpoint(VM&, const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor);
+    inline void performMicrotaskCheckpoint(VM&, NOESCAPE const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor);
 
     bool hasMicrotasksForFullyActiveDocument() const
     {

--- a/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueueInlines.h
@@ -31,7 +31,7 @@
 
 namespace JSC {
 
-inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor)
+inline void MicrotaskQueue::performMicrotaskCheckpoint(VM& vm, NOESCAPE const Invocable<QueuedTask::Result(QueuedTask&)> auto& functor)
 {
     auto catchScope = DECLARE_CATCH_SCOPE(vm);
     while (!m_queue.isEmpty()) {

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -920,17 +920,6 @@ bool VM::hasExceptionsAfterHandlingTraps()
     return exception();
 }
 
-void VM::clearException()
-{
-#if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
-    m_needExceptionCheck = false;
-    m_nativeStackTraceOfLastThrow = nullptr;
-    m_throwingThread = nullptr;
-#endif
-    m_exception = nullptr;
-    traps().clearTrapBit(VMTraps::NeedExceptionHandling);
-}
-
 void VM::setException(Exception* exception)
 {
     ASSERT(!exception || !isTerminationException(exception) || hasTerminationRequest());

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -998,7 +998,17 @@ private:
         return m_exception;
     }
 
-    JS_EXPORT_PRIVATE void clearException();
+    void clearException()
+    {
+#if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
+        m_needExceptionCheck = false;
+        m_nativeStackTraceOfLastThrow = nullptr;
+        m_throwingThread = nullptr;
+#endif
+        m_exception = nullptr;
+        traps().clearTrapBit(VMTraps::NeedExceptionHandling);
+    }
+
     JS_EXPORT_PRIVATE void setException(Exception*);
 
 #if ENABLE(C_LOOP)

--- a/Source/WebCore/bindings/js/JSExecState.cpp
+++ b/Source/WebCore/bindings/js/JSExecState.cpp
@@ -28,6 +28,7 @@
 
 #include "EventLoop.h"
 #include "JSDOMExceptionHandling.h"
+#include "Microtasks.h"
 #include "RejectedPromiseTracker.h"
 #include "ScriptExecutionContext.h"
 #include "WorkerGlobalScope.h"
@@ -53,6 +54,12 @@ JSC::JSValue evaluateHandlerFromAnyThread(JSC::JSGlobalObject* lexicalGlobalObje
     return JSExecState::evaluate(lexicalGlobalObject, source, thisValue, returnedException);
 }
 
+void JSExecState::runTask(JSC::JSGlobalObject* globalObject, JSC::QueuedTask& task)
+{
+    JSExecState currentState(globalObject);
+    MicrotaskQueue::runJSMicrotask(globalObject, globalObject->vm(), task);
+}
+
 ScriptExecutionContext* executionContext(JSC::JSGlobalObject* globalObject)
 {
     if (!globalObject || !globalObject->inherits<JSDOMGlobalObject>())
@@ -64,55 +71,5 @@ RefPtr<ScriptExecutionContext> protectedExecutionContext(JSC::JSGlobalObject* gl
 {
     return executionContext(globalObject);
 }
-
-void JSExecState::runTask(JSC::JSGlobalObject* globalObject, JSC::QueuedTask& task)
-{
-    JSExecState currentState(globalObject);
-
-    auto& vm = globalObject->vm();
-    auto scope = DECLARE_CATCH_SCOPE(vm);
-
-    if (UNLIKELY(!task.job().isObject()))
-        return;
-
-    auto* job = JSC::asObject(task.job());
-
-    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
-        return;
-
-    auto* lexicalGlobalObject = job->globalObject();
-    auto callData = JSC::getCallData(job);
-    if (UNLIKELY(!scope.clearExceptionExceptTermination()))
-        return;
-    ASSERT(callData.type != JSC::CallData::Type::None);
-
-    unsigned count = 0;
-    for (auto argument : task.arguments()) {
-        if (!argument)
-            break;
-        ++count;
-    }
-
-    if (UNLIKELY(globalObject->hasDebugger())) {
-        JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
-        globalObject->debugger()->willRunMicrotask(globalObject, task.identifier());
-        scope.clearException();
-    }
-
-    NakedPtr<JSC::Exception> returnedException = nullptr;
-    if (LIKELY(!vm.hasPendingTerminationException())) {
-        JSExecState::profiledCall(lexicalGlobalObject, JSC::ProfilingReason::Microtask, job, callData, JSC::jsUndefined(), JSC::ArgList { std::bit_cast<JSC::EncodedJSValue*>(task.arguments().data()), count }, returnedException);
-        if (returnedException)
-            reportException(lexicalGlobalObject, returnedException);
-        scope.clearExceptionExceptTermination();
-    }
-
-    if (UNLIKELY(globalObject->hasDebugger())) {
-        JSC::DeferTerminationForAWhile deferTerminationForAWhile(vm);
-        globalObject->debugger()->didRunMicrotask(globalObject, task.identifier());
-        scope.clearException();
-    }
-}
-
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -68,6 +68,8 @@ public:
     bool isEmpty() const { return m_microtaskQueue.isEmpty(); }
     bool hasMicrotasksForFullyActiveDocument() const;
 
+    static void runJSMicrotask(JSC::JSGlobalObject*, JSC::VM&, JSC::QueuedTask&);
+
 private:
     JSC::VM& vm() const { return m_vm.get(); }
 


### PR DESCRIPTION
#### fb47e460117fd9f9ab9557aeaa1dac713abb98df
<pre>
Further optimize performMicrotaskCheckpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=289399">https://bugs.webkit.org/show_bug.cgi?id=289399</a>
<a href="https://rdar.apple.com/146537356">rdar://146537356</a>

Reviewed by Ryosuke Niwa.

From profiling data, it turned out that still performMicrotaskCheckpoint
is taking significant amount of time. This patch further optimizes this
code driven by collected profile data.

1. We do realm switching in performMicrotaskCheckpoint instead of using
   JSExecState. Since this is the code in performMicrotaskCheckpoint,
   we do not need to have JSExecState. We can avoid repeated lookup of
   ThreadGlobalData.
2. Profile data turned out that VM::clearException (non inlined) is hot.
   We were thinking this is rarely called. But since microtask is
   draining the exception, we need to clear exception frequently and it
   is calling this function frequently. This patch makes it inlined.

* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::clearException): Deleted.
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::clearException):
* Source/WebCore/bindings/js/JSExecState.cpp:
(WebCore::JSExecState::runTask): Deleted.
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::runJSMicrotask):
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):

Canonical link: <a href="https://commits.webkit.org/291849@main">https://commits.webkit.org/291849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/252b1b49a980ae840cc6372c9bded78aa01f4479

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99201 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44717 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96240 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22207 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/71851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29191 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85039 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52192 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10130 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2726 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44035 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86900 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80362 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2816 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101246 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92856 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15460 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81054 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/80241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24781 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14421 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15109 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26405 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115506 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20913 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24373 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22654 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->