### PR TITLE
[SwiftUI] Setting `.scrollBounceBehavior` to `.basedOnSize` on WebView has no effect on the vertical axis on iOS

### DIFF
--- a/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
+++ b/Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift
@@ -108,7 +108,10 @@ struct WebViewRepresentable {
 
         // By default, SwiftUI allows representable views to have fractional sizes, however WebKit does not support this
         // (it may result in incorrect behavior such as the size of the content view and scroll view being slightly mismatched).
-        return CGSize(width: width.rounded(), height: height.rounded());
+        //
+        // Rounding down is needed to ensure that the view is never bigger than the requested size, otherwise miscellaneous UI
+        // issues manifest.
+        return CGSize(width: width.rounded(.down), height: height.rounded(.down));
     }
 }
 


### PR DESCRIPTION
#### 2a248a3e94c0dda2e6adc7421def2807f48fdee1
<pre>
[SwiftUI] Setting `.scrollBounceBehavior` to `.basedOnSize` on WebView has no effect on the vertical axis on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=289400">https://bugs.webkit.org/show_bug.cgi?id=289400</a>
<a href="https://rdar.apple.com/146537443">rdar://146537443</a>

Reviewed by Aditya Keerthi.

In the existing implementation of `sizeThatFits`, the logic may result in rounding up, causing the resulting view
to be larger than the size requested. This manifests in a few miscellaneous issues, one of them being the view&apos;s
content insets containing a fractional size. As a result, UIKit sees that the content size is a tiny bit larger
than the scroll view size, and so always allows scrolling.

Fix this by always rounding down, which also fixes some incidental issues (such as applying a background color to
the WebView and ensuring it only covers the WebView).

* Source/WebKit/_WebKit_SwiftUI/Implementation/WebViewRepresentable.swift:
(WebViewRepresentable.sizeThatFits(_:platformView:context:)):

Canonical link: <a href="https://commits.webkit.org/291845@main">https://commits.webkit.org/291845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8cc9276e6e4989d7ef6869e1bc98e8aff2d2ca3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99177 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71827 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29168 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85009 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52168 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10105 "Passed tests") | | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44011 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80338 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101234 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21218 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15435 "Found 4 new test failures: imported/w3c/IndexedDB-private-browsing/idbcursor_advance_index8.html imported/w3c/IndexedDB-private-browsing/idbcursor_continue_index8.html svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-default-context.svg svg/W3C-I18N/tspan-dirRTL-ubEmbed-in-ltr-context.svg (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80842 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81026 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80224 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24759 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2116 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14385 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15106 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21202 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26381 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->