### PR TITLE
Correct URLPattern's hostname and port canonicalization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
@@ -1202,6 +1202,15 @@
   {
     "pattern": [{ "protocol": "http", "port": "80 " }],
     "inputs": [{ "protocol": "http", "port": "80" }],
+    "expected_obj": {
+      "protocol": "http",
+      "port": "80"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "protocol": "http", "port": "100000" }],
+    "inputs": [{ "protocol": "http", "port": "100000" }],
     "expected_obj": "error"
   },
   {
@@ -1866,7 +1875,17 @@
   {
     "pattern": [ "https://{sub.}?example{.com/}foo" ],
     "inputs": [ "https://example.com/foo" ],
-    "expected_obj": "error"
+    "exactly_empty_components": [ "port" ],
+    "expected_obj": {
+      "protocol": "https",
+      "hostname": "{sub.}?example.com",
+      "pathname": "*"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo", "groups": { "0": "/foo" } }
+    }
   },
   {
     "pattern": [ "{https://}example.com/foo" ],
@@ -2424,7 +2443,13 @@
   },
   {
     "pattern": [{ "hostname": "bad#hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname":  "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad%hostname" }],
@@ -2432,7 +2457,13 @@
   },
   {
     "pattern": [{ "hostname": "bad/hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "bad" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": {
+      "hostname": { "input": "bad", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\\:hostname" }],
@@ -2464,7 +2495,11 @@
   },
   {
     "pattern": [{ "hostname": "bad\\\\hostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "bad"
+    },
+    "expected_match": null
   },
   {
     "pattern": [{ "hostname": "bad^hostname" }],
@@ -2476,15 +2511,33 @@
   },
   {
     "pattern": [{ "hostname": "bad\nhostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\rhostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{ "hostname": "bad\thostname" }],
-    "expected_obj": "error"
+    "inputs": [{ "hostname": "badhostname" }],
+    "expected_obj": {
+      "hostname": "badhostname"
+    },
+    "expected_match": {
+      "hostname": { "input": "badhostname", "groups": {} }
+    }
   },
   {
     "pattern": [{}],

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/w3c-import.log
@@ -15,7 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpattern-compare-test-data.json
-/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpattern-compare-tests.js
+/LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpattern-compare-tests.tentative.js
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpattern-hasregexpgroups-tests.js
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntests.js

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt
@@ -166,6 +166,7 @@ PASS Pattern: [{"port":""}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80{20}?"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http","port":"80 "}] Inputs: [{"protocol":"http","port":"80"}]
+PASS Pattern: [{"protocol":"http","port":"100000"}] Inputs: [{"protocol":"http","port":"100000"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"protocol":"http{s}?","port":"80"}] Inputs: [{"protocol":"http","port":"80"}]
 PASS Pattern: [{"port":"80"}] Inputs: [{"port":"80"}]
@@ -284,9 +285,9 @@ PASS Pattern: [{"protocol":":name*"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name+"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"protocol":":name"}] Inputs: [{"protocol":"foobar"}]
 PASS Pattern: [{"hostname":"bad hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad#hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad%hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad/hostname"}] Inputs: [{"hostname":"bad"}]
 PASS Pattern: [{"hostname":"bad\\:hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad<hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad>hostname"}] Inputs: undefined
@@ -294,12 +295,12 @@ PASS Pattern: [{"hostname":"bad?hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad@hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad[hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad]hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\\\\hostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{"hostname":"bad^hostname"}] Inputs: undefined
 PASS Pattern: [{"hostname":"bad|hostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: undefined
-PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: undefined
+PASS Pattern: [{"hostname":"bad\nhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\rhostname"}] Inputs: [{"hostname":"badhostname"}]
+PASS Pattern: [{"hostname":"bad\thostname"}] Inputs: [{"hostname":"badhostname"}]
 PASS Pattern: [{}] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: ["https://example.com/"]
 PASS Pattern: [] Inputs: [{}]

--- a/LayoutTests/imported/w3c/web-platform-tests/urlpattern/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/urlpattern/w3c-import.log
@@ -15,8 +15,8 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/WEB_FEATURES.yml
-/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.any.js
-/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.https.any.js
+/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.any.js
+/LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-compare.tentative.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern-hasregexpgroups.any.js
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.js
 /LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.js

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -489,23 +489,23 @@ static bool slashHashOrQuestionMark(UChar c)
     return forwardSlashHashOrQuestionMark(c) || c == '\\';
 }
 
-void URL::setHost(StringView newHost)
+bool URL::setHost(StringView newHost)
 {
     if (!m_isValid || hasOpaquePath())
-        return;
+        return false;
 
     if (auto index = newHost.find(hasSpecialScheme() ? slashHashOrQuestionMark : forwardSlashHashOrQuestionMark); index != notFound)
         newHost = newHost.left(index);
 
     if (newHost.contains('@'))
-        return;
+        return false;
 
     if (newHost.contains(':') && !newHost.startsWith('['))
-        return;
+        return false;
 
     Vector<UChar, 512> encodedHostName;
     if (hasSpecialScheme() && !appendEncodedHostname(encodedHostName, newHost))
-        return;
+        return false;
 
     bool slashSlashNeeded = m_userStart == m_schemeEnd + 1U;
     parse(makeString(
@@ -514,6 +514,8 @@ void URL::setHost(StringView newHost)
         hasSpecialScheme() ? StringView(encodedHostName.span()) : newHost,
         StringView(m_string).substring(m_hostEnd)
     ));
+
+    return m_isValid;
 }
 
 void URL::setPort(std::optional<uint16_t> port)

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -195,7 +195,7 @@ public:
     WTF_EXPORT_PRIVATE bool isMatchingDomain(StringView) const;
 
     WTF_EXPORT_PRIVATE bool setProtocol(StringView);
-    WTF_EXPORT_PRIVATE void setHost(StringView);
+    WTF_EXPORT_PRIVATE bool setHost(StringView);
 
     WTF_EXPORT_PRIVATE void setPort(std::optional<uint16_t>);
 

--- a/Source/WebCore/Modules/url-pattern/URLPattern.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPattern.cpp
@@ -81,10 +81,8 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
     if  (!init.baseURL.isNull()) {
         baseURL = URL(init.baseURL);
 
-        if (!baseURL.isValid()) {
-            // FIXME: Check if empty string should be allowed.
+        if (!baseURL.isValid())
             return Exception { ExceptionCode::TypeError, "Invalid baseURL."_s };
-        }
 
         if (init.protocol.isNull())
             result.protocol = processBaseURLString(baseURL.protocol(), type);
@@ -166,7 +164,7 @@ static ExceptionOr<URLPatternInit> processInit(URLPatternInit&& init, BaseURLStr
     }
 
     if (!init.port.isNull()) {
-        auto portResult = canonicalizePort(init.port, init.protocol, type);
+        auto portResult = canonicalizePort(init.port, result.protocol, type);
 
         if (portResult.hasException())
             return portResult.releaseException();

--- a/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternCanonical.h
@@ -38,7 +38,7 @@ String canonicalizeUsername(StringView value, BaseURLStringType valueType);
 String canonicalizePassword(StringView value, BaseURLStringType valueType);
 ExceptionOr<String> canonicalizeHostname(StringView value, BaseURLStringType valueType);
 ExceptionOr<String> canonicalizeIPv6Hostname(StringView value, BaseURLStringType valueType);
-ExceptionOr<String> canonicalizePort(StringView portValue, const std::optional<StringView> protocolValue, BaseURLStringType portValueType);
+ExceptionOr<String> canonicalizePort(StringView portValue, StringView protocolValue, BaseURLStringType portValueType);
 ExceptionOr<String> processPathname(StringView pathnameValue, const StringView protocolValue, BaseURLStringType pathnameValueType);
 ExceptionOr<String> canonicalizePathname(StringView pathnameValue);
 ExceptionOr<String> canonicalizeOpaquePathname(StringView value);

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -121,7 +121,7 @@ String URLDecomposition::port() const
 }
 
 // Outer optional is whether we could parse at all. Inner optional is "no port specified".
-static std::optional<std::optional<uint16_t>> parsePort(StringView string, StringView protocol)
+std::optional<std::optional<uint16_t>> URLDecomposition::parsePort(StringView string, StringView protocol)
 {
     // https://url.spec.whatwg.org/#port-state with state override given.
     uint32_t port { 0 };
@@ -152,7 +152,7 @@ void URLDecomposition::setPort(StringView value)
     auto fullURL = this->fullURL();
     if (fullURL.host().isEmpty() || fullURL.protocolIsFile())
         return;
-    auto port = parsePort(value, fullURL.protocol());
+    auto port = URLDecomposition::parsePort(value, fullURL.protocol());
     if (!port)
         return;
     fullURL.setPort(*port);

--- a/Source/WebCore/html/URLDecomposition.h
+++ b/Source/WebCore/html/URLDecomposition.h
@@ -60,6 +60,8 @@ public:
     WEBCORE_EXPORT String hash() const;
     void setHash(StringView);
 
+    static std::optional<std::optional<uint16_t>> parsePort(StringView, StringView protocol);
+
 protected:
     virtual ~URLDecomposition() = default;
 


### PR DESCRIPTION
#### 9144dd425d320123dcf0c43beda144e2f8b9b248
<pre>
Correct URLPattern&apos;s hostname and port canonicalization
<a href="https://bugs.webkit.org/show_bug.cgi?id=289401">https://bugs.webkit.org/show_bug.cgi?id=289401</a>

Reviewed by Youenn Fablet.

This corrects our canonicalize a hostname and port algorithms to match
the specification (modulo a small change I had to make to the URL
standard to make the hostname state override return failure more
often).

New tests are upstreamed here:
<a href="https://github.com/web-platform-tests/wpt/pull/51316">https://github.com/web-platform-tests/wpt/pull/51316</a>

* LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/urlpatterntestdata.json:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/urlpattern.https.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/urlpattern/w3c-import.log:
* Source/WTF/wtf/URL.cpp:
(WTF::URL::setHost):
* Source/WTF/wtf/URL.h:
* Source/WebCore/Modules/url-pattern/URLPattern.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.cpp:
(WebCore::canonicalizeHostname):
(WebCore::canonicalizePort):
* Source/WebCore/Modules/url-pattern/URLPatternCanonical.h:
* Source/WebCore/html/URLDecomposition.cpp:
(WebCore::URLDecomposition::parsePort):
(WebCore::URLDecomposition::setPort):
(WebCore::parsePort): Deleted.
* Source/WebCore/html/URLDecomposition.h:

Canonical link: <a href="https://commits.webkit.org/292382@main">https://commits.webkit.org/292382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1400dc930238e16fbe104a0b6be545a66e3c3ef8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/4358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99940 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45410 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22932 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/72407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29700 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/11029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85706 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52738 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3425 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44751 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87588 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101981 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/93540 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/16050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/81404 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/22200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81730 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80797 "Found 1 new API test failure: /TestWebCore:GStreamerTest.capsFromCodecString (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25357 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sonoma-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/15196 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15430 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/27046 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/116230 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21588 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/33276 "Found 326 jsc stress test failures: microbenchmarks/interpreter-wasm.js.default, microbenchmarks/memcpy-wasm-large.js.bytecode-cache, microbenchmarks/memcpy-wasm-large.js.default, microbenchmarks/memcpy-wasm-large.js.dfg-eager, microbenchmarks/memcpy-wasm-large.js.dfg-eager-no-cjit-validate ...") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/25060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/23329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->