### PR TITLE
REGRESSION (Sequoia): [ x86_64 ] 5 swipe layout tests are timing out due to "Timed out waiting for notifyDone to be called"

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1037,8 +1037,6 @@ webkit.org/b/209624 tiled-drawing/scrolling/fixed/four-bars-zoomed.html [ Pass F
 
 webkit.org/b/68278 http/tests/history/back-with-fragment-change.py [ Pass Failure ]
 
-webkit.org/b/210433 swipe/basic-cached-back-swipe.html [ Pass Crash Timeout ]
-
 webkit.org/b/207518 tiled-drawing/simple-document-with-margin-tiles.html [ Pass Failure ]
 
 webkit.org/b/212091 platform/mac/media/media-source/media-source-change-source.html [ Pass Failure ]
@@ -1547,8 +1545,6 @@ imported/w3c/web-platform-tests/fetch/api/abort/serviceworker-intercepted.https.
 # rdar://99153669 ([ iOS macOS ] 4X imported/w3c/web-platform-tests/html/cross-origin-opener-policy/(Layout tests) are flaky failures (244358))
 imported/w3c/web-platform-tests/html/cross-origin-opener-policy/iframe-popup-same-origin-allow-popups-to-unsafe-none.https.html [ Pass Crash ]
 
-webkit.org/b/261005 swipe/pushState-cached-back-swipe.html [ Pass Failure Timeout ]
-
 webkit.org/b/227761 imported/w3c/web-platform-tests/beacon/beacon-cors.https.window.html [ Pass Failure ]
 
 webkit.org/b/261226 [ Sonoma+ ] fast/images/mac/play-pause-individual-animation-context-menu-items.html [ Pass ] # backing functionality only in Sonoma+
@@ -1844,11 +1840,6 @@ imported/w3c/web-platform-tests/navigation-api/navigation-methods/return-value/b
 # webkit.org/b/282063 REGRESSION (285464@main?) : [ macOS iOS wk2 ] media/remote-control-comman d-is-user-gesture.html is a constant timeout.
 media/remote-control-command-is-user-gesture.html [ Timeout ]
 
-# webkit.org/b/282126 NEW TEST [ Sequoia+ x86_64 ] 5 swipe layout tests are timing due to "Timed out waiting for notifyDone to be called"
-[ Sequoia+ x86_64 ] http/tests/swipe/swipe-back-with-outstanding-load-cancellation.html [ Timeout ]
-[ Sonoma+ ] swipe/navigate-event-back-swipe-verify-ua-transition.html [ Pass Timeout ]
-[ Sequoia+ x86_64 ] swipe/pushState-back-swipe-verify-ua-transition.html [ Timeout ]
-
 webkit.org/b/282565 [ Sequoia+ ] imported/w3c/web-platform-tests/css/css-writing-modes/text-combine-upright-sideways-001.html [ ImageOnlyFailure ]
 
 webkit.org/b/282726 http/tests/media/fairplay/legacy-fairplay-hls.html [ Failure ]
@@ -1857,9 +1848,6 @@ webkit.org/b/282726 http/tests/media/fairplay/legacy-fairplay-hls.html [ Failure
 [ Sequoia+ ] http/tests/cookies/same-site/fetch-after-navigating-iframe-in-cross-origin-page.html [ Failure ]
 [ Sequoia+ ] http/tests/cookies/same-site/fetch-in-cross-origin-service-worker.html [ Failure ]
 [ Sequoia+ ] http/tests/cookies/same-site/popup-cross-site-post.html [ Failure ]
-
-# webkit.org/b/282126 NEW TEST [ Sequoia+ x86_64 ] 5 swipe layout tests are timing due to "Timed out waiting for notifyDone to be called"
-swipe/main-frame-pinning-requirement.html [ Failure Timeout ]
 
 webkit.org/b/283596 [ Sequoia+ Debug ] ipc/cfnetwork-crashes-with-string-to-string-http-headers.html [ Skip ]
 
@@ -1956,10 +1944,6 @@ webkit.org/b/288404 [ Sonoma+ Release ] fast/text/canvas-color-fonts/stroke-grad
 webkit.org/b/287012 [ Sonoma+ Debug ] http/tests/pdf/linearized-pdf-in-iframe.html [ Pass Crash ]
 
 webkit.org/b/288411 [ Sequoia x86_64 ] imported/w3c/web-platform-tests/webrtc/simulcast/getStats.https.html [ Failure ]
-
-webkit.org/b/288521 [ Sequoia+ X86_64 ] swipe/swipe-disables-view-transition.html [ Timeout ]
-
-webkit.org/b/288535 [ Sequoia+ X86_64 ] swipe/pushstate-with-manual-scrollrestoration.html [ Timeout ]
 
 webkit.org/b/288545 [ Sequoia x86_64 ] imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Failure ]
 webkit.org/b/288545 [ Sonoma Release ] imported/w3c/web-platform-tests/requestidlecallback/deadline-max-rAF-dynamic.html [ Pass Failure ]

--- a/LayoutTests/swipe/main-frame-pinning-requirement.html
+++ b/LayoutTests/swipe/main-frame-pinning-requirement.html
@@ -15,26 +15,20 @@ async function runTest()
     // pinned to the edge.
     await startSwipeGesture();
     await completeSwipeGesture();
-    
-    testRunner.clearTestRunnerCallbacks();
-    testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
-    testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
-    testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
-    testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);    
+
+    window.localStorage["hasFinishedFirstSwipe"] = "YES";
 
     // The second swipe should succeed because we are now scrolled to the left edge.
     await startSwipeGesture();
     await completeSwipeGesture();
 }
 
-function didBeginSwipeNotReachedCallback()
-{
-    log("Failure. Should never begin a swipe, because we were in the middle of a scrolling gesture that started when the main frame was not pinned to the left.");
-}
-
 function didBeginSwipeCallback()
 {
-    log("didBeginSwipe");
+    if (window.localStorage["hasFinishedFirstSwipe"] == "YES")
+        log("didBeginSwipe");
+    else
+        log("Failure. Should not begin a swipe, because we were in the middle of a scrolling gesture that started when the main frame was not pinned to the left.");
 }
 
 function willEndSwipeCallback()
@@ -75,15 +69,17 @@ window.onload = async function () {
     document.getElementById("large").innerHTML = isFirstPage() ? "first" : "second";
 
     if (isFirstPage()) {
-        initializeSwipeTest();
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
 
-        testRunner.installDidBeginSwipeCallback(didBeginSwipeNotReachedCallback);
+        await initializeSwipeTest();
+
+        window.localStorage["hasFinishedFirstSwipe"] = "NO";
+
+        testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
         testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
         testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
         testRunner.installDidRemoveSwipeSnapshotCallback(didRemoveSwipeSnapshotCallback);
-
-        testRunner.dumpAsText();
-        testRunner.waitUntilDone();
 
         setTimeout(function () {
             window.location.href = window.location.href + "?second";

--- a/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.h
+++ b/Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.h
@@ -27,22 +27,18 @@
 
 #import <AppKit/AppKit.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Forward.h>
 #import <wtf/RetainPtr.h>
 
 @interface EventSerializer : NSObject
 
 + (NSDictionary *)dictionaryForEvent:(CGEventRef)event relativeToTime:(CGEventTimestamp)referenceTimestamp;
 
-+ (RetainPtr<CGEventRef>)createEventForDictionary:(NSDictionary *)dict inWindow:(NSWindow *)window relativeToTime:(CGEventTimestamp)referenceTimestamp;
++ (RetainPtr<CGEventRef>)createEventForDictionary:(NSDictionary *)dict inWindow:(NSWindow *)window relativeToTime:(MonotonicTime)referenceTimestamp;
 
 @end
 
-@interface EventStreamPlayer : NSObject {
-    RetainPtr<NSMutableArray> _remainingEventDictionaries;
-    RetainPtr<NSWindow> _window;
-    BlockPtr<void ()> _completionHandler;
-    uint64_t _startTime;
-}
+@interface EventStreamPlayer : NSObject
 
 + (void)playStream:(NSArray<NSDictionary *> *)eventDicts window:(NSWindow *)window completionHandler:(void(^)())completionHandler;
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -294,8 +294,6 @@ interface TestRunner {
     undefined runUIScript(DOMString script, object callback);
     undefined runUIScriptImmediately(DOMString script, object callback);
 
-    undefined clearTestRunnerCallbacks();
-
     undefined accummulateLogsForChannel(DOMString channel);
 
     // Contextual menu actions


### PR DESCRIPTION
#### 7596ac02075f631c107be8d4e0b056d236288433
<pre>
REGRESSION (Sequoia): [ x86_64 ] 5 swipe layout tests are timing out due to &quot;Timed out waiting for notifyDone to be called&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=282126">https://bugs.webkit.org/show_bug.cgi?id=282126</a>
<a href="https://rdar.apple.com/138679110">rdar://138679110</a>

Reviewed by Abrar Rahman Protyasha.

Fix a series of bugs with the swipe tests:

1) The tests often timed out, and took much longer to run than necessary even when they passed.

   Matt Woodrow noticed that I mixed up the units of CGEventTimestamp and mach_absolute_time,
   causing the tests that were intended to run in hundreds of milliseconds to take tens of seconds
   instead. This also means that the actual delays are dependent on the mach_absolute_time to
   physical time conversion factor, which varies between platforms and is subject to change.

   Fix this by adopting MonotonicTime, which has the same epoch as CGEventTimestamp and mach_absolute_time,
   but handles all the unit conversions correctly.

2) Fixing only part 1 caused all of the tests to fail, and no swipe (or scrolling) to take place at all.

   It turns out that our wildly misplaced timestamps were triggering some logic in AppKit to go down a
   &quot;fix up the event&apos;s window location, because the window has moved since the event was created&quot; path,
   which made AppKit use the CGEvent&apos;s global location (which we set with `CGEventSetLocation`) as the
   source of truth, ignoring the in-window location that we set with `CGEventSetWindowLocation`.
   Now that our timestamps are right, we don&apos;t go down this path, and AppKit uses our in-window location
   as the source of truth. This *would* be fine, as we attempted to set both global and in-window location
   on the CGEvent, and set them to the right value, but apparently `CGEventSetLocation` clears
   the window location, so the order of these two calls is critical! To fix, swap them around.

3) After this, all tests except `main-frame-pinning-requirement.html` pass, and pass quickly.

   I did not come to a satisfying conclusion about what exactly was wrong with this test, but narrowed
   it down to clearing and re-installing the swipe callbacks.
   Since it&apos;s easy to rewrite this test to not have to do that, do so.

4) As a result of part 3, there are no longer any JS callers of `clearTestRunnerCallbacks`.

   Because it seems fraught with peril (because it clears UIScriptController callbacks, which
   are important!), hide it from tests by removing it from the IDL. The only remaining caller
   is the test runner itself, between tests, which seems fine.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/swipe/main-frame-pinning-requirement.html:
* Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.h:
* Tools/TestRunnerShared/EventSerialization/mac/EventSerializerMac.mm:
(+[EventSerializer createEventForDictionary:inWindow:relativeToTime:]):
(+[EventStreamPlayer playStream:window:completionHandler:]):
(-[EventStreamPlayer playbackTimerFired:]):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:

Canonical link: <a href="https://commits.webkit.org/291844@main">https://commits.webkit.org/291844@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1627ef7454b0a4cccf03d78839e2316684ff7655

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44704 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71836 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29179 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52177 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2710 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44022 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80348 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101231 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21229 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Debug-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80841 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21481 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80223 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2128 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14400 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21213 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20900 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->