### PR TITLE
[JSC] Add utility function to clear the gap of optimal and actual vector length

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1767,25 +1767,7 @@ static JSArray* concatAppendArray(JSGlobalObject* globalObject, VM& vm, JSArray*
         copyArrayElements<ArrayFillMode::Empty, NeedsGCSafeOps::No>(buffer, firstArraySize, secondButterfly->contiguous().data(), secondArraySize, secondType);
     }
 
-    if (size_t remaining = vectorLength - resultSize; remaining) {
-        if (hasDouble(type)) {
-#if OS(DARWIN)
-            constexpr double pattern = PNaN;
-            memset_pattern8(static_cast<void*>(butterfly->contiguous().data() + resultSize), &pattern, sizeof(JSValue) * remaining);
-#else
-            for (unsigned i = resultSize; i < vectorLength; ++i)
-                butterfly->contiguousDouble().atUnsafe(i) = PNaN;
-#endif
-        } else {
-#if USE(JSVALUE64)
-            memset(static_cast<void*>(butterfly->contiguous().data() + resultSize), 0, sizeof(JSValue) * remaining);
-#else
-            for (unsigned i = resultSize; i < vectorLength; ++i)
-                butterfly->contiguous().atUnsafe(i).clear();
-#endif
-        }
-    }
-
+    Butterfly::clearOptimalVectorLengthGap(type, butterfly, vectorLength, resultSize);
     return JSArray::createWithButterfly(vm, nullptr, resultStructure, butterfly);
 }
 

--- a/Source/JavaScriptCore/runtime/Butterfly.h
+++ b/Source/JavaScriptCore/runtime/Butterfly.h
@@ -240,6 +240,8 @@ public:
     Butterfly* resizeArray(VM&, JSObject* intendedOwner, Structure*, size_t newPreCapacity, size_t newIndexingPayloadSizeInBytes); // Assumes that you're not changing whether or not the object has an indexing header.
     Butterfly* unshift(Structure*, size_t numberOfSlots);
     Butterfly* shift(Structure*, size_t numberOfSlots);
+
+    ALWAYS_INLINE static void clearOptimalVectorLengthGap(IndexingType, Butterfly*, unsigned optimalVectorLength, unsigned vectorLength);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -166,7 +166,7 @@ public:
     JS_EXPORT_PRIVATE bool isIteratorProtocolFastAndNonObservable();
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue, IndexingType);
-        
+
 protected:
 #if ASSERT_ENABLED
     void finishCreation(VM& vm)


### PR DESCRIPTION
#### e6d3dcaf7b3c44a6f563d872280ee747a6bce322
<pre>
[JSC] Add utility function to clear the gap of optimal and actual vector length
<a href="https://bugs.webkit.org/show_bug.cgi?id=289406">https://bugs.webkit.org/show_bug.cgi?id=289406</a>

Reviewed by Yusuke Suzuki.

This patch adds a utility function to clear the gap of optimal and
actual vector length.

* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::tryCreateUninitializedRestricted):
(JSC::JSArray::fastToReversed):
(JSC::JSArray::fastWith):
(JSC::JSArray::fastSlice):
(JSC::tryCloneArrayFromFast):
* Source/JavaScriptCore/runtime/JSArray.h:
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::clearOptimalVectorLengthGap):

Canonical link: <a href="https://commits.webkit.org/291863@main">https://commits.webkit.org/291863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b084bcb357a7dda6b5cc400580e0d5bc888bc459

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94227 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13814 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99239 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44754 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71879 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29221 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85089 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52237 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10164 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2763 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44072 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86937 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101283 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92893 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21279 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80273 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24816 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2183 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14479 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15116 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26442 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115543 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20950 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24410 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->