### PR TITLE
Form associated ElementInternals always reports customError when using setValidity

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -8,6 +8,7 @@ PASS willValidate after upgrade
 PASS willValidate after upgrade (document.createElement)
 PASS willValidate should throw NotSupportedError if the target element is not a form-associated custom element
 PASS validity and setValidity()
+PASS validity.customError should be false if not explicitly set via setValidity()
 PASS "anchor" argument of setValidity()
 PASS checkValidity() should throw NotSupportedError if the target element is not a form-associated custom element
 PASS checkValidity()

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html
@@ -189,6 +189,15 @@ test(() => {
 }, 'validity and setValidity()');
 
 test(() => {
+  const control = document.createElement('my-control');
+  control.i.setValidity({badInput: true}, 'error message');
+  const validity = control.i.validity;
+  assert_false(validity.customError);
+  assert_false(validity.valid);
+  assert_equals(control.i.validationMessage, 'error message');
+}, "validity.customError should be false if not explicitly set via setValidity()");
+
+test(() => {
   document.body.insertAdjacentHTML('afterbegin', '<my-control><light-child></my-control>');
   let control = document.body.firstChild;
   const flags = {valueMissing: true};

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
@@ -8,6 +8,7 @@ FAIL willValidate after upgrade assert_false: in datalist expected false got tru
 PASS willValidate after upgrade (document.createElement)
 PASS willValidate should throw NotSupportedError if the target element is not a form-associated custom element
 PASS validity and setValidity()
+PASS validity.customError should be false if not explicitly set via setValidity()
 PASS "anchor" argument of setValidity()
 PASS checkValidity() should throw NotSupportedError if the target element is not a form-associated custom element
 PASS checkValidity()

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -84,6 +84,7 @@ private:
     void didChangeForm() final;
     void invalidateElementsCollectionCachesInAncestors();
 
+    bool customError() const final { return m_validityStateFlags.customError; }
     bool hasBadInput() const final { return m_validityStateFlags.badInput; }
     bool patternMismatch() const final { return m_validityStateFlags.patternMismatch; }
     bool rangeOverflow() const final { return m_validityStateFlags.rangeOverflow; }

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -68,7 +68,7 @@ public:
 
     // ValidityState attribute implementations
     bool badInput() const { return hasBadInput(); }
-    bool customError() const;
+    virtual bool customError() const;
 
     // Implementations of patternMismatch, rangeOverflow, rangerUnderflow, stepMismatch, tooShort, tooLong and valueMissing must call willValidate.
     virtual bool hasBadInput() const;


### PR DESCRIPTION
#### 072d9cabfbfae74efdac59127bf9f568dee9c593
<pre>
Form associated ElementInternals always reports customError when using setValidity
<a href="https://bugs.webkit.org/show_bug.cgi?id=261432">https://bugs.webkit.org/show_bug.cgi?id=261432</a>

Reviewed by Ryosuke Niwa.

The current implementation toggles customError when any validationMessage is
set, which works for native form elements, but breaks with ElementInternals.
This PR fixes this by overriding the customError check in FormAssociatedCustomElement.
(Test was added in <a href="https://github.com/web-platform-tests/wpt/pull/51039)">https://github.com/web-platform-tests/wpt/pull/51039)</a>

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation.html:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/custom-elements/form-associated/ElementInternals-validation-expected.txt
* Source/WebCore/html/FormAssociatedCustomElement.h:
* Source/WebCore/html/FormListedElement.h:

Canonical link: <a href="https://commits.webkit.org/291878@main">https://commits.webkit.org/291878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a97679c4e74ed13978a2a05b4e412ce0bd18cbc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44794 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71915 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29253 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97268 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10510 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85120 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52261 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10199 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2804 "Found 1 new test failure: http/tests/security/contentSecurityPolicy/block-all-mixed-content/insecure-script-in-iframe.html (failure)") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44112 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80431 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101322 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21318 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80918 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20020 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2224 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/14535 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26481 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22730 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->