### PR TITLE
Re-land 291425@main

### DIFF
--- a/Source/JavaScriptCore/API/JSValue.mm
+++ b/Source/JavaScriptCore/API/JSValue.mm
@@ -845,6 +845,9 @@ private:
 
 inline id JSContainerConvertor::convert(JSValueRef value)
 {
+    if (!value)
+        return nil;
+
     auto iter = m_objectMap.find(value);
     if (iter != m_objectMap.end())
         return iter->value;

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -98,6 +98,7 @@ enum class SDKAlignedBehavior {
     SessionCleanupByDefault,
     SharedNetworkProcess,
     SiteSpecificQuirksAreEnabledByDefault,
+    SkipsSerializedScriptValueRoundtripOfJavaScriptEvaluationResults,
     SnapshotAfterScreenUpdates,
     SupportsDeviceOrientationAndMotionPermissionAPI,
     SupportsInitConstructors,

--- a/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp
@@ -62,7 +62,11 @@ TEST(WebKit, EvaluateJavaScriptThatThrowsAnException)
 
 static void didCreateBlob(WKTypeRef result, WKErrorRef error, void* context)
 {
+#if PLATFORM(COCOA)
+    EXPECT_EQ(WKGetTypeID(result), WKDictionaryGetTypeID());
+#else
     EXPECT_NULL(result);
+#endif
     testDone = true;
 }
 


### PR DESCRIPTION
#### 5b0f914d1fa281421d2e6e93917e6760af113cbd
<pre>
Re-land 291425@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=289410">https://bugs.webkit.org/show_bug.cgi?id=289410</a>
<a href="https://rdar.apple.com/146563641">rdar://146563641</a>

Reviewed by Sihui Liu.

The tests found a missing null check in JSContainerConvertor::convert so it was reverted in 291600@main.
This redoes it and adds the null check.  Covered by API tests TestWebKitAPI.WebKit.FindTextInImageOverlay
and TestWebKitAPI.ResourceLoadStatistics.StorageAccessPromptSiteWithTrigger.

* Source/JavaScriptCore/API/JSValue.mm:
(JSContainerConvertor::convert):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::extract):
* Tools/TestWebKitAPI/Tests/WebKit/EvaluateJavaScript.cpp:
(TestWebKitAPI::didCreateBlob):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptErrorCases)):
(ReturnTypes)):

Canonical link: <a href="https://commits.webkit.org/291895@main">https://commits.webkit.org/291895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff6c14cdddd0062c87080d439ea63845a010a7bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99200 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44716 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29189 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85037 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2724 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44034 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86899 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80360 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101244 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92855 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80851 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81052 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80233 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24780 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2143 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14418 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15131 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26404 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115505 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20912 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24372 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->