### PR TITLE
Changing field-sizing doesn't cause relayout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
@@ -8,7 +8,7 @@ PASS text: Explicit width and auto height
 PASS text: Explicit height and auto width
 PASS text: Text caret is taller than the placeholder
 FAIL text: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL text: Update field-sizing property dynamically assert_less_than: expected a number less than 148 but got 148
+PASS text: Update field-sizing property dynamically
 PASS search: Empty value
 PASS search: Empty value with a size atttribute
 PASS search: Auto width and auto height with a long text
@@ -17,7 +17,7 @@ PASS search: Explicit width and auto height
 PASS search: Explicit height and auto width
 PASS search: Text caret is taller than the placeholder
 FAIL search: Text caret is shorter than the placeholder assert_less_than: expected a number less than 19 but got 19
-FAIL search: Update field-sizing property dynamically assert_less_than: expected a number less than 148 but got 148
+PASS search: Update field-sizing property dynamically
 PASS tel: Empty value
 PASS tel: Empty value with a size atttribute
 PASS tel: Auto width and auto height with a long text
@@ -26,7 +26,7 @@ PASS tel: Explicit width and auto height
 PASS tel: Explicit height and auto width
 PASS tel: Text caret is taller than the placeholder
 FAIL tel: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL tel: Update field-sizing property dynamically assert_less_than: expected a number less than 148 but got 148
+PASS tel: Update field-sizing property dynamically
 PASS url: Empty value
 PASS url: Empty value with a size atttribute
 PASS url: Auto width and auto height with a long text
@@ -35,7 +35,7 @@ PASS url: Explicit width and auto height
 PASS url: Explicit height and auto width
 PASS url: Text caret is taller than the placeholder
 FAIL url: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL url: Update field-sizing property dynamically assert_less_than: expected a number less than 148 but got 148
+PASS url: Update field-sizing property dynamically
 PASS email: Empty value
 PASS email: Empty value with a size atttribute
 PASS email: Auto width and auto height with a long text
@@ -44,7 +44,7 @@ PASS email: Explicit width and auto height
 PASS email: Explicit height and auto width
 PASS email: Text caret is taller than the placeholder
 FAIL email: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL email: Update field-sizing property dynamically assert_less_than: expected a number less than 148 but got 148
+PASS email: Update field-sizing property dynamically
 PASS password: Empty value
 PASS password: Empty value with a size atttribute
 PASS password: Auto width and auto height with a long text
@@ -53,5 +53,5 @@ PASS password: Explicit width and auto height
 PASS password: Explicit height and auto width
 PASS password: Text caret is taller than the placeholder
 FAIL password: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL password: Update field-sizing property dynamically assert_less_than: expected a number less than 148 but got 148
+PASS password: Update field-sizing property dynamically
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt
@@ -8,5 +8,5 @@ FAIL Explicit width and auto height assert_greater_than: expected a number great
 PASS Explicit height and auto width
 PASS Text caret is taller than the placeholder
 FAIL Text caret is shorter than the placeholder assert_less_than: height expected a number less than 29 but got 29
-FAIL Update field-sizing property dynamically assert_less_than: expected a number less than 161 but got 161
+PASS Update field-sizing property dynamically
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt
@@ -8,5 +8,5 @@ FAIL Explicit width and auto height assert_greater_than: expected a number great
 PASS Explicit height and auto width
 PASS Text caret is taller than the placeholder
 FAIL Text caret is shorter than the placeholder assert_less_than: height expected a number less than 29 but got 29
-FAIL Update field-sizing property dynamically assert_less_than: expected a number less than 221 but got 221
+PASS Update field-sizing property dynamically
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
@@ -8,7 +8,7 @@ PASS text: Explicit width and auto height
 PASS text: Explicit height and auto width
 PASS text: Text caret is taller than the placeholder
 FAIL text: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL text: Update field-sizing property dynamically assert_less_than: expected a number less than 192 but got 192
+PASS text: Update field-sizing property dynamically
 PASS search: Empty value
 PASS search: Empty value with a size atttribute
 PASS search: Auto width and auto height with a long text
@@ -17,7 +17,7 @@ PASS search: Explicit width and auto height
 PASS search: Explicit height and auto width
 PASS search: Text caret is taller than the placeholder
 FAIL search: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL search: Update field-sizing property dynamically assert_less_than: expected a number less than 192 but got 192
+PASS search: Update field-sizing property dynamically
 PASS tel: Empty value
 PASS tel: Empty value with a size atttribute
 PASS tel: Auto width and auto height with a long text
@@ -26,7 +26,7 @@ PASS tel: Explicit width and auto height
 PASS tel: Explicit height and auto width
 PASS tel: Text caret is taller than the placeholder
 FAIL tel: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL tel: Update field-sizing property dynamically assert_less_than: expected a number less than 192 but got 192
+PASS tel: Update field-sizing property dynamically
 PASS url: Empty value
 PASS url: Empty value with a size atttribute
 PASS url: Auto width and auto height with a long text
@@ -35,7 +35,7 @@ PASS url: Explicit width and auto height
 PASS url: Explicit height and auto width
 PASS url: Text caret is taller than the placeholder
 FAIL url: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL url: Update field-sizing property dynamically assert_less_than: expected a number less than 192 but got 192
+PASS url: Update field-sizing property dynamically
 PASS email: Empty value
 PASS email: Empty value with a size atttribute
 PASS email: Auto width and auto height with a long text
@@ -44,7 +44,7 @@ PASS email: Explicit width and auto height
 PASS email: Explicit height and auto width
 PASS email: Text caret is taller than the placeholder
 FAIL email: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL email: Update field-sizing property dynamically assert_less_than: expected a number less than 192 but got 192
+PASS email: Update field-sizing property dynamically
 PASS password: Empty value
 PASS password: Empty value with a size atttribute
 PASS password: Auto width and auto height with a long text
@@ -53,5 +53,5 @@ PASS password: Explicit width and auto height
 PASS password: Explicit height and auto width
 PASS password: Text caret is taller than the placeholder
 FAIL password: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL password: Update field-sizing property dynamically assert_less_than: expected a number less than 192 but got 192
+PASS password: Update field-sizing property dynamically
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
@@ -8,7 +8,7 @@ PASS text: Explicit width and auto height
 PASS text: Explicit height and auto width
 PASS text: Text caret is taller than the placeholder
 FAIL text: Text caret is shorter than the placeholder assert_less_than: expected a number less than 37 but got 37
-FAIL text: Update field-sizing property dynamically assert_less_than: expected a number less than 155 but got 155
+PASS text: Update field-sizing property dynamically
 PASS search: Empty value
 PASS search: Empty value with a size atttribute
 PASS search: Auto width and auto height with a long text
@@ -17,7 +17,7 @@ PASS search: Explicit width and auto height
 PASS search: Explicit height and auto width
 PASS search: Text caret is taller than the placeholder
 FAIL search: Text caret is shorter than the placeholder assert_less_than: expected a number less than 37 but got 37
-FAIL search: Update field-sizing property dynamically assert_less_than: expected a number less than 155 but got 155
+PASS search: Update field-sizing property dynamically
 PASS tel: Empty value
 PASS tel: Empty value with a size atttribute
 PASS tel: Auto width and auto height with a long text
@@ -26,7 +26,7 @@ PASS tel: Explicit width and auto height
 PASS tel: Explicit height and auto width
 PASS tel: Text caret is taller than the placeholder
 FAIL tel: Text caret is shorter than the placeholder assert_less_than: expected a number less than 37 but got 37
-FAIL tel: Update field-sizing property dynamically assert_less_than: expected a number less than 155 but got 155
+PASS tel: Update field-sizing property dynamically
 PASS url: Empty value
 PASS url: Empty value with a size atttribute
 PASS url: Auto width and auto height with a long text
@@ -35,7 +35,7 @@ PASS url: Explicit width and auto height
 PASS url: Explicit height and auto width
 PASS url: Text caret is taller than the placeholder
 FAIL url: Text caret is shorter than the placeholder assert_less_than: expected a number less than 37 but got 37
-FAIL url: Update field-sizing property dynamically assert_less_than: expected a number less than 155 but got 155
+PASS url: Update field-sizing property dynamically
 PASS email: Empty value
 PASS email: Empty value with a size atttribute
 PASS email: Auto width and auto height with a long text
@@ -44,7 +44,7 @@ PASS email: Explicit width and auto height
 PASS email: Explicit height and auto width
 PASS email: Text caret is taller than the placeholder
 FAIL email: Text caret is shorter than the placeholder assert_less_than: expected a number less than 37 but got 37
-FAIL email: Update field-sizing property dynamically assert_less_than: expected a number less than 155 but got 155
+PASS email: Update field-sizing property dynamically
 PASS password: Empty value
 PASS password: Empty value with a size atttribute
 PASS password: Auto width and auto height with a long text
@@ -53,5 +53,5 @@ PASS password: Explicit width and auto height
 PASS password: Explicit height and auto width
 PASS password: Text caret is taller than the placeholder
 FAIL password: Text caret is shorter than the placeholder assert_less_than: expected a number less than 37 but got 37
-FAIL password: Update field-sizing property dynamically assert_less_than: expected a number less than 155 but got 155
+PASS password: Update field-sizing property dynamically
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt
@@ -8,5 +8,5 @@ FAIL Explicit width and auto height assert_greater_than: expected a number great
 PASS Explicit height and auto width
 PASS Text caret is taller than the placeholder
 FAIL Text caret is shorter than the placeholder assert_less_than: height expected a number less than 27 but got 27
-FAIL Update field-sizing property dynamically assert_less_than: expected a number less than 168 but got 168
+PASS Update field-sizing property dynamically
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt
@@ -8,7 +8,7 @@ PASS text: Explicit width and auto height
 PASS text: Explicit height and auto width
 PASS text: Text caret is taller than the placeholder
 FAIL text: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL text: Update field-sizing property dynamically assert_less_than: expected a number less than 173 but got 173
+PASS text: Update field-sizing property dynamically
 PASS search: Empty value
 PASS search: Empty value with a size atttribute
 PASS search: Auto width and auto height with a long text
@@ -17,7 +17,7 @@ PASS search: Explicit width and auto height
 PASS search: Explicit height and auto width
 PASS search: Text caret is taller than the placeholder
 FAIL search: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL search: Update field-sizing property dynamically assert_less_than: expected a number less than 173 but got 173
+PASS search: Update field-sizing property dynamically
 PASS tel: Empty value
 PASS tel: Empty value with a size atttribute
 PASS tel: Auto width and auto height with a long text
@@ -26,7 +26,7 @@ PASS tel: Explicit width and auto height
 PASS tel: Explicit height and auto width
 PASS tel: Text caret is taller than the placeholder
 FAIL tel: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL tel: Update field-sizing property dynamically assert_less_than: expected a number less than 173 but got 173
+PASS tel: Update field-sizing property dynamically
 PASS url: Empty value
 PASS url: Empty value with a size atttribute
 PASS url: Auto width and auto height with a long text
@@ -35,7 +35,7 @@ PASS url: Explicit width and auto height
 PASS url: Explicit height and auto width
 PASS url: Text caret is taller than the placeholder
 FAIL url: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL url: Update field-sizing property dynamically assert_less_than: expected a number less than 173 but got 173
+PASS url: Update field-sizing property dynamically
 PASS email: Empty value
 PASS email: Empty value with a size atttribute
 PASS email: Auto width and auto height with a long text
@@ -44,7 +44,7 @@ PASS email: Explicit width and auto height
 PASS email: Explicit height and auto width
 PASS email: Text caret is taller than the placeholder
 FAIL email: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL email: Update field-sizing property dynamically assert_less_than: expected a number less than 173 but got 173
+PASS email: Update field-sizing property dynamically
 PASS password: Empty value
 PASS password: Empty value with a size atttribute
 PASS password: Auto width and auto height with a long text
@@ -53,5 +53,5 @@ PASS password: Explicit width and auto height
 PASS password: Explicit height and auto width
 PASS password: Text caret is taller than the placeholder
 FAIL password: Text caret is shorter than the placeholder assert_less_than: expected a number less than 29 but got 29
-FAIL password: Update field-sizing property dynamically assert_less_than: expected a number less than 173 but got 173
+PASS password: Update field-sizing property dynamically
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -925,6 +925,9 @@ static bool rareDataChangeRequiresLayout(const StyleRareNonInheritedData& first,
     if (first.anchorScope != second.anchorScope || first.positionArea != second.positionArea)
         return true;
 
+    if (first.fieldSizing != second.fieldSizing)
+        return true;
+
     return false;
 }
 


### PR DESCRIPTION
#### cd15c70abb505d63c007147a0dd3e57ccc10ca3a
<pre>
Changing field-sizing doesn&apos;t cause relayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=269176">https://bugs.webkit.org/show_bug.cgi?id=269176</a>

Reviewed by Tim Nguyen.

This patch makes changing field-sizing value cause a relayout.

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-textarea-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-text-expected.txt:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::rareDataChangeRequiresLayout):

Canonical link: <a href="https://commits.webkit.org/291851@main">https://commits.webkit.org/291851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75d333e6a131d1521de28fb1b5b5f87b65145434

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99204 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96243 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71853 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29192 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85047 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52200 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2729 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44038 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80364 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101249 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21245 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80855 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80237 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20007 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24784 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2148 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14425 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21229 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26408 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20916 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24376 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->