### PR TITLE
Logging of `cornerShapeValue` is suboptimal

### DIFF
--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -35,6 +35,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 
@@ -132,7 +133,12 @@ struct CustomIdentifier {
     bool operator==(const CustomIdentifier&) const = default;
     bool operator==(const AtomString& other) const { return value == other; }
 };
-WTF::TextStream& operator<<(WTF::TextStream&, const CustomIdentifier&);
+TextStream& operator<<(TextStream&, const CustomIdentifier&);
+
+template<CSSValueID C> TextStream& operator<<(TextStream& ts, const Constant<C>&)
+{
+    return ts << nameLiteral(C);
+}
 
 // MARK: - Standard Aggregates
 
@@ -162,6 +168,11 @@ template<CSSValueID C, typename T> bool operator==(const UniqueRef<FunctionNotat
 template<size_t, CSSValueID C, typename T> const auto& get(const FunctionNotation<C, T>& function)
 {
     return function.parameters;
+}
+
+template<CSSValueID C, typename T> TextStream& operator<<(TextStream& ts, const FunctionNotation<C, T>& function)
+{
+    return ts << nameLiteral(function.name) << '(' << function.parameters << ')';
 }
 
 template<CSSValueID C, typename T> inline constexpr auto TreatAsTupleLike<FunctionNotation<C, T>> = true;

--- a/Source/WebCore/css/values/CSSValueTypes.h
+++ b/Source/WebCore/css/values/CSSValueTypes.h
@@ -399,5 +399,20 @@ template<> struct CSSValueChildrenVisitor<CustomIdentifier> {
     }
 };
 
+// MARK: - Logging
+
+// Specialization for `VariantLike`.
+template<VariantLike CSSType> TextStream& operator<<(TextStream& ts, const CSSType& value)
+{
+    WTF::switchOn(value, [&](const auto& value) { ts << value; });
+    return ts;
+}
+
+// Specialization for `TupleLike` (wrapper).
+template<TupleLike CSSType> requires (std::tuple_size_v<CSSType> == 1) TextStream& operator<<(TextStream& ts, const CSSType& value)
+{
+    return ts << get<0>(value);
+}
+
 } // namespace CSS
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -29,6 +29,7 @@
 
 #include "OutlineValue.h"
 #include "RenderStyle.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/PointerComparison.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/style/StyleInterpolationWrappers.h
+++ b/Source/WebCore/style/StyleInterpolationWrappers.h
@@ -37,6 +37,7 @@
 #include "AnimationMalloc.h"
 #include "StyleInterpolationFunctions.h"
 #include "StyleInterpolationWrapperBase.h"
+#include "StylePrimitiveNumericTypes+Logging.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/TextStream.h>
 

--- a/Source/WebCore/style/values/StyleValueTypes.h
+++ b/Source/WebCore/style/values/StyleValueTypes.h
@@ -715,5 +715,20 @@ template<typename T> struct IsEmpty<SpaceSeparatedSize<T>> {
     }
 };
 
+// MARK: - Logging
+
+// Specialization for `VariantLike`.
+template<VariantLike StyleType> TextStream& operator<<(TextStream& ts, const StyleType& value)
+{
+    WTF::switchOn(value, [&](const auto& value) { ts << value; });
+    return ts;
+}
+
+// Specialization for `TupleLike` (wrapper).
+template<TupleLike StyleType> requires (std::tuple_size_v<StyleType> == 1) TextStream& operator<<(TextStream& ts, const StyleType& value)
+{
+    return ts << get<0>(value);
+}
+
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
@@ -29,7 +29,6 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSValuePool.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
-#include "StylePrimitiveNumericTypes+Logging.h"
 
 namespace WebCore {
 namespace Style {
@@ -95,14 +94,6 @@ auto Blending<CornerShapeValue>::blend(const CornerShapeValue& a, const CornerSh
     auto interpolatedValue = Style::blend(aInterpolationValue, bInterpolationValue, context);
 
     return convertInterpolationValueToExponent(interpolatedValue);
-}
-
-
-// MARK: - TextStream
-
-TextStream& operator<<(TextStream& ts, const CornerShapeValue& cornerShapeValue)
-{
-    return ts << cornerShapeValue.superellipse.name << "(" << cornerShapeValue.superellipse->value << ")";
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
@@ -62,10 +62,6 @@ template<> struct Blending<CornerShapeValue> {
     auto blend(const CornerShapeValue&, const CornerShapeValue&, const BlendingContext&) -> CornerShapeValue;
 };
 
-// MARK: - TextStream
-
-TextStream& operator<<(TextStream&, const CornerShapeValue&);
-
 } // namespace Style
 } // namespace WebCore
 

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp
@@ -31,7 +31,6 @@
 #include "CSSDynamicRangeLimitMix.h"
 #include "PlatformDynamicRangeLimit.h"
 #include "StyleDynamicRangeLimitMix.h"
-#include <wtf/text/TextStream.h>
 
 namespace WebCore {
 namespace Style {
@@ -115,14 +114,6 @@ PlatformDynamicRangeLimit DynamicRangeLimit::toPlatformDynamicRangeLimit() const
         else if constexpr (std::is_same_v<Kind, Style::DynamicRangeLimitMixFunction>)
             return PlatformDynamicRangeLimit(float(kind->standard.value), float(kind->constrainedHigh.value), float(kind->noLimit.value));
     });
-}
-
-// MARK: - Logging
-
-TextStream& operator<<(TextStream& ts, const DynamicRangeLimit& limit)
-{
-    WTF::switchOn(limit, [&](const auto& value) { ts << value; });
-    return ts;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
+++ b/Source/WebCore/style/values/color/StyleDynamicRangeLimit.h
@@ -143,10 +143,6 @@ template<> struct Blending<DynamicRangeLimit> {
     auto blend(const DynamicRangeLimit&, const DynamicRangeLimit&, const BlendingContext&) -> DynamicRangeLimit;
 };
 
-// MARK: Logging
-
-TextStream& operator<<(TextStream&, const DynamicRangeLimit&);
-
 } // namespace Style
 } // namespace WebCore
 


### PR DESCRIPTION
#### 2815e519efc84feed36197d1ee0857277ba7a87f
<pre>
Logging of `cornerShapeValue` is suboptimal
<a href="https://bugs.webkit.org/show_bug.cgi?id=289253">https://bugs.webkit.org/show_bug.cgi?id=289253</a>

Reviewed by Simon Fraser.

Add better support for logging style value types by
making default logging functions for FunctionNotation,
Constant&lt;CSSValueID&gt;, wrapper tuples and variants.

* Source/WebCore/css/values/CSSValueAggregates.h:
    - Add default TextStream overloads base types.

* Source/WebCore/css/values/CSSValueTypes.h:
* Source/WebCore/style/values/StyleValueTypes.h:
    - Add default TextStream overloads CSS and Style value types.

* Source/WebCore/rendering/style/BorderData.cpp:
* Source/WebCore/style/StyleInterpolationWrappers.h:
    - Add include to allow logging functions to use primitive numeric
      logging types.

* Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp:
* Source/WebCore/style/values/borders/StyleCornerShapeValue.h:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.cpp:
* Source/WebCore/style/values/color/StyleDynamicRangeLimit.h:
    - Remove now unnecessary logging functions that instead just
      use the defaulted ones.

Canonical link: <a href="https://commits.webkit.org/291865@main">https://commits.webkit.org/291865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8375e4a7613ff735d370355228d590f3dad26ba4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94202 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44729 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71861 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29201 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10451 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85054 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52205 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10141 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2739 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44047 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80373 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2829 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101258 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80867 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81067 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80249 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26417 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20925 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24385 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22666 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->