### PR TITLE
[HDR] Enable HDR display for SVG <image> elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2496,8 +2496,10 @@ fast/images/animated-jpegxl-loop-count.html [ Skip ]
 compositing/hdr/hdr-basic-canvas.html [ Skip ]
 compositing/hdr/hdr-basic-image.html [ Skip ]
 compositing/hdr/hdr-css-image.html [ Skip ]
+compositing/hdr/hdr-svg-inline-image.html [ Skip ]
 fast/images/hdr-basic-image.html [ Skip ]
 fast/images/hdr-css-image.html [ Skip ]
+fast/images/hdr-svg-inline-image.html [ Skip ]
 
 # Experimental H265 support.
 webrtc/h265.html [ Pass Failure ]

--- a/LayoutTests/compositing/hdr/hdr-basic-image.html
+++ b/LayoutTests/compositing/hdr/hdr-basic-image.html
@@ -26,7 +26,7 @@
         var image = new Image;
         image.onload = (() => {
             if (window.internals)
-                internals.setHeadroomForTesting(image, 5);
+                internals.setHasPaintedHDRContentForTesting(image);
 
             var divElement = document.querySelector("div.image-box");
             divElement.style.backgroundImage = 'url(' + image.src + ')';

--- a/LayoutTests/compositing/hdr/hdr-css-image.html
+++ b/LayoutTests/compositing/hdr/hdr-css-image.html
@@ -43,7 +43,7 @@
                     let image = new Image;
                     image.onload = (e) => {
                         if (window.internals)
-                            internals.setHeadroomForTesting(image, 5);
+                            internals.setHasPaintedHDRContentForTesting(image);
 
                         resolve({ width: image.width, height: image.height });
                     };

--- a/LayoutTests/compositing/hdr/hdr-svg-inline-image.html
+++ b/LayoutTests/compositing/hdr/hdr-svg-inline-image.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-<meta name="fuzzy" content="maxDifference=0-6; totalPixels=0-40000" />
 <style>
     .image-box {
         width: 200px;
@@ -9,34 +8,34 @@
     }
 </style>
 <body>
+    <pre id="layers">Layer tree goes here in DRT</pre>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <img class="image-box">
-    </div>
-    <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="image-box"></div>
+        <svg class="image-box">
+            <image width="100%" height="100%"/>
+        </svg>
     </div>
     <script>
         if (window.internals && window.testRunner) {
             internals.clearMemoryCache();
             internals.setScreenContentsFormatsForTesting(["RGBA8", "RGBA16F"]);
+            testRunner.dumpAsText();
             testRunner.waitUntilDone();
         }
-
+ 
         var image = new Image;
         image.onload = (() => {
             if (window.internals)
                 internals.setHasPaintedHDRContentForTesting(image);
 
-            var divElement = document.querySelector("div.image-box");
-            divElement.style.backgroundImage = 'url(' + image.src + ')';
+            var imageElement = document.querySelector("svg.image-box image");
+            imageElement.setAttribute("href", image.src);
 
-            var imgElement = document.querySelector("img.image-box");
-            imgElement.src = image.src;
-
-            if (window.testRunner)
+            if (window.testRunner) {
+                document.getElementById("layers").textContent = internals.layerTreeAsText(document);
                 testRunner.notifyDone();
+            }
         });
-        image.src = "resources/green-400x400.png";
+        image.src = "../../fast/images/resources/green-400x400.png";
     </script>
 </body>
 </html>

--- a/LayoutTests/fast/images/hdr-css-image.html
+++ b/LayoutTests/fast/images/hdr-css-image.html
@@ -42,7 +42,7 @@
                     let image = new Image;
                     image.onload = (e) => {
                         if (window.internals)
-                            internals.setHeadroomForTesting(image, 5);
+                            internals.setHasPaintedHDRContentForTesting(image);
 
                         resolve({ width: image.width, height: image.height });
                     };

--- a/LayoutTests/fast/images/hdr-svg-inline-image-expected.html
+++ b/LayoutTests/fast/images/hdr-svg-inline-image-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<style>
+    .image-box {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<body>
+    <div style="position: fixed; top: 10px; left: 10px;">
+        <div class="image-box" style="background-color: rgb(255 215 0);">
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/images/hdr-svg-inline-image.html
+++ b/LayoutTests/fast/images/hdr-svg-inline-image.html
@@ -10,10 +10,9 @@
 </style>
 <body>
     <div style="position: fixed; top: 10px; left: 10px;">
-        <img class="image-box">
-    </div>
-    <div style="position: fixed; top: 10px; left: 220px;">
-        <div class="image-box"></div>
+        <svg class="image-box">
+            <image width="100%" height="100%"/>
+        </svg>
     </div>
     <script>
         if (window.internals && window.testRunner) {
@@ -27,11 +26,8 @@
             if (window.internals)
                 internals.setHasPaintedHDRContentForTesting(image);
 
-            var divElement = document.querySelector("div.image-box");
-            divElement.style.backgroundImage = 'url(' + image.src + ')';
-
-            var imgElement = document.querySelector("img.image-box");
-            imgElement.src = image.src;
+            var imageElement = document.querySelector("svg.image-box image");
+            imageElement.setAttribute("href", image.src);
 
             if (window.testRunner)
                 testRunner.notifyDone();

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4519,8 +4519,10 @@ fast/images/pagewide-play-pause-offscreen-animations.html [ Pass ]
 compositing/hdr/hdr-basic-canvas.html [ Pass ]
 compositing/hdr/hdr-basic-image.html [ Pass ]
 compositing/hdr/hdr-css-image.html [ Pass ]
+compositing/hdr/hdr-svg-inline-image.html [ Pass ]
 fast/images/hdr-basic-image.html [ Pass ]
 fast/images/hdr-css-image.html [ Pass ]
+fast/images/hdr-svg-inline-image.html [ Pass ]
 
 # Re-enabling tests fixed by DocumentManager in iOS16+ rdar://102159271
 fast/forms/ios/file-upload-panel-capture.html [ Pass Crash ] # remove crash after this is resolved: webkit.org/b/268568

--- a/LayoutTests/platform/ios/compositing/hdr/hdr-svg-inline-image-expected.txt
+++ b/LayoutTests/platform/ios/compositing/hdr/hdr-svg-inline-image-expected.txt
@@ -1,0 +1,29 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 205.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1496,8 +1496,10 @@ webkit.org/b/260113 [ arm64 ] http/wpt/webauthn/ctap-hid-failure.https.html [ Pa
 [ Sequoia+ ] compositing/hdr/hdr-basic-canvas.html [ Pass ]
 [ Sequoia+ ] compositing/hdr/hdr-basic-image.html [ Pass ]
 [ Sequoia+ ] compositing/hdr/hdr-css-image.html [ Pass ]
+[ Sequoia+ ] compositing/hdr/hdr-svg-inline-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-basic-image.html [ Pass ]
 [ Sequoia+ ] fast/images/hdr-css-image.html [ Pass ]
+[ Sequoia+ ] fast/images/hdr-svg-inline-image.html [ Pass ]
 
 # The direct image codepath is not used with the remote layer tree.
 [ Sonoma+ ] compositing/images/direct-image-object-fit.html [ Skip ]

--- a/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-svg-inline-image-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/hdr/hdr-svg-inline-image-expected.txt
@@ -1,0 +1,29 @@
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 10.00 10.00)
+          (preserves3D 1)
+          (children 1
+            (GraphicsLayer
+              (bounds 200.00 204.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 200.00 200.00)
+                  (drawsContent 1)
+                  (drawsHDRContent 1)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -746,6 +746,7 @@ public:
 
     void imageFrameAvailable(const Image&, ImageAnimatingState, const IntRect* = nullptr, DecodingStatus = DecodingStatus::Invalid) override { }
     void changedInRect(const Image&, const IntRect* = nullptr) override { }
+    void imageContentChanged(const Image&) override { }
     void scheduleRenderingUpdate(const Image&) override { }
 
 private:

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -97,10 +97,7 @@ public:
     LayoutSize unclampedImageSizeForRenderer(const RenderElement* renderer, float multiplier, SizeType = UsedSize) const;
     void computeIntrinsicDimensions(Length& intrinsicWidth, Length& intrinsicHeight, FloatSize& intrinsicRatio);
 
-    Headroom headroom() const;
-#if HAVE(SUPPORT_HDR_DISPLAY)
-    bool isHDR() const { return headroom() > Headroom::None; }
-#endif
+    bool hasPaintedHDRContent() const;
 
     bool isManuallyCached() const { return m_isManuallyCached; }
     RevalidationDecision makeRevalidationDecision(CachePolicy) const override;
@@ -175,6 +172,7 @@ private:
         bool canDestroyDecodedData(const Image&) const final;
         void imageFrameAvailable(const Image&, ImageAnimatingState, const IntRect* changeRect = nullptr, DecodingStatus = DecodingStatus::Invalid) final;
         void changedInRect(const Image&, const IntRect*) final;
+        void imageContentChanged(const Image&) final;
         void scheduleRenderingUpdate(const Image&) final;
 
         bool allowsAnimation(const Image&) const final;
@@ -189,6 +187,7 @@ private:
     bool canDestroyDecodedData(const Image&) const;
     void imageFrameAvailable(const Image&, ImageAnimatingState, const IntRect* changeRect = nullptr, DecodingStatus = DecodingStatus::Invalid);
     void changedInRect(const Image&, const IntRect*);
+    void imageContentChanged(const Image&);
     void scheduleRenderingUpdate(const Image&);
 
     void updateBufferInternal(const FragmentedSharedBuffer&);

--- a/Source/WebCore/loader/cache/CachedImageClient.h
+++ b/Source/WebCore/loader/cache/CachedImageClient.h
@@ -53,7 +53,7 @@ public:
     virtual VisibleInViewportState imageVisibleInViewport(const Document&) const { return VisibleInViewportState::No; }
 
     virtual void didRemoveCachedImageClient(CachedImage&) { }
-
+    virtual void imageContentChanged(CachedImage&) { }
     virtual void scheduleRenderingUpdateForImage(CachedImage&) { }
 
     virtual bool allowsAnimation() const { return true; }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -115,6 +115,7 @@ class PopupMenu;
 class PopupMenuClient;
 class RegistrableDomain;
 class SearchPopupMenu;
+class SVGImageElement;
 class ScrollingCoordinator;
 class SecurityOrigin;
 class SecurityOriginData;
@@ -260,6 +261,7 @@ public:
 #endif
 
     virtual void didFinishLoadingImageForElement(HTMLImageElement&) = 0;
+    virtual void didFinishLoadingImageForSVGImage(SVGImageElement&) { }
 
     virtual PlatformPageClient platformPageClient() const = 0;
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4659,6 +4659,11 @@ void Page::didFinishLoadingImageForElement(HTMLImageElement& element)
     });
 }
 
+void Page::didFinishLoadingImageForSVGImage(SVGImageElement& element)
+{
+    chrome().client().didFinishLoadingImageForSVGImage(element);
+}
+
 #if ENABLE(TEXT_AUTOSIZING)
 
 void Page::recomputeTextAutoSizingInAllFrames()

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -161,6 +161,7 @@ class RTCController;
 class RenderObject;
 class ResourceUsageOverlay;
 class RenderingUpdateScheduler;
+class SVGImageElement;
 class ScreenOrientationManager;
 class ScrollLatchingController;
 class ScrollingCoordinator;
@@ -870,6 +871,7 @@ public:
     WEBCORE_EXPORT void resumeAnimatingImages();
 
     void didFinishLoadingImageForElement(HTMLImageElement&);
+    void didFinishLoadingImageForSVGImage(SVGImageElement&);
 
     WEBCORE_EXPORT void addLayoutMilestones(OptionSet<LayoutMilestone>);
     WEBCORE_EXPORT void removeLayoutMilestones(OptionSet<LayoutMilestone>);

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -122,7 +122,7 @@ ImageDrawResult BitmapImage::draw(GraphicsContext& context, const FloatRect& des
             orientation = currentFrameOrientation();
 
         auto headroom = options.headroom();
-        if (headroom == Headroom::FromImage && headroomForTesting().value_or(Headroom::None) > Headroom::None)
+        if (headroom == Headroom::FromImage && hasPaintedHDRContentForTesting())
             fillWithSolidColor(context, destinationRect, Color::gold, options.compositeOperator());
         else {
             if (headroom == Headroom::FromImage)

--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -72,7 +72,7 @@ public:
     FloatSize size(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const final { return m_source->size(orientation); }
     FloatSize sourceSize(ImageOrientation orientation = ImageOrientation::Orientation::FromImage) const { return m_source->sourceSize(orientation); }
     DestinationColorSpace colorSpace() final { return m_source->colorSpace(); }
-    Headroom headroom() const final { return headroomForTesting().value_or(m_source->headroom()); }
+    bool hasPaintedHDRContent() const final { return hasPaintedHDRContentForTesting() || m_source->headroom() > Headroom::None; }
     ImageOrientation orientation() const final { return m_source->orientation(); }
     unsigned frameCount() const final { return m_source->frameCount(); }
 #if ASSERT_ENABLED
@@ -91,8 +91,8 @@ public:
     bool isAsyncDecodingEnabledForTesting() const { return m_source->isAsyncDecodingEnabledForTesting(); }
     void setMinimumDecodingDurationForTesting(Seconds duration) { m_source->setMinimumDecodingDurationForTesting(duration); }
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) { m_source->setClearDecoderAfterAsyncFrameRequestForTesting(enabled); }
-    void setHeadroomForTesting(Headroom headroom) { m_source->setHeadroomForTesting(headroom); }
-    std::optional<Headroom> headroomForTesting() const { return m_source->headroomForTesting(); }
+    void setHasPaintedHDRContentForTesting() { m_source->setHasPaintedHDRContentForTesting(); }
+    bool hasPaintedHDRContentForTesting() const { return m_source->hasPaintedHDRContentForTesting(); }
     unsigned decodeCountForTesting() const { return m_source->decodeCountForTesting(); }
     unsigned blankDrawCountForTesting() const { return m_source->blankDrawCountForTesting(); }
 

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -192,8 +192,8 @@ private:
     void setClearDecoderAfterAsyncFrameRequestForTesting(bool enabled) final { m_clearDecoderAfterAsyncFrameRequestForTesting = enabled; }
     void setAsyncDecodingEnabledForTesting(bool enabled) final { m_isAsyncDecodingEnabledForTesting = enabled; }
     bool isAsyncDecodingEnabledForTesting() const final { return m_isAsyncDecodingEnabledForTesting; }
-    void setHeadroomForTesting(Headroom headroom) final { m_headroomForTesting = headroom; }
-    std::optional<Headroom> headroomForTesting() const final { return m_headroomForTesting; }
+    void setHasPaintedHDRContentForTesting() final { m_hasPaintedHDRContentForTesting = true; }
+    bool hasPaintedHDRContentForTesting() const final { return m_hasPaintedHDRContentForTesting; }
 
     void dump(TextStream&) const final;
 
@@ -219,7 +219,7 @@ private:
     unsigned m_blankDrawCountForTesting { 0 };
     bool m_isAsyncDecodingEnabledForTesting { false };
     bool m_clearDecoderAfterAsyncFrameRequestForTesting { false };
-    std::optional<Headroom> m_headroomForTesting;
+    bool m_hasPaintedHDRContentForTesting { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -121,7 +121,7 @@ public:
     WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> protectedData() const;
 
     virtual DestinationColorSpace colorSpace();
-    virtual Headroom headroom() const { return Headroom::None; }
+    virtual bool hasPaintedHDRContent() const { return false; }
 
     // Animation begins whenever someone draws the image, so startAnimation() is not normally called.
     // It will automatically pause once all observers no longer want to render the image anywhere.

--- a/Source/WebCore/platform/graphics/ImageObserver.h
+++ b/Source/WebCore/platform/graphics/ImageObserver.h
@@ -55,6 +55,7 @@ public:
     virtual bool canDestroyDecodedData(const Image&) const { return true; }
     virtual void imageFrameAvailable(const Image&, ImageAnimatingState, const IntRect* changeRect = nullptr, DecodingStatus = DecodingStatus::Invalid) = 0;
     virtual void changedInRect(const Image&, const IntRect* changeRect = nullptr) = 0;
+    virtual void imageContentChanged(const Image&) = 0;
     virtual void scheduleRenderingUpdate(const Image&) = 0;
 
     virtual bool allowsAnimation(const Image&) const { return true; }

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -111,8 +111,8 @@ public:
     virtual void setClearDecoderAfterAsyncFrameRequestForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual void setAsyncDecodingEnabledForTesting(bool) { RELEASE_ASSERT_NOT_REACHED(); }
     virtual bool isAsyncDecodingEnabledForTesting() const { return false; }
-    virtual void setHeadroomForTesting(Headroom) { RELEASE_ASSERT_NOT_REACHED(); }
-    virtual std::optional<Headroom> headroomForTesting() const { return std::nullopt; }
+    virtual void setHasPaintedHDRContentForTesting() { RELEASE_ASSERT_NOT_REACHED(); }
+    virtual bool hasPaintedHDRContentForTesting() const { return false; }
 
     virtual void dump(WTF::TextStream&) const { }
 };

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1712,6 +1712,21 @@ void RenderElement::didRemoveCachedImageClient(CachedImage& cachedImage)
         checkedView()->removeRendererWithPausedImageAnimations(*this, cachedImage);
 }
 
+void RenderElement::imageContentChanged(CachedImage& cachedImage)
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (!document().hasPaintedHDRContent()) {
+        if (cachedImage.hasPaintedHDRContent())
+            document().setHasPaintedHDRContent();
+    }
+#else
+    UNUSED_PARAM(cachedImage);
+#endif
+
+    if (auto layer = layerParent())
+        layer->contentChanged(ContentChangeType::Image);
+}
+
 void RenderElement::scheduleRenderingUpdateForImage(CachedImage&)
 {
     if (RefPtr page = document().page())

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -383,6 +383,7 @@ private:
     VisibleInViewportState imageFrameAvailable(CachedImage&, ImageAnimatingState, const IntRect* changeRect) final;
     VisibleInViewportState imageVisibleInViewport(const Document&) const final;
     void didRemoveCachedImageClient(CachedImage&) final;
+    void imageContentChanged(CachedImage&) final;
     void scheduleRenderingUpdateForImage(CachedImage&) final;
 
     bool getLeadingCorner(FloatPoint& output, bool& insideFixed) const;

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -435,7 +435,7 @@ void RenderImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetr
         page().didFinishLoadingImageForElement(*image);
 #if HAVE(SUPPORT_HDR_DISPLAY)
         if (!document().hasPaintedHDRContent()) {
-            if (cachedImage() && cachedImage()->isHDR())
+            if (cachedImage() && cachedImage()->hasPaintedHDRContent())
                 document().setHasPaintedHDRContent();
         }
 #endif

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -595,8 +595,8 @@ public:
     // True if this layer container renderers that paint.
     void determineNonLayerDescendantsPaintedContent(PaintedContentRequest&) const;
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    // True of if renderer itself draws HDR content, no traversal is done.
-    bool isReplacedElementWithHDR() const;
+    // True if renderer itself draws HDR content, no traversal is done.
+    bool isRenderElementWithHDR() const;
 #endif
 
     // FIXME: We should ASSERT(!m_hasSelfPaintingLayerDescendantDirty); here but we hit the same bugs as visible content above.

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -153,7 +153,7 @@ public:
 #if HAVE(SUPPORT_HDR_DISPLAY)
         if (m_backing.renderer().document().canDrawHDRContent()) {
             m_hdrContent = RequestState::Unknown;
-            m_isReplacedElementWithHDR = RequestState::Unknown;
+            m_isRenderElementWithHDR = RequestState::Unknown;
         }
 #endif
     }
@@ -193,7 +193,7 @@ public:
     bool isContentsTypeSatisfied() const
     {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-        if (m_isReplacedElementWithHDR == RequestState::Unknown)
+        if (m_isRenderElementWithHDR == RequestState::Unknown)
             return false;
 #endif
         return m_contentsType != ContentsType::Unknown;
@@ -219,10 +219,10 @@ public:
     }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    bool isReplacedElementWithHDR()
+    bool isRenderElementWithHDR()
     {
         determineContentsType();
-        return m_isReplacedElementWithHDR == RequestState::True;
+        return m_isRenderElementWithHDR == RequestState::True;
     }
 #endif
 
@@ -231,7 +231,7 @@ public:
     RequestState m_content { RequestState::Unknown };
 #if HAVE(SUPPORT_HDR_DISPLAY)
     RequestState m_hdrContent { RequestState::DontCare };
-    RequestState m_isReplacedElementWithHDR { RequestState::DontCare };
+    RequestState m_isRenderElementWithHDR { RequestState::DontCare };
 #endif
 
     ContentsType m_contentsType { ContentsType::Unknown };
@@ -274,8 +274,8 @@ void PaintedContentsInfo::determineContentsType()
         m_contentsType = ContentsType::Painted;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (m_isReplacedElementWithHDR == RequestState::Unknown)
-        m_isReplacedElementWithHDR = m_backing.isReplacedElementWithHDR() ? RequestState::True : RequestState::False;
+    if (m_isRenderElementWithHDR == RequestState::Unknown)
+        m_isRenderElementWithHDR = m_backing.isRenderElementWithHDR() ? RequestState::True : RequestState::False;
 #endif
 }
 
@@ -2024,7 +2024,7 @@ void RenderLayerBacking::updateDrawsContent(PaintedContentsInfo& contentsInfo)
         m_backgroundLayer->setDrawsContent(m_backgroundLayerPaintsFixedRootBackground ? hasPaintedContent : contentsInfo.paintsBoxDecorations());
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    if (contentsInfo.paintsHDRContent() || contentsInfo.isReplacedElementWithHDR())
+    if (contentsInfo.paintsHDRContent() || contentsInfo.isRenderElementWithHDR())
         m_graphicsLayer->setDrawsHDRContent(true);
 #endif
 }
@@ -3365,9 +3365,9 @@ bool RenderLayerBacking::isUnscaledBitmapOnly() const
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-bool RenderLayerBacking::isReplacedElementWithHDR() const
+bool RenderLayerBacking::isRenderElementWithHDR() const
 {
-    return m_owningLayer.isReplacedElementWithHDR();
+    return m_owningLayer.isRenderElementWithHDR();
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -393,7 +393,7 @@ private:
     bool isUnscaledBitmapOnly() const;
     bool isBitmapOnly() const;
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    bool isReplacedElementWithHDR() const;
+    bool isRenderElementWithHDR() const;
 #endif
 
     void updateDirectlyCompositedBoxDecorations(PaintedContentsInfo&, bool& didUpdateContentsRect);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -65,6 +65,25 @@ CheckedRef<RenderImageResource> LegacyRenderSVGImage::checkedImageResource() con
     return *m_imageResource;
 }
 
+void LegacyRenderSVGImage::notifyFinished(CachedResource& newImage, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
+{
+    if (renderTreeBeingDestroyed())
+        return;
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (!document().hasPaintedHDRContent()) {
+        CachedImage* cachedImage = imageResource().cachedImage();
+
+        if (cachedImage && cachedImage->hasPaintedHDRContent()) {
+            document().setHasPaintedHDRContent();
+            page().didFinishLoadingImageForSVGImage(imageElement());
+        }
+    }
+#endif
+
+    LegacyRenderSVGModelObject::notifyFinished(newImage, metrics, loadWillContinueInAnotherProcess);
+}
+
 void LegacyRenderSVGImage::willBeDestroyed()
 {
     imageResource().shutdown();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -62,6 +62,8 @@ private:
 
     const AffineTransform& localToParentTransform() const override { return m_localTransform; }
 
+    void notifyFinished(CachedResource& newImage, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
+
     FloatRect calculateObjectBoundingBox() const;
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const override { return m_objectBoundingBox; }

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -34,7 +34,7 @@ class SVGImageElement final : public SVGGraphicsElement, public SVGURIReference 
 public:
     static Ref<SVGImageElement> create(const QualifiedName&, Document&);
 
-    CachedImage* cachedImage() const;
+    WEBCORE_EXPORT CachedImage* cachedImage() const;
     bool renderingTaintsOrigin() const;
     const AtomString& imageSourceURL() const final;
 

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -208,6 +208,15 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     return result;
 }
 
+bool SVGImage::hasPaintedHDRContent() const
+{
+#if HAVE(SUPPORT_HDR_DISPLAY)
+    if (RefPtr localTopDocument = m_page->localTopDocument())
+        return localTopDocument->hasPaintedHDRContent();
+#endif
+    return false;
+}
+
 RefPtr<NativeImage> SVGImage::nativeImage(const DestinationColorSpace& colorSpace)
 {
     return nativeImage(size(), colorSpace);

--- a/Source/WebCore/svg/graphics/SVGImage.h
+++ b/Source/WebCore/svg/graphics/SVGImage.h
@@ -95,6 +95,7 @@ private:
     // FIXME: Implement this to be less conservative.
     bool currentFrameKnownToBeOpaque() const final { return false; }
 
+    bool hasPaintedHDRContent() const final;
     RefPtr<NativeImage> nativeImage(const DestinationColorSpace& = DestinationColorSpace::SRGB()) final;
 
     void startAnimationTimerFired();

--- a/Source/WebCore/svg/graphics/SVGImageClients.h
+++ b/Source/WebCore/svg/graphics/SVGImageClients.h
@@ -57,7 +57,17 @@ private:
     {
         m_image = nullptr;
     }
-    
+
+    void didFinishLoadingImageForSVGImage(SVGImageElement&) final
+    {
+        RefPtr image { m_image.get() };
+        if (!image || !image->internalPage())
+            return;
+
+        if (RefPtr imageObserver = image->imageObserver())
+            imageObserver->imageContentChanged(*image);
+    }
+
     void invalidateContentsAndRootView(const IntRect& rect) final
     {
         RefPtr image { m_image.get() };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1256,10 +1256,10 @@ void Internals::setForceUpdateImageDataEnabledForTesting(HTMLImageElement& eleme
         cachedImage->setForceUpdateImageDataEnabledForTesting(enabled);
 }
 
-void Internals::setHeadroomForTesting(HTMLImageElement& element, float headroom)
+void Internals::setHasPaintedHDRContentForTesting(HTMLImageElement& element)
 {
     if (auto* bitmapImage = bitmapImageFromImageElement(element))
-        bitmapImage->setHeadroomForTesting(headroom);
+        bitmapImage->setHasPaintedHDRContentForTesting();
 }
 
 #if ENABLE(WEB_CODECS)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -270,7 +270,7 @@ public:
     unsigned remoteImagesCountForTesting() const;
     void setAsyncDecodingEnabledForTesting(HTMLImageElement&, bool enabled);
     void setForceUpdateImageDataEnabledForTesting(HTMLImageElement&, bool enabled);
-    void setHeadroomForTesting(HTMLImageElement&, float headroom);
+    void setHasPaintedHDRContentForTesting(HTMLImageElement&);
 
 #if ENABLE(WEB_CODECS)
     bool hasPendingActivity(const WebCodecsVideoDecoder&) const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -750,7 +750,7 @@ enum ContentsFormat {
     unsigned long remoteImagesCountForTesting();
     undefined setAsyncDecodingEnabledForTesting(HTMLImageElement element, boolean enabled);
     undefined setForceUpdateImageDataEnabledForTesting(HTMLImageElement element, boolean enabled);
-    undefined setHeadroomForTesting(HTMLImageElement element, float headroom);
+    undefined setHasPaintedHDRContentForTesting(HTMLImageElement element);
 
     [Conditional=WEB_CODECS] boolean hasPendingActivity(WebCodecsVideoDecoder decoder);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp
@@ -75,6 +75,10 @@ private:
     {
     }
 
+    void imageContentChanged(const Image&) final
+    {
+    }
+
     void scheduleRenderingUpdate(const Image&) final
     {
     }


### PR DESCRIPTION
#### afbdfa6e4029e7ff7d76e8b04d049915f4528dad
<pre>
[HDR] Enable HDR display for SVG &lt;image&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=289419#">https://bugs.webkit.org/show_bug.cgi?id=289419#</a>
<a href="https://rdar.apple.com/146582114">rdar://146582114</a>

Reviewed by Cameron McCormack.

BitmapImage and SVGImage will implement the virtual method hasPaintedHDRContent().
This will enable HDR display support for these images. This method will replace
the existing method headroom() since it does not make sense to have SVGImage
implement it. Similarly setHasPaintedHDRContentForTesting() will replace
setHeadroomForTesting().

LegacyRenderSVGImage needs to implement notifyFinished() which will be used to
mark the document to have setHasPaintedHDRContent(). It will be used also to call
RenderLayer::contentChanged(ContentChangeType::Image) for the SVGImage case.

To go from LegacyRenderSVGImage inside an SVGImage to the parent layer which owns
the SVGImage, the SVGImageChromeClient will be used. A new virtual method called
didFinishLoadingImageForSVGImage() will be added to ChromeClient. This method will
be called form LegacyRenderSVGImage::notifyFinished() through Page. This method
will use the ImageObserver to call the method RenderElement::imageContentChanged()
which will mark the layer for image content change.

* LayoutTests/TestExpectations:
* LayoutTests/compositing/hdr/hdr-basic-image.html:
* LayoutTests/compositing/hdr/hdr-css-image.html:
* LayoutTests/compositing/hdr/hdr-svg-inline-image.html: Copied from LayoutTests/compositing/hdr/hdr-basic-image.html.
* LayoutTests/fast/images/hdr-basic-image.html:
* LayoutTests/fast/images/hdr-css-image.html:
* LayoutTests/fast/images/hdr-svg-inline-image-expected.html: Added.
* LayoutTests/fast/images/hdr-svg-inline-image.html: Copied from LayoutTests/fast/images/hdr-basic-image.html.
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/compositing/hdr/hdr-svg-inline-image-expected.txt: Added.
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/compositing/hdr/hdr-svg-inline-image-expected.txt: Added.
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::hasPaintedHDRContent const):
(WebCore::CachedImage::CachedImageObserver::imageContentChanged):
(WebCore::CachedImage::imageContentChanged):
(WebCore::CachedImage::headroom const): Deleted.
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedImageClient.h:
(WebCore::CachedImageClient::imageContentChanged):
* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::didFinishLoadingImageForSVGImage):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::didFinishLoadingImageForSVGImage):
* Source/WebCore/page/Page.h:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::draw):
* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::hasPaintedHDRContent const):
(WebCore::Image::headroom const): Deleted.
* Source/WebCore/platform/graphics/ImageObserver.h:
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::setHasPaintedHDRContentForTesting):
(WebCore::ImageSource::hasPaintedHDRContentForTesting const):
(WebCore::ImageSource::setHeadroomForTesting): Deleted.
(WebCore::ImageSource::headroomForTesting const): Deleted.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::imageContentChanged):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::notifyFinished):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::PaintedContentsInfo):
(WebCore::PaintedContentsInfo::isContentsTypeSatisfied const):
(WebCore::PaintedContentsInfo::isRenderElementWithHDR):
(WebCore::PaintedContentsInfo::determineContentsType):
(WebCore::RenderLayerBacking::updateDrawsContent):
(WebCore::RenderLayerBacking::isRenderElementWithHDR const):
(WebCore::PaintedContentsInfo::isReplacedElementWithHDR): Deleted.
(WebCore::RenderLayerBacking::isReplacedElementWithHDR const): Deleted.
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::notifyFinished):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/svg/SVGImageElement.h:
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::hasPaintedHDRContent const):
* Source/WebCore/svg/graphics/SVGImage.h:
* Source/WebCore/svg/graphics/SVGImageClients.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::setHasPaintedHDRContentForTesting):
(WebCore::Internals::setHeadroomForTesting): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Tools/TestWebKitAPI/Tests/WebCore/SVGImageCasts.cpp:

Canonical link: <a href="https://commits.webkit.org/291982@main">https://commits.webkit.org/291982@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3159641d1917a85a400d13526e8bbac803fe66b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/14192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3995 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/45112 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22620 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/72183 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29489 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97602 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/132/builds/10788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52514 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/133/builds/10481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/3113 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44437 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/3217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21651 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/81177 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21899 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80555 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20089 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/25115 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/137/builds/2504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14867 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21629 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/26752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/125/builds/21302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24767 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/124/builds/23040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->