### PR TITLE
[JSC] PerfLog should be generated from WorkQueue

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -118,7 +118,7 @@ void LinkBuffer::logJITCodeForPerf(CodeRef<LinkBufferPtrTag>& codeRef, ASCIILite
         break;
     }
     if (!m_isRewriting)
-        PerfLog::log(out.toCString(), codeRef.code().untaggedPtr<const uint8_t*>(), codeRef.size());
+        PerfLog::log(out.toCString(), codeRef);
 #else
     UNUSED_PARAM(codeRef);
     UNUSED_PARAM(simpleName);

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -28,10 +28,12 @@
 
 #if ENABLE(ASSEMBLER) && (OS(LINUX) || OS(DARWIN))
 
+#include "LinkBuffer.h"
 #include <stdio.h>
 #include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/text/CString.h>
 
 namespace JSC {
@@ -41,8 +43,7 @@ class PerfLog {
     WTF_MAKE_NONCOPYABLE(PerfLog);
     friend class LazyNeverDestroyed<PerfLog>;
 public:
-    static void log(CString&&, const uint8_t* executableAddress, size_t);
-    static void flush();
+    static void log(CString&& name, MacroAssemblerCodeRef<LinkBufferPtrTag>);
 
 private:
     PerfLog();
@@ -51,6 +52,7 @@ private:
     void write(const AbstractLocker&, const void*, size_t) WTF_REQUIRES_LOCK(m_lock);
     void flush(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
+    Ref<WorkQueue> m_queue;
     FILE* m_file { nullptr };
     void* m_marker { nullptr };
     uint64_t m_codeIndex { 0 };


### PR DESCRIPTION
#### 58d49eb0e58033146deb6455f4cfa38c79e668a1
<pre>
[JSC] PerfLog should be generated from WorkQueue
<a href="https://bugs.webkit.org/show_bug.cgi?id=289421">https://bugs.webkit.org/show_bug.cgi?id=289421</a>
<a href="https://rdar.apple.com/146585632">rdar://146585632</a>

Reviewed by Yijia Huang.

Let&apos;s move PerfLog generation from the caller thread to WorkQueue to
avoid blocking the caller. This makes PerfLog more lightweight for
profiling.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::logJITCodeForPerf):
* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::PerfLog):
(JSC::PerfLog::log):
* Source/JavaScriptCore/assembler/PerfLog.h:

Canonical link: <a href="https://commits.webkit.org/291857@main">https://commits.webkit.org/291857@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ea39156f3885c292b23ad71411bb187235c7040

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13805 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99229 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44745 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71874 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29215 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97220 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10467 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/85073 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52219 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10157 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2758 "Build is in progress. Recent messages:OS: Sonoma (14.7.3), Xcode: 15.4; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 12 flakes") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44063 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86928 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80389 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101274 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92884 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21270 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/122/builds/15491 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80881 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80263 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14468 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15113 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21254 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26433 "Found 1 new failure in assembler/PerfLog.cpp") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115534 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20941 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->