### PR TITLE
Implement field-sizing support for file inputs

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional-expected.txt
@@ -1,0 +1,9 @@
+
+
+PASS file: Empty value
+PASS file: Auto width with a short filename
+PASS file: Auto width with a long filename
+PASS file: Fixed width with a long filename
+PASS file: Auto width after form reset
+PASS file: Update field-sizing property dynamically
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#field-sizing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.disable-default {
+  field-sizing: content;
+}
+
+input {
+    border: 1px solid black;
+}
+</style>
+<body>
+<form id="container"></form>
+<script>
+const LONG_FILENAME = "The quick brown fox jumps over the lazy dog";
+
+function addElements(source) {
+  const container = document.querySelector('#container');
+  container.innerHTML = source + source;
+  container.lastElementChild.classList.add('disable-default');
+  return {
+    fixed: container.firstElementChild,
+    content: container.lastElementChild
+  };
+}
+
+function generateFiles(filename) {
+  const file = new File(["Hello world"], filename, { type: "text/plain" });
+
+  // Create a DataTransfer to hold the file list
+  const dataTransfer = new DataTransfer();
+  dataTransfer.items.add(file);
+  return dataTransfer.files;
+}
+
+test(() => {
+  let pair = addElements(`<input type=file>`);
+  // A file <input> has approximately a 22 character file name width by default.
+  // A file <input> with field-sizing:content should be shorter than the default.
+  assert_less_than(pair.content.offsetWidth, pair.fixed.offsetWidth);
+}, `file: Empty value`);
+
+test(() => {
+  let pair = addElements(`<input type=file>`);
+  pair.content.files = generateFiles("a");
+  pair.fixed.files = generateFiles("a");
+  assert_less_than(pair.content.offsetWidth, pair.fixed.offsetWidth);
+}, `file: Auto width with a short filename`);
+
+test(() => {
+  let pair = addElements(`<input type=file>`);
+  pair.content.files = generateFiles(LONG_FILENAME);
+  pair.fixed.files = generateFiles(LONG_FILENAME);
+  assert_greater_than(pair.content.offsetWidth, pair.fixed.offsetWidth);
+}, `file: Auto width with a long filename`);
+
+test(() => {
+  let pair = addElements(`<input style="width: 20ch" type=file>`);
+  pair.content.files = generateFiles(LONG_FILENAME);
+  pair.fixed.files = generateFiles(LONG_FILENAME);
+  assert_equals(pair.content.offsetWidth, pair.fixed.offsetWidth);
+}, `file: Fixed width with a long filename`);
+
+test(() => {
+  let pair = addElements(`<input type=file>`);
+  pair.content.files = generateFiles(LONG_FILENAME);
+  pair.fixed.files = generateFiles(LONG_FILENAME);
+  const container = document.querySelector('#container');
+  container.reset();
+  assert_equals(pair.content.files.length, 0);
+  assert_less_than(pair.content.offsetWidth, pair.fixed.offsetWidth);
+}, `file: Auto width after form reset`);
+
+test(() => {
+   const container = document.querySelector('#container');
+   container.innerHTML = `<input type=file>`;
+   const element = container.firstChild;
+   const w = element.offsetWidth;
+   element.classList.add('disable-default');
+   assert_less_than(element.offsetWidth, w);
+}, `file: Update field-sizing property dynamically`);
+
+</script>
+</body>

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -42,6 +42,7 @@
 #include "LocalizedStrings.h"
 #include "MIMETypeRegistry.h"
 #include "RenderFileUploadControl.h"
+#include "RenderObjectInlines.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
@@ -365,8 +366,11 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
     if (shouldRequestIcon == RequestIcon::Yes)
         requestIcon(protect(this->files())->paths());
 
-    if (CheckedPtr renderer = element->renderer())
+    if (CheckedPtr renderer = element->renderer()) {
+        if (renderer->style().fieldSizing() == FieldSizing::Content)
+            renderer->setNeedsLayoutAndPreferredWidthsUpdate();
         renderer->repaint();
+    }
 
     if (wasSetByJavaScript == WasSetByJavaScript::Yes)
         return;

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -101,8 +101,11 @@ void RenderFileUploadControl::updateFromElement()
     // security reasons that's the only change the DOM is allowed to make.
     RefPtr files = inputElement().files();
     ASSERT(files);
-    if (files && files->isEmpty())
+    if (files && files->isEmpty()) {
+        if (style().fieldSizing() == FieldSizing::Content)
+            setNeedsLayoutAndPreferredWidthsUpdate();
         repaint();
+    }
 }
 
 static int NODELETE nodeLogicalWidth(Node* node)
@@ -273,6 +276,31 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
 
 void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
+    if (style().fieldSizing() == FieldSizing::Content) {
+        const String label = fileTextValue();
+        const FontCascade& font = style().fontCascade();
+
+        float labelWidth = font.width(constructTextRun(label, style(), ExpansionBehavior::allowRightOnly()));
+        maxLogicalWidth = labelWidth;
+        if (RefPtr button = uploadButton()) {
+            if (CheckedPtr buttonRenderer = dynamicDowncast<RenderBox>(button->renderer())) {
+                maxLogicalWidth += buttonRenderer->maxPreferredLogicalWidth();
+                maxLogicalWidth += afterButtonSpacing;
+                if (inputElement().icon()) {
+#if PLATFORM(COCOA)
+                    int iconLogicalWidth = nodeLogicalHeight(uploadButton());
+#endif
+                    maxLogicalWidth += iconLogicalWidth;
+                    maxLogicalWidth += iconFilenameSpacing;
+                }
+            }
+        }
+
+        if (!style().logicalWidth().isPercentOrCalculated())
+            minLogicalWidth = maxLogicalWidth;
+        return;
+    }
+
     if (shouldApplySizeOrInlineSizeContainment()) {
         if (auto logicalWidth = explicitIntrinsicInnerLogicalWidth()) {
             minLogicalWidth = logicalWidth.value();
@@ -306,6 +334,11 @@ void RenderFileUploadControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogic
 void RenderFileUploadControl::computePreferredLogicalWidths()
 {
     ASSERT(needsPreferredLogicalWidthsUpdate());
+
+    if (style().fieldSizing() == FieldSizing::Content) {
+        RenderBlockFlow::computePreferredLogicalWidths();
+        return;
+    }
 
     m_minPreferredLogicalWidth = 0;
     m_maxPreferredLogicalWidth = 0;
@@ -344,13 +377,20 @@ String RenderFileUploadControl::fileTextValue() const
     Ref input = inputElement();
     if (!input->files())
         return { };
+    auto useContentSizing = style().fieldSizing() == FieldSizing::Content;
     if (input->files()->length() && !input->displayString().isEmpty()) {
+        if (useContentSizing)
+            return input->displayString();
+
         if (input->files()->length() == 1)
             return StringTruncator::centerTruncate(input->displayString(), maxFilenameLogicalWidth(), style().fontCascade());
 
         return StringTruncator::rightTruncate(input->displayString(), maxFilenameLogicalWidth(), style().fontCascade());
     }
-    return theme().fileListNameForWidth(input->files(), style().fontCascade(), maxFilenameLogicalWidth(), input->multiple());
+    return useContentSizing
+        ? theme().fileListName(input->files(), input->multiple())
+        : theme().fileListNameForWidth(input->files(), style().fontCascade(), maxFilenameLogicalWidth(), input->multiple());
+
 }
     
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -2166,15 +2166,21 @@ String RenderTheme::fileListNameForWidth(const FileList* fileList, const FontCas
     if (width <= 0)
         return String();
 
-    String string;
-    if (fileList->isEmpty())
-        string = fileListDefaultLabel(multipleFilesAllowed);
-    else if (fileList->length() == 1)
-        string = fileList->item(0)->name();
-    else
-        return StringTruncator::rightTruncate(multipleFileUploadText(fileList->length()), width, font);
+    String string = fileListName(fileList, multipleFilesAllowed);
+    if (fileList->length() > 1)
+        return StringTruncator::rightTruncate(string, width, font);
 
     return StringTruncator::centerTruncate(string, width, font);
+}
+
+String RenderTheme::fileListName(const FileList* fileList, bool multipleFilesAllowed) const
+{
+    if (fileList->isEmpty())
+        return fileListDefaultLabel(multipleFilesAllowed);
+    if (fileList->length() == 1)
+        return fileList->item(0)->name();
+
+    return multipleFileUploadText(fileList->length());
 }
 
 #if USE(SYSTEM_PREVIEW)

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -252,6 +252,7 @@ public:
 
     virtual String fileListDefaultLabel(bool multipleFilesAllowed) const;
     virtual String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const;
+    virtual String fileListName(const FileList*, bool multipleFilesAllowed) const;
 
     enum class FileUploadDecorations : bool { SingleFile, MultipleFiles };
     virtual void paintFileUploadIconDecorations(const RenderElement& /*inputRenderer*/, const RenderElement& /*buttonRenderer*/, const PaintInfo&, const FloatRect&, Icon*, FileUploadDecorations) { }

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -143,6 +143,7 @@ public:
 #endif
 
     String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const final;
+    String fileListName(const FileList*, bool multipleFilesAllowed) const final;
 
     bool NODELETE searchFieldShouldAppearAsTextField(const RenderStyle&, const Settings&) const final;
 

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1744,6 +1744,19 @@ String RenderThemeMac::fileListNameForWidth(const FileList* fileList, const Font
     return StringTruncator::centerTruncate(strToTruncate, width, font);
 }
 
+String RenderThemeMac::fileListName(const FileList* fileList, bool multipleFilesAllowed) const
+{
+    if (fileList->isEmpty())
+        return fileListDefaultLabel(multipleFilesAllowed);
+    if (fileList->length() == 1) {
+        RefPtr file = fileList->item(0);
+        auto path = file->path();
+        return path.isEmpty() ? file->name() : [[NSFileManager defaultManager] displayNameAtPath:path.createNSString().get()];
+    }
+
+    return multipleFileUploadText(fileList->length());
+}
+
 #if ENABLE(SERVICE_CONTROLS)
 IntSize RenderThemeMac::imageControlsButtonSize() const
 {


### PR DESCRIPTION
#### 64d0a6c2b5e8293adb45b6fe9e38bbc130f5cc1e
<pre>
Implement field-sizing support for file inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=269178">https://bugs.webkit.org/show_bug.cgi?id=269178</a>

Reviewed by NOBODY (OOPS!).

Updates RenderFileUploadControl to be able to size according to the contents sizing.
This is done by adding a method to get the full label string and sizing based on that.

Also correctly invalidates when a new file is chosen and when the input is reset.

Test: imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional.html
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/field-sizing-input-file.optional.html: Added.
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::setFiles):
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::updateFromElement):
(WebCore::RenderFileUploadControl::computeIntrinsicLogicalWidths const):
(WebCore::RenderFileUploadControl::computePreferredLogicalWidths):
(WebCore::RenderFileUploadControl::fileTextValue const):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::fileListNameForWidth const):
(WebCore::RenderTheme::fileListName const):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::RenderThemeMac::fileListName const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64d0a6c2b5e8293adb45b6fe9e38bbc130f5cc1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108876 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157067 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120085 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85267 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21422 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19474 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11780 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166432 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/10585 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128189 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128326 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84631 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23188 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15796 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27615 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91719 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27423 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->