### PR TITLE
Add CF_BRIDGED_TYPE to more SPI type declarations

### DIFF
--- a/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
+++ b/Source/WTF/wtf/spi/cocoa/SecuritySPI.h
@@ -67,7 +67,7 @@ enum {
 WTF_EXTERN_C_BEGIN
 
 #if !__has_include(<Security/CSCommon.h>)
-typedef struct __SecCode const *SecStaticCodeRef;
+typedef struct CF_BRIDGED_TYPE(id) __SecCode const *SecStaticCodeRef;
 
 typedef uint32_t SecCSFlags;
 enum {
@@ -95,8 +95,8 @@ WTF_EXTERN_C_END
 
 #endif // USE(APPLE_INTERNAL_SDK)
 
-typedef struct __SecTask *SecTaskRef;
-typedef struct __SecTrust *SecTrustRef;
+typedef struct CF_BRIDGED_TYPE(id) __SecTask *SecTaskRef;
+typedef struct CF_BRIDGED_TYPE(id) __SecTrust *SecTrustRef;
 
 WTF_EXTERN_C_BEGIN
 

--- a/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h
@@ -25,7 +25,9 @@
 
 #if ENABLE(DATA_DETECTION)
 
-typedef struct __DDResult *DDResultRef;
+#include <CoreFoundation/CoreFoundation.h>
+
+typedef struct CF_BRIDGED_TYPE(id) __DDResult *DDResultRef;
 
 #if USE(APPLE_INTERNAL_SDK)
 
@@ -153,7 +155,7 @@ struct __DDScanQuery {
 static_assert(sizeof(DDQueryOffset) == 8, "DDQueryOffset is no longer 8 bytes. Update the definition of DDQueryOffset in this file to match the new size.");
 
 typedef struct __DDScanQuery *DDScanQueryRef;
-typedef struct __DDScanner *DDScannerRef;
+typedef struct CF_BRIDGED_TYPE(id) __DDScanner *DDScannerRef;
 
 #if !USE(APPLE_INTERNAL_SDK)
 static inline DDQueryFragment *DDScanQueryGetFragmentAtIndex(DDScanQueryRef query, CFIndex anIndex)

--- a/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
+++ b/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
@@ -50,8 +50,8 @@ typedef UInt32 IOOptionBits;
 typedef uint32_t IOHIDEventOptionBits;
 typedef uint32_t IOHIDEventField;
 
-typedef struct __IOHIDEventSystemClient * IOHIDEventSystemClientRef;
-typedef struct __IOHIDEvent * IOHIDEventRef;
+typedef struct CF_BRIDGED_TYPE(id) __IOHIDEventSystemClient * IOHIDEventSystemClientRef;
+typedef struct CF_BRIDGED_TYPE(id) __IOHIDEvent * IOHIDEventRef;
 
 #define IOHIDEventFieldBase(type) (type << 16)
 

--- a/Source/WebKit/Platform/mac/StringUtilities.mm
+++ b/Source/WebKit/Platform/mac/StringUtilities.mm
@@ -35,7 +35,7 @@ namespace WebKit {
 
 SOFT_LINK_PRIVATE_FRAMEWORK(PhoneNumbers);
 
-typedef struct __CFPhoneNumber* CFPhoneNumberRef;
+typedef struct CF_BRIDGED_TYPE(id) __CFPhoneNumber* CFPhoneNumberRef;
 
 // These functions are declared with __attribute__((visibility ("default")))
 // We currently don't have a way to soft link such functions, so we forward declare them again here.


### PR DESCRIPTION
#### fd73741e0116c1e75ecb1615119b25758ca06608
<pre>
Add CF_BRIDGED_TYPE to more SPI type declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=289425">https://bugs.webkit.org/show_bug.cgi?id=289425</a>

Reviewed by David Kilzer and Wenson Hsieh.

Annotate more CF types with CF_BRIDGED_TYPE so that the static analyzer can recognize them as such.

* Source/WTF/wtf/spi/cocoa/SecuritySPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/DataDetectorsCoreSPI.h:
* Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h:
* Source/WebKit/Platform/mac/StringUtilities.mm:

Canonical link: <a href="https://commits.webkit.org/291869@main">https://commits.webkit.org/291869@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0267c9883872014e6ca742ad0cdca2f2fe4c2e83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94252 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13839 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99264 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44779 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96302 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71902 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29242 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10497 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85105 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52248 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2789 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44097 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86962 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80418 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101308 "Built successfully") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92918 "Found 6 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.34-1.js.mozilla-no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21556 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/81120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80289 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14514 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15120 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26467 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115568 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20975 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->