### PR TITLE
Sync `button-layout` tests from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9779,6 +9779,8 @@
         "web-platform-tests/html/rendering/widgets/appearance/appearance-transition-001-ref.html",
         "web-platform-tests/html/rendering/widgets/appearance/appearance-transition-002-ref.html",
         "web-platform-tests/html/rendering/widgets/button-layout/anonymous-button-content-box-ref.html",
+        "web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-ref.html",
+        "web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-ref.html",
         "web-platform-tests/html/rendering/widgets/button-layout/display-none-or-contents-ref.html",
         "web-platform-tests/html/rendering/widgets/button-layout/inline-level-ref.html",
         "web-platform-tests/html/rendering/widgets/button-layout/input-type-button-clip-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<button style="width: 100px; height: 100px;">
+  <div style="width: 100%; height: 100%; background: green;"></div>
+</button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-ref.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<button style="width: 100px; height: 100px;">
+  <div style="width: 100%; height: 100%; background: green;"></div>
+</button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<link rel="help" href="https://issues.chromium.org/issues/343257603">
+<link rel="match" href="block-in-inline-ref.html">
+<button style="width: 100px; height: 100px;">
+  <span>
+    <div style="width: 100%; height: 100%; background: green;"></div>
+  </span>
+</button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<button style="width: 100px; height: 100px;">
+  text text text text text text text text
+  <span>text</span>
+</button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<button style="width: 100px; height: 100px;">
+  text text text text text text text text
+  <span>text</span>
+</button>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://issues.chromium.org/issues/353898969">
+<link rel="match" href="button-dynamic-content-ref.html">
+<button style="width: 100px; height: 100px;">
+  text text text text text text text text
+  <span id="target"></span>
+</button>
+<script>
+document.body.offsetTop;
+document.getElementById('target').innerText = "text";
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex.html
@@ -22,6 +22,13 @@
   align-items: stretch;
   height: 3em;
 }
+
+#no-align-items {
+  border: none;
+  padding: 0;
+  display: flex;
+  height: 3em;
+}
 </style>
 <button id=inline-flex><div>1</div><div>2</div><div>3</div><div>4</div></button>
 <button id=flex><div>1</div><div>2</div><div>3</div><div>4</div></button>
@@ -30,6 +37,7 @@
 <div><button id="flexstart"><span id="flexstart-item">abc</span></button></div>
 
 <div><button id="stretch"><span id="stretch-item">abc</span></button></div>
+<div><button id="no-align-items"><span id="no-align-items-item">abc</span></button></div>
 <script>
 const ref = document.getElementById('ref');
 const expectedWidth = ref.clientWidth;
@@ -58,4 +66,10 @@ test(() => {
   assert_equals(document.getElementById('stretch').offsetHeight,
     document.getElementById('stretch-item').offsetHeight);
 }, 'align-items:stretch should work');
+
+// crbug.com/40681980
+test(() => {
+  assert_equals(document.getElementById('no-align-items').offsetHeight,
+    document.getElementById('no-align-items-item').offsetHeight);
+}, 'No align-items should work as stretch');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/w3c-import.log
@@ -17,6 +17,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/anonymous-button-content-box-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/anonymous-button-content-box-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/anonymous-button-content-box.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/computed-style.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/display-none-or-contents-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/display-none-or-contents-ref.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt
@@ -24,5 +24,5 @@ PASS inline-flex
 PASS flex
 PASS align-items:flex-start should work
 PASS align-items:stretch should work
-FAIL No align-items should work as stretch assert_equals: expected 13 but got 33
+FAIL No align-items should work as stretch assert_equals: expected 18 but got 48
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt
@@ -24,5 +24,5 @@ PASS inline-flex
 PASS flex
 PASS align-items:flex-start should work
 PASS align-items:stretch should work
-FAIL No align-items should work as stretch assert_equals: expected 13 but got 33
+FAIL No align-items should work as stretch assert_equals: expected 14 but got 33
 

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1843,6 +1843,9 @@ webkit.org/b/228311 imported/w3c/web-platform-tests/css/css-scoping/css-scoping-
 
 webkit.org/b/229291 imported/w3c/web-platform-tests/html/rendering/replaced-elements/images/revoked-blob-print.html [ Pass ImageOnlyFailure ]
 
+# Below test is flaky and only fail on 'stress' test bot and sometime due to race condition, show result of other tests
+imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html [ ImageOnlyFailure ]
+
 #rdar://82146367 ([Mac, iOS Release] imported/w3c/web-platform-tests/worklets/layout-worklet-csp.https.html is a flaky failure) 
 imported/w3c/web-platform-tests/worklets/layout-worklet-csp.https.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 0e5b38ea9ca425a5e49098160d91bc7f6b2b771f
<pre>
Sync `button-layout` tests from WPT upstream

<a href="https://bugs.webkit.org/show_bug.cgi?id=289426">https://bugs.webkit.org/show_bug.cgi?id=289426</a>
<a href="https://rdar.apple.com/146594206">rdar://146594206</a>

Reviewed by Abrar Rahman Protyasha.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/c23b0ad587af296087067b48a2f2101233589a8f">https://github.com/web-platform-tests/wpt/commit/c23b0ad587af296087067b48a2f2101233589a8f</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/block-in-inline.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/button-dynamic-content.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/button-layout/flex-expected.txt:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/291870@main">https://commits.webkit.org/291870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b317e8125e60256bc2b4414a0c06a698142a583

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44777 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71901 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29238 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97252 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10495 "Found 1 new test failure: fast/forms/ios/focus-input-via-button-no-scaling.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85102 "Found 1 new API test failure: TestWebKitAPI.FullscreenVideoTextRecognition.TogglePlaybackInElementFullscreen (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52247 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2786 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44095 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80416 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101306 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80905 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80287 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20016 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24837 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2206 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14510 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21286 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24433 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->