### PR TITLE
[JSC] `Set#union` and `Set#synmmetric` should get `next` before cloning `this`

### DIFF
--- a/JSTests/stress/set-prototype-symmetricDifference-keys-next-effects.js
+++ b/JSTests/stress/set-prototype-symmetricDifference-keys-next-effects.js
@@ -1,0 +1,44 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function compareArray(array1, array2) {
+    if (array1.length !== array2.length)
+        throw new Error(`Expected array length ${array2.length} but got array length ${array1.length}`);
+
+    for (let i = 0; i < array1.length; i++) {
+        if (array1[i] !== array2[i])
+            throw new Error(`Expected ${array2[i]} but got ${array1[i]} (${i})`);
+    }
+}
+
+
+function compareSet(set, array) {
+    let setArray = Array.from(set);
+    compareArray(setArray, array);
+}
+
+{
+  let set = new Set([1, 2, 3]);
+
+  let setLike = {
+    size: 0,
+    has() {
+      throw new Error("Unexpected call to |has| method");
+    },
+    keys() {
+      return {
+        get next() {
+          set.clear();
+          set.add(4);
+          return function() {
+            return {done: true};
+          };
+        }
+      };
+    },
+  };
+  compareSet(set.symmetricDifference(setLike), [4]);
+}
+

--- a/JSTests/stress/set-prototype-union-keys-next-effects.js
+++ b/JSTests/stress/set-prototype-union-keys-next-effects.js
@@ -1,0 +1,45 @@
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function compareArray(array1, array2) {
+    if (array1.length !== array2.length)
+        throw new Error(`Expected array length ${array2.length} but got array length ${array1.length}`);
+
+    for (let i = 0; i < array1.length; i++) {
+        if (array1[i] !== array2[i])
+            throw new Error(`Expected ${array2[i]} but got ${array1[i]} (${i})`);
+    }
+}
+
+
+function compareSet(set, array) {
+    let setArray = Array.from(set);
+    compareArray(setArray, array);
+}
+
+{
+  let set = new Set([1, 2, 3]);
+
+  let setLike = {
+    size: 0,
+    has() {
+      throw new Error("Unexpected call to |has| method");
+    },
+    keys() {
+      return {
+        get next() {
+          set.clear();
+          set.add(4);
+          return function() {
+            return {done: true};
+          };
+        }
+      };
+    },
+  };
+
+  compareSet(set.union(setLike), [4]);
+}
+

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -1369,10 +1369,6 @@ test/staging/sm/RegExp/unicode-lead-trail.js:
   default: "Test262Error: Actual argument shouldn't be nullish. "
 test/staging/sm/RegExp/unicode-raw.js:
   default: 'Test262Error: Expected SameValue(«🐸», «null») to be true'
-test/staging/sm/Set/symmetric-difference.js:
-  default: 'Test262Error: Expected SameValue(«3», «1») to be true'
-test/staging/sm/Set/union.js:
-  default: 'Test262Error: Expected SameValue(«3», «1») to be true'
 test/staging/sm/String/string-code-point-upper-lower-mapping.js:
   default: 'Test262Error: Expected SameValue(«68976», «68944») to be true'
 test/staging/sm/String/string-upper-lower-mapping.js:

--- a/Source/JavaScriptCore/builtins/SetPrototype.js
+++ b/Source/JavaScriptCore/builtins/SetPrototype.js
@@ -86,8 +86,11 @@ function union(other)
         @throwTypeError("Set.prototype.union expects other.keys to be callable");
 
     var iterator = keys.@call(other);
+    var iteratorNextMethod = iterator.next;
     var wrapper = {
-        @@iterator: function () { return iterator; }
+        @@iterator: function () {
+           return { next: function () { return iteratorNextMethod.@call(iterator); } };
+        }
     };
 
     var result = @setClone(this);
@@ -212,8 +215,11 @@ function symmetricDifference(other)
         @throwTypeError("Set.prototype.symmetricDifference expects other.keys to be callable");
 
     var iterator = keys.@call(other);
+    var iteratorNextMethod = iterator.next;
     var wrapper = {
-        @@iterator: function () { return iterator; }
+        @@iterator: function () {
+            return { next: function () { return iteratorNextMethod.@call(iterator); } };
+        }
     };
 
     var result = @setClone(this);


### PR DESCRIPTION
#### b07e269b5a00776995010dbd160a246787241626
<pre>
[JSC] `Set#union` and `Set#synmmetric` should get `next` before cloning `this`
<a href="https://bugs.webkit.org/show_bug.cgi?id=289430">https://bugs.webkit.org/show_bug.cgi?id=289430</a>

Reviewed by Yusuke Suzuki.

According to the spec[1][2], `Set#symmetricDifference` and `Set#union` get
keys iterator&apos;s `next` method via `GetIteratorFromMethod`[3] and
`GetIteratorDirect`[4] before cloning `this`.

However, the current JSC implementation don&apos;t get it. Getting `next` method
can occur observable side effects, so we need to fix it.

[1]: <a href="https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference">https://tc39.es/ecma262/#sec-set.prototype.symmetricdifference</a>
[2]: <a href="https://tc39.es/ecma262/#sec-set.prototype.union">https://tc39.es/ecma262/#sec-set.prototype.union</a>
[3]: <a href="https://tc39.es/ecma262/#sec-getiteratorfrommethod">https://tc39.es/ecma262/#sec-getiteratorfrommethod</a>
[4]: <a href="https://tc39.es/ecma262/#sec-getiteratordirect">https://tc39.es/ecma262/#sec-getiteratordirect</a>

* JSTests/stress/set-prototype-symmetricDifference-keys-next-effects.js: Added.
(shouldBe):
(compareArray):
(let.setLike.keys.return.get next.set add):
* JSTests/stress/set-prototype-union-keys-next-effects.js: Added.
(shouldBe):
(compareArray):
(let.setLike.keys.return.get next.set add):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/builtins/SetPrototype.js:
(union.wrapper.return.next):
(union.wrapper.iterator):
(union):
(symmetricDifference.wrapper.return.next):
(symmetricDifference.wrapper.iterator):
(symmetricDifference):

Canonical link: <a href="https://commits.webkit.org/291875@main">https://commits.webkit.org/291875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/462b353c4f8c1a75627fbbe900b87984e5434a1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99254 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44769 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14129 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71892 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29231 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97244 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85093 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52238 "Found 1 new API test failure: /WPE/TestWebKitWebView:/webkit/WebKitWebView/save (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10176 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2777 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44087 "Built successfully") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/86952 "Found 6 new JSC stress test failures: mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-baseline, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-dfg-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-ftl-eager-no-cjit-validate-phases, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-llint, mozilla-tests.yaml/ecma/Date/15.9.5.14.js.mozilla-no-ftl (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80408 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101298 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92908 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15513 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80897 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80279 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20019 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21278 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26457 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115558 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20965 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->