### PR TITLE
Add support for generating more pair consumers

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9995,10 +9995,8 @@
             ],
             "codegen-properties": {
                 "style-builder-converter": "InitialLetter",
-                "parser-function": "consumeWebkitInitialLetter",
-                "parser-grammar-unused": "normal | <number [0,inf]>{1,2}",
-                "parser-grammar-comment": "Spec does not match our implementation. Spec is 'normal | [ <number [1,inf]> <integer [1,inf]> ] | [ <number [1,inf]> && [ drop | raise ]? ]'",
-                "parser-grammar-unused-reason": "Needs support for ordered groups, '&&' groups and additional range restrictions for number and integer."
+                "parser-grammar": "normal | <number [0,inf]>{1,2}@(type=CSSValuePair default=previous)",
+                "parser-grammar-comment": "Spec does not match our implementation. Spec is 'normal | [ <number [1,inf]> <integer [1,inf]> ] | [ <number [1,inf]> && [ drop | raise ]? ]'"
             },
             "status": {
                 "status": "experimental"
@@ -11519,9 +11517,7 @@
             ],
             "codegen-properties": {
                 "style-builder-converter": "ScrollSnapAlign",
-                "parser-function": "consumeScrollSnapAlign",
-                "parser-grammar-unused": "[ none | start | end | center ]{1,2}",
-                "parser-grammar-unused-reason": "Needs support for '{A,B}' multipliers."
+                "parser-grammar": "[ none | start | end | center ]{1,2}@(type=CSSValuePair default=previous)"
             },
             "specification": {
                 "category": "css-scroll-snap",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1359,11 +1359,9 @@ static Ref<CSSValueList> valueForScrollSnapType(const ScrollSnapType& type)
         createConvertingToCSSValueID(type.strictness));
 }
 
-static Ref<CSSValueList> valueForScrollSnapAlignment(const ScrollSnapAlign& alignment)
+static Ref<CSSValue> valueForScrollSnapAlignment(const ScrollSnapAlign& alignment)
 {
-    if (alignment.inlineAlign == alignment.blockAlign)
-        return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(alignment.blockAlign));
-    return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(alignment.blockAlign),
+    return CSSValuePair::create(createConvertingToCSSValueID(alignment.blockAlign),
         createConvertingToCSSValueID(alignment.inlineAlign));
 }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Inline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Inline.cpp
@@ -85,28 +85,6 @@ RefPtr<CSSValue> consumeTextBoxEdge(CSSParserTokenRange& range, const CSSParserC
     return consumeTextEdge(range);
 }
 
-RefPtr<CSSValue> consumeWebkitInitialLetter(CSSParserTokenRange& range, const CSSParserContext& context)
-{
-    // Standard says this should be:
-    //
-    // <'initial-letter'> = normal | <number [1,∞]> <integer [1,∞]> | <number [1,∞]> && [ drop | raise ]?
-    // https://drafts.csswg.org/css-inline-3/#sizing-drop-initials
-
-    if (auto ident = consumeIdent<CSSValueNormal>(range))
-        return ident;
-    auto height = consumeNumber(range, context, ValueRange::NonNegative);
-    if (!height)
-        return nullptr;
-    RefPtr<CSSPrimitiveValue> position;
-    if (!range.atEnd()) {
-        position = consumeNumber(range, context, ValueRange::NonNegative);
-        if (!position || !range.atEnd())
-            return nullptr;
-    } else
-        position = height.copyRef();
-    return CSSValuePair::create(position.releaseNonNull(), height.releaseNonNull());
-}
-
 RefPtr<CSSValue> consumeWebkitLineBoxContain(CSSParserTokenRange& range, const CSSParserContext&)
 {
     // <'-webkit-line-box-contain'> = none | [ block || inline || font || glyphs || replaced || inline-box || initial-letter ]

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Inline.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Inline.h
@@ -43,10 +43,6 @@ RefPtr<CSSValue> consumeLineFitEdge(CSSParserTokenRange&, const CSSParserContext
 // https://drafts.csswg.org/css-inline-3/#propdef-text-box-edge
 RefPtr<CSSValue> consumeTextBoxEdge(CSSParserTokenRange&, const CSSParserContext&);
 
-// MARK: <'-webkit-initial-letter'> consuming
-// Standard equivalent is https://drafts.csswg.org/css-inline-3/#sizing-drop-initials
-RefPtr<CSSValue> consumeWebkitInitialLetter(CSSParserTokenRange&, const CSSParserContext&);
-
 // MARK: <'-webkit-line-box-contain'> consuming
 // No standard equivalent
 RefPtr<CSSValue> consumeWebkitLineBoxContain(CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ScrollSnap.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ScrollSnap.cpp
@@ -35,26 +35,6 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-RefPtr<CSSValue> consumeScrollSnapAlign(CSSParserTokenRange& range, const CSSParserContext&)
-{
-    // <'scroll-snap-align'> = [ none | start | end | center ]{1,2}
-    // https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-align
-
-    auto firstValue = consumeIdent<CSSValueNone, CSSValueStart, CSSValueCenter, CSSValueEnd>(range);
-    if (!firstValue)
-        return nullptr;
-
-    auto secondValue = consumeIdent<CSSValueNone, CSSValueStart, CSSValueCenter, CSSValueEnd>(range);
-    bool shouldAddSecondValue = secondValue && !secondValue->equals(*firstValue);
-
-    // Only add the second value if it differs from the first so that we produce the canonical
-    // serialization of this CSSValueList.
-    if (shouldAddSecondValue)
-        return CSSValueList::createSpaceSeparated(firstValue.releaseNonNull(), secondValue.releaseNonNull());
-
-    return CSSValueList::createSpaceSeparated(firstValue.releaseNonNull());
-}
-
 RefPtr<CSSValue> consumeScrollSnapType(CSSParserTokenRange& range, const CSSParserContext&)
 {
     // <'scroll-snap-type'> = none | [ x | y | block | inline | both ] [ mandatory | proximity ]?

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+ScrollSnap.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+ScrollSnap.h
@@ -35,10 +35,6 @@ struct CSSParserContext;
 
 namespace CSSPropertyParserHelpers {
 
-// MARK: <'scroll-snap-align'> consuming
-// https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-align
-RefPtr<CSSValue> consumeScrollSnapAlign(CSSParserTokenRange&, const CSSParserContext&);
-
 // MARK: <'scroll-snap-type'> consuming
 // https://drafts.csswg.org/css-scroll-snap-1/#scroll-snap-type
 RefPtr<CSSValue> consumeScrollSnapType(CSSParserTokenRange&, const CSSParserContext&);

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -1166,8 +1166,8 @@ inline IntSize BuilderConverter::convertInitialLetter(BuilderState& builderState
         return { };
 
     return {
-        pair->first.resolveAsNumber<int>(conversionData),
-        pair->second.resolveAsNumber<int>(conversionData)
+        pair->second.resolveAsNumber<int>(conversionData),
+        pair->first.resolveAsNumber<int>(conversionData)
     };
 }
 
@@ -1273,17 +1273,14 @@ inline ScrollSnapType BuilderConverter::convertScrollSnapType(BuilderState& buil
 
 inline ScrollSnapAlign BuilderConverter::convertScrollSnapAlign(BuilderState& builderState, const CSSValue& value)
 {
-    auto list = requiredListDowncast<CSSValueList, CSSPrimitiveValue>(builderState, value);
-    if (!list)
+    auto pair = requiredPairDowncast<CSSPrimitiveValue>(builderState, value);
+    if (!pair)
         return { };
 
-    ScrollSnapAlign alignment;
-    alignment.blockAlign = fromCSSValue<ScrollSnapAxisAlignType>(list->item(0));
-    if (list->size() == 1)
-        alignment.inlineAlign = alignment.blockAlign;
-    else
-        alignment.inlineAlign = fromCSSValue<ScrollSnapAxisAlignType>(list->item(1));
-    return alignment;
+    return {
+        fromCSSValue<ScrollSnapAxisAlignType>(pair->first),
+        fromCSSValue<ScrollSnapAxisAlignType>(pair->second)
+    };
 }
 
 inline ScrollSnapStop BuilderConverter::convertScrollSnapStop(BuilderState&, const CSSValue& value)


### PR DESCRIPTION
#### 21915b3edbe66caaaaac2b821dd67504a293081c
<pre>
Add support for generating more pair consumers
<a href="https://bugs.webkit.org/show_bug.cgi?id=289432">https://bugs.webkit.org/show_bug.cgi?id=289432</a>

Reviewed by Tim Nguyen.

Switch more consumers that use the form `[...]{1,2}` in their
grammars to match the modeling used already where a coalescing
CSSValuePair is used. With the consumer generated, the style
builder and computed style extractors need to be updated to
match.

These allow generation of:
    -webkit-initial-letter
    scroll-snap-align

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Inline.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Inline.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ScrollSnap.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+ScrollSnap.h:
* Source/WebCore/style/StyleBuilderConverter.h:

Canonical link: <a href="https://commits.webkit.org/291873@main">https://commits.webkit.org/291873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a0b0cf25116ec7c65d6f166759482de6007d5c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99286 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44802 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71922 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29262 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52268 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2811 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44120 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80440 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80926 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80308 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20018 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24859 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14544 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26489 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/20997 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24457 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22738 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->