### PR TITLE
[Page color sampler] Fine-tune color sampling heuristics to avoid backdrop filters

### DIFF
--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters-expected.txt
@@ -1,0 +1,27 @@
+Headline
+Headline
+
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(211, 211, 211)"
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(211, 211, 211)"
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(211, 211, 211)"
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(211, 211, 211)"
+PASS colors.top is null
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(211, 211, 211)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Bottom bar

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+        }
+
+        header {
+            font-size: 40px;
+            line-height: 100px;
+            text-align: center;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100px;
+            backdrop-filter: blur(40px);
+            color: white;
+        }
+
+        h1 {
+            margin-top: 100px;
+            text-align: center;
+        }
+
+        .gradient {
+            margin: 1em 0 500px 0;
+            width: 100%;
+            height: 1000px;
+            background: linear-gradient(to bottom, red 0%, green 50%, blue 100%);
+        }
+
+        footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 100px;
+            color: white;
+            font-size: 20px;
+            line-height: 100px;
+            background: lightgray;
+            text-align: center;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.ensurePresentationUpdate();
+        sampledColors = [];
+        for (i = 0; i < 5; ++i) {
+            sampledColors.push(await UIHelper.fixedContainerEdgeColors());
+            scrollBy(0, 100);
+            await UIHelper.ensurePresentationUpdate();
+        }
+
+        for (colors of sampledColors) {
+            shouldBeNull("colors.top");
+            shouldBeNull("colors.left");
+            shouldBeNull("colors.right");
+            shouldBeEqualToString("colors.bottom", "rgb(211, 211, 211)");
+        }
+
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<header>Headline</header>
+<h1>Headline</h1>
+<div class="gradient"></div>
+<pre id="console"></pre>
+<pre id="description"></pre>
+<footer>Bottom bar</footer>
+</body>
+</html>

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images-expected.txt
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images-expected.txt
@@ -1,0 +1,9 @@
+
+PASS colors.top is "rgb(255, 99, 71)"
+PASS colors.left is null
+PASS colors.right is null
+PASS colors.bottom is "rgb(211, 211, 211)"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Bottom bar

--- a/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
+++ b/LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ FixedContainerEdgeSamplingEnabled=true useFlexibleViewport=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        body {
+            font-family: system-ui;
+        }
+
+        header {
+            text-align: center;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100px;
+            background: tomato;
+        }
+
+        img {
+            margin-top: 1px;
+            width: 280px;
+            height: 40px;
+            border-radius: 6px;
+        }
+
+        footer {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            width: 100%;
+            height: 100px;
+            color: white;
+            font-size: 20px;
+            line-height: 100px;
+            background: lightgray;
+            text-align: center;
+        }
+    </style>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    addEventListener("load", async () => {
+        await UIHelper.ensurePresentationUpdate();
+        colors = await UIHelper.fixedContainerEdgeColors();
+        shouldBeEqualToString("colors.top", "rgb(255, 99, 71)");
+        shouldBeNull("colors.left");
+        shouldBeNull("colors.right");
+        shouldBeEqualToString("colors.bottom", "rgb(211, 211, 211)");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+<header>
+    <img src="../images/resources/animated-red-green-blue-repeat-1.png" />
+</header>
+<div class="tall"></div>
+<pre id="console"></pre>
+<pre id="description"></pre>
+<footer>Bottom bar</footer>
+</body>
+</html>


### PR DESCRIPTION
#### 8ad316d5e199d82b9b8de009b2dda01309248ca4
<pre>
[Page color sampler] Fine-tune color sampling heuristics to avoid backdrop filters
<a href="https://bugs.webkit.org/show_bug.cgi?id=289443">https://bugs.webkit.org/show_bug.cgi?id=289443</a>
<a href="https://rdar.apple.com/146618551">rdar://146618551</a>

Reviewed by Abrar Rahman Protyasha.

Apply several minor adjustments to the page color sampling heuristic for fixed-position elements at
the edges of the viewport.

* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-backdrop-filters.html: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-images-expected.txt: Added.
* LayoutTests/fast/page-color-sampling/color-sampling-ignores-images.html: Added.

Add a couple of layout test to exercise these changes.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::fixedContainerEdges const):

Bail immediately if we find an hit-test to an element with a backdrop filter.

* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::PageColorSampler::predominantColor):

Several small fixes here:
- Bump the sample count up slightly.
- Use `isVisible` instead of `isValid` to ignore completely transparent colors.
- Exclude replaced content when painting the snapshot.

Canonical link: <a href="https://commits.webkit.org/291901@main">https://commits.webkit.org/291901@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bba296a4951985d9ca47cc9a7989b774f86b898b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44862 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/96384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71970 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29309 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97336 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10570 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85185 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52315 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10259 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2868 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44180 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/80506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101391 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15601 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/80974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80356 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/20034 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14615 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26550 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21057 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24517 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22798 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->