### PR TITLE
REGRESSION (285042@main-285687@main): `RegExp["$&"]` incorrectly returns an empty string

### DIFF
--- a/JSTests/stress/regexp-cache-adjustment.js
+++ b/JSTests/stress/regexp-cache-adjustment.js
@@ -1,0 +1,87 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function clearCache()
+{
+    "".match(/(?:)/g);
+}
+
+clearCache();
+"foo bar bar bar bar baz".match(/bar/g);
+shouldBe(RegExp.leftContext, "foo bar bar bar ");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "bar");
+
+clearCache();
+"foo bar bar bar bar baz".substring(1).match(/bar/g);
+shouldBe(RegExp.leftContext, "oo bar bar bar ");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "bar");
+
+clearCache();
+"foo bar baz".match(/bar/g);
+shouldBe(RegExp.leftContext, "foo ");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "bar");
+
+clearCache();
+"foo bar baz".match(/ba(r)/g);
+shouldBe(RegExp.leftContext, "foo ");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "bar");
+
+clearCache();
+"foo xxxxxxxx baz".match(/x/g);
+shouldBe(RegExp.leftContext, "foo xxxxxxx");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "x");
+
+clearCache();
+"foo xxxxxxxx baz".substring(1).match(/x/g);
+shouldBe(RegExp.leftContext, "oo xxxxxxx");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "x");
+
+clearCache();
+"foo x baz".match(/x/g);
+shouldBe(RegExp.leftContext, "foo ");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "x");
+
+clearCache();
+"foo x baz".match(/(x)/g);
+shouldBe(RegExp.leftContext, "foo ");
+shouldBe(RegExp.rightContext, " baz");
+shouldBe(RegExp.lastMatch, "x");
+
+{
+    const veryLong = "foo bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar bar baz";
+    clearCache();
+    veryLong.substring(0, 10).match(/bar/g);
+    shouldBe(RegExp.leftContext, "foo ");
+    shouldBe(RegExp.rightContext, " ba");
+    shouldBe(RegExp.lastMatch, "bar");
+
+    clearCache();
+    veryLong.substring(0, 20).match(/bar/g);
+    shouldBe(RegExp.leftContext, "foo bar bar bar ");
+    shouldBe(RegExp.rightContext, " ");
+    shouldBe(RegExp.lastMatch, "bar");
+}
+
+{
+    const veryLong = "foo xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx baz";
+    clearCache();
+    veryLong.substring(0, 10).match(/x/g);
+    shouldBe(RegExp.leftContext, "foo xxxxx");
+    shouldBe(RegExp.rightContext, "");
+    shouldBe(RegExp.lastMatch, "x");
+
+    clearCache();
+    veryLong.substring(0, 20).match(/x/g);
+    shouldBe(RegExp.leftContext, "foo xxxxxxxxxxxxxxx");
+    shouldBe(RegExp.rightContext, "");
+    shouldBe(RegExp.lastMatch, "x");
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1456,7 +1456,7 @@ JSC_DEFINE_JIT_OPERATION(operationRegExpExecNonGlobalOrSticky, EncodedJSValue, (
     if (!array)
         OPERATION_RETURN(scope, JSValue::encode(jsNull()));
 
-    globalObject->regExpGlobalData().recordMatch(vm, globalObject, regExp, string, result);
+    globalObject->regExpGlobalData().recordMatch(vm, globalObject, regExp, string, result, /* oneCharacterMatch */ false);
     OPERATION_RETURN(scope, JSValue::encode(array));
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13431,6 +13431,9 @@ void SpeculativeJIT::compileRecordRegExpCachedResult(Node* node)
     store8(
         TrustedImm32(0),
         Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfReified()));
+    store8(
+        TrustedImm32(0),
+        Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfOneCharacterMatch()));
 
     noResult(node);
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3074,6 +3074,7 @@ void SpeculativeJIT::compileRegExpTestInline(Node* node)
         store32(yarrRegisters.returnRegister, Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, start)));
         store32(yarrRegisters.returnRegister2, Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end)));
         store8(TrustedImm32(0), Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfReified()));
+        store8(TrustedImm32(0), Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfOneCharacterMatch()));
 
         JumpList doneCases;
 

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -119,6 +119,7 @@ namespace JSC { namespace FTL {
     macro(JSGlobalObject_regExpGlobalData_cachedResult_result_start, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, start)) \
     macro(JSGlobalObject_regExpGlobalData_cachedResult_result_end, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end)) \
     macro(JSGlobalObject_regExpGlobalData_cachedResult_reified, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfReified()) \
+    macro(JSGlobalObject_regExpGlobalData_cachedResult_oneCharacterMatch, JSGlobalObject::regExpGlobalDataOffset() + RegExpGlobalData::offsetOfCachedResult() + RegExpCachedResult::offsetOfOneCharacterMatch()) \
     macro(JSGlobalProxy_target, JSGlobalProxy::targetOffset()) \
     macro(JSObject_butterfly, JSObject::butterflyOffset()) \
     macro(JSPropertyNameEnumerator_cachedInlineCapacity, JSPropertyNameEnumerator::cachedInlineCapacityOffset()) \

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -17017,6 +17017,7 @@ IGNORE_CLANG_WARNINGS_END
                 jit.store32(returnGPR, CCallHelpers::Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, start)));
                 jit.store32(return2GPR, CCallHelpers::Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfResult() + OBJECT_OFFSETOF(MatchResult, end)));
                 jit.store8(CCallHelpers::TrustedImm32(0), CCallHelpers::Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfReified()));
+                jit.store8(CCallHelpers::TrustedImm32(0), CCallHelpers::Address(globalObjectGPR, offset + RegExpCachedResult::offsetOfOneCharacterMatch()));
 
                 jit.move(CCallHelpers::TrustedImm32(1), returnGPR);
                 done.append(jit.jump());
@@ -17299,6 +17300,9 @@ IGNORE_CLANG_WARNINGS_END
         m_out.store32As8(
             m_out.constInt32(0),
             m_out.address(globalObject, m_heaps.JSGlobalObject_regExpGlobalData_cachedResult_reified));
+        m_out.store32As8(
+            m_out.constInt32(0),
+            m_out.address(globalObject, m_heaps.JSGlobalObject_regExpGlobalData_cachedResult_oneCharacterMatch));
     }
 
     struct ArgumentsLength {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1225,7 +1225,7 @@ void JSGlobalObject::init(VM& vm)
     RegExpConstructor* regExpConstructor = RegExpConstructor::create(vm, RegExpConstructor::createStructure(vm, this, m_functionPrototype.get()), m_regExpPrototype.get());
     m_regExpConstructor.set(vm, this, regExpConstructor);
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::RegExp)].set(vm, this, regExpConstructor);
-    m_regExpGlobalData.cachedResult().record(vm, this, nullptr, jsEmptyString(vm), MatchResult(0, 0));
+    m_regExpGlobalData.cachedResult().record(vm, this, nullptr, jsEmptyString(vm), MatchResult(0, 0), /*oneCharacterMatch */ false);
 
 #define CREATE_CONSTRUCTOR_FOR_SIMPLE_TYPE(capitalName, lowerName, properName, instanceType, jsName, prototypeBase, featureFlag) \
 capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName ## Constructor::create(vm, capitalName ## Constructor::createStructure(vm, this, m_functionPrototype.get()), m_ ## lowerName ## Prototype.get()) : nullptr; \

--- a/Source/JavaScriptCore/runtime/RegExpCachedResult.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpCachedResult.cpp
@@ -57,11 +57,32 @@ JSArray* RegExpCachedResult::lastResult(JSGlobalObject* globalObject, JSObject* 
             m_lastRegExp.set(vm, owner, vm.regExpCache()->ensureEmptyRegExp(vm));
 
         JSArray* result = nullptr;
-        if (m_result)
-            result = createRegExpMatchesArray(globalObject, m_lastInput.get(), m_lastRegExp.get(), m_result.start);
-        else
+        if (m_result) {
+            auto* string = m_lastInput.get();
+            auto input = string->view(globalObject);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+
+            if (m_oneCharacterMatch) {
+                ASSERT(m_lastRegExp->hasValidAtom());
+                const String& pattern = m_lastRegExp->atom();
+                ASSERT(!pattern.isEmpty());
+                ASSERT(pattern.length() == 1);
+                // Reify precise m_result.
+                size_t found = input->reverseFind(pattern.characterAt(0));
+                if (found != notFound) {
+                    m_result.start = found;
+                    m_result.end = found + 1;
+                }
+                m_oneCharacterMatch = false;
+            }
+
+            MatchResult ignoreMatched;
+            result = createRegExpMatchesArray(vm, globalObject, string, input, m_lastRegExp.get(), m_result.start, ignoreMatched);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+        } else {
             result = createEmptyRegExpMatchesArray(globalObject, m_lastInput.get(), m_lastRegExp.get());
-        RETURN_IF_EXCEPTION(scope, nullptr);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+        }
 
         m_reifiedResult.setWithoutWriteBarrier(result);
         m_reifiedLeftContext.clear();

--- a/Source/JavaScriptCore/runtime/RegExpCachedResult.h
+++ b/Source/JavaScriptCore/runtime/RegExpCachedResult.h
@@ -46,7 +46,7 @@ class RegExp;
 // m_reifiedResult and m_reifiedInput hold the cached results.
 class RegExpCachedResult {
 public:
-    inline void record(VM&, JSObject* owner, RegExp*, JSString* input, MatchResult);
+    inline void record(VM&, JSObject* owner, RegExp*, JSString* input, MatchResult, bool oneCharacterMatch);
 
     JSArray* lastResult(JSGlobalObject*, JSObject* owner);
     void setInput(JSGlobalObject*, JSObject* owner, JSString*);
@@ -67,12 +67,14 @@ public:
     static constexpr ptrdiff_t offsetOfLastInput() { return OBJECT_OFFSETOF(RegExpCachedResult, m_lastInput); }
     static constexpr ptrdiff_t offsetOfResult() { return OBJECT_OFFSETOF(RegExpCachedResult, m_result); }
     static constexpr ptrdiff_t offsetOfReified() { return OBJECT_OFFSETOF(RegExpCachedResult, m_reified); }
+    static constexpr ptrdiff_t offsetOfOneCharacterMatch() { return OBJECT_OFFSETOF(RegExpCachedResult, m_oneCharacterMatch); }
 
     MatchResult result() const { return m_result; }
 
 private:
     MatchResult m_result { 0, 0 };
     bool m_reified { false };
+    bool m_oneCharacterMatch { false };
     WriteBarrier<JSString> m_lastInput;
     WriteBarrier<RegExp> m_lastRegExp;
     WriteBarrier<JSArray> m_reifiedResult;

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.h
@@ -51,7 +51,7 @@ public:
 
     MatchResult performMatch(JSGlobalObject*, RegExp*, JSString*, StringView, int startOffset, int** ovector);
     MatchResult performMatch(JSGlobalObject*, RegExp*, JSString*, StringView, int startOffset);
-    void recordMatch(VM&, JSGlobalObject*, RegExp*, JSString*, const MatchResult&);
+    void recordMatch(VM&, JSGlobalObject*, RegExp*, JSString*, const MatchResult&, bool oneCharacterMatch);
 
     static constexpr ptrdiff_t offsetOfCachedResult() { return OBJECT_OFFSETOF(RegExpGlobalData, m_cachedResult); }
 

--- a/Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h
@@ -29,12 +29,13 @@
 
 namespace JSC {
 
-ALWAYS_INLINE void RegExpCachedResult::record(VM& vm, JSObject* owner, RegExp* regExp, JSString* input, MatchResult result)
+ALWAYS_INLINE void RegExpCachedResult::record(VM& vm, JSObject* owner, RegExp* regExp, JSString* input, MatchResult result, bool oneCharacterMatch)
 {
     m_lastRegExp.setWithoutWriteBarrier(regExp);
     m_lastInput.setWithoutWriteBarrier(input);
     m_result = result;
     m_reified = false;
+    m_oneCharacterMatch = oneCharacterMatch;
     vm.writeBarrier(owner);
 }
 
@@ -67,7 +68,7 @@ ALWAYS_INLINE MatchResult RegExpGlobalData::performMatch(JSGlobalObject* owner, 
     ASSERT(m_ovector[1] >= position);
     size_t end = m_ovector[1];
 
-    m_cachedResult.record(vm, owner, regExp, string, MatchResult(position, end));
+    m_cachedResult.record(vm, owner, regExp, string, MatchResult(position, end), /* oneCharacterMatch */ false);
 
     return MatchResult(position, end);
 }
@@ -80,14 +81,14 @@ ALWAYS_INLINE MatchResult RegExpGlobalData::performMatch(JSGlobalObject* owner, 
     MatchResult result = regExp->match(owner, input, startOffset);
     RETURN_IF_EXCEPTION(scope, MatchResult::failed());
     if (result)
-        m_cachedResult.record(vm, owner, regExp, string, result);
+        m_cachedResult.record(vm, owner, regExp, string, result, /* oneCharacterMatch */ false);
     return result;
 }
 
-ALWAYS_INLINE void RegExpGlobalData::recordMatch(VM& vm, JSGlobalObject* owner, RegExp* regExp, JSString* string, const MatchResult& result)
+ALWAYS_INLINE void RegExpGlobalData::recordMatch(VM& vm, JSGlobalObject* owner, RegExp* regExp, JSString* string, const MatchResult& result, bool oneCharacterMatch)
 {
     ASSERT(result);
-    m_cachedResult.record(vm, owner, regExp, string, result);
+    m_cachedResult.record(vm, owner, regExp, string, result, oneCharacterMatch);
 }
 
 inline MatchResult RegExpGlobalData::matchResult() const
@@ -98,7 +99,7 @@ inline MatchResult RegExpGlobalData::matchResult() const
 inline void RegExpGlobalData::resetResultFromCache(JSGlobalObject* owner, RegExp* regExp, JSString* string, MatchResult matchResult, Vector<int>&& vector)
 {
     m_ovector = WTFMove(vector);
-    m_cachedResult.record(getVM(owner), owner, regExp, string, matchResult);
+    m_cachedResult.record(getVM(owner), owner, regExp, string, matchResult, /* oneCharacterMatch */ false);
 }
 
 }

--- a/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
+++ b/Source/JavaScriptCore/runtime/RegExpMatchesArray.h
@@ -230,17 +230,6 @@ ALWAYS_INLINE JSArray* createRegExpMatchesArray(
     return array;
 }
 
-inline JSArray* createRegExpMatchesArray(JSGlobalObject* globalObject, JSString* string, RegExp* regExp, unsigned startOffset)
-{
-    VM& vm = getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    MatchResult ignoredResult;
-    auto input = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    RELEASE_AND_RETURN(scope, createRegExpMatchesArray(vm, globalObject, string, input, regExp, startOffset, ignoredResult));
-}
 JSArray* createEmptyRegExpMatchesArray(JSGlobalObject*, JSString*, RegExp*);
 Structure* createRegExpMatchesArrayStructure(VM&, JSGlobalObject*);
 Structure* createRegExpMatchesArrayWithIndicesStructure(VM&, JSGlobalObject*);

--- a/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.h
+++ b/Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.h
@@ -55,6 +55,7 @@ private:
     WriteBarrier<RegExp> m_lastRegExp;
     size_t m_lastNumberOfMatches { 0 };
     size_t m_lastMatchEnd { 0 };
+    MatchResult m_lastResult { };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -440,7 +440,7 @@ static ALWAYS_INLINE JSString* removeUsingRegExpSearch(VM& vm, JSGlobalObject* g
             return string;
 
         // Record the last matching.
-        globalObject->regExpGlobalData().recordMatch(vm, globalObject, regExp, string, MatchResult { static_cast<unsigned>(lastIndex), static_cast<unsigned>(lastIndex + pattern.length()) });
+        globalObject->regExpGlobalData().recordMatch(vm, globalObject, regExp, string, MatchResult { static_cast<unsigned>(lastIndex), static_cast<unsigned>(lastIndex + pattern.length()) }, /* oneCharacterMatch */ false);
         RELEASE_AND_RETURN(scope, jsSpliceSubstrings(globalObject, string, source, sourceRanges.span()));
     }
 


### PR DESCRIPTION
#### cc0a0f9071482e027fb284c59762c16c5cb25026
<pre>
REGRESSION (285042@main-285687@main): `RegExp[&quot;$&amp;&quot;]` incorrectly returns an empty string
<a href="https://bugs.webkit.org/show_bug.cgi?id=289337">https://bugs.webkit.org/show_bug.cgi?id=289337</a>
<a href="https://rdar.apple.com/146622507">rdar://146622507</a>

Reviewed by Yijia Huang.

For Atom matching, we need to update RegExpCachedResult correctly to
update RegExp.rightContext / RegExp.lastMatch etc. This patch does it.

1. For normal RegExp matching, we just store the lastResult to update
   the cache.
2. For Atom string matching, we use last matched string index, creating
   MatchResult from that and update the cache with it.
3. For one character matching, we do not want to make this slower by
   getting the last offset of matched character since these fields are
   rarely accessed. Instead, we record oneCharacterMatch flag, and when
   reifying the result, we scan the string from reverse order to find
   the last matched one character.

* JSTests/stress/regexp-cache-adjustment.js: Added.
(shouldBe):
(clearCache):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileRegExpTestInline):
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/RegExpCachedResult.cpp:
(JSC::RegExpCachedResult::lastResult):
* Source/JavaScriptCore/runtime/RegExpCachedResult.h:
(JSC::RegExpCachedResult::offsetOfOneCharacterMatch):
* Source/JavaScriptCore/runtime/RegExpGlobalData.h:
* Source/JavaScriptCore/runtime/RegExpGlobalDataInlines.h:
(JSC::RegExpCachedResult::record):
(JSC::RegExpGlobalData::performMatch):
(JSC::RegExpGlobalData::recordMatch):
(JSC::RegExpGlobalData::resetResultFromCache):
* Source/JavaScriptCore/runtime/RegExpMatchesArray.h:
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::RegExpObject::execInline):
(JSC::genericMatches):
(JSC::collectGlobalAtomMatches):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.cpp:
(JSC::RegExpSubstringGlobalAtomCache::collectMatches):
* Source/JavaScriptCore/runtime/RegExpSubstringGlobalAtomCache.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::removeUsingRegExpSearch):

Canonical link: <a href="https://commits.webkit.org/291881@main">https://commits.webkit.org/291881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbd63ad44168795205bfa59935143fbb61e31ad7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/94296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/131/builds/13883 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/138/builds/3654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/99308 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/44824 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/130/builds/14183 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/123/builds/22313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/71942 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/29283 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/97298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/132/builds/10533 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/85146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/52288 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/133/builds/10222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/135/builds/2829 "Passed tests") | [✅ 🛠 wpe-cairo](https://ews-build.webkit.org/#/builders/65/builds/44142 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/87006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/80454 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/136/builds/2921 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/101353 "Built successfully") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/92962 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/128/builds/21348 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/122/builds/15561 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/80949 "Failure limit exceed. At least found 1 new test failure: compositing/patterns/direct-pattern-compositing-size.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/121/builds/21600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/81159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/80331 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/126/builds/24876 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/137/builds/2250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/14568 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/15126 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/127/builds/21332 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/26511 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/115612 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/125/builds/21019 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/33176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/129/builds/24479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/124/builds/22760 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->